### PR TITLE
fix(migrations): align alembic nullability with field optionality

### DIFF
--- a/docs/guide/migrations.md
+++ b/docs/guide/migrations.md
@@ -53,6 +53,17 @@ target_metadata = get_metadata()
 # Rest of env.py remains unchanged
 ```
 
+### Column nullability (`get_metadata()`)
+
+Ferro maps each model field to a SQLAlchemy `Column` with a `nullable` flag used by autogenerate.
+
+- With the default **`nullable="infer"`** on `FerroField`, `ForeignKey`, and `ferro.Field(...)`, the column is nullable if and only if the field’s **Python annotation** allows `None` (for example `T | None`). Having a default or `default_factory` does **not** by itself make a column nullable in the migration metadata.
+- Shadow **`{name}_id`** foreign-key columns infer from the **forward relation** field’s annotation, not from the synthetic `*_id` field (which often uses `| None` for assignment convenience).
+- `ForeignKey(..., on_delete="SET NULL")` implies a nullable shadow FK column unless you explicitly override it; `nullable=False` is rejected for that combination.
+- Set **`nullable=False`** or **`nullable=True`** on `FerroField`, `ForeignKey`, or `ferro.Field(...)` to force NOT NULL or NULL when you intentionally diverge from the type (for example `int | None` for a type checker while keeping a NOT NULL column).
+
+Primary keys are always emitted as `nullable=False`.
+
 ### 3. Generate Your First Migration
 
 ```bash

--- a/docs/guide/models-and-fields.md
+++ b/docs/guide/models-and-fields.md
@@ -97,6 +97,7 @@ All of the above support the same database constraint parameters on `Field` / `F
 | `autoincrement` | `bool \| None` | `None` | If `True`, the database generates values automatically. Defaults to `True` for integer primary keys. |
 | `unique` | `bool` | `False` | Enforces a **single-column** uniqueness constraint on that column only. For uniqueness on a combination of columns, see [Composite unique constraints](#composite-unique-constraints) below. |
 | `index` | `bool` | `False` | Creates a database index for this column to improve query performance. |
+| `nullable` | `"infer" \| bool` | `"infer"` | Controls Alembic `Column.nullable` emitted by `get_metadata()`. `"infer"` follows whether the Python annotation allows `None`; `True` / `False` force NULL / NOT NULL. |
 
 #### Examples
 

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -17,7 +17,7 @@ from ._core import (
 from ._core import (
     connect as _core_connect,
 )
-from .base import FerroField, ForeignKey, ManyToManyField
+from .base import FerroField, FerroNullable, ForeignKey, ManyToManyField
 from .fields import Field
 from .models import Model, transaction
 from .query import BackRef
@@ -55,6 +55,7 @@ __all__ = [
     "connect",
     "Model",
     "FerroField",
+    "FerroNullable",
     "Field",
     "ForeignKey",
     "ManyToManyField",

--- a/src/ferro/_annotation_utils.py
+++ b/src/ferro/_annotation_utils.py
@@ -1,0 +1,28 @@
+"""Annotation helpers for schema bridges (Alembic, etc.)."""
+
+from __future__ import annotations
+
+import types
+from typing import Annotated, Any, Union, get_args, get_origin
+
+
+def annotation_allows_none(annotation: Any) -> bool:
+    """True if the annotation permits ``None`` (unwraps ``Annotated``)."""
+    hint: Any = annotation
+    while True:
+        alias_value = getattr(hint, "__value__", None)
+        if alias_value is not None:
+            hint = alias_value
+            continue
+        origin = get_origin(hint)
+        if origin is Annotated:
+            args = get_args(hint)
+            if not args:
+                return False
+            hint = args[0]
+            continue
+        if origin is Union or origin is types.UnionType:
+            if type(None) in get_args(hint):
+                return True
+            return False
+        return False

--- a/src/ferro/base.py
+++ b/src/ferro/base.py
@@ -4,10 +4,24 @@ This module provides lightweight configuration objects used by model annotations
 """
 
 from typing import (
+    Any,
+    Literal,
     TypeVar,
 )
 
+from ._annotation_utils import annotation_allows_none
+
 T = TypeVar("T")
+
+FerroNullable = Literal["infer"] | bool
+"""Alembic column nullability: ``'infer'`` from the field type, or forced bool."""
+
+
+def _validate_nullable_option(nullable: FerroNullable, owner: str) -> FerroNullable:
+    """Validate the public ``nullable`` tri-state option."""
+    if nullable == "infer" or isinstance(nullable, bool):
+        return nullable
+    raise TypeError(f"{owner} nullable must be 'infer', True, or False")
 
 
 class FerroField:
@@ -22,6 +36,10 @@ class FerroField:
             ``__ferro_composite_uniques__`` on the :class:`ferro.models.Model` subclass
             (see the models guide).
         index: Request an index for the column.
+        nullable: Alembic ``Column.nullable`` when using :func:`~ferro.migrations.get_metadata`.
+            ``'infer'`` (default) uses whether the annotation allows ``None``.
+            ``False`` / ``True`` force NOT NULL / NULL regardless of the type (for
+            advanced cases such as ``int | None`` used only for static typing).
 
     Examples:
         >>> from typing import Annotated
@@ -38,6 +56,7 @@ class FerroField:
         autoincrement: bool | None = None,
         unique: bool = False,
         index: bool = False,
+        nullable: FerroNullable = "infer",
     ):
         """Initialize field metadata options
 
@@ -48,6 +67,7 @@ class FerroField:
                 When not provided, the backend infers a default for integer primary keys.
             unique: Set to True to enforce **single-column** uniqueness only.
             index: Set to True to create a database index.
+            nullable: See :class:`FerroField` attribute ``nullable`` in the class docstring.
 
         Examples:
             >>> from typing import Annotated
@@ -61,6 +81,7 @@ class FerroField:
         self.autoincrement = autoincrement
         self.unique = unique
         self.index = index
+        self.nullable = _validate_nullable_option(nullable, "FerroField")
 
 
 class ForeignKey:
@@ -72,6 +93,9 @@ class ForeignKey:
         related_name: Name of the reverse relationship attribute on the target model.
         on_delete: Referential action applied when the parent row is deleted.
         unique: Treat the relation as one-to-one when True.
+        nullable: Alembic nullability for the shadow ``*_id`` column (see
+            :class:`FerroField` ``nullable``). When ``'infer'``, uses whether the
+            **relation** annotation allows ``None``.
 
     Examples:
         >>> from typing import Annotated
@@ -86,7 +110,11 @@ class ForeignKey:
     """
 
     def __init__(
-        self, related_name: str, on_delete: str = "CASCADE", unique: bool = False
+        self,
+        related_name: str,
+        on_delete: str = "CASCADE",
+        unique: bool = False,
+        nullable: FerroNullable = "infer",
     ):
         """Initialize foreign-key relationship metadata
 
@@ -96,6 +124,7 @@ class ForeignKey:
             on_delete: Referential action for parent deletion.
                 Common values include "CASCADE", "RESTRICT", "SET NULL", "SET DEFAULT", and "NO ACTION".
             unique: Set to True to enforce one-to-one behavior.
+            nullable: See :class:`ForeignKey` class docstring.
 
         Examples:
             >>> from typing import Annotated
@@ -109,6 +138,26 @@ class ForeignKey:
         self.related_name = related_name
         self.on_delete = on_delete
         self.unique = unique
+        self.nullable = _validate_nullable_option(nullable, "ForeignKey")
+        if str(self.on_delete).upper() == "SET NULL" and self.nullable is False:
+            raise ValueError("ForeignKey(on_delete='SET NULL') requires nullable=True or 'infer'")
+        #: First type argument of ``Annotated[..., ForeignKey]``; set by the metaclass
+        #: for Alembic nullability inference (forward fields are not in ``model_fields``).
+        self.relation_annotation: Any | None = None
+
+
+def foreign_key_allows_none(metadata: "ForeignKey") -> bool | None:
+    """Effective FK nullability from explicit override, delete action, and relation type."""
+    if metadata.nullable is True:
+        return True
+    if metadata.nullable is False:
+        return False
+    if str(metadata.on_delete).upper() == "SET NULL":
+        return True
+    relation_annotation = getattr(metadata, "relation_annotation", None)
+    if relation_annotation is None:
+        return None
+    return annotation_allows_none(relation_annotation)
 
 
 class ManyToManyField:

--- a/src/ferro/fields.py
+++ b/src/ferro/fields.py
@@ -9,6 +9,8 @@ from pydantic.fields import Field as PydanticField
 from pydantic.fields import _EmptyKwargs, _Unset
 from pydantic_core import PydanticUndefined
 
+from .base import FerroNullable, _validate_nullable_option
+
 if TYPE_CHECKING:
     import re
 
@@ -31,6 +33,7 @@ def Field(
     unique: bool = ...,
     index: bool = ...,
     back_ref: bool = ...,
+    nullable: FerroNullable = ...,
     alias: str | None = ...,
     alias_priority: int | None = ...,
     validation_alias: str | AliasPath | AliasChoices | None = ...,
@@ -78,6 +81,7 @@ def Field(
     unique: bool = ...,
     index: bool = ...,
     back_ref: bool = ...,
+    nullable: FerroNullable = ...,
     alias: str | None = ...,
     alias_priority: int | None = ...,
     validation_alias: str | AliasPath | AliasChoices | None = ...,
@@ -125,6 +129,7 @@ def Field(
     unique: bool = ...,
     index: bool = ...,
     back_ref: bool = ...,
+    nullable: FerroNullable = ...,
     alias: str | None = ...,
     alias_priority: int | None = ...,
     validation_alias: str | AliasPath | AliasChoices | None = ...,
@@ -171,6 +176,7 @@ def Field(
     unique: bool = ...,
     index: bool = ...,
     back_ref: bool = ...,
+    nullable: FerroNullable = ...,
     default_factory: Callable[[], Any] | Callable[[dict[str, Any]], Any],
     alias: str | None = ...,
     alias_priority: int | None = ...,
@@ -218,6 +224,7 @@ def Field(
     unique: bool = ...,
     index: bool = ...,
     back_ref: bool = ...,
+    nullable: FerroNullable = ...,
     default_factory: Callable[[], _T] | Callable[[dict[str, Any]], _T],
     alias: str | None = ...,
     alias_priority: int | None = ...,
@@ -265,6 +272,7 @@ def Field(
     unique: bool = ...,
     index: bool = ...,
     back_ref: bool = ...,
+    nullable: FerroNullable = ...,
     alias: str | None = ...,
     alias_priority: int | None = ...,
     validation_alias: str | AliasPath | AliasChoices | None = ...,
@@ -311,6 +319,7 @@ def Field(
     unique: bool | Any = _Unset,
     index: bool | Any = _Unset,
     back_ref: bool | Any = _Unset,
+    nullable: FerroNullable | Any = _Unset,
     default_factory: Callable[[], Any]
     | Callable[[dict[str, Any]], Any]
     | None = _Unset,
@@ -362,6 +371,8 @@ def Field(
         index: Request an index for this column in Ferro.
         back_ref: Mark this field as a reverse relationship (same as BackRef in the type).
             Do not use together with a BackRef annotation on the same field.
+        nullable: Alembic ``Column.nullable`` override for :func:`~ferro.migrations.get_metadata`.
+            ``\"infer\"`` (default) derives nullability from the field annotation.
         default_factory: A callable to generate the default value. The callable can either take 0 arguments
             (in which case it is called as is) or a single argument containing the already validated data.
         alias: The name to use for the attribute when validating or serializing by alias.
@@ -440,6 +451,9 @@ def Field(
         ferro_kwargs["index"] = index
     if back_ref is not _Unset:
         ferro_kwargs["back_ref"] = back_ref
+    if nullable is not _Unset:
+        _validate_nullable_option(nullable, "Field")
+        ferro_kwargs["nullable"] = nullable
 
     schema_extra = json_schema_extra
     if ferro_kwargs:

--- a/src/ferro/metaclass.py
+++ b/src/ferro/metaclass.py
@@ -184,6 +184,7 @@ class ModelMetaclass(type(BaseModel)):
                 args = get_args(hint)
                 for metadata in args:
                     if isinstance(metadata, ForeignKey):
+                        metadata.relation_annotation = args[0]
                         inner = ModelMetaclass._strip_optional_union(args[0])
                         metadata.to = inner
                         local_relations[field_name] = metadata

--- a/src/ferro/migrations/alembic.py
+++ b/src/ferro/migrations/alembic.py
@@ -8,6 +8,8 @@ try:
 except ImportError:
     sa = None
 
+from .._annotation_utils import annotation_allows_none
+from ..base import ForeignKey, foreign_key_allows_none
 from ..composite_uniques import apply_composite_uniques_to_schema
 from ..state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY
 
@@ -26,6 +28,14 @@ def get_metadata() -> "sa.MetaData":
     For :class:`~ferro.base.ForeignKey` fields with ``unique=True`` (one-to-one
     relations), the shadow ``*_id`` column is emitted with ``Column(unique=True)``
     so Alembic autogenerate includes the matching UNIQUE constraint.
+
+    **Column nullability:** ``Column.nullable`` follows :class:`~ferro.base.FerroField`
+    / :class:`~ferro.base.ForeignKey` ``nullable`` when set to a boolean (force
+    NULL / NOT NULL). The default ``nullable='infer'`` uses whether the Python
+    annotation allows ``None`` (after unwrapping ``Annotated``). Shadow ``*_id``
+    columns infer from the **forward relation** field's annotation, not from the
+    synthetic ``*_id`` field. Primary key columns are always ``nullable=False``.
+    Pydantic "required" and JSON-schema defaults do not change inferred nullability.
     """
     if sa is None:
         raise ImportError(
@@ -89,11 +99,12 @@ def _enrich_schema_with_ferro_metadata(model_cls, schema: Dict[str, Any]):
             schema["properties"][f_name]["primary_key"] = metadata.primary_key
             schema["properties"][f_name]["unique"] = metadata.unique
             schema["properties"][f_name]["index"] = metadata.index
+            fn = getattr(metadata, "nullable", "infer")
+            if isinstance(fn, bool):
+                schema["properties"][f_name]["ferro_nullable"] = fn
 
     # Apply ForeignKey metadata
     for f_name, metadata in model_cls.ferro_relations.items():
-        from ..base import ForeignKey
-
         if isinstance(metadata, ForeignKey):
             id_field = f"{f_name}_id"
             if id_field in schema["properties"]:
@@ -107,6 +118,9 @@ def _enrich_schema_with_ferro_metadata(model_cls, schema: Dict[str, Any]):
                     "on_delete": metadata.on_delete,
                     "unique": metadata.unique,
                 }
+                fk_nullable = getattr(metadata, "nullable", "infer")
+                if isinstance(fk_nullable, bool):
+                    schema["properties"][id_field]["ferro_nullable"] = fk_nullable
 
     apply_composite_uniques_to_schema(model_cls, schema)
 
@@ -151,6 +165,55 @@ def _field_python_enum(model_cls: type[Any] | None, field_name: str) -> type[enu
     return _annotation_as_enum_subclass(field.annotation)
 
 
+def _infer_nullable_join_table(
+    col_name: str,
+    col_info: Dict[str, Any],
+    required_fields: list[str],
+) -> bool:
+    """Join-table schemas without a model class: JSON-schema-only nullability."""
+    if "anyOf" in col_info:
+        return any(item.get("type") == "null" for item in col_info["anyOf"])
+    if col_info.get("type") == "null":
+        return True
+    return col_name not in required_fields
+
+
+def _resolve_sa_column_nullable(
+    col_name: str,
+    col_info: Dict[str, Any],
+    model_cls: type[Any] | None,
+    required_fields: list[str],
+) -> bool:
+    """SQLAlchemy ``Column.nullable`` for one table column."""
+    if col_info.get("primary_key"):
+        return False
+
+    override = col_info.get("ferro_nullable")
+    if isinstance(override, bool):
+        return override
+
+    if model_cls is not None:
+        model_fields = getattr(model_cls, "model_fields", None)
+        fk_info = col_info.get("foreign_key") or {}
+        if model_fields and fk_info and col_name.endswith("_id"):
+            rel_name = col_name[:-3]
+            rels = getattr(model_cls, "ferro_relations", {})
+            meta = rels.get(rel_name)
+            if isinstance(meta, ForeignKey):
+                fk_nullable = foreign_key_allows_none(meta)
+                if fk_nullable is not None:
+                    return fk_nullable
+                rel_field = model_fields.get(rel_name)
+                if rel_field is not None:
+                    return annotation_allows_none(rel_field.annotation)
+        if model_fields:
+            field_info = model_fields.get(col_name)
+            if field_info is not None:
+                return annotation_allows_none(field_info.annotation)
+
+    return _infer_nullable_join_table(col_name, col_info, required_fields)
+
+
 def _build_sa_table(
     metadata: "sa.MetaData",
     table_name: str,
@@ -170,32 +233,9 @@ def _build_sa_table(
         python_enum = _field_python_enum(model_cls, col_name)
         sa_type = _map_to_sa_type(schema, col_info, col_name, python_enum)
 
-        # Better nullability detection
-        is_nullable = True
-
-        # 1. If it's in required, it's definitely not nullable
-        if col_name in required_fields:
-            is_nullable = False
-
-        # 2. Check for explicit null in anyOf
-        if "anyOf" in col_info:
-            has_null = any(item.get("type") == "null" for item in col_info["anyOf"])
-            if not has_null:
-                # If there's an anyOf but none of them are null, it's not nullable
-                is_nullable = False
-            else:
-                is_nullable = True
-        elif col_info.get("type") == "null":
-            is_nullable = True
-        elif "type" in col_info and col_info["type"] != "null":
-            # If it has a single type that is not null, and it's not in anyOf
-            # We still respect 'required_fields' for the 'optional' case
-            pass
-
-        # 3. Special case: if it has a default value that is not None,
-        # it is often intended to be NOT NULL in the DB with a default.
-        if "default" in col_info and col_info["default"] is not None:
-            is_nullable = False
+        is_nullable = _resolve_sa_column_nullable(
+            col_name, col_info, model_cls, required_fields
+        )
 
         fk_info = col_info.get("foreign_key") or {}
         column_unique = bool(col_info.get("unique")) or bool(fk_info.get("unique"))
@@ -205,10 +245,6 @@ def _build_sa_table(
             "unique": column_unique,
             "index": col_info.get("index", False),
         }
-
-        # For primary keys, we often want nullable=False explicitly
-        if kwargs["primary_key"]:
-            kwargs["nullable"] = False
 
         args = [col_name, sa_type]
 

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -12,7 +12,7 @@ from typing import (
     get_type_hints,
 )
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from ._core import (
     begin_transaction,
@@ -26,7 +26,7 @@ from ._core import (
     save_bulk_records,
     save_record,
 )
-from .base import ForeignKey
+from .base import ForeignKey, foreign_key_allows_none
 from .metaclass import ModelMetaclass
 from .query import Query, QueryNode
 from .state import _CURRENT_TRANSACTION
@@ -123,6 +123,18 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                     data[f"{field_name}_id"] = val
 
         super().__init__(**data)
+
+    @model_validator(mode="after")
+    def _validate_required_foreign_keys(self) -> Self:
+        """Keep Python model validation aligned with required FK nullability."""
+        relations = getattr(self.__class__, "ferro_relations", {})
+        for field_name, metadata in relations.items():
+            if not isinstance(metadata, ForeignKey):
+                continue
+            if foreign_key_allows_none(metadata) is False:
+                if getattr(self, f"{field_name}_id", None) is None:
+                    raise ValueError(f"{field_name} is required")
+        return self
 
     async def save(self) -> None:
         """Persist the current model instance

--- a/tests/test_alembic_bridge.py
+++ b/tests/test_alembic_bridge.py
@@ -153,3 +153,4 @@ def test_on_delete_translation():
     product_table = metadata.tables["product"]
     fk = list(product_table.c.category_id.foreign_keys)[0]
     assert fk.ondelete == "SET NULL"
+    assert product_table.c.category_id.nullable is True

--- a/tests/test_alembic_nullability.py
+++ b/tests/test_alembic_nullability.py
@@ -1,0 +1,270 @@
+"""Alembic bridge: Column.nullable from infer / explicit overrides."""
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Annotated, TypeAliasType, Union
+
+import pytest
+from pydantic import ValidationError
+
+from ferro import FerroField, Field, ForeignKey, Model, clear_registry, reset_engine
+from ferro._annotation_utils import annotation_allows_none
+from ferro.migrations import get_metadata
+from ferro.query import BackRef
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+    reset_engine()
+    clear_registry()
+    yield
+
+
+def test_annotation_allows_none_primitive_and_union():
+    assert annotation_allows_none(int) is False
+    assert annotation_allows_none(int | None) is True
+    assert annotation_allows_none(Union[str, None]) is True
+    assert annotation_allows_none(Annotated[int | None, "x"]) is True
+    assert annotation_allows_none(Annotated[int, "x"]) is False
+
+
+def test_annotation_allows_none_type_alias():
+    maybe_int = TypeAliasType("MaybeInt", int | None)
+
+    assert annotation_allows_none(maybe_int) is True
+
+
+def test_infer_assignment_int_required_with_field_default():
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        field_a: int = Field(default=0)
+
+    t = get_metadata().tables["row"]
+    assert t.c.field_a.nullable is False
+
+
+def test_infer_assignment_int_optional_union():
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        field_a: int | None = None
+
+    t = get_metadata().tables["row"]
+    assert t.c.field_a.nullable is True
+
+
+def test_infer_assignment_optional_union_with_non_none_default_stays_nullable():
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        field_a: int | None = 0
+
+    t = get_metadata().tables["row"]
+    assert t.c.field_a.nullable is True
+
+
+def test_infer_type_alias_optional_field_is_nullable():
+    maybe_int = TypeAliasType("MaybeInt", int | None)
+
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        field_a: maybe_int = None
+
+    t = get_metadata().tables["row"]
+    assert t.c.field_a.nullable is True
+
+
+def test_infer_annotated_int_field_default():
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        field_a: Annotated[int, Field(default=0)]
+
+    t = get_metadata().tables["row"]
+    assert t.c.field_a.nullable is False
+
+
+def test_infer_annotated_int_union_none_field():
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        field_a: Annotated[int | None, Field(default=None)]
+
+    t = get_metadata().tables["row"]
+    assert t.c.field_a.nullable is True
+
+
+def test_infer_annotated_int_ferrofield():
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        field_a: Annotated[int, FerroField(unique=True)]
+
+    t = get_metadata().tables["row"]
+    assert t.c.field_a.nullable is False
+
+
+def test_infer_annotated_int_union_none_ferrofield():
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        field_a: Annotated[int | None, FerroField()]
+
+    t = get_metadata().tables["row"]
+    assert t.c.field_a.nullable is True
+
+
+def test_infer_datetime_default_factory_not_nullable():
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    t = get_metadata().tables["row"]
+    assert t.c.created_at.nullable is False
+
+
+def test_infer_enum_default_not_nullable():
+    class Status(StrEnum):
+        DRAFT = "draft"
+        ACTIVE = "active"
+
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        status: Status = Status.DRAFT
+
+    t = get_metadata().tables["row"]
+    assert t.c.status.nullable is False
+
+
+def test_infer_fk_shadow_required():
+    class Parent(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        name: str
+        children: BackRef[list["ChildReq"]] = None
+
+    class ChildReq(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        parent: Annotated[Parent, ForeignKey(related_name="children")]
+
+    t = get_metadata().tables["childreq"]
+    assert t.c.parent_id.nullable is False
+
+
+def test_required_fk_shadow_rejects_missing_value():
+    class Parent(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        name: str
+        children: BackRef[list["ChildReqValidation"]] = None
+
+    class ChildReqValidation(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        parent: Annotated[Parent, ForeignKey(related_name="children")]
+
+    with pytest.raises(ValidationError):
+        ChildReqValidation(id=1)
+
+    with pytest.raises(ValidationError):
+        ChildReqValidation(id=1, parent=None)
+
+    with pytest.raises(ValidationError):
+        ChildReqValidation(id=1, parent_id=None)
+
+
+def test_infer_fk_shadow_optional():
+    class Parent(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        name: str
+        children: BackRef[list["ChildOpt"]] = None
+
+    class ChildOpt(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        parent: Annotated[Parent | None, ForeignKey(related_name="children")] = None
+
+    t = get_metadata().tables["childopt"]
+    assert t.c.parent_id.nullable is True
+
+
+def test_override_ferrofield_nullable_false_on_optional_type():
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        field_a: Annotated[int | None, FerroField(nullable=False)] = None
+
+    t = get_metadata().tables["row"]
+    assert t.c.field_a.nullable is False
+
+
+def test_override_field_nullable_false_on_optional_type():
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        field_a: int | None = Field(default=None, nullable=False)
+
+    t = get_metadata().tables["row"]
+    assert t.c.field_a.nullable is False
+
+
+def test_override_ferrofield_nullable_true_on_required_type():
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        field_a: Annotated[int, FerroField(nullable=True)] = 0
+
+    t = get_metadata().tables["row"]
+    assert t.c.field_a.nullable is True
+
+
+def test_override_field_nullable_true_on_required_type():
+    class Row(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        field_a: int = Field(default=0, nullable=True)
+
+    t = get_metadata().tables["row"]
+    assert t.c.field_a.nullable is True
+
+
+def test_override_foreign_key_nullable_false_optional_relation():
+    class Parent(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        name: str
+        children: BackRef[list["ChildOv"]] = None
+
+    class ChildOv(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        parent: Annotated[
+            Parent | None,
+            ForeignKey(related_name="children", nullable=False),
+        ] = None
+
+    t = get_metadata().tables["childov"]
+    assert t.c.parent_id.nullable is False
+
+
+def test_override_foreign_key_nullable_true_required_relation():
+    class Parent(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        name: str
+        children: BackRef[list["ChildFkTrue"]] = None
+
+    class ChildFkTrue(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        parent: Annotated[
+            Parent,
+            ForeignKey(related_name="children", nullable=True),
+        ]
+
+    t = get_metadata().tables["childfktrue"]
+    assert t.c.parent_id.nullable is True
+
+
+def test_on_delete_set_null_infers_nullable_shadow_fk():
+    class Parent(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        name: str
+        children: BackRef[list["ChildSetNull"]] = None
+
+    class ChildSetNull(Model):
+        id: Annotated[int, FerroField(primary_key=True)]
+        parent: Annotated[
+            Parent,
+            ForeignKey(related_name="children", on_delete="SET NULL"),
+        ]
+
+    t = get_metadata().tables["childsetnull"]
+    assert t.c.parent_id.nullable is True


### PR DESCRIPTION
## Description

Fixes issue #18 by making Alembic nullability follow Ferro field optionality instead of inferred defaults, so generated schemas match required and optional model fields more reliably.

## Changes

- Add `nullable="infer" | bool` support to `FerroField`, `ForeignKey`, and `ferro.Field(...)`, plus shared annotation helpers for `Annotated` and type-alias optional detection
- Update Alembic metadata generation so field columns and shadow foreign-key columns infer nullability from annotations, honor explicit overrides, ignore `default` / `default_factory`, and force nullable shadow columns for `on_delete="SET NULL"`
- Align required foreign-key Python validation with the new nullability rules and add docs plus regression tests covering FK shadows, `SET NULL`, explicit overrides, and optional type aliases

## Bridge and Schema Impact

- [ ] No Rust/Python bridge changes
- [x] Python model/schema changed
- [ ] Rust core or SQL generation changed
- [ ] `src/ferro/_core.pyi` updated (if needed)
- [ ] Integration test added first for new behavior

## Migration / Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes included (details below)

## Documentation and Changelog

- [ ] No docs update needed
- [x] Docs updated (README/docs/inline docs)
- [ ] Changelog entry needed

## Related Issues

Closes #18
