### PR TITLE
fix(postgres): add dual-db ORM test matrix

### DIFF
--- a/docs/howto/testing.md
+++ b/docs/howto/testing.md
@@ -2,6 +2,64 @@
 
 Test your Ferro applications with pytest and test database isolation strategies.
 
+## Ferro Test Matrix
+
+The repository test suite supports two database modes:
+
+- **Default SQLite run** for the full fast suite
+- **Dual-backend matrix** for ORM coverage on both SQLite and PostgreSQL/Supabase
+
+The matrix is opt-in so day-to-day test runs stay quick and deterministic.
+
+### Local Setup
+
+Install the development dependencies used by the matrix:
+
+```bash
+uv sync --group dev
+uv run maturin develop
+```
+
+Set `FERRO_SUPABASE_URL` to a PostgreSQL connection string. A root `.env` file works well for local development:
+
+```bash
+FERRO_SUPABASE_URL='postgresql://...'
+```
+
+The Postgres matrix reads `FERRO_SUPABASE_URL` from either the environment or the project `.env` file. Tests create a dedicated schema per test and use that schema as the search path so one shared Supabase database can still run isolated tests safely.
+
+### Run The Default Suite
+
+Run the normal SQLite-first suite:
+
+```bash
+uv run pytest -q
+```
+
+### Run The Dual-Backend ORM Matrix
+
+Run the backend-matrix and Postgres-specific tests on both SQLite and PostgreSQL:
+
+```bash
+uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres -q
+```
+
+If you only want the PostgreSQL side of the matrix:
+
+```bash
+uv run pytest -m "backend_matrix or postgres_only" --db-backends=postgres -q
+```
+
+### Test Markers
+
+The repository uses three database markers:
+
+- `backend_matrix`: run this test once per selected backend
+- `sqlite_only`: keep SQLite-specific catalog, file-path, or pragma assertions on SQLite
+- `postgres_only`: run Postgres/Supabase-specific assertions only when `FERRO_SUPABASE_URL` is configured
+
+If `FERRO_SUPABASE_URL` is not set, `postgres_only` tests are skipped and `backend_matrix` tests run only on SQLite.
+
 ## Basic Setup
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     "mkdocstrings[python]>=0.24.0",
     "pymdown-extensions>=10.7.0",
     "pytest-examples>=0.0.18",
+    "psycopg[binary]>=3.3.3",
 ]
 
 [tool.pytest.ini_options]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -9,6 +9,38 @@ use pyo3::prelude::*;
 use sqlx::any::AnyPoolOptions;
 use std::sync::Arc;
 
+fn split_search_path(url: &str) -> (String, Option<String>) {
+    let Some((base, query)) = url.split_once('?') else {
+        return (url.to_string(), None);
+    };
+
+    let mut retained = Vec::new();
+    let mut search_path = None;
+
+    for pair in query.split('&') {
+        if let Some(value) = pair.strip_prefix("ferro_search_path=") {
+            search_path = Some(value.to_string());
+        } else if !pair.is_empty() {
+            retained.push(pair);
+        }
+    }
+
+    let clean_url = if retained.is_empty() {
+        base.to_string()
+    } else {
+        format!("{}?{}", base, retained.join("&"))
+    };
+
+    (clean_url, search_path)
+}
+
+fn is_safe_search_path(search_path: &str) -> bool {
+    !search_path.is_empty()
+        && search_path
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
 /// Initializes the global database connection pool.
 ///
 /// This is an asynchronous function that returns a Python coroutine.
@@ -24,17 +56,44 @@ use std::sync::Arc;
 #[pyo3(signature = (url, auto_migrate=false))]
 pub fn connect(py: Python<'_>, url: String, auto_migrate: bool) -> PyResult<Bound<'_, PyAny>> {
     sqlx::any::install_default_drivers();
+    let (connection_url, search_path) = split_search_path(&url);
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let dialect = if url.starts_with("postgres://") || url.starts_with("postgresql://") {
+        let dialect = if connection_url.starts_with("postgres://")
+            || connection_url.starts_with("postgresql://")
+        {
             SqlDialect::Postgres
         } else {
             SqlDialect::Sqlite
         };
 
-        let pool = AnyPoolOptions::new()
-            .max_connections(5)
-            .connect(&url)
+        if let Some(ref search_path) = search_path
+            && !is_safe_search_path(search_path)
+        {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Invalid ferro_search_path '{}'",
+                search_path
+            )));
+        }
+
+        let mut pool_options = AnyPoolOptions::new().max_connections(5);
+        if dialect == SqlDialect::Postgres
+            && let Some(search_path) = search_path
+        {
+            let set_search_path_sql = Arc::new(format!("SET search_path TO {}", search_path));
+            pool_options = pool_options.after_connect(move |conn, _meta| {
+                let set_search_path_sql = set_search_path_sql.clone();
+                Box::pin(async move {
+                    sqlx::query(set_search_path_sql.as_str())
+                        .execute(conn)
+                        .await?;
+                    Ok(())
+                })
+            });
+        }
+
+        let pool = pool_options
+            .connect(&connection_url)
             .await
             .map_err(|e| {
                 pyo3::exceptions::PyConnectionError::new_err(format!("DB Connection failed: {}", e))
@@ -53,7 +112,7 @@ pub fn connect(py: Python<'_>, url: String, auto_migrate: bool) -> PyResult<Boun
             .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("Failed to lock Engine"))?;
         *engine = Some(arc_pool);
 
-        crate::log_debug(format!("⚡️ Ferro Engine: Connected to {}", url));
+        crate::log_debug(format!("⚡️ Ferro Engine: Connected to {}", connection_url));
         Ok(())
     })
 }

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -186,23 +186,25 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> if user:
             ...     await user.delete()
         """
-        pk_val = None
-        for field_name, metadata in self.__class__.ferro_fields.items():
-            if metadata.primary_key:
-                pk_val = getattr(self, field_name)
-                break
-
-        if pk_val is None:
-            for field_name, field in self.__class__.model_fields.items():
-                if getattr(field, "json_schema_extra", {}).get("primary_key"):
-                    pk_val = getattr(self, field_name)
-                    break
+        pk_field_name = self.__class__._primary_key_field_name()
+        pk_val = getattr(self, pk_field_name) if pk_field_name is not None else None
 
         if pk_val is not None:
             name = self.__class__.__name__
-            tx_id = _CURRENT_TRANSACTION.get()
-            await delete_record(name, str(pk_val), tx_id)
+            await self.__class__.where(getattr(self.__class__, pk_field_name) == pk_val).delete()
             evict_instance(name, str(pk_val))
+
+    @classmethod
+    def _primary_key_field_name(cls) -> str | None:
+        for field_name, metadata in cls.ferro_fields.items():
+            if metadata.primary_key:
+                return field_name
+
+        for field_name, field in cls.model_fields.items():
+            if getattr(field, "json_schema_extra", {}).get("primary_key"):
+                return field_name
+
+        return None
 
     @classmethod
     def _fix_types(cls, instance: Self) -> None:
@@ -287,8 +289,11 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> user is None or isinstance(user, User)
             True
         """
-        tx_id = _CURRENT_TRANSACTION.get()
-        instance = await fetch_one(cls, str(pk), tx_id)
+        pk_field_name = cls._primary_key_field_name()
+        if pk_field_name is None:
+            raise RuntimeError(f"Model {cls.__name__} does not define a primary key")
+
+        instance = await cls.where(getattr(cls, pk_field_name) == pk).first()
         if instance:
             cls._fix_types(instance)
         return instance
@@ -307,26 +312,17 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> if user:
             ...     await user.refresh()
         """
-        pk_val = None
-        for field_name, metadata in self.__class__.ferro_fields.items():
-            if metadata.primary_key:
-                pk_val = getattr(self, field_name)
-                break
-
-        if pk_val is None:
-            for field_name, field in self.__class__.model_fields.items():
-                if getattr(field, "json_schema_extra", {}).get("primary_key"):
-                    pk_val = getattr(self, field_name)
-                    break
+        pk_field_name = self.__class__._primary_key_field_name()
+        pk_val = getattr(self, pk_field_name) if pk_field_name is not None else None
 
         if pk_val is None:
             raise RuntimeError("Cannot refresh a model without a primary key")
 
         name = self.__class__.__name__
         evict_instance(name, str(pk_val))
-
-        tx_id = _CURRENT_TRANSACTION.get()
-        fresh_instance = await fetch_one(self.__class__, str(pk_val), tx_id)
+        fresh_instance = await self.__class__.where(
+            getattr(self.__class__, pk_field_name) == pk_val
+        ).first()
 
         if fresh_instance is None:
             raise RuntimeError(f"Instance not found in database: {name}({pk_val})")

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -3,7 +3,7 @@
 //! This module implements high-performance CRUD operations, leveraging
 //! GIL-free parsing and zero-copy Direct Injection into Python objects.
 
-use crate::query::{property_schema_is_uuid, QueryDef};
+use crate::query::{property_schema_format, property_schema_is_decimal, property_schema_is_uuid, QueryDef};
 use crate::state::{ENGINE, IDENTITY_MAP, MODEL_REGISTRY, RustValue, TRANSACTION_REGISTRY};
 use pyo3::prelude::*;
 use sea_query::{
@@ -61,7 +61,16 @@ macro_rules! decode_column {
         let is_decimal = prop
             .and_then(|p| p.get("anyOf"))
             .and_then(|a| a.as_array())
-            .map(|types| types.iter().any(|t| t.get("pattern").is_some()))
+            .map(|types| {
+                let has_number = types
+                    .iter()
+                    .any(|t| t.get("type").and_then(|ty| ty.as_str()) == Some("number"));
+                let has_patterned_string = types.iter().any(|t| {
+                    t.get("type").and_then(|ty| ty.as_str()) == Some("string")
+                        && t.get("pattern").is_some()
+                });
+                has_number && has_patterned_string
+            })
             .unwrap_or(false);
 
         let json_type = prop
@@ -127,10 +136,9 @@ macro_rules! decode_column {
     }};
 }
 
-/// On Postgres, `sqlx::Any` cannot decode native `uuid` columns. When the model schema marks
-/// UUID fields, expand `SELECT *` into explicit columns with `::text` casts so decoding uses
-/// text (same representation as SQLite).
-fn apply_postgres_uuid_select_columns(
+/// On Postgres, `sqlx::Any` cannot decode some native types we use in tests. Expand `SELECT *`
+/// into explicit columns with `::text` casts so decoding uses the text-first path.
+fn apply_postgres_text_cast_select_columns(
     select: &mut sea_query::SelectStatement,
     table_name: &str,
     schema: &serde_json::Value,
@@ -146,13 +154,20 @@ fn apply_postgres_uuid_select_columns(
         select.column((tbl.clone(), sea_query::Asterisk));
         return;
     };
-    if !properties.values().any(property_schema_is_uuid) {
+    if !properties.values().any(|col_info| {
+        property_schema_is_uuid(col_info)
+            || property_schema_format(col_info) == Some("date")
+            || property_schema_format(col_info) == Some("date-time")
+    }) {
         select.column((tbl.clone(), sea_query::Asterisk));
         return;
     }
     for (col_name, col_info) in properties {
         let col_iden = Alias::new(col_name.as_str());
-        if property_schema_is_uuid(col_info) {
+        if property_schema_is_uuid(col_info)
+            || property_schema_format(col_info) == Some("date")
+            || property_schema_format(col_info) == Some("date-time")
+        {
             let expr = Expr::cast_as(
                 Expr::col((tbl.clone(), col_iden.clone())),
                 Alias::new("text"),
@@ -186,6 +201,54 @@ fn bind_query<'a>(
         };
     }
     query
+}
+
+fn json_value_to_simple_expr(
+    value: &serde_json::Value,
+    col_info: Option<&serde_json::Value>,
+) -> sea_query::SimpleExpr {
+    if let serde_json::Value::String(s) = value
+        && crate::state::sql_dialect() == crate::state::SqlDialect::Postgres
+    {
+        if col_info.is_some_and(property_schema_is_uuid) && uuid::Uuid::parse_str(s).is_ok() {
+            return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
+                .cast_as("uuid");
+        }
+        if col_info.and_then(property_schema_format) == Some("date") {
+            return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
+                .cast_as("date");
+        }
+        if col_info.and_then(property_schema_format) == Some("date-time") {
+            return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
+                .cast_as("timestamptz");
+        }
+        if col_info.and_then(property_schema_format) == Some("binary") {
+            return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
+                .cast_as("bytea");
+        }
+        if col_info.is_some_and(property_schema_is_decimal) {
+            return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
+                .cast_as("numeric");
+        }
+    }
+
+    let val = match value {
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                sea_query::Value::BigInt(Some(i))
+            } else if let Some(f) = n.as_f64() {
+                sea_query::Value::Double(Some(f))
+            } else {
+                sea_query::Value::String(None)
+            }
+        }
+        serde_json::Value::String(s) => sea_query::Value::String(Some(Box::new(s.clone()))),
+        serde_json::Value::Bool(b) => sea_query::Value::Bool(Some(*b)),
+        serde_json::Value::Null => sea_query::Value::String(None),
+        _ => sea_query::Value::String(Some(Box::new(value.to_string()))),
+    };
+
+    Expr::value(val)
 }
 
 #[pyfunction]
@@ -316,7 +379,7 @@ pub fn fetch_all<'py>(
                 }
             }
             let mut stmt = Query::select();
-            apply_postgres_uuid_select_columns(&mut stmt, &table_name, schema);
+            apply_postgres_text_cast_select_columns(&mut stmt, &table_name, schema);
             let s = sea_query_to_string!(stmt.from(Alias::new(&table_name)));
             (s, pk)
         };
@@ -466,7 +529,7 @@ pub fn fetch_one<'py>(
             let pk_name =
                 pk.ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("No primary key"))?;
             let mut stmt = Query::select();
-            apply_postgres_uuid_select_columns(&mut stmt, &table_name, schema);
+            apply_postgres_text_cast_select_columns(&mut stmt, &table_name, schema);
             let (s, values) = sea_query_build!(stmt
                 .from(Alias::new(&table_name))
                 .and_where(Expr::col(Alias::new(&pk_name)).eq(pk_val.clone())));
@@ -585,10 +648,11 @@ pub fn save_record(
         }
 
         let table_name = name.to_lowercase();
-        let (sql, bind_values) = {
+        let (sql, bind_values, should_return_pk, pk_name_for_returning) = {
             let mut columns = Vec::new();
             let mut values = Vec::new();
             let mut pk_provided = false;
+            let properties = schema.get("properties").and_then(|p| p.as_object());
             for (key, value) in &record_obj {
                 let is_pk = if let Some(ref pk) = pk_col {
                     key == pk
@@ -602,24 +666,10 @@ pub fn save_record(
                     pk_provided = true;
                 }
                 columns.push(Alias::new(key));
-                let val = match value {
-                    serde_json::Value::Number(n) => {
-                        if let Some(i) = n.as_i64() {
-                            sea_query::Value::BigInt(Some(i))
-                        } else if let Some(f) = n.as_f64() {
-                            sea_query::Value::Double(Some(f))
-                        } else {
-                            sea_query::Value::String(None)
-                        }
-                    }
-                    serde_json::Value::String(s) => {
-                        sea_query::Value::String(Some(Box::new(s.clone())))
-                    }
-                    serde_json::Value::Bool(b) => sea_query::Value::Bool(Some(*b)),
-                    serde_json::Value::Null => sea_query::Value::String(None),
-                    _ => sea_query::Value::String(Some(Box::new(value.to_string()))),
-                };
-                values.push(Expr::value(val));
+                values.push(json_value_to_simple_expr(
+                    value,
+                    properties.and_then(|props| props.get(key)),
+                ));
             }
             let mut insert_stmt = InsertStatement::new()
                 .into_table(Alias::new(&table_name))
@@ -627,13 +677,13 @@ pub fn save_record(
                 .values(values)
                 .unwrap()
                 .to_owned();
-            if let Some(pk) = pk_col
+            if let Some(ref pk) = pk_col
                 && (pk_provided || !pk_is_auto)
             {
-                let mut on_conflict = OnConflict::column(Alias::new(&pk));
+                let mut on_conflict = OnConflict::column(Alias::new(pk));
                 let mut update_cols = Vec::new();
                 for col in &columns {
-                    if col.to_string() != pk {
+                    if col.to_string() != *pk {
                         update_cols.push(col.clone());
                     }
                 }
@@ -642,11 +692,53 @@ pub fn save_record(
                     insert_stmt.on_conflict(on_conflict);
                 }
             }
-            sea_query_build!(insert_stmt)
+            let should_return_pk = crate::state::sql_dialect() == crate::state::SqlDialect::Postgres
+                && pk_col.is_some()
+                && pk_is_auto
+                && !pk_provided;
+            let pk_name_for_returning = pk_col.clone();
+            let (mut sql, values) = sea_query_build!(insert_stmt);
+            if should_return_pk
+                && let Some(ref pk_name) = pk_name_for_returning
+            {
+                sql.push_str(&format!(" RETURNING {}", pk_name));
+            }
+            (sql, values, should_return_pk, pk_name_for_returning)
         };
 
         let query = bind_query(sqlx::query(&sql), &bind_values.0);
-        if let Some(conn_arc) = tx_conn {
+        if should_return_pk {
+            let pk_name = pk_name_for_returning.ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err("Missing primary key for RETURNING")
+            })?;
+            if let Some(conn_arc) = tx_conn {
+                let mut conn = conn_arc.lock().await;
+                let row = query.fetch_one(&mut *conn).await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!("Save failed: {}", e))
+                })?;
+                let returned_id: i64 = row.try_get(pk_name.as_str()).or_else(|_| row.try_get(0)).map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to decode returned primary key '{}': {}",
+                        pk_name, e
+                    ))
+                })?;
+                Ok(Some(returned_id))
+            } else {
+                let mut conn = pool.acquire().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!("Pool acquire failed: {}", e))
+                })?;
+                let row = query.fetch_one(&mut *conn).await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!("Save failed: {}", e))
+                })?;
+                let returned_id: i64 = row.try_get(pk_name.as_str()).or_else(|_| row.try_get(0)).map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to decode returned primary key '{}': {}",
+                        pk_name, e
+                    ))
+                })?;
+                Ok(Some(returned_id))
+            }
+        } else if let Some(conn_arc) = tx_conn {
             let mut conn = conn_arc.lock().await;
             let res = query.execute(&mut *conn).await;
             if res.is_err() {
@@ -763,6 +855,7 @@ pub fn save_bulk_records(
                 .to_owned();
 
             let mut column_names = Vec::new();
+            let properties = schema.get("properties").and_then(|p| p.as_object());
 
             for (i, record) in records.iter().enumerate() {
                 let record_obj = record.as_object().ok_or_else(|| {
@@ -789,24 +882,10 @@ pub fn save_bulk_records(
                     let value = record_obj
                         .get(key.to_string().as_str())
                         .unwrap_or(&serde_json::Value::Null);
-                    let val = match value {
-                        serde_json::Value::Number(n) => {
-                            if let Some(i) = n.as_i64() {
-                                sea_query::Value::BigInt(Some(i))
-                            } else if let Some(f) = n.as_f64() {
-                                sea_query::Value::Double(Some(f))
-                            } else {
-                                sea_query::Value::String(None)
-                            }
-                        }
-                        serde_json::Value::String(s) => {
-                            sea_query::Value::String(Some(Box::new(s.clone())))
-                        }
-                        serde_json::Value::Bool(b) => sea_query::Value::Bool(Some(*b)),
-                        serde_json::Value::Null => sea_query::Value::String(None),
-                        _ => sea_query::Value::String(Some(Box::new(value.to_string()))),
-                    };
-                    row_values.push(Expr::value(val));
+                    row_values.push(json_value_to_simple_expr(
+                        value,
+                        properties.and_then(|props| props.get(key.to_string().as_str())),
+                    ));
                 }
                 insert_stmt.values(row_values).map_err(|e| {
                     pyo3::exceptions::PyRuntimeError::new_err(format!(
@@ -889,7 +968,7 @@ pub fn fetch_filtered<'py>(
             }
 
             let mut select = Query::select();
-            apply_postgres_uuid_select_columns(&mut select, &table_name, schema);
+            apply_postgres_text_cast_select_columns(&mut select, &table_name, schema);
             select.from(Alias::new(&table_name));
 
             if let Some(m2m) = &query_def.m2m {
@@ -1262,29 +1341,22 @@ pub fn update_filtered(
         let table_name = name.to_lowercase();
         // ... sql ...
         let (sql, bind_values) = {
+            let registry = MODEL_REGISTRY.read().map_err(|_| {
+                pyo3::exceptions::PyRuntimeError::new_err("Failed to lock registry")
+            })?;
+            let schema = registry.get(&name).ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!("Model '{}' not found", name))
+            })?;
+            let properties = schema.get("properties").and_then(|p| p.as_object());
             let mut update = UpdateStatement::new()
                 .table(Alias::new(&table_name))
                 .cond_where(query_def.to_condition())
                 .to_owned();
             for (key, value) in update_map {
-                let val = match value {
-                    serde_json::Value::Number(n) => {
-                        if let Some(i) = n.as_i64() {
-                            sea_query::Value::BigInt(Some(i))
-                        } else if let Some(f) = n.as_f64() {
-                            sea_query::Value::Double(Some(f))
-                        } else {
-                            sea_query::Value::String(None)
-                        }
-                    }
-                    serde_json::Value::String(s) => {
-                        sea_query::Value::String(Some(Box::new(s.clone())))
-                    }
-                    serde_json::Value::Bool(b) => sea_query::Value::Bool(Some(b)),
-                    serde_json::Value::Null => sea_query::Value::String(None),
-                    _ => sea_query::Value::String(Some(Box::new(value.to_string()))),
-                };
-                update.value(Alias::new(key), Expr::value(val));
+                update.value(
+                    Alias::new(&key),
+                    json_value_to_simple_expr(&value, properties.and_then(|props| props.get(&key))),
+                );
             }
             sea_query_build!(update)
         };

--- a/src/query.rs
+++ b/src/query.rs
@@ -110,11 +110,31 @@ impl QueryDef {
         infer_uuid_without_schema: bool,
     ) -> SimpleExpr {
         if let Value::String(s) = val {
-            if sql_dialect() == SqlDialect::Postgres && uuid::Uuid::parse_str(s).is_ok() {
+            if sql_dialect() == SqlDialect::Postgres {
                 let schema_uuid = model_column_is_uuid(&self.model_name, col_name);
-                if schema_uuid || infer_uuid_without_schema {
+                if uuid::Uuid::parse_str(s).is_ok() && (schema_uuid || infer_uuid_without_schema) {
                     return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
                         .cast_as("uuid");
+                }
+                if model_column_format(&self.model_name, col_name).as_deref() == Some("date") {
+                    return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
+                        .cast_as("date");
+                }
+                if model_column_format(&self.model_name, col_name).as_deref()
+                    == Some("date-time")
+                {
+                    return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
+                        .cast_as("timestamptz");
+                }
+                if model_column_format(&self.model_name, col_name).as_deref()
+                    == Some("binary")
+                {
+                    return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
+                        .cast_as("bytea");
+                }
+                if model_column_is_decimal(&self.model_name, col_name) {
+                    return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
+                        .cast_as("numeric");
                 }
             }
         }
@@ -160,9 +180,39 @@ fn column_is_uuid_property(schema: &Value, col: &str) -> bool {
     property_schema_is_uuid(col_info)
 }
 
+pub(crate) fn property_schema_format(col_info: &Value) -> Option<&str> {
+    col_info.get("format").and_then(|f| f.as_str()).or_else(|| {
+        col_info
+            .get("anyOf")
+            .and_then(|a| a.as_array())
+            .and_then(|types| {
+                types
+                    .iter()
+                    .find_map(|t| t.get("format").and_then(|f| f.as_str()))
+            })
+    })
+}
+
+pub(crate) fn property_schema_is_decimal(col_info: &Value) -> bool {
+    col_info
+        .get("anyOf")
+        .and_then(|a| a.as_array())
+        .map(|types| {
+            let has_number = types
+                .iter()
+                .any(|t| t.get("type").and_then(|ty| ty.as_str()) == Some("number"));
+            let has_patterned_string = types.iter().any(|t| {
+                t.get("type").and_then(|ty| ty.as_str()) == Some("string")
+                    && t.get("pattern").is_some()
+            });
+            has_number && has_patterned_string
+        })
+        .unwrap_or(false)
+}
+
 /// JSON Schema fragment for one model field: `string` + `format: uuid` (incl. optional `anyOf`).
 pub(crate) fn property_schema_is_uuid(col_info: &Value) -> bool {
-    let format = col_info.get("format").and_then(|f| f.as_str());
+    let format = property_schema_format(col_info);
     let json_type = col_info.get("type").and_then(|t| t.as_str()).or_else(|| {
         col_info
             .get("anyOf")
@@ -175,4 +225,36 @@ pub(crate) fn property_schema_is_uuid(col_info: &Value) -> bool {
             })
     });
     json_type == Some("string") && format == Some("uuid")
+}
+
+fn model_column_format(model_name: &str, col: &str) -> Option<String> {
+    let Ok(registry) = MODEL_REGISTRY.read() else {
+        return None;
+    };
+    let Some(schema) = registry.get(model_name) else {
+        return None;
+    };
+    let Some(props) = schema.get("properties").and_then(|p| p.as_object()) else {
+        return None;
+    };
+    let Some(col_info) = props.get(col) else {
+        return None;
+    };
+    property_schema_format(col_info).map(str::to_string)
+}
+
+fn model_column_is_decimal(model_name: &str, col: &str) -> bool {
+    let Ok(registry) = MODEL_REGISTRY.read() else {
+        return false;
+    };
+    let Some(schema) = registry.get(model_name) else {
+        return false;
+    };
+    let Some(props) = schema.get("properties").and_then(|p| p.as_object()) else {
+        return false;
+    };
+    let Some(col_info) = props.get(col) else {
+        return false;
+    };
+    property_schema_is_decimal(col_info)
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -10,6 +10,7 @@ use sea_query::{
     Table,
 };
 use sqlx::{Any, Pool};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 /// Maps a JSON schema type string to a Sea-Query `ColumnDef`.
@@ -25,8 +26,15 @@ pub fn json_type_to_sea_query(col_def: &mut ColumnDef, json_type: &str) {
             col_def.double();
         }
         "boolean" => {
-            // CX Choice: Use integer for booleans to satisfy SQLx Any driver quirks with SQLite.
-            col_def.integer();
+            match sql_dialect() {
+                SqlDialect::Sqlite => {
+                    // SQLite stores booleans as integers.
+                    col_def.integer();
+                }
+                SqlDialect::Postgres => {
+                    col_def.boolean();
+                }
+            }
         }
         "object" | "array" => {
             col_def.text(); // SQLite stores JSON as text
@@ -35,6 +43,19 @@ pub fn json_type_to_sea_query(col_def: &mut ColumnDef, json_type: &str) {
             col_def.string();
         }
     }
+}
+
+fn schema_format(col_info: &serde_json::Value) -> Option<&str> {
+    col_info.get("format").and_then(|f| f.as_str()).or_else(|| {
+        col_info
+            .get("anyOf")
+            .and_then(|a| a.as_array())
+            .and_then(|variants| {
+                variants
+                    .iter()
+                    .find_map(|variant| variant.get("format").and_then(|f| f.as_str()))
+            })
+    })
 }
 
 /// Unique index name for `ferro_composite_uniques`; matches Python Alembic `_build_sa_table`.
@@ -89,6 +110,59 @@ fn append_composite_unique_index_sqls(
     }
 }
 
+fn schema_dependencies(schema: &serde_json::Value) -> HashSet<String> {
+    schema
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .map(|properties| {
+            properties
+                .values()
+                .filter_map(|col_info| {
+                    col_info
+                        .get("foreign_key")
+                        .and_then(|fk| fk.get("to_table"))
+                        .and_then(|t| t.as_str())
+                        .map(|name| name.to_lowercase())
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn order_schemas_for_creation(
+    schemas: std::collections::HashMap<String, serde_json::Value>,
+) -> Vec<(String, serde_json::Value)> {
+    let mut remaining: Vec<(String, serde_json::Value)> = schemas.into_iter().collect();
+    let mut created = HashSet::new();
+    let mut ordered = Vec::new();
+
+    while !remaining.is_empty() {
+        let mut progressed = false;
+        let mut deferred = Vec::new();
+
+        for (name, schema) in remaining {
+            let deps = schema_dependencies(&schema);
+            if deps.iter().all(|dep| dep == &name.to_lowercase() || created.contains(dep)) {
+                created.insert(name.to_lowercase());
+                ordered.push((name, schema));
+                progressed = true;
+            } else {
+                deferred.push((name, schema));
+            }
+        }
+
+        if !progressed {
+            deferred.sort_by(|(left, _), (right, _)| left.cmp(right));
+            ordered.extend(deferred);
+            break;
+        }
+
+        remaining = deferred;
+    }
+
+    ordered
+}
+
 /// Internal utility to create all registered tables in the database.
 ///
 /// This is used by both the `connect(auto_migrate=True)` flow and the
@@ -108,7 +182,7 @@ pub async fn internal_create_tables(pool: Arc<Pool<Any>>) -> PyResult<()> {
         pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to acquire connection: {}", e))
     })?;
 
-    for (name, schema) in schemas {
+    for (name, schema) in order_schemas_for_creation(schemas) {
         let (sql, index_sqls) = {
             let table_lower = name.to_lowercase();
             let mut table_stmt = Table::create()
@@ -135,12 +209,19 @@ pub async fn internal_create_tables(pool: Arc<Pool<Any>>) -> PyResult<()> {
                             })
                     });
 
-                    let format = col_info.get("format").and_then(|f| f.as_str());
+                    let format = schema_format(col_info);
 
                     if let Some(t) = json_type {
                         match (t, format) {
                             ("string", Some("date-time")) => {
-                                col_def.date_time();
+                                match sql_dialect() {
+                                    SqlDialect::Sqlite => {
+                                        col_def.date_time();
+                                    }
+                                    SqlDialect::Postgres => {
+                                        col_def.timestamp_with_time_zone();
+                                    }
+                                }
                             }
                             ("string", Some("date")) => {
                                 col_def.date();
@@ -153,6 +234,8 @@ pub async fn internal_create_tables(pool: Arc<Pool<Any>>) -> PyResult<()> {
                             }
                             _ => json_type_to_sea_query(&mut col_def, t),
                         }
+                    } else {
+                        col_def.string();
                     }
 
                     // Check for primary key and autoincrement from our custom metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,104 @@
 import asyncio
+import os
+import uuid
+from pathlib import Path
 
 import pytest
 
 from ferro import version
+from tests.db_backends import (
+    backends_for_test,
+    build_postgres_test_url,
+    get_supabase_url,
+    parse_backend_option,
+)
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ENV_FILE = ROOT_DIR / ".env"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--db-backends",
+        action="store",
+        default="sqlite",
+        help="Comma-separated database backends to use for backend_matrix tests: sqlite,postgres.",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "backend_matrix: run this test against each selected database backend.",
+    )
+    config.addinivalue_line(
+        "markers",
+        "sqlite_only: run this test only against SQLite.",
+    )
+    config.addinivalue_line(
+        "markers",
+        "postgres_only: run this test only against Postgres/Supabase.",
+    )
+
+
+def _selected_backends(config: pytest.Config) -> tuple[str, ...]:
+    try:
+        return parse_backend_option(config.getoption("--db-backends"))
+    except ValueError as exc:
+        raise pytest.UsageError(str(exc)) from exc
+
+
+def _available_postgres_url() -> str | None:
+    return get_supabase_url(dict(os.environ), ENV_FILE)
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    if "db_url" not in metafunc.fixturenames:
+        return
+
+    selected_backends = _selected_backends(metafunc.config)
+    test_backends = backends_for_test(
+        selected_backends,
+        is_backend_matrix=metafunc.definition.get_closest_marker("backend_matrix")
+        is not None,
+        is_sqlite_only=metafunc.definition.get_closest_marker("sqlite_only") is not None,
+        is_postgres_only=metafunc.definition.get_closest_marker("postgres_only") is not None,
+        has_postgres_url=bool(_available_postgres_url()),
+    )
+
+    if not test_backends:
+        metafunc.parametrize(
+            "db_url",
+            [
+                pytest.param(
+                    None,
+                    marks=pytest.mark.skip(
+                        reason="FERRO_SUPABASE_URL is not configured for Postgres-backed tests.",
+                    ),
+                )
+            ],
+            indirect=True,
+            ids=["postgres"],
+        )
+        return
+
+    metafunc.parametrize("db_url", test_backends, indirect=True, ids=test_backends)
+
+
+def _connect_postgres_admin(base_url: str):
+    import psycopg
+
+    return psycopg.connect(base_url, autocommit=True)
+
+
+def _create_postgres_schema(base_url: str, schema_name: str) -> None:
+    with _connect_postgres_admin(base_url) as conn:
+        conn.execute(f'CREATE SCHEMA "{schema_name}"')
+
+
+def _drop_postgres_schema(base_url: str, schema_name: str) -> None:
+    with _connect_postgres_admin(base_url) as conn:
+        conn.execute(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE')
 
 
 # This fixture ensures the Rust binary is actually loaded and working
@@ -25,16 +121,47 @@ def event_loop():
 
 
 @pytest.fixture(scope="function")
-async def db_engine():
-    """
-    Setup a clean SQLite memory database for each test.
-    This is where we would eventually call our Rust 'connect' method.
-    """
-    db_url = "sqlite::memory:"
-    # engine = await ferro.connect(db_url)
-    # yield engine
-    # await engine.disconnect()
-    yield db_url
+def db_url(request: pytest.FixtureRequest, tmp_path: Path):
+    backend = getattr(request, "param", "sqlite")
+
+    if backend == "sqlite":
+        request.node._ferro_db_schema = None
+        db_file = tmp_path / f"{request.node.name}.db"
+        yield f"sqlite:{db_file}?mode=rwc"
+        return
+
+    base_url = _available_postgres_url()
+    if not base_url:
+        pytest.skip("FERRO_SUPABASE_URL is not configured for Postgres-backed tests.")
+
+    schema_name = f"ferro_{uuid.uuid4().hex[:16]}"
+    _create_postgres_schema(base_url, schema_name)
+    request.node._ferro_db_schema = schema_name
+
+    try:
+        yield build_postgres_test_url(base_url, schema_name)
+    finally:
+        from ferro import reset_engine
+
+        reset_engine()
+        _drop_postgres_schema(base_url, schema_name)
+
+
+@pytest.fixture(scope="session")
+def postgres_base_url() -> str | None:
+    return _available_postgres_url()
+
+
+@pytest.fixture(scope="function")
+def db_schema_name(request: pytest.FixtureRequest) -> str | None:
+    return getattr(request.node, "_ferro_db_schema", None)
+
+
+@pytest.fixture(scope="function")
+def db_backend(db_url: str) -> str:
+    if db_url.startswith("postgres://") or db_url.startswith("postgresql://"):
+        return "postgres"
+    return "sqlite"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/db_backends.py
+++ b/tests/db_backends.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+
+SUPPORTED_BACKENDS = ("sqlite", "postgres")
+
+
+def load_env_value(env_file: Path, key: str) -> str | None:
+    if not env_file.exists():
+        return None
+
+    prefix = f"{key}="
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or not line.startswith(prefix):
+            continue
+
+        value = line[len(prefix) :].strip()
+        if value[:1] == value[-1:] and value[:1] in {'"', "'"}:
+            value = value[1:-1]
+        return value
+
+    return None
+
+
+def get_supabase_url(env: dict[str, str], env_file: Path) -> str | None:
+    return env.get("FERRO_SUPABASE_URL") or load_env_value(env_file, "FERRO_SUPABASE_URL")
+
+
+def parse_backend_option(raw_value: str) -> tuple[str, ...]:
+    backends = tuple(part.strip() for part in raw_value.split(",") if part.strip())
+    invalid = sorted(set(backends) - set(SUPPORTED_BACKENDS))
+    if invalid:
+        joined = ", ".join(invalid)
+        raise ValueError(f"Unsupported database backend: {joined}")
+    return backends or ("sqlite",)
+
+
+def backends_for_test(
+    selected_backends: tuple[str, ...],
+    *,
+    is_backend_matrix: bool,
+    is_sqlite_only: bool,
+    is_postgres_only: bool,
+    has_postgres_url: bool,
+) -> tuple[str, ...]:
+    if is_sqlite_only:
+        return ("sqlite",)
+
+    if is_postgres_only:
+        return ("postgres",) if has_postgres_url and "postgres" in selected_backends else ()
+
+    if is_backend_matrix:
+        if has_postgres_url:
+            return selected_backends
+        return tuple(backend for backend in selected_backends if backend != "postgres")
+
+    return ("sqlite",)
+
+
+def build_postgres_test_url(base_url: str, schema_name: str) -> str:
+    parsed = urlparse(base_url)
+    params = parse_qsl(parsed.query, keep_blank_values=True)
+    params.append(("ferro_search_path", schema_name))
+    return urlunparse(parsed._replace(query=urlencode(params)))

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,18 +1,8 @@
 import pytest
-import uuid
-import os
 from typing import Annotated
 from ferro import Model, connect, FerroField
 
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_agg_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
-
+pytestmark = pytest.mark.backend_matrix
 
 @pytest.mark.asyncio
 async def test_count_operation(db_url):

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -8,6 +8,7 @@ from ferro import Model
 from ferro.base import FerroField, ManyToManyField
 from ferro.query import BackRef
 
+pytestmark = pytest.mark.backend_matrix
 
 class AutoMigratedUser(Model):
     id: int = Field(json_schema_extra={"primary_key": True})
@@ -15,14 +16,14 @@ class AutoMigratedUser(Model):
 
 
 @pytest.mark.asyncio
-async def test_connect_with_auto_migrate():
+async def test_connect_with_auto_migrate(db_url):
     """Test that connect(auto_migrate=True) creates tables automatically."""
     # Reset engine to ensure clean state
     ferro.reset_engine()
 
     # Connect with auto_migrate=True
     # This should internally call the same logic as create_tables()
-    await ferro.connect("sqlite::memory:", auto_migrate=True)
+    await ferro.connect(db_url, auto_migrate=True)
 
     # We can verify it works by trying to call create_tables again
     # or by just ensuring it doesn't crash.
@@ -32,18 +33,18 @@ async def test_connect_with_auto_migrate():
 
 
 @pytest.mark.asyncio
-async def test_connect_without_auto_migrate():
+async def test_connect_without_auto_migrate(db_url):
     """Test that connect(auto_migrate=False) does not create tables (manual mode)."""
     ferro.reset_engine()
 
-    await ferro.connect("sqlite::memory:", auto_migrate=False)
+    await ferro.connect(db_url, auto_migrate=False)
     # Manual call still works
     await ferro.create_tables()
     assert True
 
 
 @pytest.mark.asyncio
-async def test_m2m_join_table_created_during_auto_migrate():
+async def test_m2m_join_table_created_during_auto_migrate(db_url):
     """Verify that the many-to-many join table is created when auto_migrate=True.
     We clear registries, migrate a fresh in-memory DB, then use the M2M API; if the
     join table were not created, .add() would fail. No second connection needed."""
@@ -66,7 +67,7 @@ async def test_m2m_join_table_created_during_auto_migrate():
         title: str
         actors: BackRef[Actor] = None
 
-    await connect("sqlite::memory:", auto_migrate=True)
+    await connect(db_url, auto_migrate=True)
 
     actor = await Actor.create(name="Alice")
     movie = await Movie.create(title="Matrix")

--- a/tests/test_bulk_update.py
+++ b/tests/test_bulk_update.py
@@ -1,17 +1,8 @@
 import pytest
-import uuid
-import os
 from typing import Annotated
 from ferro import Model, connect, FerroField
 
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_bulk_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
+pytestmark = pytest.mark.backend_matrix
 
 
 @pytest.mark.asyncio

--- a/tests/test_composite_unique.py
+++ b/tests/test_composite_unique.py
@@ -1,8 +1,6 @@
 """Composite unique constraints and default M2M join-table uniqueness (TDD)."""
 
-import os
 import sqlite3
-import uuid
 from typing import Annotated, ClassVar
 
 import pytest
@@ -19,6 +17,7 @@ from ferro import (
 )
 from ferro.migrations import get_metadata
 
+pytestmark = pytest.mark.backend_matrix
 
 def _expected_uq_constraint_name(table_name: str, col_ids: list[str]) -> str:
     """Match Alembic `_build_sa_table` naming (63-char cap)."""
@@ -26,15 +25,6 @@ def _expected_uq_constraint_name(table_name: str, col_ids: list[str]) -> str:
     if len(raw) > 63:
         return raw[:60] + "_uq"
     return raw
-
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_composite_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
 
 
 @pytest.fixture(autouse=True)
@@ -93,7 +83,7 @@ async def test_composite_unique_enforced_on_user_model(db_url):
         await PairRow(alpha_id=1, beta_id=2).save()
 
     msg = str(excinfo.value)
-    assert "UNIQUE constraint failed" in msg
+    assert "unique" in msg.lower()
 
 
 @pytest.mark.asyncio
@@ -118,7 +108,7 @@ async def test_m2m_duplicate_link_rejected(db_url):
     with pytest.raises(RuntimeError, match="Add M2M links failed") as excinfo:
         await actor.movies.add(movie)
     msg = str(excinfo.value)
-    assert "UNIQUE constraint failed" in msg
+    assert "unique" in msg.lower()
 
 
 def test_alembic_metadata_has_unique_constraints():
@@ -159,6 +149,7 @@ def test_alembic_metadata_has_unique_constraints():
 
 
 @pytest.mark.asyncio
+@pytest.mark.sqlite_only
 async def test_composite_unique_index_exists_in_sqlite(db_url):
     """SQLite should have a unique index spanning both columns."""
 
@@ -191,6 +182,7 @@ async def test_composite_unique_index_exists_in_sqlite(db_url):
 
 
 @pytest.mark.asyncio
+@pytest.mark.sqlite_only
 async def test_composite_unique_truncated_name_matches_alembic_and_sqlite(db_url):
     """Long uq_* names must be <=63 chars and match between Alembic metadata and Rust-created SQLite indexes."""
 
@@ -244,6 +236,61 @@ async def test_composite_unique_truncated_name_matches_alembic_and_sqlite(db_url
     idx_name = composite_rows[0][0]
     assert idx_name == expected
     assert len(idx_name) <= 63
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
+async def test_composite_unique_truncated_name_matches_postgres_catalog(
+    db_url, postgres_base_url, db_schema_name
+):
+    """Long uq_* names must match between Alembic metadata and Postgres catalogs."""
+
+    class VeryLongCompositeUniqueModelNameForIndexTruncationTest(Model):
+        __ferro_composite_uniques__: ClassVar[tuple[tuple[str, ...], ...]] = (
+            (
+                "very_long_column_name_alpha_for_composite_unique_test",
+                "very_long_column_name_beta_for_composite_unique_test",
+            ),
+        )
+
+        id: int | None = Field(default=None, primary_key=True)
+        very_long_column_name_alpha_for_composite_unique_test: int
+        very_long_column_name_beta_for_composite_unique_test: int
+
+    table = VeryLongCompositeUniqueModelNameForIndexTruncationTest.__name__.lower()
+    col_a = "very_long_column_name_alpha_for_composite_unique_test"
+    col_b = "very_long_column_name_beta_for_composite_unique_test"
+    expected = _expected_uq_constraint_name(table, [col_a, col_b])
+
+    metadata = get_metadata()
+    ucs = _unique_constraints(metadata.tables[table])
+    assert len(ucs) == 1
+    assert ucs[0].name == expected
+
+    await connect(db_url, auto_migrate=True)
+
+    import psycopg
+
+    with psycopg.connect(postgres_base_url) as conn:
+        conn.execute(f'SET search_path TO "{db_schema_name}"')
+        row = conn.execute(
+            """
+            SELECT indexname, indexdef
+            FROM pg_indexes
+            WHERE schemaname = %s
+              AND tablename = %s
+              AND indexname = %s
+            """,
+            (db_schema_name, table, expected),
+        ).fetchone()
+
+    assert row is not None
+    idx_name, indexdef = row
+    assert idx_name == expected
+    assert len(idx_name) <= 63
+    assert "UNIQUE" in indexdef.upper()
+    assert col_a in indexdef
+    assert col_b in indexdef
 
 
 def test_composite_unique_multiple_groups_in_metadata_and_sqlite():

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2,12 +2,13 @@ import pytest
 
 import ferro
 
+pytestmark = pytest.mark.backend_matrix
+
 
 @pytest.mark.asyncio
-async def test_sqlite_memory_connection():
-    """Test connecting to an in-memory SQLite database."""
-    # This should succeed and print the success message from Rust
-    await ferro.connect("sqlite::memory:")
+async def test_connection_smoke(db_url):
+    """Test connecting to the configured backend."""
+    await ferro.connect(db_url)
 
 
 @pytest.mark.asyncio
@@ -20,8 +21,8 @@ async def test_invalid_connection_string():
     assert "DB Connection failed" in str(excinfo.value)
 
 
-@pytest.mark.skip(reason="Requires a running Postgres instance")
 @pytest.mark.asyncio
-async def test_postgres_connection():
-    """Placeholder for postgres testing."""
-    await ferro.connect("postgres://user:pass@localhost/db")
+@pytest.mark.postgres_only
+async def test_postgres_connection(db_url):
+    """Test connecting to the configured Postgres backend."""
+    await ferro.connect(db_url)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,18 +1,8 @@
 import pytest
-import uuid
-import os
 from typing import Annotated
 from ferro import Model, connect, FerroField
 
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_const_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
-
+pytestmark = pytest.mark.backend_matrix
 
 @pytest.mark.asyncio
 async def test_unique_constraint(db_url):
@@ -31,13 +21,11 @@ async def test_unique_constraint(db_url):
     with pytest.raises(Exception) as excinfo:
         await UniqueUser(email="test@example.com").save()
 
-    assert (
-        "UNIQUE constraint failed" in str(excinfo.value)
-        or "uniqueness" in str(excinfo.value).lower()
-    )
+    assert "unique" in str(excinfo.value).lower()
 
 
 @pytest.mark.asyncio
+@pytest.mark.sqlite_only
 async def test_index_creation(db_url):
     """Test that index=True creates an index (verified via SQLite schema)."""
 
@@ -59,6 +47,36 @@ async def test_index_creation(db_url):
     )
     index = cursor.fetchone()
     conn.close()
+
+    assert index is not None
+    assert "sku" in index[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
+async def test_index_creation_in_postgres(db_url, postgres_base_url, db_schema_name):
+    """Test that index=True creates an index in the active Postgres schema."""
+
+    class IndexedProduct(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        sku: Annotated[str, FerroField(index=True)]
+
+    await connect(db_url, auto_migrate=True)
+
+    import psycopg
+
+    with psycopg.connect(postgres_base_url) as conn:
+        conn.execute(f'SET search_path TO "{db_schema_name}"')
+        index = conn.execute(
+            """
+            SELECT indexname
+            FROM pg_indexes
+            WHERE schemaname = %s
+              AND tablename = 'indexedproduct'
+              AND indexname LIKE %s
+            """,
+            (db_schema_name, "%sku%"),
+        ).fetchone()
 
     assert index is not None
     assert "sku" in index[0]

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,18 +1,11 @@
 import pytest
 from pydantic import Field
-import os
-import uuid
+
 import ferro
 from ferro import Model
 
 
-@pytest.fixture
-def db_url():
-    db_file = f"test_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
+pytestmark = pytest.mark.backend_matrix
 
 
 @pytest.mark.asyncio
@@ -85,14 +78,9 @@ async def test_upsert_does_not_duplicate(db_url):
     await user_dup.save()
     ferro.reset_engine()
     await ferro.connect(db_url, auto_migrate=True)
-    import sqlite3
-
-    conn = sqlite3.connect(db_url.replace("sqlite:", "").split("?")[0])
-    cursor = conn.cursor()
-    cursor.execute("SELECT username FROM cruduser WHERE id = 42")
-    row = cursor.fetchone()
-    assert row[0] == "updated"
-    conn.close()
+    fetched = await CrudUser.get(42)
+    assert fetched is not None
+    assert fetched.username == "updated"
 
 
 @pytest.mark.asyncio

--- a/tests/test_db_backends.py
+++ b/tests/test_db_backends.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import pytest
+
+from tests import db_backends
+
+
+def test_load_env_value_reads_quoted_values(tmp_path: Path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        'IGNORED_KEY="ignore me"\nFERRO_SUPABASE_URL="postgresql://user:pass@db.supabase.co/postgres?sslmode=require"\n',
+        encoding="utf-8",
+    )
+
+    assert (
+        db_backends.load_env_value(env_file, "FERRO_SUPABASE_URL")
+        == "postgresql://user:pass@db.supabase.co/postgres?sslmode=require"
+    )
+
+
+def test_get_supabase_url_prefers_environment_over_dotenv(tmp_path: Path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "FERRO_SUPABASE_URL=postgresql://dotenv.example/postgres\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        db_backends.get_supabase_url(
+            {"FERRO_SUPABASE_URL": "postgresql://env.example/postgres"},
+            env_file,
+        )
+        == "postgresql://env.example/postgres"
+    )
+
+
+def test_parse_backend_option_validates_backend_names():
+    assert db_backends.parse_backend_option("sqlite,postgres") == ("sqlite", "postgres")
+
+    with pytest.raises(ValueError, match="Unsupported database backend"):
+        db_backends.parse_backend_option("sqlite,mysql")
+
+
+def test_backends_for_test_respects_markers_and_available_postgres():
+    assert db_backends.backends_for_test(
+        ("sqlite", "postgres"),
+        is_backend_matrix=True,
+        is_sqlite_only=False,
+        is_postgres_only=False,
+        has_postgres_url=True,
+    ) == ("sqlite", "postgres")
+
+    assert db_backends.backends_for_test(
+        ("sqlite", "postgres"),
+        is_backend_matrix=False,
+        is_sqlite_only=True,
+        is_postgres_only=False,
+        has_postgres_url=True,
+    ) == ("sqlite",)
+
+    assert db_backends.backends_for_test(
+        ("sqlite", "postgres"),
+        is_backend_matrix=False,
+        is_sqlite_only=False,
+        is_postgres_only=True,
+        has_postgres_url=False,
+    ) == ()
+
+
+def test_build_postgres_test_url_sets_search_path():
+    url = db_backends.build_postgres_test_url(
+        "postgresql://user:pass@db.supabase.co/postgres?sslmode=require",
+        "ferro_test_schema",
+    )
+
+    assert "sslmode=require" in url
+    assert "ferro_search_path=ferro_test_schema" in url

--- a/tests/test_deletion.py
+++ b/tests/test_deletion.py
@@ -1,17 +1,8 @@
 import pytest
-import uuid
-import os
 from typing import Annotated
 from ferro import Model, connect, FerroField
 
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_delete_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
+pytestmark = pytest.mark.backend_matrix
 
 
 @pytest.mark.asyncio

--- a/tests/test_documentation_features.py
+++ b/tests/test_documentation_features.py
@@ -11,7 +11,10 @@ from decimal import Decimal
 from enum import Enum
 from typing import Annotated
 
+
 import pytest
+
+pytestmark = pytest.mark.backend_matrix
 
 from ferro import (
     BackRef,
@@ -99,22 +102,6 @@ def _ensure_models_registered():
         model_cls._reregister_ferro()
         _MODEL_REGISTRY_PY[model_cls.__name__] = model_cls
     yield
-
-
-@pytest.fixture
-def db_url():
-    """Generate a unique database URL for each test"""
-    import uuid
-
-    db_file = f"test_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    # Cleanup
-    import os
-
-    if os.path.exists(db_file):
-        os.remove(db_file)
-
 
 # ============================================================================
 # MODELS & FIELDS TESTS (docs/guide/models-and-fields.md)

--- a/tests/test_field_wrapper.py
+++ b/tests/test_field_wrapper.py
@@ -1,19 +1,10 @@
-import os
-import uuid
 from typing import Annotated
 
 import pytest
 
 from ferro import FerroField, Field, Model, connect
 
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_field_wrapper_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
+pytestmark = pytest.mark.backend_matrix
 
 
 @pytest.mark.asyncio
@@ -86,6 +77,20 @@ async def test_annotation_field_pattern_persists_like_assignment(db_url):
     user = AnnotatedUser(email="ann@example.com")
     await user.save()
     assert user.id is not None
+
+
+@pytest.mark.asyncio
+async def test_optional_patterned_string_roundtrip(db_url):
+    class WrappedInventory(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        code: str | None = Field(default=None, pattern=r"^SKU-[0-9]+$")
+
+    await connect(db_url, auto_migrate=True)
+    item = await WrappedInventory.create(code="SKU-123")
+    fetched = await WrappedInventory.get(item.id)
+
+    assert fetched is not None
+    assert fetched.code == "SKU-123"
 
 
 def test_annotated_and_wrapped_ferro_field_conflict_raises():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,17 +1,8 @@
 import pytest
-import uuid
-import os
 from typing import Annotated
 from ferro import Model, connect, FerroField
 
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_help_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
+pytestmark = pytest.mark.backend_matrix
 
 
 @pytest.mark.asyncio

--- a/tests/test_hydration.py
+++ b/tests/test_hydration.py
@@ -1,20 +1,10 @@
-import os
-import uuid
-
 import pytest
 from pydantic import Field
 
 import ferro
 from ferro import Model
 
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_hydration_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
+pytestmark = pytest.mark.backend_matrix
 
 
 INIT_CALLED_COUNT = 0

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,18 +1,9 @@
 import pytest
 import uuid
-import os
 from typing import Annotated
 from ferro import Model, connect, FerroField
 
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_metadata_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
-
+pytestmark = pytest.mark.backend_matrix
 
 @pytest.mark.asyncio
 async def test_autoincrement_id_retrieval(db_url):

--- a/tests/test_one_to_one.py
+++ b/tests/test_one_to_one.py
@@ -12,6 +12,8 @@ from ferro import (
     clear_registry,
 )
 
+pytestmark = pytest.mark.sqlite_only
+
 
 @pytest.fixture(autouse=True)
 def cleanup():

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -1,19 +1,9 @@
-import os
-import uuid
 import pytest
 from ferro import Model, connect
 from pydantic import Field
 from ferro.query import Query, QueryNode
 
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
-
+pytestmark = pytest.mark.backend_matrix
 
 def test_field_proxy_operator_overloading():
     """

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -1,18 +1,8 @@
 import pytest
-import uuid
-import os
 from typing import Annotated
 from ferro import Model, connect, FerroField
 
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_refresh_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
-
+pytestmark = pytest.mark.backend_matrix
 
 @pytest.mark.asyncio
 async def test_instance_refresh(db_url):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,6 +3,8 @@ import ferro
 from ferro import Model
 from pydantic import Field
 
+pytestmark = pytest.mark.backend_matrix
+
 
 class Product(Model):
     id: int = Field(json_schema_extra={"primary_key": True})
@@ -12,10 +14,10 @@ class Product(Model):
 
 
 @pytest.mark.asyncio
-async def test_create_tables_success():
+async def test_create_tables_success(db_url):
     """Test that create_tables generates and executes SQL correctly."""
     # Connect to in-memory SQLite
-    await ferro.connect("sqlite::memory:")
+    await ferro.connect(db_url)
 
     # This should generate CREATE TABLE product (...)
     await ferro.create_tables()

--- a/tests/test_schema_constraints.py
+++ b/tests/test_schema_constraints.py
@@ -13,6 +13,8 @@ from ferro import (
     reset_engine,
 )
 
+pytestmark = pytest.mark.sqlite_only
+
 
 @pytest.fixture(autouse=True)
 def cleanup():

--- a/tests/test_shadow_fk_types.py
+++ b/tests/test_shadow_fk_types.py
@@ -16,6 +16,8 @@ from ferro._shadow_fk_types import (
 )
 from ferro.base import ForeignKey as ForeignKeyCls
 
+pytestmark = pytest.mark.backend_matrix
+
 
 def test_pk_python_type_for_model_uuid():
     class UuidPkParent(Model):
@@ -84,7 +86,7 @@ def test_reconcile_upgrades_forward_ref_shadow(_cleanup_registry):
 
 
 @pytest.mark.asyncio
-async def test_uuid_fk_create_get_dump():
+async def test_uuid_fk_create_get_dump(db_url):
     """Regression for GitHub #16: UUID PK through shadow FK without validation/serialization issues."""
     ferro.reset_engine()
     ferro.clear_registry()
@@ -98,7 +100,7 @@ async def test_uuid_fk_create_get_dump():
         id: UUID = Field(default_factory=uuid4, primary_key=True)
         parent: Annotated[UuidIssueParent, ForeignKey(related_name="children")]
 
-    await connect("sqlite::memory:", auto_migrate=True)
+    await connect(db_url, auto_migrate=True)
 
     parent = await UuidIssueParent.create(name="p")
     child = await UuidIssueChild.create(parent=parent)
@@ -123,7 +125,7 @@ async def test_uuid_fk_create_get_dump():
 
 
 @pytest.mark.asyncio
-async def test_uuid_fk_forward_ref_child_declared_first():
+async def test_uuid_fk_forward_ref_child_declared_first(db_url):
     """Circular-import style: child model references parent by string before parent exists."""
     ferro.reset_engine()
     ferro.clear_registry()
@@ -137,7 +139,7 @@ async def test_uuid_fk_forward_ref_child_declared_first():
         name: str
         children: BackRef[list[UuidFrwChild]] = None
 
-    await connect("sqlite::memory:", auto_migrate=True)
+    await connect(db_url, auto_migrate=True)
 
     parent = await UuidFrwParent.create(name="p")
     child = await UuidFrwChild.create(parent=parent)
@@ -189,7 +191,7 @@ def test_nullable_fk_annotation_does_not_crash():
 
 
 @pytest.mark.asyncio
-async def test_uuid_fk_save_after_reparenting():
+async def test_uuid_fk_save_after_reparenting(db_url):
     """Update an existing row: change only the UUID foreign key, then save() and re-fetch."""
     ferro.reset_engine()
     ferro.clear_registry()
@@ -204,7 +206,7 @@ async def test_uuid_fk_save_after_reparenting():
         label: str
         parent: Annotated[UuidMutParent, ForeignKey(related_name="kids")]
 
-    await connect("sqlite::memory:", auto_migrate=True)
+    await connect(db_url, auto_migrate=True)
 
     parent_a = await UuidMutParent.create(name="a")
     parent_b = await UuidMutParent.create(name="b")
@@ -221,7 +223,7 @@ async def test_uuid_fk_save_after_reparenting():
 
 
 @pytest.mark.asyncio
-async def test_uuid_fk_bulk_create():
+async def test_uuid_fk_bulk_create(db_url):
     """bulk_create serializes UUID FK columns via model_dump(mode='json')."""
     ferro.reset_engine()
     ferro.clear_registry()
@@ -236,7 +238,7 @@ async def test_uuid_fk_bulk_create():
         sku: str
         parent: Annotated[UuidBulkParent, ForeignKey(related_name="items")]
 
-    await connect("sqlite::memory:", auto_migrate=True)
+    await connect(db_url, auto_migrate=True)
 
     px = await UuidBulkParent.create(name="x")
     py = await UuidBulkParent.create(name="y")

--- a/tests/test_string_search.py
+++ b/tests/test_string_search.py
@@ -1,18 +1,8 @@
 import pytest
-import uuid
-import os
 from typing import Annotated
 from ferro import Model, connect, FerroField
 
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_search_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
-
+pytestmark = pytest.mark.backend_matrix
 
 @pytest.mark.asyncio
 async def test_like_search(db_url):

--- a/tests/test_structural_types.py
+++ b/tests/test_structural_types.py
@@ -1,24 +1,16 @@
 import pytest
 import uuid
-import os
 from decimal import Decimal
 from enum import Enum
 from typing import Annotated, Dict, List
 from ferro import Model, connect, FerroField
 
+pytestmark = pytest.mark.backend_matrix
+
 
 class UserRole(str, Enum):
     ADMIN = "admin"
     USER = "user"
-
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_struct_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
 
 
 @pytest.mark.asyncio

--- a/tests/test_temporal_types.py
+++ b/tests/test_temporal_types.py
@@ -1,19 +1,9 @@
 import pytest
-import uuid
-import os
 from datetime import datetime, date, timezone
 from typing import Annotated
 from ferro import Model, connect, FerroField
 
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_temp_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
-
+pytestmark = pytest.mark.backend_matrix
 
 @pytest.mark.asyncio
 async def test_temporal_types_roundtrip(db_url):

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,18 +1,8 @@
 import pytest
-import uuid
-import os
 from typing import Annotated
 from ferro import Model, connect, FerroField, transaction
 
-
-@pytest.fixture
-def db_url():
-    db_file = f"test_tx_{uuid.uuid4()}.db"
-    url = f"sqlite:{db_file}?mode=rwc"
-    yield url
-    if os.path.exists(db_file):
-        os.remove(db_file)
-
+pytestmark = pytest.mark.backend_matrix
 
 @pytest.mark.asyncio
 async def test_transaction_commit(db_url):

--- a/uv.lock
+++ b/uv.lock
@@ -560,6 +560,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "prek" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pymdown-extensions" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -606,6 +607,7 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.5.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.24.0" },
     { name = "prek", specifier = ">=0.2.25" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
     { name = "pymdown-extensions", specifier = ">=10.7.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
@@ -1716,6 +1718,52 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/15/dd6fd869753ce82ff64dcbc18356093471a5a5adf4f77ed1f805d473d859/psutil-7.2.1-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:99a4cd17a5fdd1f3d014396502daa70b5ec21bf4ffe38393e152f8e449757d67", size = 147402, upload-time = "2025-12-29T08:26:39.21Z" },
     { url = "https://files.pythonhosted.org/packages/34/68/d9317542e3f2b180c4306e3f45d3c922d7e86d8ce39f941bb9e2e9d8599e/psutil-7.2.1-cp37-abi3-win_amd64.whl", hash = "sha256:b1b0671619343aa71c20ff9767eced0483e4fc9e1f489d50923738caf6a03c17", size = 136938, upload-time = "2025-12-29T08:26:41.036Z" },
     { url = "https://files.pythonhosted.org/packages/3e/73/2ce007f4198c80fcf2cb24c169884f833fe93fbc03d55d302627b094ee91/psutil-7.2.1-cp37-abi3-win_arm64.whl", hash = "sha256:0d67c1822c355aa6f7314d92018fb4268a76668a536f133599b91edd48759442", size = 133836, upload-time = "2025-12-29T08:26:43.086Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/0a/cac9fdf1df16a269ba0e5f0f06cac61f826c94cadb39df028cdfe19d3a33/psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d", size = 4590414, upload-time = "2026-02-18T16:50:01.441Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c0/d8f8508fbf440edbc0099b1abff33003cd80c9e66eb3a1e78834e3fb4fb9/psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1", size = 4669021, upload-time = "2026-02-18T16:50:08.803Z" },
+    { url = "https://files.pythonhosted.org/packages/04/05/097016b77e343b4568feddf12c72171fc513acef9a4214d21b9478569068/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925", size = 5467453, upload-time = "2026-02-18T16:50:14.985Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/73244e5feb55b5ca109cede6e97f32ef45189f0fdac4c80d75c99862729d/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d", size = 5151135, upload-time = "2026-02-18T16:50:24.82Z" },
+    { url = "https://files.pythonhosted.org/packages/11/49/5309473b9803b207682095201d8708bbc7842ddf3f192488a69204e36455/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1", size = 6737315, upload-time = "2026-02-18T16:50:35.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5d/03abe74ef34d460b33c4d9662bf6ec1dd38888324323c1a1752133c10377/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482", size = 4979783, upload-time = "2026-02-18T16:50:42.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/3fbf8e604e15f2f3752900434046c00c90bb8764305a1b81112bff30ba24/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12", size = 4509023, upload-time = "2026-02-18T16:50:50.116Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6b/1a06b43b7c7af756c80b67eac8bfaa51d77e68635a8a8d246e4f0bb7604a/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83", size = 4185874, upload-time = "2026-02-18T16:50:55.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d3/bf49e3dcaadba510170c8d111e5e69e5ae3f981c1554c5bb71c75ce354bb/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508", size = 3925668, upload-time = "2026-02-18T16:51:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/92/0aac830ed6a944fe334404e1687a074e4215630725753f0e3e9a9a595b62/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1", size = 4234973, upload-time = "2026-02-18T16:51:09.097Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/96/102244653ee5a143ece5afe33f00f52fe64e389dfce8dbc87580c6d70d3d/psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b", size = 3551342, upload-time = "2026-02-18T16:51:13.892Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/71/7a57e5b12275fe7e7d84d54113f0226080423a869118419c9106c083a21c/psycopg_binary-3.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:497852c5eaf1f0c2d88ab74a64a8097c099deac0c71de1cbcf18659a8a04a4b2", size = 4607368, upload-time = "2026-02-18T16:51:19.295Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/04/cb834f120f2b2c10d4003515ef9ca9d688115b9431735e3936ae48549af8/psycopg_binary-3.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:258d1ea53464d29768bf25930f43291949f4c7becc706f6e220c515a63a24edd", size = 4687047, upload-time = "2026-02-18T16:51:23.84Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e9/47a69692d3da9704468041aa5ed3ad6fc7f6bb1a5ae788d261a26bbca6c7/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:111c59897a452196116db12e7f608da472fbff000693a21040e35fc978b23430", size = 5487096, upload-time = "2026-02-18T16:51:29.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b6/0e0dd6a2f802864a4ae3dbadf4ec620f05e3904c7842b326aafc43e5f464/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17bb6600e2455993946385249a3c3d0af52cd70c1c1cdbf712e9d696d0b0bf1b", size = 5168720, upload-time = "2026-02-18T16:51:36.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0d/977af38ac19a6b55d22dff508bd743fd7c1901e1b73657e7937c7cccb0a3/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642050398583d61c9856210568eb09a8e4f2fe8224bf3be21b67a370e677eead", size = 6762076, upload-time = "2026-02-18T16:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/34/40/912a39d48322cf86895c0eaf2d5b95cb899402443faefd4b09abbba6b6e1/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:533efe6dc3a7cba5e2a84e38970786bb966306863e45f3db152007e9f48638a6", size = 4997623, upload-time = "2026-02-18T16:51:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0c/c14d0e259c65dc7be854d926993f151077887391d5a081118907a9d89603/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5958dbf28b77ce2033482f6cb9ef04d43f5d8f4b7636e6963d5626f000efb23e", size = 4532096, upload-time = "2026-02-18T16:51:51.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/21/8b7c50a194cfca6ea0fd4d1f276158307785775426e90700ab2eba5cd623/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a6af77b6626ce92b5817bf294b4d45ec1a6161dba80fc2d82cdffdd6814fd023", size = 4208884, upload-time = "2026-02-18T16:51:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds a dual-database ORM test matrix that runs the selected suite against both SQLite and Supabase-backed Postgres. This exposes backend drift in the same tests and fixes the Postgres runtime differences the matrix surfaced so the shared ORM coverage now passes on both backends.

## Changes

- centralize pytest backend selection in `tests/conftest.py` with `backend_matrix`, `sqlite_only`, and `postgres_only` markers plus `FERRO_SUPABASE_URL` support
- add Postgres schema-per-test isolation helpers, backend fixture tests, and Postgres-specific catalog assertions for indexes and composite unique naming
- fix Postgres runtime gaps in connection setup, schema ordering, typed binds, typed reads, autoincrement PK retrieval, and model/query helpers uncovered by the new matrix

## Bridge and Schema Impact

- [ ] No Rust/Python bridge changes
- [x] Python model/schema changed
- [x] Rust core or SQL generation changed
- [ ] `src/ferro/_core.pyi` updated (if needed)
- [x] Integration test added first for new behavior

## Migration / Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes included (details below)

## Documentation and Changelog

- [ ] No docs update needed
- [x] Docs updated (README/docs/inline docs)
- [ ] Changelog entry needed

## Related Issues

- None referenced

## Verification

- `uv run pytest -q` (`199 passed, 8 skipped`)
- `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres -q` with `FERRO_SUPABASE_URL` loaded from the root `.env` (`210 passed, 9 skipped, 83 deselected`)

Made with [Cursor](https://cursor.com)