### PR TITLE
feat: shadow FK types from related PK + post-resolve reconcile

### DIFF
--- a/docs/superpowers/plans/2026-04-22-shadow-fk-types.md
+++ b/docs/superpowers/plans/2026-04-22-shadow-fk-types.md
@@ -1,0 +1,589 @@
+# Shadow FK types and forward-reference reconciliation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Derive shadow `{relation}_id` Pydantic types from the related model’s primary key type, keep a safe fallback when `ForeignKey.to` is unresolved, unwrap `Target | None` for FK metadata, and after `resolve_relationships()` upgrade shadows + `model_rebuild` + Rust schema registration so forward refs match concrete FK behavior (per `docs/superpowers/specs/2026-04-22-shadow-fk-types-design.md`).
+
+**Architecture:** Shared pure helpers live in `src/ferro/_shadow_fk_types.py` (no import from `models` to avoid cycles). `ModelMetaclass` calls them when injecting shadows and when scanning `Annotated` FK/M2M targets. `resolve_relationships()` runs a reconciliation pass after binding `rel.to`, then `model_rebuild(force=True)` on touched models, then a single consolidated schema re-registration path for all registry models.
+
+**Tech stack:** Python 3.13+, Pydantic v2 (`model_rebuild`), existing Ferro `ForeignKey` / `_MODEL_REGISTRY_PY` / `register_model_schema`.
+
+---
+
+## File map
+
+
+| File                                | Role                                                                                                                                                                                                                        |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/ferro/_shadow_fk_types.py`     | **Create** — PK resolution, optional wrapping, fallback detection, annotation comparison, `reconcile_shadow_fk_types(registry: dict[str, type]) -> list[type]`.                                                             |
+| `src/ferro/metaclass.py`            | **Modify** — FK/M2M scan: strip `                                                                                                                                                                                           |
+| `src/ferro/relations/__init__.py`   | **Modify** — After the first `for model_name, field_name, rel in to_process:` loop, call reconciliation + rebuilds; extract or inline schema re-register loop so rebuilt models get correct `__ferro_schema_`_ / Rust JSON. |
+| `tests/test_shadow_fk_types.py`     | **Create** — Unit tests for helpers; UUID + forward-ref integration-style tests (registry + `resolve_relationships`).                                                                                                       |
+| `tests/test_metaclass_internals.py` | **Modify** — Expectations for `_inject_shadow_fields` when `fk.to` is a concrete model with known PK type.                                                                                                                  |
+| `tests/test_relationship_engine.py` | **Modify** — Extend `test_forward_ref_resolution` (or add sibling test) to assert `Post.__annotations__["author_id"]` matches `Author` PK after `resolve_relationships()`.                                                  |
+
+
+---
+
+### Task 1: Helper module — types and PK resolution
+
+**Files:**
+
+- Create: `src/ferro/_shadow_fk_types.py`
+- Test: `tests/test_shadow_fk_types.py` (added in Task 2 after red phase — or create minimal stub first; here implement module first per dependency order)
+
+Implement the module below (single file). **Do not** import `Model` from `models`; use duck typing (`hasattr(cls, "ferro_fields")` and `model_fields`).
+
+- **Step 1: Add `src/ferro/_shadow_fk_types.py`**
+
+```python
+"""Shadow foreign-key column typing helpers (issue #16, design spec 2026-04-22)."""
+
+from __future__ import annotations
+
+import types
+from typing import Annotated, Any, Union, get_args, get_origin
+
+from pydantic import BaseModel
+
+# Matches metaclass fallback for unresolved FK targets
+_FALLBACK_SHADOW_ANNOTATION = Union[int, str, None]
+
+
+def is_concrete_ferro_model(obj: Any) -> bool:
+    return isinstance(obj, type) and issubclass(obj, BaseModel) and hasattr(
+        obj, "ferro_fields"
+    )
+
+
+def _scalar_part_of_annotation(ann: Any) -> Any:
+    """Strip ``Annotated[T, ...]`` to ``T`` so shadow columns stay plain unions/scalars."""
+    origin = get_origin(ann)
+    if origin is Annotated:
+        return get_args(ann)[0]
+    return ann
+
+
+def pk_python_type_for_model(target: type[Any]) -> Any | None:
+    """Return the PK field's scalar annotation (inner ``T`` of ``Annotated[T, ...]``), or None."""
+    ferro_fields = getattr(target, "ferro_fields", None)
+    if not ferro_fields:
+        return None
+    pk_name = None
+    for fname, fmeta in ferro_fields.items():
+        if getattr(fmeta, "primary_key", False):
+            pk_name = fname
+            break
+    if pk_name is None:
+        return None
+    mf = getattr(target, "model_fields", {}).get(pk_name)
+    if mf is None:
+        return None
+    return _scalar_part_of_annotation(mf.annotation)
+
+
+def shadow_annotation_for_pk(pk_ann: Any) -> Any:
+    """Shadow *_id is optional at the ORM level (default None before assignment)."""
+    if pk_ann is None:
+        return _FALLBACK_SHADOW_ANNOTATION
+    pk_ann = _scalar_part_of_annotation(pk_ann)
+    origin = get_origin(pk_ann)
+    args = get_args(pk_ann)
+    if origin is Union or origin is types.UnionType:
+        if type(None) in args:
+            return pk_ann
+    return pk_ann | None
+
+
+def shadow_annotation_for_foreign_key(metadata: Any) -> Any:
+    """Annotation for {name}_id at class creation time."""
+    from .base import ForeignKey  # local import to avoid cycles at module import
+
+    if not isinstance(metadata, ForeignKey):
+        return _FALLBACK_SHADOW_ANNOTATION
+    to = metadata.to
+    if not is_concrete_ferro_model(to):
+        return _FALLBACK_SHADOW_ANNOTATION
+    pk_ann = pk_python_type_for_model(to)
+    return shadow_annotation_for_pk(pk_ann)
+
+
+def is_fallback_shadow_annotation(ann: Any) -> bool:
+    """True if annotation is the legacy Union[int, str, None] shadow."""
+    if ann is _FALLBACK_SHADOW_ANNOTATION:
+        return True
+    origin = get_origin(ann)
+    if origin is not Union and origin is not types.UnionType:
+        return False
+    args = set(get_args(ann))
+    return args == {int, str, type(None)}
+
+
+def reconcile_shadow_fk_types(registry: dict[str, type[Any]]) -> list[type[Any]]:
+    """
+    After ForeignKey.to is concrete, upgrade shadow *_id annotations from fallback.
+
+    Mutates cls.__annotations__ and calls model_rebuild(force=True) per changed class.
+
+    Returns model classes that were rebuilt.
+    """
+    from .base import ForeignKey
+
+    rebuilt: list[type[Any]] = []
+    for model_name, model_cls in registry.items():
+        if model_name == "Model":
+            continue
+        relations = getattr(model_cls, "ferro_relations", None)
+        if not relations:
+            continue
+        changed = False
+        for fname, meta in relations.items():
+            if not isinstance(meta, ForeignKey):
+                continue
+            if not is_concrete_ferro_model(meta.to):
+                continue
+            pk_ann = pk_python_type_for_model(meta.to)
+            if pk_ann is None:
+                continue
+            desired = shadow_annotation_for_pk(pk_ann)
+            id_field = f"{fname}_id"
+            if id_field not in getattr(model_cls, "model_fields", {}):
+                continue
+            current = model_cls.__annotations__.get(id_field)
+            if current == desired:
+                continue
+            if current is not None and not is_fallback_shadow_annotation(current):
+                # Explicit non-fallback annotation: do not override (custom user types)
+                continue
+            ann = model_cls.__dict__.get("__annotations__")
+            if ann is None:
+                model_cls.__annotations__ = {}
+            else:
+                model_cls.__annotations__ = dict(ann)
+            model_cls.__annotations__[id_field] = desired
+            changed = True
+        if changed:
+            model_cls.model_rebuild(force=True)
+            rebuilt.append(model_cls)
+    return rebuilt
+```
+
+- **Step 2: Commit**
+
+```bash
+git add src/ferro/_shadow_fk_types.py
+git commit -m "feat: add shadow FK type helpers for PK-derived annotations"
+```
+
+---
+
+### Task 2: Unit tests for `_shadow_fk_types`
+
+**Files:**
+
+- Create: `tests/test_shadow_fk_types.py`
+- **Step 1: Write failing tests**
+
+```python
+"""Tests for ferro._shadow_fk_types."""
+
+from typing import Annotated, Union
+from uuid import UUID
+
+import pytest
+
+from uuid import uuid4
+
+from ferro import FerroField, Field, ForeignKey, Model
+from ferro._shadow_fk_types import (
+    is_fallback_shadow_annotation,
+    pk_python_type_for_model,
+    shadow_annotation_for_foreign_key,
+    shadow_annotation_for_pk,
+)
+from ferro.base import ForeignKey as ForeignKeyCls
+
+
+def test_pk_python_type_for_model_uuid():
+    class Parent(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        name: str
+
+    assert pk_python_type_for_model(Parent) is UUID
+
+
+def test_shadow_annotation_for_pk_wraps_required_uuid():
+    ann = shadow_annotation_for_pk(UUID)
+    assert ann == UUID | None
+
+
+def test_is_fallback_shadow_annotation():
+    assert is_fallback_shadow_annotation(Union[int, str, None])
+
+
+def test_shadow_annotation_for_foreign_key_concrete():
+    class Parent(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    fk = ForeignKeyCls(related_name="children")
+    fk.to = Parent
+    assert shadow_annotation_for_foreign_key(fk) == (int | None)
+
+
+def test_shadow_annotation_for_foreign_key_unresolved_string():
+    fk = ForeignKeyCls(related_name="children")
+    fk.to = "Parent"
+    ann = shadow_annotation_for_foreign_key(fk)
+    assert is_fallback_shadow_annotation(ann)
+
+
+@pytest.fixture
+def _cleanup_registry():
+    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    yield
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+
+
+def test_reconcile_upgrades_forward_ref_shadow(_cleanup_registry):
+    """Models self-register on class creation; do not hand-fill _MODEL_REGISTRY_PY."""
+    from ferro import BackRef
+    from ferro.relations import resolve_relationships
+
+    class Child(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        parent: Annotated["Parent", ForeignKey(related_name="children")]
+
+    class Parent(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+        children: BackRef[list[Child]] = None
+
+    assert is_fallback_shadow_annotation(Child.__annotations__["parent_id"])
+
+    resolve_relationships()
+
+    assert Child.__annotations__["parent_id"] == (int | None)
+```
+
+- **Step 2: Run tests (expect failures until Task 3–4 wire imports)**
+
+```bash
+cd /Users/taylorroberts/GitHub/syn54x/ferro && uv run pytest tests/test_shadow_fk_types.py -v --tb=short
+```
+
+Expected: failures until `reconcile` is invoked from `resolve_relationships` and `UUID` model registers `ferro_fields` correctly — you may need to fix `test_pk_python_type_for_model_uuid` if `Field(primary_key=True)` does not populate `ferro_fields` the same as `FerroField`; align with how issue #16 declares models (`Field` vs `FerroField`). Inspect `Child.ferro_fields` in a REPL if needed.
+
+- **Step 3: Commit after all tests green**
+
+```bash
+git add tests/test_shadow_fk_types.py
+git commit -m "test: cover shadow FK type helpers and forward-ref reconciliation"
+```
+
+---
+
+### Task 3: Metaclass — unwrap optional FK/M2M target + inject shadow from helper
+
+**Files:**
+
+- Modify: `src/ferro/metaclass.py` (imports top; `_scan_relationship_annotations` ~165–205; `_inject_shadow_fields` ~207–222)
+- **Step 1: Imports**
+
+Add:
+
+```python
+from ._shadow_fk_types import shadow_annotation_for_foreign_key
+```
+
+- **Step 2: ForeignKey branch in `_scan_relationship_annotations`**
+
+Replace only the assignment `metadata.to = args[0]` with optional stripping; **keep** `_PENDING_RELATIONS.append`, `local_relations[field_name] = metadata`, `fields_to_remove.append`, and `break`:
+
+```python
+                for metadata in args:
+                    if isinstance(metadata, ForeignKey):
+                        inner = ModelMetaclass._strip_optional_union(args[0])
+                        metadata.to = inner
+                        local_relations[field_name] = metadata
+                        _PENDING_RELATIONS.append((model_name, field_name, metadata))
+                        fields_to_remove.append(field_name)
+                        break
+```
+
+- **Step 3: ManyToManyField inner target**
+
+After resolving `metadata.to` from `list[...]` or plain `args[0]`, if the result is not a list origin, still apply `_strip_optional_union` to the inner model type:
+
+```python
+                    if isinstance(metadata, ManyToManyField):
+                        origin_inner = get_origin(args[0])
+                        if origin_inner is list:
+                            inner_args = get_args(args[0])
+                            if inner_args:
+                                metadata.to = ModelMetaclass._strip_optional_union(
+                                    inner_args[0]
+                                )
+                        else:
+                            metadata.to = ModelMetaclass._strip_optional_union(args[0])
+                        local_relations[field_name] = metadata
+                        _PENDING_RELATIONS.append((model_name, field_name, metadata))
+                        fields_to_remove.append(field_name)
+                        break
+```
+
+- **Step 4: `_inject_shadow_fields`**
+
+Replace `annotations[id_field] = Union[int, str, None]` with:
+
+```python
+                annotations[id_field] = shadow_annotation_for_foreign_key(metadata)
+```
+
+Keep `namespace[id_field] = PydanticField(default=None)` unchanged.
+
+- **Step 5: Run targeted tests**
+
+```bash
+uv run pytest tests/test_metaclass_internals.py::TestInjectShadowFields -v --tb=short
+uv run pytest tests/test_relationship_engine.py -v --tb=short
+```
+
+- **Step 6: Commit**
+
+```bash
+git add src/ferro/metaclass.py
+git commit -m "feat(metaclass): derive shadow FK types and unwrap optional relation targets"
+```
+
+---
+
+### Task 4: `resolve_relationships` — reconcile + schema pass
+
+**Files:**
+
+- Modify: `src/ferro/relations/__init__.py`
+- **Step 1: Import**
+
+```python
+from .._shadow_fk_types import reconcile_shadow_fk_types
+```
+
+- **Step 2: After the `for model_name, field_name, rel in to_process:` loop ends, before the “Second pass: Re-register schemas” comment**
+
+Insert:
+
+```python
+    reconcile_shadow_fk_types(_MODEL_REGISTRY_PY)
+```
+
+- **Step 3: Run full relationship + shadow tests**
+
+```bash
+uv run pytest tests/test_relationship_engine.py tests/test_shadow_fk_types.py tests/test_metaclass_internals.py -v --tb=short
+```
+
+Expected: green. If `__ferro_schema__` stale after rebuild, the existing second pass already calls `model_json_schema()` again — verify `tests/test_alembic_bridge.py` if present after full suite.
+
+- **Step 4: Commit**
+
+```bash
+git add src/ferro/relations/__init__.py
+git commit -m "feat(relations): reconcile shadow FK types after forward refs resolve"
+```
+
+---
+
+### Task 5: Update metaclass internal tests for concrete `int | None` PK
+
+**Files:**
+
+- Modify: `tests/test_metaclass_internals.py`
+- **Step 1: Add minimal concrete Parent model in test module** (or reuse pattern from `test_relationship_engine`) so `ForeignKey.to` is a real class with `int | None` PK.
+- **Step 2: Change `test_foreign_key_injects_id_field` assertion**
+
+From:
+
+```python
+assert annotations["owner_id"] == Union[int, str, None]
+```
+
+To:
+
+```python
+assert annotations["owner_id"] == (int | None)
+```
+
+only if the fake `Owner` model in that test exposes `ferro_fields` with `primary_key` on `id`. If the test uses `fk.to = "User"` string only, **keep** fallback expectation `Union[int, str, None]` (unresolved `to`).
+
+- **Step 3: Run**
+
+```bash
+uv run pytest tests/test_metaclass_internals.py::TestInjectShadowFields -v
+```
+
+- **Step 4: Commit**
+
+```bash
+git add tests/test_metaclass_internals.py
+git commit -m "test: align shadow FK inject tests with PK-derived annotations"
+```
+
+---
+
+### Task 6: Async integration — issue #16 reproducer (UUID)
+
+**Files:**
+
+- Modify: `tests/test_shadow_fk_types.py` (or new `tests/test_shadow_fk_uuid_integration.py`)
+- **Step 1: Add async test** — follow `tests/test_connection.py` / `tests/test_auto_migrate.py`: call `await connect("sqlite::memory:", auto_migrate=True)` directly (no `db_engine` fixture is required; `conftest.py` only defines `db_engine` and it is unused elsewhere). At the **start** of the test call `ferro.reset_engine()` and `ferro.clear_registry()` so dynamically defined models do not collide with other tests. Use **unique model class names** (e.g. `UuidIssueParent`, `UuidIssueChild`) to avoid registry clashes.
+
+```python
+import warnings
+from typing import Annotated
+from uuid import UUID, uuid4
+
+import pytest
+
+import ferro
+from ferro import BackRef, Field, ForeignKey, Model, connect
+
+
+@pytest.mark.asyncio
+async def test_uuid_fk_create_get_dump():
+    """Regression for GitHub #16: UUID PK through shadow FK without validation/serialization issues."""
+    ferro.reset_engine()
+    ferro.clear_registry()
+
+    class UuidIssueParent(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        name: str
+        children: BackRef[list["UuidIssueChild"]] = None
+
+    class UuidIssueChild(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        parent: Annotated[UuidIssueParent, ForeignKey(related_name="children")]
+
+    await connect("sqlite::memory:", auto_migrate=True)
+
+    parent = await UuidIssueParent.create(name="p")
+    child = await UuidIssueChild.create(parent=parent)
+
+    fetched = await UuidIssueChild.get(child.id)
+    assert fetched.parent_id == parent.id
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        fetched.model_dump_json()
+    unexpected = [
+        x
+        for x in w
+        if x.category.__name__ == "PydanticSerializationUnexpectedValue"
+    ]
+    assert not unexpected
+```
+
+- **Step 2: Run**
+
+```bash
+uv run maturin develop && uv run pytest tests/test_shadow_fk_types.py::test_uuid_fk_create_get_dump -v --tb=short
+```
+
+- **Step 3: Commit**
+
+```bash
+git add tests/test_shadow_fk_types.py
+git commit -m "test: UUID foreign key create/get/serialize integration"
+```
+
+---
+
+### Task 7: Nullable `Annotated[Parent | None, ForeignKey]` regression
+
+**Files:**
+
+- Modify: `tests/test_shadow_fk_types.py`
+- **Step 1: Test model** (in-memory registry; call `resolve_relationships`)
+
+```python
+def test_nullable_fk_annotation_does_not_crash():
+    import ferro
+    from ferro import BackRef, Field, ForeignKey, Model
+    from ferro.relations import resolve_relationships
+
+    ferro.clear_registry()
+
+    class Parent(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        children: BackRef[list["Child"]] = None
+
+    class Child(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        parent: Annotated[Parent | None, ForeignKey(related_name="children")] = None
+
+    resolve_relationships()
+    assert Child.ferro_relations["parent"].to is Parent
+```
+
+- **Step 2: Run + commit**
+
+```bash
+uv run pytest tests/test_shadow_fk_types.py::test_nullable_fk_annotation_does_not_crash -v
+git add tests/test_shadow_fk_types.py && git commit -m "test: nullable FK annotated target unwraps cleanly"
+```
+
+---
+
+### Task 8: Full verification
+
+- **Step 1: Lint + full test suite**
+
+```bash
+cd /Users/taylorroberts/GitHub/syn54x/ferro
+uv run ruff check src tests
+uv run maturin develop
+uv run pytest -q
+```
+
+Expected: all pass; `cargo test` optional if Rust untouched.
+
+- **Step 2: Commit** (only if fixes needed)
+
+```bash
+git add -A && git commit -m "fix: ruff/pytest cleanup for shadow FK types"
+```
+
+---
+
+## Spec coverage (self-review)
+
+
+| Spec section                                     | Task(s)                                       |
+| ------------------------------------------------ | --------------------------------------------- |
+| PK type helper                                   | Task 1                                        |
+| `_inject_shadow_fields` concrete vs fallback     | Tasks 1, 3                                    |
+| `Target | None` unwrap for FK (and M2M inner)    | Task 3                                        |
+| Post-`resolve_relationships` reconcile + rebuild | Tasks 1 (reconcile), 4                        |
+| Rust / `register_model_schema` refresh           | Task 4 (existing second pass after reconcile) |
+| UUID repro + forward ref + nullable FK tests     | Tasks 2, 5, 6, 7                              |
+| Metaclass / relationship regressions             | Tasks 3–5, 8                                  |
+
+
+**Placeholder scan:** None intentional; replace `...` and duplicate-class mistakes in Task 6 before implementation.
+
+**Consistency:** Single helper module name `_shadow_fk_types.py`; public functions as listed; `ForeignKey` import inside `shadow_annotation_for_foreign_key` / `reconcile_shadow_fk_types` only to avoid import cycles. PK annotations strip `Annotated[..., FerroField]` to the inner scalar before building shadow `| None`.
+
+---
+
+## Execution handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-22-shadow-fk-types.md`. Two execution options:**
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, review between tasks, fast iteration. **REQUIRED SUB-SKILL:** superpowers:subagent-driven-development.
+2. **Inline execution** — Run tasks in this session with checkpoints. **REQUIRED SUB-SKILL:** superpowers:executing-plans.
+
+**Which approach do you want?**

--- a/docs/superpowers/specs/2026-04-22-shadow-fk-types-design.md
+++ b/docs/superpowers/specs/2026-04-22-shadow-fk-types-design.md
@@ -1,0 +1,91 @@
+# Design: Shadow foreign-key column types and forward references
+
+**Date:** 2026-04-22
+**Context:** [GitHub issue #16](https://github.com/syn54x/ferro-orm/issues/16) — shadow `{relation}_id` fields are typed as `Union[int, str, None]`, which breaks models whose related primary key is `UUID` or another non-coercible type under Pydantic v2. Forward references on `ForeignKey` targets are common (circular imports); this spec records the agreed behavior and implementation shape.
+
+## Problem statement
+
+1. **Validation:** Assigning a related model instance during `create()` copies the target’s PK into `{name}_id`. If that slot is typed `Union[int, str, None]`, Pydantic does not accept a `UUID` in the same way it would for a `UUID | None` field.
+2. **Equality:** Values hydrated from the database may be `str` while the in-memory PK is `UUID`, so strict equality checks fail.
+3. **Serialization:** Dumping a model can emit `PydanticSerializationUnexpectedValue` when a `UUID` sits in a `Union[int, str, None]` slot.
+
+Root cause: the shadow column type is **not derived** from the related model’s primary key type; it is hardcoded.
+
+Secondary issue (same theme): `Annotated[Target | None, ForeignKey(...)]` can leave `metadata.to` as a union type, which breaks code paths that assume a model type or forward ref (e.g. `.__name__` in descriptor setup).
+
+## Goals
+
+- Shadow `{relation}_id` annotations should **match the related model’s PK Python type** (plus `None` when the column is nullable in the ORM sense), when that type can be determined.
+- **Forward references** must remain ergonomic: unresolved targets at class body time must **not** require a specific import order for basic functionality.
+- After `resolve_relationships()` has bound every `ForeignKey.to` to a concrete `Model` subclass, **upgrade** shadow fields that were created with the fallback type so forward-ref-heavy codebases get the same behavior as `Annotated[ConcreteParent, ForeignKey(...)]`.
+- Reconcile **nullable relationship annotations** (`Target | None`) so the inner type used for `metadata.to` is always the model (or forward ref), not a `UnionType`.
+
+## Non-goals
+
+- Changing database drivers or Rust hydration formats solely for this feature (coercion should follow Pydantic rules for the chosen Python type, e.g. `str` → `UUID` where applicable).
+- Composite primary keys (unless already first-class elsewhere); this spec assumes **one** PK field per model, consistent with existing `Model.__init__` logic that discovers `pk_field` from `ferro_fields`.
+- Many-to-many join table column types (still hardcoded integer in join schema in places); separate work if UUID PKs appear there.
+
+## Design
+
+### 1. PK type resolution helper
+
+Introduce a small internal helper (name TBD), e.g. `_pk_python_type_for_model(target: type[Model]) -> Any`, that:
+
+- Iterates `target.ferro_fields` (or equivalent) to find the field with `primary_key=True`.
+- Returns that field’s **Python** annotation from `target.model_fields[pk_name].annotation` (or from resolved `__annotations__` if that is the single source of truth in edge cases).
+
+If no PK is found, fall back to today’s conservative union or raise a clear error (match existing product behavior for invalid models).
+
+### 2. Metaclass: `_inject_shadow_fields`
+
+- When `metadata.to` is a **concrete** `Model` subclass (already true for `Annotated[Parent, ForeignKey]` when `Parent` is defined): set
+`annotations[id_field] = _optional_pk_type(pk_type)`
+(exact optional representation should match current semantics, e.g. `T | None` on supported Python versions).
+- When `metadata.to` is **not** resolvable to a concrete model (string, `ForwardRef`, missing): set
+`annotations[id_field] = Union[int, str, None]`
+(same as today) — **policy A** from brainstorming.
+
+### 3. Metaclass: FK scan and optional `Target | None`
+
+When scanning `Annotated[..., ForeignKey]`, unwrap `args[0]` with the same optional-stripping logic already used for backrefs (`_strip_optional_union`), so:
+
+- `metadata.to` is the model type or forward reference, not `A | None` as a union object.
+- Descriptor / name resolution never receives a bare `UnionType` from this path.
+
+### 4. Post-resolution upgrade (`resolve_relationships`)
+
+After existing logic resolves each `rel.to` to a concrete class and mutates registries:
+
+1. **Shadow type reconciliation pass** over `_MODEL_REGISTRY_PY` (or equivalent registry):
+  - For each `ForeignKey`, compute `desired = _optional_pk_type(_pk_python_type_for_model(rel.to))`.
+  - If the shadow field’s current annotation (or rebuilt core schema) should differ from `desired` — including the case “was fallback union, now target has `UUID` PK” — set `cls.__annotations__[f"{field}_id"] = desired` and mark `cls` for rebuild.
+2. For each affected model: `cls.model_rebuild(force=True)` (Pydantic v2).
+3. **Re-register Rust schemas** for updated models using the same path as today’s second-pass registration in `resolve_relationships` (or a shared helper), so `model_json_schema()` / `__ferro_schema__` / `register_model_schema` reflect new FK property types.
+
+**Ordering:** One full pass over all models is expected to suffice because PK types come from targets, not from peer children. If tests reveal ordering edge cases, a bounded second pass (“repeat until no model marked dirty”) is acceptable.
+
+**Idempotency:** Safe to call `resolve_relationships()` multiple times (tests); skip or no-op when annotation already matches `desired`.
+
+### 5. Testing expectations
+
+- **Regression:** Existing int/str PK + `ForeignKey` tests and `test_metaclass_internals` expectations for concrete targets must be updated if assertions pin `Union[int, str, None]` where the target PK is known.
+- **UUID PK:** Reproducer from issue #16 — `create` with instance, equality after `get`, `model_dump` / `model_dump_json` without serialization warnings.
+- **Forward ref:** Model with `Annotated["Other", ForeignKey(...)]` where `Other` is declared later; after import completes and `resolve_relationships()` runs, shadow field annotation should match `Other`’s PK type (e.g. `UUID | None`).
+- **Nullable FK annotation:** `Annotated[Parent | None, ForeignKey(...)]` does not crash metaclass or relationship resolution.
+
+## Open questions (resolved for this spec)
+
+
+| Question                                     | Decision                                                                                  |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Unresolved `ForeignKey.to` at metaclass time | Fallback `Union[int, str, None]` (policy A).                                              |
+| Forward refs after full model graph load     | Upgrade shadow types + `model_rebuild` + schema re-register post-`resolve_relationships`. |
+
+
+## References
+
+- `src/ferro/metaclass.py` — `_inject_shadow_fields`, `_scan_relationship_annotations`, `_strip_optional_union`
+- `src/ferro/relations/__init__.py` — `resolve_relationships`, second-pass schema registration
+- `src/ferro/models.py` — `Model.__init__` FK → `{name}_id` assignment
+- Issue #16 — symptoms, minimal reproducer, suggested `_get_target_pk_type` direction

--- a/src/ferro/_shadow_fk_types.py
+++ b/src/ferro/_shadow_fk_types.py
@@ -1,0 +1,129 @@
+"""Shadow foreign-key column typing helpers (issue #16, design spec 2026-04-22)."""
+
+from __future__ import annotations
+
+import types
+from typing import Annotated, Any, Union, get_args, get_origin
+
+from pydantic import BaseModel
+
+# Matches metaclass fallback for unresolved FK targets
+_FALLBACK_SHADOW_ANNOTATION = Union[int, str, None]
+
+
+def is_concrete_ferro_model(obj: Any) -> bool:
+    return isinstance(obj, type) and issubclass(obj, BaseModel) and hasattr(
+        obj, "ferro_fields"
+    )
+
+
+def _scalar_part_of_annotation(ann: Any) -> Any:
+    """Strip ``Annotated[T, ...]`` to ``T`` so shadow columns stay plain unions/scalars."""
+    origin = get_origin(ann)
+    if origin is Annotated:
+        return get_args(ann)[0]
+    return ann
+
+
+def pk_python_type_for_model(target: type[Any]) -> Any | None:
+    """Return the PK field's scalar annotation (inner ``T`` of ``Annotated[T, ...]``), or None."""
+    ferro_fields = getattr(target, "ferro_fields", None)
+    if not ferro_fields:
+        return None
+    pk_name = None
+    for fname, fmeta in ferro_fields.items():
+        if getattr(fmeta, "primary_key", False):
+            pk_name = fname
+            break
+    if pk_name is None:
+        return None
+    mf = getattr(target, "model_fields", {}).get(pk_name)
+    if mf is None:
+        return None
+    return _scalar_part_of_annotation(mf.annotation)
+
+
+def shadow_annotation_for_pk(pk_ann: Any) -> Any:
+    """Shadow *_id is optional at the ORM level (default None before assignment)."""
+    if pk_ann is None:
+        return _FALLBACK_SHADOW_ANNOTATION
+    pk_ann = _scalar_part_of_annotation(pk_ann)
+    origin = get_origin(pk_ann)
+    args = get_args(pk_ann)
+    if origin is Union or origin is types.UnionType:
+        if type(None) in args:
+            return pk_ann
+    return pk_ann | None
+
+
+def shadow_annotation_for_foreign_key(metadata: Any) -> Any:
+    """Annotation for {name}_id at class creation time."""
+    from .base import ForeignKey  # local import to avoid cycles at module import
+
+    if not isinstance(metadata, ForeignKey):
+        return _FALLBACK_SHADOW_ANNOTATION
+    to = metadata.to
+    if not is_concrete_ferro_model(to):
+        return _FALLBACK_SHADOW_ANNOTATION
+    pk_ann = pk_python_type_for_model(to)
+    return shadow_annotation_for_pk(pk_ann)
+
+
+def is_fallback_shadow_annotation(ann: Any) -> bool:
+    """True if annotation is the legacy Union[int, str, None] shadow."""
+    if ann is _FALLBACK_SHADOW_ANNOTATION:
+        return True
+    origin = get_origin(ann)
+    if origin is not Union and origin is not types.UnionType:
+        return False
+    args = set(get_args(ann))
+    return args == {int, str, type(None)}
+
+
+def reconcile_shadow_fk_types(registry: dict[str, type[Any]]) -> list[type[Any]]:
+    """
+    After ForeignKey.to is concrete, upgrade shadow *_id annotations from fallback.
+
+    Mutates cls.__annotations__ and calls model_rebuild(force=True) per changed class.
+
+    Returns model classes that were rebuilt.
+    """
+    from .base import ForeignKey
+
+    rebuilt: list[type[Any]] = []
+    for model_name, model_cls in registry.items():
+        if model_name == "Model":
+            continue
+        relations = getattr(model_cls, "ferro_relations", None)
+        if not relations:
+            continue
+        changed = False
+        for fname, meta in relations.items():
+            if not isinstance(meta, ForeignKey):
+                continue
+            if not is_concrete_ferro_model(meta.to):
+                continue
+            pk_ann = pk_python_type_for_model(meta.to)
+            if pk_ann is None:
+                continue
+            desired = shadow_annotation_for_pk(pk_ann)
+            id_field = f"{fname}_id"
+            if id_field not in getattr(model_cls, "model_fields", {}):
+                continue
+            current = model_cls.__annotations__.get(id_field)
+            if current == desired:
+                continue
+            if current is not None and not is_fallback_shadow_annotation(current):
+                # Explicit non-fallback annotation: do not override (custom user types)
+                continue
+            ann = model_cls.__dict__.get("__annotations__")
+            if ann is None:
+                model_cls.__annotations__ = {}
+            else:
+                model_cls.__annotations__ = dict(ann)
+            model_cls.__annotations__[id_field] = desired
+            changed = True
+        if changed:
+            model_cls.model_rebuild(force=True)
+            rebuilt.append(model_cls)
+    return rebuilt

--- a/src/ferro/_shadow_fk_types.py
+++ b/src/ferro/_shadow_fk_types.py
@@ -97,7 +97,7 @@ def reconcile_shadow_fk_types(registry: dict[str, type[Any]]) -> list[type[Any]]
         relations = getattr(model_cls, "ferro_relations", None)
         if not relations:
             continue
-        changed = False
+        id_fields_updated: list[str] = []
         for fname, meta in relations.items():
             if not isinstance(meta, ForeignKey):
                 continue
@@ -122,8 +122,16 @@ def reconcile_shadow_fk_types(registry: dict[str, type[Any]]) -> list[type[Any]]
             else:
                 model_cls.__annotations__ = dict(ann)
             model_cls.__annotations__[id_field] = desired
-            changed = True
-        if changed:
+            id_fields_updated.append(id_field)
+        if id_fields_updated:
+            # Pydantic only re-evaluates a field when FieldInfo._complete is False; without
+            # this, model_rebuild updates __annotations__ but model_fields stays stale (#16).
+            pydantic_fields = model_cls.__pydantic_fields__
+            for id_field in id_fields_updated:
+                fi = pydantic_fields.get(id_field)
+                if fi is not None:
+                    fi._complete = False
+                    fi._original_annotation = model_cls.__annotations__[id_field]
             model_cls.model_rebuild(force=True)
             rebuilt.append(model_cls)
     return rebuilt

--- a/src/ferro/metaclass.py
+++ b/src/ferro/metaclass.py
@@ -15,6 +15,7 @@ from pydantic import Field as PydanticField
 from pydantic.fields import FieldInfo
 
 from ._core import register_model_schema
+from ._shadow_fk_types import shadow_annotation_for_foreign_key
 from .base import FerroField, ForeignKey, ManyToManyField
 from .composite_uniques import apply_composite_uniques_to_schema
 from .fields import FERRO_FIELD_EXTRA_KEY
@@ -183,7 +184,8 @@ class ModelMetaclass(type(BaseModel)):
                 args = get_args(hint)
                 for metadata in args:
                     if isinstance(metadata, ForeignKey):
-                        metadata.to = args[0]
+                        inner = ModelMetaclass._strip_optional_union(args[0])
+                        metadata.to = inner
                         local_relations[field_name] = metadata
                         _PENDING_RELATIONS.append((model_name, field_name, metadata))
                         fields_to_remove.append(field_name)
@@ -194,9 +196,11 @@ class ModelMetaclass(type(BaseModel)):
                         if origin_inner is list:
                             inner_args = get_args(args[0])
                             if inner_args:
-                                metadata.to = inner_args[0]
+                                metadata.to = ModelMetaclass._strip_optional_union(
+                                    inner_args[0]
+                                )
                         else:
-                            metadata.to = args[0]
+                            metadata.to = ModelMetaclass._strip_optional_union(args[0])
                         local_relations[field_name] = metadata
                         _PENDING_RELATIONS.append((model_name, field_name, metadata))
                         fields_to_remove.append(field_name)
@@ -217,7 +221,7 @@ class ModelMetaclass(type(BaseModel)):
             if isinstance(metadata, ForeignKey):
                 # INJECT SHADOW FIELD into annotations
                 id_field = f"{field_name}_id"
-                annotations[id_field] = Union[int, str, None]
+                annotations[id_field] = shadow_annotation_for_foreign_key(metadata)
                 # Set a default so Pydantic doesn't make it required
                 namespace[id_field] = PydanticField(default=None)
 

--- a/src/ferro/relations/__init__.py
+++ b/src/ferro/relations/__init__.py
@@ -2,6 +2,7 @@ import json
 from typing import ForwardRef
 
 from .._core import register_model_schema
+from .._shadow_fk_types import reconcile_shadow_fk_types
 from ..base import ForeignKey, ManyToManyField
 from ..composite_uniques import apply_composite_uniques_to_schema
 from ..state import (  # noqa: F401
@@ -115,6 +116,8 @@ def resolve_relationships():
             }
             register_model_schema(join_table, json.dumps(join_schema))
             _JOIN_TABLE_REGISTRY[join_table] = join_schema
+
+    reconcile_shadow_fk_types(_MODEL_REGISTRY_PY)
 
     # Second pass: Re-register schemas
     for model_name, model_cls in _MODEL_REGISTRY_PY.items():

--- a/tests/test_alembic_bridge.py
+++ b/tests/test_alembic_bridge.py
@@ -1,7 +1,9 @@
 from typing import Annotated
+from uuid import UUID, uuid4
 
 import pytest
 import sqlalchemy as sa
+from pydantic import Field
 
 from ferro import (
     BackRef,
@@ -91,6 +93,26 @@ def test_m2m_translation():
     assert "actor.id" in fks
     assert "movie.id" in fks
     assert fks["actor.id"].ondelete == "CASCADE"
+
+
+def test_uuid_foreign_key_shadow_column_type():
+    """Alembic bridge: UUID PK targets produce a UUID-capable SQLAlchemy type on *_id columns."""
+
+    class UuidAlembicOrg(Model):
+        id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
+        name: str
+        members: BackRef[list["UuidAlembicMember"]] = None
+
+    class UuidAlembicMember(Model):
+        id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
+        org: Annotated[UuidAlembicOrg, ForeignKey(related_name="members")]
+
+    metadata = get_metadata()
+    member_table = metadata.tables["uuidalembicmember"]
+    col = member_table.c.org_id
+    assert isinstance(col.type, sa.Uuid) or (
+        isinstance(col.type, sa.String) and getattr(col.type, "length", None) == 36
+    )
 
 
 def test_on_delete_translation():

--- a/tests/test_metaclass_internals.py
+++ b/tests/test_metaclass_internals.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock
 import pytest
 from pydantic.fields import FieldInfo
 
+from ferro import Model
 from ferro.base import FerroField, ForeignKey, ManyToManyField
 from ferro.fields import FERRO_FIELD_EXTRA_KEY
 from ferro.metaclass import ModelMetaclass
@@ -223,6 +224,24 @@ class TestInjectShadowFields:
         assert "owner_id" in namespace
         assert isinstance(namespace["owner_id"], FieldInfo)
 
+    def test_foreign_key_injects_id_field_concrete_pk(self):
+        """Concrete FK target: shadow type follows related model PK annotation."""
+
+        class ShadowOwner(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            name: str
+
+        annotations = {"name": str}
+        namespace = {}
+        fk = ForeignKey(related_name="items")
+        fk.to = ShadowOwner
+        local_relations = {"owner": fk}
+
+        ModelMetaclass._inject_shadow_fields(annotations, namespace, local_relations)
+
+        assert annotations["owner_id"] == (int | None)
+        assert "owner_id" in namespace
+
     def test_multiple_foreign_keys(self):
         """Multiple ForeignKeys should inject multiple shadow fields."""
         annotations = {"name": str}
@@ -257,7 +276,7 @@ class TestPrepareNamespaceForPydantic:
 
         assert get_origin(annotations["owner"]) is ClassVar
         assert get_origin(annotations["posts"]) is ClassVar
-        assert annotations["name"] == str
+        assert annotations["name"] is str
 
     def test_removes_annotate_func(self):
         """__annotate_func__ should be removed if present."""

--- a/tests/test_relationship_engine.py
+++ b/tests/test_relationship_engine.py
@@ -102,6 +102,7 @@ async def test_forward_ref_resolution():
     # Now it should be the class
     assert Post.ferro_relations["author"].to is Author
     assert Post.__annotations__["author_id"] == (int | None)
+    assert Post.model_fields["author_id"].annotation == (int | None)
 
 
 def test_relationship_validation_failure():

--- a/tests/test_relationship_engine.py
+++ b/tests/test_relationship_engine.py
@@ -101,6 +101,7 @@ async def test_forward_ref_resolution():
 
     # Now it should be the class
     assert Post.ferro_relations["author"].to is Author
+    assert Post.__annotations__["author_id"] == (int | None)
 
 
 def test_relationship_validation_failure():

--- a/tests/test_shadow_fk_types.py
+++ b/tests/test_shadow_fk_types.py
@@ -186,3 +186,73 @@ def test_nullable_fk_annotation_does_not_crash():
 
     resolve_relationships()
     assert NullableFkChild.ferro_relations["parent"].to is NullableFkParent
+
+
+@pytest.mark.asyncio
+async def test_uuid_fk_save_after_reparenting():
+    """Update an existing row: change only the UUID foreign key, then save() and re-fetch."""
+    ferro.reset_engine()
+    ferro.clear_registry()
+
+    class UuidMutParent(Model):
+        id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
+        name: str
+        kids: BackRef[list["UuidMutChild"]] = None
+
+    class UuidMutChild(Model):
+        id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
+        label: str
+        parent: Annotated[UuidMutParent, ForeignKey(related_name="kids")]
+
+    await connect("sqlite::memory:", auto_migrate=True)
+
+    parent_a = await UuidMutParent.create(name="a")
+    parent_b = await UuidMutParent.create(name="b")
+    child = await UuidMutChild.create(label="row", parent=parent_a)
+    assert child.parent_id == parent_a.id
+
+    child.parent_id = parent_b.id
+    await child.save()
+
+    refetched = await UuidMutChild.get(child.id)
+    assert refetched is not None
+    assert refetched.parent_id == parent_b.id
+    assert refetched.label == "row"
+
+
+@pytest.mark.asyncio
+async def test_uuid_fk_bulk_create():
+    """bulk_create serializes UUID FK columns via model_dump(mode='json')."""
+    ferro.reset_engine()
+    ferro.clear_registry()
+
+    class UuidBulkParent(Model):
+        id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
+        name: str
+        items: BackRef[list["UuidBulkItem"]] = None
+
+    class UuidBulkItem(Model):
+        id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
+        sku: str
+        parent: Annotated[UuidBulkParent, ForeignKey(related_name="items")]
+
+    await connect("sqlite::memory:", auto_migrate=True)
+
+    px = await UuidBulkParent.create(name="x")
+    py = await UuidBulkParent.create(name="y")
+
+    rows = [
+        UuidBulkItem(sku="1", parent_id=px.id),
+        UuidBulkItem(sku="2", parent_id=py.id),
+        UuidBulkItem(sku="3", parent_id=px.id),
+    ]
+    inserted = await UuidBulkItem.bulk_create(rows)
+    assert inserted == 3
+
+    all_items = await UuidBulkItem.all()
+    assert len(all_items) == 3
+    by_sku = {item.sku: item for item in all_items}
+    # Hydration may return UUID or TEXT from SQLite; compare normalized strings.
+    assert str(by_sku["1"].parent_id) == str(px.id)
+    assert str(by_sku["2"].parent_id) == str(py.id)
+    assert str(by_sku["3"].parent_id) == str(px.id)

--- a/tests/test_shadow_fk_types.py
+++ b/tests/test_shadow_fk_types.py
@@ -1,0 +1,135 @@
+"""Tests for ferro._shadow_fk_types."""
+
+import warnings
+from typing import Annotated, Union
+from uuid import UUID, uuid4
+
+import pytest
+
+import ferro
+from ferro import BackRef, FerroField, Field, ForeignKey, Model, connect
+from ferro._shadow_fk_types import (
+    is_fallback_shadow_annotation,
+    pk_python_type_for_model,
+    shadow_annotation_for_foreign_key,
+    shadow_annotation_for_pk,
+)
+from ferro.base import ForeignKey as ForeignKeyCls
+
+
+def test_pk_python_type_for_model_uuid():
+    class UuidPkParent(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        name: str
+
+    assert pk_python_type_for_model(UuidPkParent) is UUID
+
+
+def test_shadow_annotation_for_pk_wraps_required_uuid():
+    ann = shadow_annotation_for_pk(UUID)
+    assert ann == UUID | None
+
+
+def test_is_fallback_shadow_annotation():
+    assert is_fallback_shadow_annotation(Union[int, str, None])
+
+
+def test_shadow_annotation_for_foreign_key_concrete():
+    class IntPkParent(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    fk = ForeignKeyCls(related_name="children")
+    fk.to = IntPkParent
+    assert shadow_annotation_for_foreign_key(fk) == (int | None)
+
+
+def test_shadow_annotation_for_foreign_key_unresolved_string():
+    fk = ForeignKeyCls(related_name="children")
+    fk.to = "Parent"
+    ann = shadow_annotation_for_foreign_key(fk)
+    assert is_fallback_shadow_annotation(ann)
+
+
+@pytest.fixture
+def _cleanup_registry():
+    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    yield
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+
+
+def test_reconcile_upgrades_forward_ref_shadow(_cleanup_registry):
+    """Models self-register on class creation; do not hand-fill _MODEL_REGISTRY_PY."""
+    from ferro.relations import resolve_relationships
+
+    class ReconcileChild(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        parent: Annotated["ReconcileParent", ForeignKey(related_name="children")]
+
+    class ReconcileParent(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+        children: BackRef[list[ReconcileChild]] = None
+
+    assert is_fallback_shadow_annotation(ReconcileChild.__annotations__["parent_id"])
+
+    resolve_relationships()
+
+    assert ReconcileChild.__annotations__["parent_id"] == (int | None)
+
+
+@pytest.mark.asyncio
+async def test_uuid_fk_create_get_dump():
+    """Regression for GitHub #16: UUID PK through shadow FK without validation/serialization issues."""
+    ferro.reset_engine()
+    ferro.clear_registry()
+
+    class UuidIssueParent(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        name: str
+        children: BackRef[list["UuidIssueChild"]] = None
+
+    class UuidIssueChild(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        parent: Annotated[UuidIssueParent, ForeignKey(related_name="children")]
+
+    await connect("sqlite::memory:", auto_migrate=True)
+
+    parent = await UuidIssueParent.create(name="p")
+    child = await UuidIssueChild.create(parent=parent)
+
+    fetched = await UuidIssueChild.get(child.id)
+    assert fetched.parent_id == parent.id
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        fetched.model_dump_json()
+    unexpected = [
+        x
+        for x in w
+        if x.category.__name__ == "PydanticSerializationUnexpectedValue"
+    ]
+    assert not unexpected
+
+
+def test_nullable_fk_annotation_does_not_crash():
+    from ferro.relations import resolve_relationships
+
+    ferro.clear_registry()
+
+    class NullableFkParent(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        children: BackRef[list["NullableFkChild"]] = None
+
+    class NullableFkChild(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        parent: Annotated[NullableFkParent | None, ForeignKey(related_name="children")] = (
+            None
+        )
+
+    resolve_relationships()
+    assert NullableFkChild.ferro_relations["parent"].to is NullableFkParent

--- a/tests/test_shadow_fk_types.py
+++ b/tests/test_shadow_fk_types.py
@@ -80,6 +80,7 @@ def test_reconcile_upgrades_forward_ref_shadow(_cleanup_registry):
     resolve_relationships()
 
     assert ReconcileChild.__annotations__["parent_id"] == (int | None)
+    assert ReconcileChild.model_fields["parent_id"].annotation == (int | None)
 
 
 @pytest.mark.asyncio
@@ -105,15 +106,67 @@ async def test_uuid_fk_create_get_dump():
     fetched = await UuidIssueChild.get(child.id)
     assert fetched.parent_id == parent.id
 
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        fetched.model_dump_json()
-    unexpected = [
-        x
-        for x in w
-        if x.category.__name__ == "PydanticSerializationUnexpectedValue"
-    ]
-    assert not unexpected
+    by_shadow = await UuidIssueChild.where(UuidIssueChild.parent_id == parent.id).first()
+    assert by_shadow is not None
+    assert by_shadow.id == child.id
+
+    for dumper in (fetched.model_dump, fetched.model_dump_json):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            dumper()
+        unexpected = [
+            x
+            for x in w
+            if x.category.__name__ == "PydanticSerializationUnexpectedValue"
+        ]
+        assert not unexpected
+
+
+@pytest.mark.asyncio
+async def test_uuid_fk_forward_ref_child_declared_first():
+    """Circular-import style: child model references parent by string before parent exists."""
+    ferro.reset_engine()
+    ferro.clear_registry()
+
+    class UuidFrwChild(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        parent: Annotated["UuidFrwParent", ForeignKey(related_name="children")]
+
+    class UuidFrwParent(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        name: str
+        children: BackRef[list[UuidFrwChild]] = None
+
+    await connect("sqlite::memory:", auto_migrate=True)
+
+    parent = await UuidFrwParent.create(name="p")
+    child = await UuidFrwChild.create(parent=parent)
+    fetched = await UuidFrwChild.get(child.id)
+    assert fetched.parent_id == parent.id
+
+
+def test_uuid_child_model_validate_accepts_string_parent_id():
+    """API / JSON payloads often send UUID FKs as strings; shadow typing should coerce."""
+    ferro.clear_registry()
+
+    class VParent(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        name: str
+        children: BackRef[list["VChild"]] = None
+
+    class VChild(Model):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        parent: Annotated[VParent, ForeignKey(related_name="children")]
+
+    from ferro.relations import resolve_relationships
+
+    resolve_relationships()
+
+    pid = uuid4()
+    cid = uuid4()
+    row = VChild.model_validate({"id": cid, "parent_id": str(pid)})
+    assert row.parent_id == pid
+    assert isinstance(row.parent_id, UUID)
 
 
 def test_nullable_fk_annotation_does_not_crash():


### PR DESCRIPTION
## Description

Fixes shadow `{relation}_id` fields always being typed as `Union[int, str, None]`, which broke UUID (and similar) primary keys for validation, equality after fetch, and serialization (GitHub #16). Forward references now receive the same shadow typing as concrete FK targets once `resolve_relationships()` runs.

## Changes

- Add `src/ferro/_shadow_fk_types.py` with PK type resolution, fallback detection, and `reconcile_shadow_fk_types` + `model_rebuild(force=True)` for upgraded models.
- Metaclass: unwrap `Target | None` for FK/M2M inner types; inject shadow annotations from the related model PK when the target class is known, otherwise keep the legacy union fallback.
- Call reconciliation after relationship resolution, before the existing schema re-registration pass.
- Tests: helpers, forward-ref upgrade, UUID async integration, nullable FK annotation; extend metaclass and relationship engine coverage.
- Design/spec and implementation plan under `docs/superpowers/`.

## Bridge and Schema Impact

- [x] No Rust/Python bridge changes
- [x] Python model/schema changed
- [ ] Rust core or SQL generation changed
- [ ] `src/ferro/_core.pyi` updated (if needed)
- [x] Integration test added first for new behavior

## Migration / Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes included (details below)

Shadow column annotations become more accurate (e.g. `UUID | None` instead of `Union[int, str, None]`). Code that relied on the overly wide union may see stricter typing (generally desirable).

## Documentation and Changelog

- [ ] No docs update needed
- [x] Docs updated (README/docs/inline docs)
- [ ] Changelog entry needed

Added internal spec/plan markdown only.

## Related Issues

Closes #16

Made with [Cursor](https://cursor.com)