### PR TITLE
refactor: make ModelConnection generic to preserve model typing through .using()

### DIFF
--- a/docs/plans/2026-05-07-001-refactor-generic-model-connection-plan.md
+++ b/docs/plans/2026-05-07-001-refactor-generic-model-connection-plan.md
@@ -1,0 +1,192 @@
+---
+title: "refactor: Make ModelConnection generic to preserve model typing through .using()"
+type: refactor
+status: active
+date: 2026-05-07
+---
+
+# refactor: Make ModelConnection generic to preserve model typing through .using()
+
+## Summary
+
+`ModelConnection` (the object returned by `Model.using(name)`) is not generic, so every method that should return the bound model class falls back to the unbound `Model` base — `Transcript.using(SERVICE).get("...")` resolves to `Model | None` instead of `Transcript | None`. This plan parameterizes `ModelConnection` over `M: Model` using PEP 695 syntax, propagates `M` through every method return type, and renames the conflicting `self.using` instance attribute so the class isn't shadowing its own classmethod entrypoint. No behavior changes — pure typing + naming hygiene.
+
+---
+
+## Requirements
+
+- R1. `Transcript.using(SERVICE).get(pk)` resolves to `Transcript | None` under Pyright/Pylance.
+- R2. Every other `ModelConnection` method preserves the model type: `create -> M`, `all -> list[M]`, `select -> Query[M]`, `where -> Query[M]`, `bulk_create -> int`, `get_or_create -> tuple[M, bool]`, `update_or_create -> tuple[M, bool]`.
+- R3. The instance attribute previously named `self.using` no longer shadows the `Model.using` classmethod name.
+- R4. Existing runtime behavior is preserved — every test under `tests/test_connection.py` and `tests/test_named_connections_integration.py` continues to pass without modification.
+- R5. Public surface is unchanged: `Model.using("name")` still returns a `ModelConnection`-shaped object with all the same methods and call signatures.
+
+---
+
+## Scope Boundaries
+
+- No widening of `Model.using()` to accept transaction handles, connection objects, role hints, or anything other than the existing `name: str`.
+- No audit of unrelated typing erasure elsewhere in the ORM (relation descriptors, raw queries, query builder internals). Anything discovered during this work that is out-of-scope routes to deferred follow-up rather than expanding this plan.
+- No changes to `Query`, `Model`, or any FFI signatures — `Query` is already generic and that infrastructure is sufficient.
+- No new type-checker wiring into CI. The repo currently has no Pyright/mypy hook (see `.pre-commit-config.yaml` lines 45–51, type checking is commented out). Adding CI enforcement for static typing is a separate, larger discussion.
+
+### Deferred to Follow-Up Work
+
+- Wiring Pyright into pre-commit / CI so `assert_type` regressions fail builds: separate plan, larger scope (config, ignore lists, baseline noise).
+- Audit of `relations/descriptors.py` and other Model-returning APIs for similar erasure: separate plan if/when surfaced.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/ferro/models.py` lines 452–455: `Model.using` classmethod, already annotated `-> ModelConnection[Self]` (the annotation is aspirational today — `ModelConnection` is not actually subscriptable).
+- `src/ferro/models.py` lines 557–619: `ModelConnection` class definition. All eight methods to retype live here.
+- `src/ferro/query/builder.py` line 29: `class Query(Generic[T])` — already generic. `select()` and `where()` should return `Query[M]` after this refactor; the constructor `Query(self.model_cls, using=...)` already infers `T` from the class argument.
+- `src/ferro/relations/descriptors.py` line 112: `await self._target_model.using(origin).get(id_val)` — only external caller of `ModelConnection`'s instance-level methods we found in repo. Will benefit automatically from the typing fix; no change needed.
+
+### Internal Usages of `self.using` (the instance attribute being renamed)
+
+Confirmed via grep — all references are inside `ModelConnection`'s own method bodies:
+
+- `models.py:566` — `await instance.save(using=self.using)`
+- `models.py:570` — `using=self.using`
+- `models.py:573` — `Query(..., using=self.using)`
+- `models.py:588` — `bulk_create(..., using=self.using)`
+- `models.py:593` — `Query(..., using=self.using)`
+- `models.py:607` — `Query(..., using=self.using)`
+- `models.py:615` — `await instance.save(using=self.using)`
+
+No external code reads `instance.using` on a `ModelConnection` object. Renaming is safe.
+
+### Institutional Learnings
+
+- `.cursorrules` §4 — TDD workflow: write a failing test first, then implement. Applies here even though the "test" for the typing fix is a static `assert_type` rather than runtime assertion. The runtime regression test for the rename is conventional pytest.
+- `AGENTS.md` I-3 — no `unwrap()` across FFI. Not applicable here (Python-only change), but reinforces "this should not need to touch Rust."
+- `AGENTS.md` I-5 — `docs/solutions/` is institutional memory. Worth adding a short note under `docs/solutions/patterns/` if the PEP 695 generic syntax is the first instance in the codebase, so future agents have a reference.
+
+### External References
+
+- PEP 695 (Type Parameter Syntax, Python 3.12+) — Ferro's `requires-python = ">=3.13"` makes this the modern default over `Generic[M]`. No external lookup needed; the syntax is well-known.
+
+---
+
+## Key Technical Decisions
+
+- **Use PEP 695 syntax (`class ModelConnection[M: Model]:`) over `Generic[M]`.** Project pins Python 3.13+ (`pyproject.toml:9`), so the older syntax has no compatibility benefit and adds an import (`Generic`, `TypeVar`). PEP 695 is also what `Query` should eventually move to for consistency, but that migration is out of scope here.
+- **Rename `self.using` to `self._connection_name`.** Underscore-prefix signals "internal — don't read this from outside the class," which matches how the attribute is actually used. Avoids the `Model.using` / `ModelConnection.using` name collision that prompted this work in the first place.
+- **Test typing via `typing.assert_type` co-located with existing connection tests, not in a new `tests/typing/` directory.** No type checker runs in CI today, so a separate typing test directory would be a discoverability problem (no signal points at it). Inline `assert_type` calls in the existing test files make the intent visible to readers, run as no-ops at runtime, and can be picked up later if/when Pyright is wired into CI.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- *Should we use `Generic[M]` or PEP 695 `[M: Model]`?* — PEP 695, see Key Technical Decisions.
+- *What to rename `self.using` to?* — `self._connection_name`, see Key Technical Decisions.
+- *Do we need to update `src/ferro/_core.pyi`?* — No. `ModelConnection` is a pure-Python class; no FFI signatures cross.
+
+### Deferred to Implementation
+
+- *Does `Query`'s existing generic propagation flow through the new `M` cleanly when `ModelConnection.select()` returns `Query[M]`?* — Should "just work" since `Query(model_cls, ...)` infers `T` from `type[T]`, and after the refactor `self.model_cls: type[M]`. Verified at implementation time by writing the `assert_type` calls and running Pyright locally.
+
+---
+
+## Implementation Units
+
+- U1. **Add typing regression coverage for `.using()`**
+
+**Goal:** Lock in the desired post-refactor types via `typing.assert_type` calls so the typing improvement is observable and won't silently regress.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `tests/test_connection.py` (or `tests/test_named_connections_integration.py` — pick the file that already exercises the same model)
+- Test: same file (typing assertions co-located with runtime tests)
+
+**Approach:**
+- Add a small block of `typing.assert_type(...)` calls against an existing test model (e.g., `ConnectionRouteMarker` or `NamedSmokeMarker`).
+- Cover the full surface called out in R2: `create`, `all`, `select`, `where`, `bulk_create`, `get_or_create`, `update_or_create`, `get`.
+- These are no-ops at runtime; Pyright/Pylance will flag any future regression. Document at the top of the block that they're for static type checking.
+
+**Execution note:** Test-first per `.cursorrules` §4. Write these assertions before touching `models.py` — Pyright should report errors on every line until U2 lands.
+
+**Patterns to follow:**
+- Existing test file structure under `tests/`.
+
+**Test scenarios:**
+- Happy path: `assert_type(ConnectionRouteMarker.using("service"), ModelConnection[ConnectionRouteMarker])` — proves the classmethod's annotation is now truthful.
+- Happy path: `assert_type(await ConnectionRouteMarker.using("service").get(1), ConnectionRouteMarker | None)` — covers R1 directly.
+- Happy path: one `assert_type` per remaining method in R2 (`create`, `all`, `select`, `where`, `bulk_create`, `get_or_create`, `update_or_create`).
+- Test expectation at runtime: these statements should execute without error. `assert_type` is a runtime no-op.
+
+**Verification:**
+- Before U2 lands: `uv run pytest` passes (assert_type doesn't fail at runtime), but Pyright on the test file reports type errors on each new line.
+- After U2 lands: Pyright on the test file is clean.
+
+---
+
+- U2. **Make `ModelConnection` generic and rename the connection-name attribute**
+
+**Goal:** Parameterize `ModelConnection` over `M: Model` and rename `self.using` → `self._connection_name`.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `src/ferro/models.py` (lines 557–619 — the `ModelConnection` class body)
+
+**Approach:**
+- Change class header to `class ModelConnection[M: Model]:`.
+- `__init__` signature: `model_cls: type[M], connection_name: str` (parameter name change is internal — callers go through `Model.using()` which positional-passes the string).
+- `self.model_cls: type[M] = model_cls`; `self._connection_name: str = connection_name`.
+- Replace all seven `self.using` references in method bodies with `self._connection_name`.
+- Method return-type annotations:
+  - `create(...) -> M`
+  - `all() -> list[M]`
+  - `select() -> Query[M]`
+  - `where(node) -> Query[M]`
+  - `get(pk) -> M | None`
+  - `bulk_create(instances: list[M]) -> int`
+  - `get_or_create(...) -> tuple[M, bool]`
+  - `update_or_create(...) -> tuple[M, bool]`
+- `Model.using` classmethod (lines 452–455) stays as-is — its `-> "ModelConnection[Self]"` annotation now resolves correctly.
+
+**Patterns to follow:**
+- `src/ferro/query/builder.py:29` (`class Query(Generic[T])`) for how a generic ORM-side class is wired, though we use the newer PEP 695 syntax here.
+
+**Test scenarios:**
+- Covers R4. Happy path: full existing `tests/test_connection.py` and `tests/test_named_connections_integration.py` suites pass unchanged. The rename is purely internal so no behavior changes.
+- Covers R1, R2. Happy path: every `assert_type` call added in U1 type-checks clean under Pyright after this unit lands.
+- Edge case: confirm that `Model.using("name").select().where(...).first()` chains all the way through — each link preserves `M`. Already covered indirectly by the U1 `select` and `where` assertions plus existing query tests.
+
+**Verification:**
+- `uv run pytest tests/test_connection.py tests/test_named_connections_integration.py` is green.
+- `uv run maturin develop && uv run pytest` is green (full suite — confirms no relation-descriptor or other internal caller broke).
+- Manually run Pyright on `tests/test_connection.py` (or whichever file got the U1 assertions): no errors on the typing block.
+- Visual check: `Transcript.using(SERVICE).get("…")` in a fresh editor session shows `Transcript | None` in the hover tooltip.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Renaming `self.using` accidentally breaks an external caller we missed in the grep. | Pre-flight grep confirmed all references are internal to the class body. The full pytest suite runs in U2 verification. |
+| `Query[M]` doesn't propagate as cleanly as expected because `Query`'s `__init__` infers `T` differently than expected from `type[M]`. | Verified at implementation time via the `assert_type(self.select(), Query[M])` assertion in U1. If it fails, fall back to an explicit cast or constructor annotation; document the fix in `docs/solutions/patterns/`. |
+| The typing improvement degrades inside generic mixins or subclasses of `Model` due to `Self` interaction. | `Model.using` returns `ModelConnection[Self]`; this is the standard pattern and shouldn't fight `M: Model`. If a subclass-specific issue surfaces, scope the fix to that subclass — don't expand U2. |
+
+---
+
+## Sources & References
+
+- Brainstorm conversation in this session establishing scope (generic + rename, no broader audit).
+- `src/ferro/models.py:452-619` — current `Model.using` and `ModelConnection` definitions.
+- `src/ferro/query/builder.py:29` — existing generic ORM class as reference pattern.
+- `pyproject.toml:9` — `requires-python = ">=3.13"`, justifying PEP 695 syntax.
+- PEP 695 — Type Parameter Syntax.

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -554,28 +554,33 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         return await cls.create(**params), True
 
 
-class ModelConnection:
-    """Connection-bound ORM entrypoint returned by ``Model.using(name)``."""
+class ModelConnection[M: Model]:
+    """Connection-bound ORM entrypoint returned by ``Model.using(name)``.
 
-    def __init__(self, model_cls: type[Model], using: str) -> None:
-        self.model_cls = model_cls
-        self.using = using
+    Generic over the concrete model class so that every accessor preserves
+    the bound type — e.g. ``Transcript.using("service").get(pk)`` resolves
+    to ``Transcript | None`` rather than ``Model | None``.
+    """
 
-    async def create(self, **fields: Any) -> Model:
+    def __init__(self, model_cls: type[M], connection_name: str) -> None:
+        self.model_cls: type[M] = model_cls
+        self._connection_name: str = connection_name
+
+    async def create(self, **fields: Any) -> M:
         instance = self.model_cls(**fields)
-        await instance.save(using=self.using)
+        await instance.save(using=self._connection_name)
         return instance
 
-    async def all(self) -> list[Model]:
-        return await self.model_cls.all(using=self.using)
+    async def all(self) -> list[M]:
+        return await self.model_cls.all(using=self._connection_name)
 
-    def select(self) -> Query[Model]:
-        return Query(self.model_cls, using=self.using)
+    def select(self) -> Query[M]:
+        return Query(self.model_cls, using=self._connection_name)
 
-    def where(self, node: QueryNode) -> Query[Model]:
+    def where(self, node: QueryNode) -> Query[M]:
         return self.select().where(node)
 
-    async def get(self, pk: Any) -> Model | None:
+    async def get(self, pk: Any) -> M | None:
         pk_field_name = self.model_cls._primary_key_field_name()
         if pk_field_name is None:
             raise RuntimeError(
@@ -584,13 +589,13 @@ class ModelConnection:
 
         return await self.where(getattr(self.model_cls, pk_field_name) == pk).first()
 
-    async def bulk_create(self, instances: list[Model]) -> int:
-        return await self.model_cls.bulk_create(instances, using=self.using)
+    async def bulk_create(self, instances: list[M]) -> int:
+        return await self.model_cls.bulk_create(instances, using=self._connection_name)
 
     async def get_or_create(
         self, defaults: dict[str, Any] | None = None, **fields: Any
-    ) -> tuple[Model, bool]:
-        query = Query(self.model_cls, using=self.using)
+    ) -> tuple[M, bool]:
+        query = Query(self.model_cls, using=self._connection_name)
         for key, val in fields.items():
             query = query.where(getattr(self.model_cls, key) == val)
 
@@ -603,8 +608,8 @@ class ModelConnection:
 
     async def update_or_create(
         self, defaults: dict[str, Any] | None = None, **fields: Any
-    ) -> tuple[Model, bool]:
-        query = Query(self.model_cls, using=self.using)
+    ) -> tuple[M, bool]:
+        query = Query(self.model_cls, using=self._connection_name)
         for key, val in fields.items():
             query = query.where(getattr(self.model_cls, key) == val)
 
@@ -612,7 +617,7 @@ class ModelConnection:
         if instance:
             for key, val in (defaults or {}).items():
                 setattr(instance, key, val)
-            await instance.save(using=self.using)
+            await instance.save(using=self._connection_name)
             return instance, False
 
         params = {**fields, **(defaults or {})}

--- a/tests/test_named_connections_integration.py
+++ b/tests/test_named_connections_integration.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated, assert_type
 
 import pytest
 
@@ -8,6 +8,43 @@ import ferro
 class NamedSmokeMarker(ferro.Model):
     id: Annotated[int | None, ferro.FerroField(primary_key=True)] = None
     label: str
+
+
+if TYPE_CHECKING:
+    from ferro.models import ModelConnection
+    from ferro.query import Query
+
+    async def _typing_assertions_for_using_interface() -> None:
+        """Static type-checking regression tests for `Model.using(...)`.
+
+        This function is never executed; it exists purely so Pyright/Pylance
+        can verify that every method on the `ModelConnection` returned by
+        `Model.using(...)` preserves the concrete model type. If any of these
+        `assert_type` calls fails under a type checker, the typing contract
+        documented on `ModelConnection` has regressed.
+
+        See `docs/plans/2026-05-07-001-refactor-generic-model-connection-plan.md`.
+        """
+        bound: ModelConnection[NamedSmokeMarker] = NamedSmokeMarker.using("service")
+        assert_type(bound, "ModelConnection[NamedSmokeMarker]")
+
+        assert_type(await bound.create(label="x"), NamedSmokeMarker)
+        assert_type(await bound.all(), list[NamedSmokeMarker])
+        assert_type(bound.select(), "Query[NamedSmokeMarker]")
+        assert_type(
+            bound.where(NamedSmokeMarker.id == 1),  # type: ignore[arg-type]
+            "Query[NamedSmokeMarker]",
+        )
+        assert_type(await bound.get(1), NamedSmokeMarker | None)
+        assert_type(await bound.bulk_create([]), int)
+        assert_type(
+            await bound.get_or_create(label="x"),
+            tuple[NamedSmokeMarker, bool],
+        )
+        assert_type(
+            await bound.update_or_create(defaults={"label": "y"}, label="x"),
+            tuple[NamedSmokeMarker, bool],
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/uv.lock
+++ b/uv.lock
@@ -537,7 +537,7 @@ wheels = [
 
 [[package]]
 name = "ferro-orm"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Description

`Model.using(name)` returns a `ModelConnection` that lost the bound model type — `Transcript.using(SERVICE).get(pk)` was resolving to `Model | None` instead of `Transcript | None` (showing as `@Todo` in editor hovers). Root cause: `ModelConnection` was non-generic, so the `Model.using(...) -> ModelConnection[Self]` annotation erased to the unbound base.

This PR parameterizes `ModelConnection` over `M: Model` using PEP 695 syntax (project pins `>=3.13`), propagates `M` through every method return, and renames the conflicting `self.using` instance attribute to stop shadowing the `Model.using` classmethod name.

Pure typing + naming hygiene — no behavior change. Verified with `uv run pytest` (329 passed, 26 skipped, 1 xfailed) and Pyright on the new typing-assertion block (0 errors).

Plan: [`docs/plans/2026-05-07-001-refactor-generic-model-connection-plan.md`](../blob/cursor/generic-model-connection-typing/docs/plans/2026-05-07-001-refactor-generic-model-connection-plan.md)

## Changes

- `src/ferro/models.py`: convert `ModelConnection` to `class ModelConnection[M: Model]:`; parameterize `create`, `all`, `select`, `where`, `get`, `bulk_create`, `get_or_create`, `update_or_create` over `M`.
- `src/ferro/models.py`: rename `self.using` instance attribute to `self._connection_name` (and the `__init__` parameter likewise) — verified all references were internal to the class body.
- `tests/test_named_connections_integration.py`: add a `TYPE_CHECKING`-guarded `assert_type` block covering the full `ModelConnection` surface as a static regression tripwire (zero runtime cost).

## Bridge and Schema Impact

- [x] No Rust/Python bridge changes
- [ ] Python model/schema changed
- [ ] Rust core or SQL generation changed
- [ ] `src/ferro/_core.pyi` updated (if needed)
- [ ] Integration test added first for new behavior

`ModelConnection` is pure-Python; no FFI signatures cross. Existing integration tests (`tests/test_connection.py`, `tests/test_named_connections_integration.py`) cover runtime behavior unchanged.

## Migration / Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes included (details below)

The renamed attribute (`self.using` → `self._connection_name`) is private and was never read by any external caller (verified by repo-wide grep). Public surface — `Model.using("name").<method>(...)` — is identical.

## Documentation and Changelog

- [x] No docs update needed
- [ ] Docs updated (README/docs/inline docs)
- [ ] Changelog entry needed

User-facing API is unchanged; the visible improvement is editor inference quality.

## Related Issues

<!-- None -->

Made with [Cursor](https://cursor.com)