### PR TITLE
feat(query): typed query predicates via col() and lambda

### DIFF
--- a/docs/api/query.md
+++ b/docs/api/query.md
@@ -2,6 +2,10 @@
 
 Complete reference for the Query Builder API.
 
+## `Query`
+
+`Query.where` accepts either a `QueryNode` (the operator and `col()` paths) or a lambda predicate of shape `Callable[[QueryProxy[TModel]], QueryNode]`. See [Typed Query Predicates](../concepts/query-typing.md) for a full treatment of the three predicate styles.
+
 ::: ferro.query.Query
     options:
       members:
@@ -16,9 +20,78 @@ Complete reference for the Query Builder API.
         - update
         - delete
       show_source: false
-      heading_level: 2
+      heading_level: 3
+
+## `Relation`
+
+`Relation` is the lazy collection-relationship subclass of `Query` returned by `BackRef` and `ManyToMany` fields. It accepts the same three predicate styles on `where`.
+
+::: ferro.query.Relation
+    options:
+      members:
+        - where
+        - order_by
+        - limit
+        - offset
+        - all
+        - first
+        - add
+        - remove
+        - clear
+      show_source: false
+      heading_level: 3
+
+## `col`
+
+Runtime-identity wrapper that statically narrows a model class attribute back to `FieldProxy[T]`. Use it when a single attribute on an existing chain trips your type checker; for new code prefer the lambda predicate style.
+
+::: ferro.query.col
+    options:
+      show_source: false
+      heading_level: 3
+
+## `FieldProxy`
+
+The typed proxy installed by Ferro's metaclass on every model class field. Generic over the column's Python type; operator overloads accept `T | FieldProxy[T]` and return `QueryNode`.
+
+::: ferro.query.FieldProxy
+    options:
+      members:
+        - in_
+        - like
+      show_source: false
+      heading_level: 3
+
+## `QueryProxy`
+
+The attribute proxy passed to lambda predicates. Each attribute access returns a fresh `FieldProxy` for the accessed name.
+
+::: ferro.query.QueryProxy
+    options:
+      show_source: false
+      heading_level: 3
+
+## `QueryNode`
+
+The serializable AST node produced by every predicate style. You normally do not construct these directly.
+
+::: ferro.query.QueryNode
+    options:
+      members:
+        - to_dict
+      show_source: false
+      heading_level: 3
+
+## `Predicate`
+
+Type alias for lambda predicates accepted by `Query.where`, `Relation.where`, and `Model.where`.
+
+```python
+Predicate[TModel] = Callable[[QueryProxy[TModel]], QueryNode]
+```
 
 ## See Also
 
 - [Queries Guide](../guide/queries.md)
+- [Typed Query Predicates](../concepts/query-typing.md)
 - [How-To: Pagination](../howto/pagination.md)

--- a/docs/brainstorms/2026-05-08-typed-query-predicates-requirements.md
+++ b/docs/brainstorms/2026-05-08-typed-query-predicates-requirements.md
@@ -1,0 +1,95 @@
+---
+date: 2026-05-08
+topic: typed-query-predicates
+---
+
+# Typed Query Predicates
+
+## Summary
+
+Add two opt-in query-predicate styles to Ferro — a `col()` wrapper and a lambda predicate API — so that `Model.field` comparisons type-check cleanly under Pyright and `ty` without changing user model annotations or breaking the current operator API. A concept doc covers when to reach for each.
+
+---
+
+## Problem Frame
+
+Ferro models are Pydantic models, so user fields carry plain-type annotations like `archived: bool` and `transcript_id: int`. At runtime the metaclass replaces each class attribute with a `FieldProxy` whose operator overloads return `QueryNode`, so `User.archived == False` builds a query predicate that `Query.where()` accepts.
+
+Static type checkers don't see that runtime swap. Pyright and `ty` resolve `User.archived` from the source annotation as `bool`, so `User.archived == False` is interpreted as `bool.__eq__(bool)` and returns `bool`. `Query.where()` then complains that it expected a `QueryNode`. Users hitting this on every typed predicate currently silence each line with a `# type: ignore` pragma.
+
+Other Python ORMs work around this by changing what users annotate (SQLAlchemy 2.x uses `Mapped[T]`), changing the API away from class-attribute predicates (Django and Tortoise use kwargs), or shipping a mypy plugin. None of those fit Ferro: `Mapped[T]`-style breaks the "user types directly" stance and adds Pydantic interop work, and a mypy plugin doesn't help Pyright or `ty` users — Pyright has no public plugin API.
+
+---
+
+## Requirements
+
+**`col()` wrapper**
+
+- R1. Ferro exposes a `col()` function whose static signature is `(value: T) -> FieldProxy[T]`. At runtime it is identity, with a guard that raises `TypeError` if the input is not a `FieldProxy`.
+- R2. `col(Model.field) == value` (and the other comparison operators) produces a `QueryNode` that `Query.where()` accepts in mypy, Pyright, basedpyright, and `ty` without ignore pragmas.
+- R3. `FieldProxy` becomes generic over its column type (`FieldProxy[T]`), with operator overloads typed to accept `T | FieldProxy[T]` and return `QueryNode`. Runtime behavior is unchanged; users do not write the generic parameter directly.
+
+**Lambda predicate API**
+
+- R4. `Query.where()` accepts a callable that takes a typed query proxy and returns a `QueryNode`. The proxy's static type is parameterized on the model type; attribute access on the proxy is statically typed as `FieldProxy[Any]`.
+- R5. At runtime, when `where()` receives a callable that is not a `QueryNode`, it constructs a per-call proxy whose `__getattr__` returns `FieldProxy(name)`, invokes the callable with the proxy, and appends the returned node to the query.
+- R6. Lambda predicates support compound expressions via the existing `&` and `|` operators on `QueryNode`.
+
+**Backward compatibility**
+
+- R7. The existing `Model.field == value` operator path continues to work unchanged at runtime. No existing test, query, or user model needs modification.
+- R8. Adding the lambda overload does not change the runtime semantics of any current `where()` call. Dispatch checks `isinstance(QueryNode)` first, then `callable()`.
+- R9. No changes to the model metaclass, Pydantic schema generation, JSON schema bridge, or the Rust hydration paths.
+
+**Documentation**
+
+- R10. A concept document under `docs/concepts/` covers the three predicate styles (operator, `col()`, lambda), shows them combined in one query chain, and recommends when to reach for each. Lambda is positioned as the recommended idiom for new code; `col()` is the lower-ceremony fallback for users who want to keep the operator shape.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2.** Given `archived: bool` declared on a model and a strict type checker run, when the user writes `.where(col(T.archived) == False)`, the line type-checks without ignore pragmas in mypy, Pyright, basedpyright, and `ty`.
+- AE2. **Covers R7, R8.** Given an existing test that uses `.where(T.field == value)`, when the new code lands, the test continues to pass with no modification.
+- AE3. **Covers R4, R5, R6.** Given the predicate `lambda t: (t.archived == False) & (t.org_id == 42)`, when passed to `.where(...)`, the runtime invokes the lambda with a model proxy, appends a single compound `QueryNode` to the query, and produces the same SQL as the equivalent operator-form predicate.
+- AE4. **Covers R1.** Given a value that is not a `FieldProxy` (e.g., a raw string), when passed to `col()` at runtime, `col()` raises `TypeError` whose message names the actual argument type.
+- AE5. **Covers R2, R7, R4.** Given a single `Query` chain that combines `.where(T.a == 1)`, `.where(col(T.b) == 2)`, and `.where(lambda t: t.c == 3)` in any order, when executed, the resulting SQL contains all three predicates and the result hydrates correctly.
+
+---
+
+## Success Criteria
+
+- Ferro users hitting the original `ty` complaint can fix it by wrapping the attribute reference with `col(...)` — a single small change per call site, with no model edits and no plugin installation.
+- New Ferro code in user projects can adopt the lambda predicate style and have those predicates type-check cleanly in every supported checker.
+- Downstream agents (planning, future API work) and human reviewers have a clear definition of which `where()` shapes are supported and which were deliberately deferred.
+- Backward-compat tests in `tests/` pass without modification, demonstrating the operator-path runtime is unchanged.
+
+---
+
+## Scope Boundaries
+
+- `Mapped[T]` / descriptor-based field annotations are deferred indefinitely; they conflict with Ferro's "user types directly" stance and would require Pydantic interop work disproportionate to the typing win.
+- A mypy plugin for Ferro is out of scope; Pyright and `ty` are the target checkers and neither has an equivalent plugin API.
+- Per-field type precision in the lambda proxy via `@dataclass_transform` is deferred; this work uses `FieldProxy[Any]` for proxy attribute types.
+- A kwargs-style filter API (e.g., `.where_kw(field=value)`) is deferred until user demand surfaces.
+- A `t""` template-string predicate API is deferred until Ferro raises its minimum Python to 3.14.
+- Per-model code generation, distributed `.pyi` stubs for user models, and `if TYPE_CHECKING` shadow declarations as a documented pattern are not adopted.
+- No changes to the metaclass, Pydantic interop, JSON schema generation, or the Rust FFI bridge.
+
+---
+
+## Key Decisions
+
+- **Single PR over staged PRs.** The three pieces (`col()`, lambda API, doc) ship together on `feat/col-and-lambda-queries`. They are small, low-risk, and meaningfully more useful as a unit than incrementally.
+- **`col()` is identity at runtime, not a constructor.** `Model.field` is already a `FieldProxy` thanks to the metaclass, so `col()` is a typed pass-through, not a wrapping layer. This keeps the runtime cost zero and avoids a parallel class hierarchy.
+- **Lambda predicate proxy is per-call, not stored on the model.** Avoids touching the metaclass and keeps the lambda path opt-in. Users who never call `where(lambda ...)` never construct the proxy.
+- **`FieldProxy[Any]` over per-field precision for the lambda proxy.** Per-field types would require `@dataclass_transform` plumbing and tighter user-facing typing semantics. Deferred to a follow-up if real demand materializes.
+- **Lambda is the recommended idiom; `col()` is the fallback.** Lambda has lower per-call ceremony for chains with several predicates; `col()` is one wrapper per reference but doesn't ask users to rewrite their query shape.
+
+---
+
+## Dependencies / Assumptions
+
+- The current metaclass behavior of replacing each `model_fields` attribute with a `FieldProxy` is a stable invariant the runtime no-op `col()` relies on.
+- `QueryNode` does not currently expose `__call__`; the runtime dispatch rule "isinstance(QueryNode) first, then callable()" depends on this remaining true.
+- Generic parameters on `FieldProxy[T]` are runtime-erased (standard Python typing semantics); existing `isinstance(x, FieldProxy)` checks remain valid.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Typed query predicates: `col()` wrapper and lambda predicate API on `Query.where`, `Relation.where`, and `Model.where` for static-typing-clean predicates without model annotation changes ([#48](https://github.com/syn54x/ferro-orm/pull/48)). See [Typed Query Predicates](concepts/query-typing.md).
+- `FieldProxy` is now generic (`FieldProxy[T]`); operator overloads are typed `T | FieldProxy[T] -> QueryNode`, `.like()` is gated to `FieldProxy[str]`.
+- New public symbols re-exported from `ferro.query`: `col`, `QueryProxy`, `Predicate`.
 - Comprehensive documentation restructure
 - Tutorial for new users
 - How-to guides for common patterns

--- a/docs/concepts/query-typing.md
+++ b/docs/concepts/query-typing.md
@@ -1,0 +1,97 @@
+# Typed query predicates
+
+Ferro's query DSL accepts three predicate styles on `Query.where` and `Relation.where`. They are interchangeable, run on the same code path, and can be mixed freely in the same chain. Pick the one that reads best for the call site you're writing.
+
+## Why this exists
+
+Ferro's metaclass replaces every model field with a `FieldProxy` at class-creation time, so `User.archived` is a `FieldProxy` at runtime — and `User.archived == False` builds a `QueryNode`, not a Python `bool`. Static type checkers (Pyright, `ty`, mypy, basedpyright) only see your Pydantic annotations, though, so they read `User.archived` as a `bool` and reject the same expression they would happily run.
+
+The two new predicate styles below give you the runtime ergonomics back without forcing a model-annotation rewrite, a type-checker plugin, or any change to the existing operator path.
+
+## The three styles
+
+### 1. Operator (the original)
+
+```python
+rows = await User.where(User.id == 1).all()
+rows = await User.where(User.email.like("%@example.com")).all()
+```
+
+Works at runtime, always has, always will. Type checkers may flag boolean-column comparisons (`User.archived == False` resolves statically to `bool`) — when that bites, reach for one of the styles below.
+
+### 2. `col()` wrapper
+
+```python
+from ferro.query import col
+
+rows = await User.where(col(User.archived) == False).all()
+```
+
+`col()` is a runtime-identity helper that statically narrows its argument back to `FieldProxy[T]`. It does no work at runtime beyond an `isinstance` guard (and raises `TypeError` if you accidentally hand it a literal). Reach for it when a single attribute trips your type checker and you don't want to restructure the call site.
+
+### 3. Lambda predicate
+
+```python
+rows = await User.where(lambda t: t.archived == False).all()
+rows = await User.where(
+    lambda t: (t.role == "admin") & (t.active == True)
+).all()
+```
+
+The lambda receives a `QueryProxy` whose attribute access yields a fresh `FieldProxy` for each name — so `t.archived == False` is a `QueryNode` from the type checker's point of view as well as at runtime. This is the recommended style for new code: it keeps the call site free of `# type: ignore` even when comparing booleans, integers, or any other value type.
+
+The proxy attribute type is currently `FieldProxy[Any]`, which is a deliberate scope decision (see [Scope boundaries](#scope-boundaries) below). Pyright still resolves the predicate's *return* type as `QueryNode` correctly.
+
+## When to use which
+
+| Style | Use when |
+|------|----------|
+| Operator | Existing code that already type-checks; quick filters where the value type isn't `bool`. |
+| `col()` | One attribute on an existing chain trips your type checker and you want minimal diff. |
+| Lambda | New code, especially boolean comparisons or compound predicates; preferred idiom. |
+
+All three are equally efficient at runtime — every one of them produces a `QueryNode` and appends it to `where_clause`.
+
+## Combining styles
+
+You can mix all three on a single chain. They compose because they all funnel through the same dispatch in `Query.where`:
+
+```python
+rows = await (
+    User.where(User.id == 1)                    # operator
+    .where(col(User.archived) == False)         # col()
+    .where(lambda t: t.role == "admin")         # lambda
+    .all()
+)
+```
+
+`Relation.where` (used on `BackRef` collections) accepts the same three shapes:
+
+```python
+published = await author.posts.where(lambda t: t.published == True).all()
+```
+
+## What this does not change
+
+- Your model annotations. `archived: bool = False` stays exactly as it is.
+- The metaclass's `FieldProxy` injection. Class attribute access is unchanged.
+- Pydantic schema generation, JSON schema output, or model validation.
+- The Rust FFI bridge or how `QueryNode`s are serialized for the engine.
+- The operator-path runtime. Existing `Model.field == value` calls take the same code path they always have.
+
+## Scope boundaries
+
+The current implementation deliberately stops short of:
+
+- **Per-field types on the lambda proxy.** `t.archived` resolves to `FieldProxy[Any]`, not `FieldProxy[bool]`. Wiring per-field types through the proxy needs `@dataclass_transform` plumbing on the metaclass; that's a future PR.
+- **A type-checker plugin.** Ferro stays plugin-free.
+- **A kwargs-style or template-string predicate API.** Both have been considered; neither shipped here.
+
+If `t.archived` resolving as `FieldProxy[Any]` ever bites you statically, drop back to `col(Model.archived) == ...` for that one comparison — that's exactly the role `col()` plays.
+
+## Reference
+
+- `ferro.query.col` — runtime-identity wrapper, raises `TypeError` for non-`FieldProxy` input.
+- `ferro.query.QueryProxy` — attribute proxy passed to lambda predicates.
+- `ferro.query.Predicate` — `Callable[[QueryProxy[TModel]], QueryNode]`, the type of any lambda predicate.
+- `ferro.query.FieldProxy` — generic over the column's Python type (`FieldProxy[T]`).

--- a/docs/concepts/query-typing.md
+++ b/docs/concepts/query-typing.md
@@ -1,6 +1,6 @@
-# Typed query predicates
+# Typed Query Predicates
 
-Ferro's query DSL accepts three predicate styles on `Query.where` and `Relation.where`. They are interchangeable, run on the same code path, and can be mixed freely in the same chain. Pick the one that reads best for the call site you're writing.
+Ferro's query DSL accepts three predicate styles on `Model.where`, `Query.where`, and `Relation.where`. They are interchangeable, run on the same code path, and can be mixed freely in the same chain. Pick the one that reads best for the call site you're writing.
 
 ## Why this exists
 
@@ -95,3 +95,11 @@ If `t.archived` resolving as `FieldProxy[Any]` ever bites you statically, drop b
 - `ferro.query.QueryProxy` — attribute proxy passed to lambda predicates.
 - `ferro.query.Predicate` — `Callable[[QueryProxy[TModel]], QueryNode]`, the type of any lambda predicate.
 - `ferro.query.FieldProxy` — generic over the column's Python type (`FieldProxy[T]`).
+
+See the [Query API reference](../api/query.md) for full signatures.
+
+## See Also
+
+- [Queries Guide](../guide/queries.md)
+- [Type Safety](type-safety.md)
+- [Query API](../api/query.md)

--- a/docs/concepts/type-safety.md
+++ b/docs/concepts/type-safety.md
@@ -85,6 +85,27 @@ User.where(
 )
 ```
 
+## Query Predicates and the Type Checker
+
+Static checkers see your Pydantic annotations, not the `FieldProxy` instances Ferro's metaclass installs at class-creation time. That means `User.archived == False` is statically a `bool` even though it is a `QueryNode` at runtime, and Pyright or `ty` will flag it where `Query.where` expects a `QueryNode`.
+
+Ferro ships three predicate styles to address this without any model-annotation changes or type-checker plugins:
+
+```python
+from ferro.query import col
+
+# Operator (unchanged)
+await User.where(User.id == 1).all()
+
+# col() — runtime identity, statically narrows back to FieldProxy[T]
+await User.where(col(User.archived) == False).all()
+
+# Lambda — receives a QueryProxy whose attributes return FieldProxy
+await User.where(lambda t: t.archived == False).all()
+```
+
+See [Typed Query Predicates](query-typing.md) for the full discussion, including when to reach for each style and how they compose.
+
 ## Field Type Validation
 
 Ferro validates field types match database types:

--- a/docs/guide/queries.md
+++ b/docs/guide/queries.md
@@ -31,6 +31,32 @@ alice_users = await User.where(User.name.like("Alice%")).all()
 | `.like()` | `LIKE` | `User.email.like("%@example.com")` |
 | `.in_()` | `IN` | `User.status.in_(["active", "pending"])` |
 
+## Predicate Styles
+
+`where()` accepts three interchangeable predicate styles. They share one runtime path and one dispatcher, and you can mix them on a single chain.
+
+```python
+from ferro.query import col
+
+# 1. Operator (the original)
+await User.where(User.id == 1).all()
+
+# 2. col() wrapper — runtime identity, statically narrows to FieldProxy[T]
+await User.where(col(User.archived) == False).all()
+
+# 3. Lambda predicate — receives a QueryProxy with FieldProxy attributes
+await User.where(lambda t: t.archived == False).all()
+```
+
+The operator style works at runtime for every column type, but static type checkers (Pyright, `ty`) flag boolean and other value-type comparisons because they see your Pydantic annotations rather than the runtime `FieldProxy`. Reach for `col()` when one attribute trips the checker, or write new code with the lambda style to sidestep the issue entirely.
+
+!!! tip "When to use which"
+    - **Operator** — existing code that already type-checks; quick filters where the column type isn't `bool`.
+    - **`col()`** — one attribute on an existing chain trips your type checker and you want minimal diff.
+    - **Lambda** — new code, especially boolean comparisons or compound predicates. Recommended idiom going forward.
+
+See [Typed Query Predicates](../concepts/query-typing.md) for the full treatment, including combined-style chains and the deliberate scope boundaries.
+
 ## Logical Operators
 
 Combine conditions with `&` (AND) and `|` (OR). **Always use parentheses** around each condition:
@@ -49,6 +75,14 @@ query = User.where(
 
 # NOT with !=
 inactive_users = await User.where(User.is_active != True).all()
+```
+
+The same compound expressions work inside lambda predicates — useful when you want the whole expression to type-check without `col()`:
+
+```python
+admins = await User.where(
+    lambda t: (t.role == "admin") & (t.active == True)
+).all()
 ```
 
 ## Chaining
@@ -201,8 +235,9 @@ author = await User.where(User.username == "alice").first()
 # Get all posts by author
 author_posts = await author.posts.all()
 
-# Filter reverse relation
+# Filter reverse relation (any of the three predicate styles works)
 published_posts = await author.posts.where(Post.published == True).all()
+published_posts = await author.posts.where(lambda t: t.published == True).all()
 
 # Count reverse relation
 post_count = await author.posts.count()

--- a/docs/plans/2026-05-08-001-feat-typed-query-predicates-plan.md
+++ b/docs/plans/2026-05-08-001-feat-typed-query-predicates-plan.md
@@ -316,6 +316,6 @@ where(other)       ─► TypeError
 
 ## Sources & References
 
-- **Origin document:** [docs/brainstorms/2026-05-08-typed-query-predicates-requirements.md](docs/brainstorms/2026-05-08-typed-query-predicates-requirements.md)
+- **Origin document:** [docs/brainstorms/2026-05-08-typed-query-predicates-requirements.md](../brainstorms/2026-05-08-typed-query-predicates-requirements.md)
 - Related code: `src/ferro/query/nodes.py`, `src/ferro/query/builder.py`, `src/ferro/query/__init__.py`, `src/ferro/metaclass.py`
 - Related work: prior identity-map config PR on the same branch family.

--- a/docs/plans/2026-05-08-001-feat-typed-query-predicates-plan.md
+++ b/docs/plans/2026-05-08-001-feat-typed-query-predicates-plan.md
@@ -1,0 +1,321 @@
+---
+title: "feat: Typed query predicates (col() + lambda)"
+type: feat
+status: active
+date: 2026-05-08
+origin: docs/brainstorms/2026-05-08-typed-query-predicates-requirements.md
+---
+
+# feat: Typed query predicates (col() + lambda)
+
+## Summary
+
+Make `FieldProxy` generic over the column's Python type, add a runtime-identity `col()` wrapper that statically narrows a model attribute back to `FieldProxy[T]`, and extend `Query.where` / `Relation.where` to accept lambda predicates of shape `Callable[[QueryProxy[TModel]], QueryNode]`. All three predicate styles (operator, `col()`, lambda) coexist on the same `where()` so existing user code keeps working unchanged. No metaclass, Pydantic, or Rust FFI changes.
+
+---
+
+## Problem Frame
+
+Pyright and `ty` resolve `Model.field` to its Pydantic-annotated type (`bool`, `int`, …) rather than the `FieldProxy` instance the metaclass installs at class-creation time. As a result, `Model.archived == False` is statically `bool`, which fails `Query.where`'s `QueryNode` parameter and forces users to sprinkle `# ty: ignore` in real queries. Origin: `docs/brainstorms/2026-05-08-typed-query-predicates-requirements.md`.
+
+---
+
+## Requirements
+
+- R1. `FieldProxy` is generic over its column's Python type (`FieldProxy[T]`).
+- R2. Operator overloads on `FieldProxy[T]` accept `T | FieldProxy[T]` and return `QueryNode`.
+- R3. `col(value: T) -> FieldProxy[T]` exists, is runtime-identity for `FieldProxy` inputs, and raises `TypeError` for anything else.
+- R4. `Query.where` accepts either a `QueryNode` or a `Callable[[QueryProxy[TModel]], QueryNode]`.
+- R5. `Relation.where` accepts the same two shapes (parity).
+- R6. The lambda runtime constructs a per-call `QueryProxy` whose `__getattr__` returns `FieldProxy(name)`.
+- R7. All existing operator-path tests pass with no source changes.
+- R8. New public symbols (`col`, `QueryProxy`, `Predicate`) are exported from `ferro.query`.
+- R9. A concept doc explains all three styles, when to use each, and shows them combined.
+- R10. New integration tests cover the lambda path, the `col()` path, and a single chain mixing all three styles.
+
+**Origin acceptance examples:** AE1 (col() typecheck-clean), AE2 (operator path unchanged), AE3 (compound lambda), AE4 (col() misuse error), AE5 (mixed predicate chain).
+
+---
+
+## Scope Boundaries
+
+- No `Mapped[T]` / descriptor-based field annotations.
+- No mypy plugin or other type-checker plugin.
+- No `@dataclass_transform` per-field typing for `QueryProxy` (proxy attribute type stays `FieldProxy[Any]` for now).
+- No kwargs-style filter API.
+- No `t""` template-string predicate API.
+- No code generation or distributed `.pyi` stubs for user models.
+- No changes to the metaclass, Pydantic schema generation, or the Rust FFI bridge.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/ferro/query/nodes.py` — current `FieldProxy` (non-generic) and `QueryNode`. Operator overloads currently take `Any` and return `QueryNode`. `like` accepts `str`; `in_` accepts `list/tuple/set` with a runtime `TypeError` guard.
+- `src/ferro/query/builder.py` — `Query.where` and the `Relation.where` override. Both currently take a single `QueryNode`. Existing `Generic[T]` usage in `Query[T]` and `Relation[T]` is the precedent for generics in this layer.
+- `src/ferro/query/__init__.py` — public re-export surface for `Query`, `Relation`, `QueryNode`, `FieldProxy`. New symbols add here.
+- `src/ferro/metaclass.py` — installs `FieldProxy` instances on the model class at class-creation. Out of scope for changes; the plan relies on this behavior remaining stable.
+
+### Institutional Learnings
+
+- No prior `docs/solutions/` entry on query typing or descriptor patterns. This work is the first time the query layer takes a static-typing stance.
+
+### External References
+
+- Origin requirements doc: `docs/brainstorms/2026-05-08-typed-query-predicates-requirements.md`.
+- Pyright `self: FieldProxy[str]` method-binding pattern (used by SQLAlchemy 2.x for str-only column methods).
+
+---
+
+## Key Technical Decisions
+
+- **`FieldProxy.like` is typed via `self: FieldProxy[str]`** so non-string columns cannot statically reach `.like(...)`. Cheap to add, prevents a real footgun, mirrors SQLAlchemy 2.x.
+- **`in_` is typed `list[T] | tuple[T, ...] | set[T]`** to align the static contract with the existing runtime guard.
+- **`col()` lives in `src/ferro/query/nodes.py`** alongside `FieldProxy` rather than in a new `dsl.py`. Co-locating the proxy primitives keeps the layer's surface easy to scan.
+- **`QueryProxy` lives in `src/ferro/query/nodes.py`** for the same reason. Public re-export from `src/ferro/query/__init__.py`.
+- **`Query.where` runtime dispatch order**: `isinstance(node, QueryNode)` → existing path; `elif callable(node)` → lambda path; else `TypeError`. `QueryNode` is not callable today, so this order is unambiguous.
+- **`Relation.where` overrides for parity**: `Relation` already overrides `where` to refine the return type to `Relation[T]`; the new overload set must be repeated on the override or relationship queries lose lambda support.
+- **`QueryProxy` proxy attributes are typed `FieldProxy[Any]`** until a future PR can teach Pyright/`ty` to map per-field types from a model class. Matches the origin scope decision.
+- **Tests for the new behavior live in a new file `tests/test_query_typing.py`** rather than extending `tests/test_query*`. Keeps the typing-focused suite easy to find, leaves existing tests as the unmodified regression bar for R7.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where does `col()` live?** → `src/ferro/query/nodes.py`, exported from `ferro.query`.
+- **Does `Relation.where` need the new overload?** → Yes (parity); origin didn't call it out explicitly but it's required to avoid a typing dead end.
+- **How precise should `like` typing be?** → Use `self: FieldProxy[str]`. Worth the one-line cost.
+
+### Deferred to Implementation
+
+- **Exact `TypeVar` bounds for `FieldProxy[T]`**: probably unbounded, but if `FieldProxy.__hash__` / equality semantics force a bound it's discovered when the type-checker actually runs.
+- **Whether to add a `__class_getitem__` runtime no-op on `FieldProxy`**: needed only if user code subscripts at runtime; will surface from a test.
+
+---
+
+## Implementation Units
+
+- U1. **Make `FieldProxy` generic and tighten operator types**
+
+**Goal:** `FieldProxy` becomes `FieldProxy[T]`; operator overloads accept `T | FieldProxy[T]` and return `QueryNode`; `like` is gated to `FieldProxy[str]`; `in_` and `__lshift__` are typed with `T`.
+
+**Requirements:** R1, R2.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `src/ferro/query/nodes.py`
+- Test: `tests/test_query_typing.py` (created in U4; U1's regression coverage is the existing suite)
+
+**Approach:**
+- Add `TField = TypeVar("TField")`.
+- Change `class FieldProxy:` to `class FieldProxy(Generic[TField]):`.
+- Update operator signatures to `__eq__(self, other: TField | "FieldProxy[TField]")`, etc.
+- Type `in_` as `Iterable[TField]` at runtime (existing guard stays); narrow signature to `list[TField] | tuple[TField, ...] | set[TField]` for the static contract.
+- Type `like` with `self: "FieldProxy[str]"`.
+- Keep `__hash__` behavior unchanged (Python autogenerates `None` when `__eq__` is overridden; existing code already lives with this — do not introduce a new hash contract).
+
+**Patterns to follow:**
+- `Query[T]` / `Relation[T]` in `src/ferro/query/builder.py` for `Generic[TVar]` usage.
+
+**Test scenarios:**
+- Happy path: existing operator-path tests under `tests/` still pass with no edits (regression for R7).
+- Happy path: at runtime `FieldProxy[bool]("active") == True` returns a `QueryNode` (subscription is type-time only, no runtime change).
+- Edge case: `like` still works at runtime when called on any `FieldProxy` (subclass typing constraint must not affect runtime dispatch).
+- Edge case: `in_` raises `TypeError` for non-iterable input — unchanged from current behavior.
+
+**Verification:**
+- `uv run pytest -q` passes with no source-test edits.
+- `uv run pyright src/ferro/query/nodes.py` (or repo-wide) does not regress on existing files.
+
+---
+
+- U2. **Add `col()` runtime-identity wrapper**
+
+**Goal:** Introduce `col(value: TField) -> FieldProxy[TField]` that returns its argument unchanged at runtime when it is a `FieldProxy`, raises `TypeError` otherwise, and statically normalizes a model class attribute back to `FieldProxy[T]`.
+
+**Requirements:** R3, R8.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `src/ferro/query/nodes.py`
+- Modify: `src/ferro/query/__init__.py`
+- Test: `tests/test_query_typing.py` (created in U4)
+
+**Approach:**
+- Add `col` as a module-level function near `FieldProxy` so they read together.
+- Runtime: `if not isinstance(value, FieldProxy): raise TypeError(f"col() expects a model column reference, got {type(value).__name__}")`; `return value`.
+- Static: `def col(value: TField) -> FieldProxy[TField]: ...` plus `# type: ignore[return-value]` on the return because the static narrowing is intentional.
+- Add `col` to `__all__` and the import block in `src/ferro/query/__init__.py`. Do not re-export from `ferro.__init__` unless a follow-up touches that surface — this PR keeps the export at `ferro.query`.
+
+**Patterns to follow:**
+- The existing module-level `_serialize_query_value` helper in `nodes.py` for placement style.
+
+**Test scenarios:**
+- Happy path: `col(User.archived)` returns the same `FieldProxy` instance (identity check via `is`).
+- Happy path: `col(User.archived) == False` builds a `QueryNode` with `column="archived"`, `operator="=="`, `value=False`.
+- Error path: `col(False)` raises `TypeError` whose message contains `"bool"`.
+- Error path: `col("archived")` raises `TypeError` whose message contains `"str"`.
+- Integration: `await User.where(col(User.archived) == False).all()` round-trips against an in-memory SQLite fixture and returns the matching rows (proves the existing pipeline accepts the produced `QueryNode` unchanged).
+
+**Verification:**
+- `uv run pytest tests/test_query_typing.py -q` is green.
+- A static-only assertion (e.g., `assert_type(col(User.archived), FieldProxy[bool])` under `if TYPE_CHECKING:`) compiles cleanly under Pyright; not run as a test, just present as a documented snippet in `tests/test_query_typing.py` so type-checkers exercise it.
+
+---
+
+- U3. **Add lambda predicate API to `Query.where` and `Relation.where`**
+
+**Goal:** Extend `where` to accept `Callable[[QueryProxy[TModel]], QueryNode]`. Construct a per-call `QueryProxy` whose attribute access yields a `FieldProxy(name)`; pass it to the predicate; append the returned `QueryNode`. Repeat on `Relation.where` for parity.
+
+**Requirements:** R4, R5, R6, R8.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `src/ferro/query/nodes.py` (add `QueryProxy`)
+- Modify: `src/ferro/query/builder.py` (overloads + dispatch on `Query.where` and `Relation.where`)
+- Modify: `src/ferro/query/__init__.py` (export `QueryProxy`, `Predicate`)
+- Test: `tests/test_query_typing.py` (created in U4)
+
+**Approach:**
+- Add `class QueryProxy(Generic[TModel])` in `nodes.py`. Runtime body: `__slots__ = ()`, `__getattr__(self, name) -> FieldProxy[Any]: return FieldProxy(name)`. Static: type the return as `FieldProxy[Any]` for now (origin scope decision).
+- Add `Predicate = Callable[[QueryProxy[TModel]], QueryNode]` (TypeAlias) in `nodes.py`.
+- In `builder.py`, add `@overload` declarations on `Query.where`: one for `QueryNode`, one for `Predicate[T]`. Implementation signature stays untyped (`node`) to keep both paths legal.
+- Implementation body:
+  ```
+  if isinstance(node, QueryNode):
+      self.where_clause.append(node)
+  elif callable(node):
+      proxy = QueryProxy()  # type: ignore[var-annotated]
+      result = node(proxy)
+      if not isinstance(result, QueryNode):
+          raise TypeError("predicate callable must return QueryNode, got ...")
+      self.where_clause.append(result)
+  else:
+      raise TypeError("where() expected QueryNode or predicate callable, got ...")
+  return self
+  ```
+  *(Directional pseudo-code; do not copy verbatim. The implementer may inline or refactor.)*
+- Mirror the overloads on `Relation.where`. The runtime body can delegate to `super().where(node)` once the parent dispatches both shapes.
+
+**Technical design:** *(directional)*
+
+```
+where(QueryNode)   ─► append(node)
+where(Predicate)   ─► proxy = QueryProxy()
+                     node  = predicate(proxy)
+                     append(node)
+where(other)       ─► TypeError
+```
+
+**Patterns to follow:**
+- Existing `Relation.where` override at `src/ferro/query/builder.py` for the subclass-narrowing pattern.
+- The `if TYPE_CHECKING: @overload` block on `Relation.all` / `Relation.first` for how this codebase mixes static overloads with a single runtime body.
+
+**Test scenarios:**
+- Happy path: `Query(User).where(lambda t: t.id == 1)` appends a single `QueryNode` whose `column == "id"`.
+- Happy path: `Query(User).where(lambda t: (t.role == "admin") & (t.active == True))` appends one compound `QueryNode` whose `is_compound is True`.
+- Happy path: `await User.where(lambda t: t.archived == False).all()` round-trips against in-memory SQLite and returns the expected rows.
+- Edge case: `Query(User).where(QueryNode(...))` (the existing path) still works unchanged — regression for R7.
+- Error path: `Query(User).where(lambda t: True)` raises `TypeError` because the predicate did not return a `QueryNode`.
+- Error path: `Query(User).where(123)` raises `TypeError` whose message names the offending type.
+- Integration: `Relation.where(lambda t: t.published == True)` on a `BackRef` relationship round-trips end-to-end (covers R5 parity, not just typing).
+- Integration: a single chain — `User.where(User.id == 1).where(col(User.archived) == False).where(lambda t: t.role == "admin")` — produces three accumulated `QueryNode`s and executes against SQLite. *(Covers AE5; this exact assertion is the U4 integration test.)*
+
+**Verification:**
+- `uv run pytest tests/test_query_typing.py -q` is green.
+- `uv run pytest tests/test_relations*.py -q` (or whatever name covers `Relation`) still green.
+
+---
+
+- U4. **Integration tests for combined predicate styles**
+
+**Goal:** Single end-to-end test file exercising operator + `col()` + lambda styles together against a real SQLite fixture, plus the static-typing snippets that make Pyright actually exercise the new generic types.
+
+**Requirements:** R7, R10.
+
+**Dependencies:** U1, U2, U3.
+
+**Files:**
+- Create: `tests/test_query_typing.py`
+
+**Approach:**
+- Reuse the existing `db_url` / `db_engine` fixtures used by `tests/test_crud.py` so the file is consistent with the rest of the suite.
+- Define a small `Model` per the project's TDD convention (`.cursorrules` §4 step 1).
+- Group tests by predicate style (`class TestColWrapper`, `class TestLambdaPredicates`, `class TestCombinedStyles`) so future readers can find the right block fast.
+- Include a `if TYPE_CHECKING:` block at the top of the file with `assert_type(...)` calls for `col()` and a lambda-built `QueryNode` to anchor the static contract. These are not runtime assertions — they exist for Pyright/`ty` to consume.
+
+**Patterns to follow:**
+- `tests/test_crud.py` for fixture wiring and async test style.
+- `.cursorrules` §4 (TDD workflow) — the integration tests are the primary acceptance gate.
+
+**Test scenarios:**
+- *Covers AE1.* `col(User.archived) == False` builds a usable `QueryNode` and Pyright sees `FieldProxy[bool]`.
+- *Covers AE2.* The unchanged `User.email == "a@b.com"` operator path still executes and returns the row (regression).
+- *Covers AE3.* Compound lambda `lambda t: (t.role == "admin") & (t.active == True)` filters correctly.
+- *Covers AE4.* `col(False)` raises `TypeError`.
+- *Covers AE5.* Mixed chain `User.where(User.id == 1).where(col(User.archived) == False).where(lambda t: t.role == "admin")` returns the expected rows from a seeded SQLite fixture.
+- Integration: `Relation.where(lambda t: ...)` via a `BackRef` relationship returns the expected child rows.
+
+**Verification:**
+- `uv run maturin develop && uv run pytest tests/test_query_typing.py -q` is green.
+- The full suite (`uv run pytest -q`) is green.
+
+---
+
+- U5. **Concept doc for query predicate styles**
+
+**Goal:** Single canonical page documenting the three predicate styles, when to reach for each, and showing them combined on one chain.
+
+**Requirements:** R9.
+
+**Dependencies:** U1, U2, U3 (so the doc reflects the shipping API).
+
+**Files:**
+- Create: `docs/concepts/query-typing.md`
+
+**Approach:**
+- Title: "Typed query predicates".
+- Sections: *Why this exists* (one paragraph on the static-typing gap) → *The three styles* (operator, `col()`, lambda — each with a runnable example) → *When to use which* (lambda for new code; `col()` when a single attribute trips your type checker; operator when the existing form already type-checks) → *Combining styles* (the AE5 chain) → *What this does not change* (no metaclass, Pydantic, or Rust changes; existing code keeps working).
+- Cross-link from `docs/concepts/index.md` if one exists; otherwise leave as a standalone page.
+
+**Patterns to follow:**
+- `docs/concepts/identity-map.md` for tone, depth, and structure.
+
+**Test scenarios:**
+- Test expectation: none — documentation only. Verified manually by reading the rendered page.
+
+**Verification:**
+- Renders correctly under the site's markdown renderer (no broken code blocks, no orphan links).
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Pyright/`ty` resolve `where` overloads ambiguously and reject existing operator-path code. | U4's `if TYPE_CHECKING:` `assert_type` block plus the unchanged-existing-tests regression bar from R7 catch this in CI before merge. If the overload order matters, the dispatch keeps `QueryNode` first. |
+| `QueryProxy.__getattr__` returning `FieldProxy[Any]` makes the lambda style appear less "typed" than `col()`. | Documented as a known scope boundary in the concept doc; future PR can add `dataclass_transform` if there's appetite. Not a correctness risk. |
+| Subscripting `FieldProxy[bool]` at runtime fails because `FieldProxy` doesn't support `__class_getitem__`. | `Generic[T]` provides `__class_getitem__` automatically — no extra work needed. Verified by U1's runtime test. |
+| `Relation.where` parity is forgotten in U3, leaving relationship queries with no lambda support. | Explicit unit dependency (U3 names `Relation.where` in **Files** and **Test scenarios**); U4's relation-lambda integration test fails loudly if dropped. |
+
+---
+
+## Documentation / Operational Notes
+
+- New concept doc lands as part of this PR (U5). No existing docs need rewrites — `docs/concepts/identity-map.md` and friends do not reference the typing posture.
+- No release-notes / migration guide needed; the change is purely additive and backward compatible.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-08-typed-query-predicates-requirements.md](docs/brainstorms/2026-05-08-typed-query-predicates-requirements.md)
+- Related code: `src/ferro/query/nodes.py`, `src/ferro/query/builder.py`, `src/ferro/query/__init__.py`, `src/ferro/metaclass.py`
+- Related work: prior identity-map config PR on the same branch family.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ plugins:
           - concepts/architecture.md
           - concepts/identity-map.md
           - concepts/type-safety.md
+          - concepts/query-typing.md
           - concepts/performance.md
         API Reference:
           - api/*.md
@@ -149,6 +150,7 @@ nav:
       - Architecture: concepts/architecture.md
       - Identity Map: concepts/identity-map.md
       - Type Safety: concepts/type-safety.md
+      - Typed Query Predicates: concepts/query-typing.md
       - Performance: concepts/performance.md
 
   - API Reference:

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -4,13 +4,18 @@ import json
 from contextlib import asynccontextmanager
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
     Any,
     ClassVar,
     Self,
     get_args,
     get_origin,
     get_type_hints,
+    overload,
 )
+
+if TYPE_CHECKING:
+    from .query import Predicate
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -418,19 +423,34 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         _set_instance_origin(self, identity_using)
         self.__class__._fix_types(self)
 
+    @overload
     @classmethod
-    def where(cls, node: QueryNode) -> Query[Self]:
-        """Start a fluent query with an initial condition
+    def where(cls, node: QueryNode) -> Query[Self]: ...
+
+    @overload
+    @classmethod
+    def where(cls, node: "Predicate[Self]") -> Query[Self]: ...
+
+    @classmethod
+    def where(cls, node: "QueryNode | Predicate[Self]") -> Query[Self]:
+        """Start a fluent query with an initial condition.
+
+        Accepts either a :class:`QueryNode` (built with operator syntax or
+        with :func:`ferro.query.col`) or a lambda predicate of shape
+        ``Callable[[QueryProxy[Self]], QueryNode]``. See
+        ``docs/concepts/query-typing.md`` for the trade-offs between the
+        three styles.
 
         Args:
-            node: Query predicate node to apply first.
+            node: A ``QueryNode`` or a predicate callable.
 
         Returns:
             A query object scoped to this model class.
 
         Examples:
-            >>> query = User.where(User.id == 1)
-            >>> isinstance(query, Query)
+            >>> q1 = User.where(User.id == 1)
+            >>> q2 = User.where(lambda t: t.archived == False)  # noqa: E712
+            >>> isinstance(q1, Query) and isinstance(q2, Query)
             True
         """
         return Query(cls).where(node)

--- a/src/ferro/query/__init__.py
+++ b/src/ferro/query/__init__.py
@@ -1,6 +1,14 @@
 """Expose query-building primitives used by Ferro models"""
 
 from .builder import Query, Relation
-from .nodes import FieldProxy, QueryNode
+from .nodes import FieldProxy, Predicate, QueryNode, QueryProxy, col
 
-__all__ = ["Query", "Relation", "QueryNode", "FieldProxy"]
+__all__ = [
+    "FieldProxy",
+    "Predicate",
+    "Query",
+    "QueryNode",
+    "QueryProxy",
+    "Relation",
+    "col",
+]

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -12,10 +12,10 @@ from .._core import (
     remove_m2m_links,
     update_filtered,
 )
-from .nodes import _serialize_query_value
+from .nodes import QueryNode, QueryProxy, _serialize_query_value
 
 if TYPE_CHECKING:
-    from .nodes import QueryNode
+    from .nodes import Predicate
 
 T = TypeVar("T")
 E = TypeVar("E")
@@ -24,6 +24,29 @@ E = TypeVar("E")
 def _query_def_to_json(query_def: dict[str, Any]) -> str:
     """Serialize query definitions while preserving typed values in live Query state."""
     return json.dumps(_serialize_query_value(query_def))
+
+
+def _resolve_where_node(node: Any) -> QueryNode:
+    """Normalize a ``where`` argument into a ``QueryNode``.
+
+    Accepts an existing ``QueryNode`` directly (the operator and ``col()``
+    paths) or a predicate callable that takes a ``QueryProxy`` and returns
+    a ``QueryNode`` (the lambda path).
+    """
+    if isinstance(node, QueryNode):
+        return node
+    if callable(node):
+        result = node(QueryProxy())
+        if not isinstance(result, QueryNode):
+            raise TypeError(
+                "where() predicate callable must return QueryNode, "
+                f"got {type(result).__name__}"
+            )
+        return result
+    raise TypeError(
+        "where() expected QueryNode or predicate callable, "
+        f"got {type(node).__name__}"
+    )
 
 
 class Query(Generic[T]):
@@ -78,21 +101,39 @@ class Query(Generic[T]):
         }
         return self
 
-    def where(self, node: "QueryNode") -> "Query[T]":
-        """Add a filter condition to the query
+    @overload
+    def where(self, node: "QueryNode") -> "Query[T]": ...
+
+    @overload
+    def where(self, node: "Predicate[T]") -> "Query[T]": ...
+
+    def where(self, node: "QueryNode | Predicate[T]") -> "Query[T]":
+        """Add a filter condition to the query.
+
+        Accepts either a :class:`QueryNode` (built directly with operator
+        syntax or with :func:`ferro.query.col`) or a lambda predicate of
+        shape ``Callable[[QueryProxy[T]], QueryNode]``. The lambda receives
+        a fresh :class:`QueryProxy` whose attributes return
+        :class:`FieldProxy` instances, so ``lambda t: t.archived == False``
+        builds a comparison without static-typing friction.
 
         Args:
-            node: A QueryNode representing the condition (e.g., User.id == 1).
+            node: A ``QueryNode`` or a predicate callable.
 
         Returns:
             The current Query instance for chaining.
 
+        Raises:
+            TypeError: If ``node`` is neither a ``QueryNode`` nor a callable,
+                or if the callable does not return a ``QueryNode``.
+
         Examples:
-            >>> query = User.where(User.id == 1)
-            >>> isinstance(query, Query)
+            >>> q1 = User.where(User.id == 1)
+            >>> q2 = User.where(lambda t: t.archived == False)  # noqa: E712
+            >>> isinstance(q1, Query) and isinstance(q2, Query)
             True
         """
-        self.where_clause.append(node)
+        self.where_clause.append(_resolve_where_node(node))
         return self
 
     def order_by(self, field: Any, direction: str = "asc") -> "Query[T]":
@@ -422,8 +463,14 @@ class Relation(Query[T]):
         super()._m2m(join_table, source_col, target_col, source_id)
         return self
 
-    def where(self, node: "QueryNode") -> "Relation[T]":
-        super().where(node)
+    @overload
+    def where(self, node: "QueryNode") -> "Relation[T]": ...
+
+    @overload
+    def where(self, node: "Predicate[T]") -> "Relation[T]": ...
+
+    def where(self, node: "QueryNode | Predicate[T]") -> "Relation[T]":
+        super().where(node)  # type: ignore[arg-type]
         return self
 
     def order_by(self, field: Any, direction: str = "asc") -> "Relation[T]":

--- a/src/ferro/query/nodes.py
+++ b/src/ferro/query/nodes.py
@@ -1,8 +1,12 @@
 """Define query AST nodes and field proxies for fluent filtering"""
 
 import uuid
+from collections.abc import Callable
 from decimal import Decimal
-from typing import Any
+from typing import Any, Generic, TypeAlias, TypeVar
+
+TField = TypeVar("TField")
+TModel = TypeVar("TModel")
 
 
 class QueryNode:
@@ -134,8 +138,12 @@ def _serialize_query_value(value: Any) -> Any:
     return value
 
 
-class FieldProxy:
+class FieldProxy(Generic[TField]):
     """Capture field comparisons and build query nodes
+
+    ``FieldProxy`` is generic over the column's Python type so that operator
+    overloads carry that type into static analysis. At runtime the type
+    parameter is erased and the proxy works identically for any column type.
 
     Attributes:
         column: Database column name associated with the model field.
@@ -154,31 +162,37 @@ class FieldProxy:
         """
         self.column = column
 
-    def __eq__(self, other: Any) -> QueryNode:
+    def __eq__(  # type: ignore[override]  # ty: ignore[invalid-method-override]
+        self, other: "TField | FieldProxy[TField]"
+    ) -> QueryNode:
         """Build an equality comparison node"""
         return QueryNode(self.column, "==", other)
 
-    def __ne__(self, other: Any) -> QueryNode:
+    def __ne__(  # type: ignore[override]  # ty: ignore[invalid-method-override]
+        self, other: "TField | FieldProxy[TField]"
+    ) -> QueryNode:
         """Build an inequality comparison node"""
         return QueryNode(self.column, "!=", other)
 
-    def __lt__(self, other: Any) -> QueryNode:
+    def __lt__(self, other: "TField | FieldProxy[TField]") -> QueryNode:
         """Build a less-than comparison node"""
         return QueryNode(self.column, "<", other)
 
-    def __le__(self, other: Any) -> QueryNode:
+    def __le__(self, other: "TField | FieldProxy[TField]") -> QueryNode:
         """Build a less-than-or-equal comparison node"""
         return QueryNode(self.column, "<=", other)
 
-    def __gt__(self, other: Any) -> QueryNode:
+    def __gt__(self, other: "TField | FieldProxy[TField]") -> QueryNode:
         """Build a greater-than comparison node"""
         return QueryNode(self.column, ">", other)
 
-    def __ge__(self, other: Any) -> QueryNode:
+    def __ge__(self, other: "TField | FieldProxy[TField]") -> QueryNode:
         """Build a greater-than-or-equal comparison node"""
         return QueryNode(self.column, ">=", other)
 
-    def in_(self, other: Any) -> QueryNode:
+    def in_(
+        self, other: "list[TField] | tuple[TField, ...] | set[TField]"
+    ) -> QueryNode:
         """Build an ``IN`` comparison node from an iterable
 
         Args:
@@ -201,8 +215,12 @@ class FieldProxy:
             )
         return QueryNode(self.column, "IN", list(other))
 
-    def like(self, pattern: str) -> QueryNode:
+    def like(self: "FieldProxy[str]", pattern: str) -> QueryNode:
         """Build a ``LIKE`` comparison node
+
+        The ``self: FieldProxy[str]`` annotation prevents type checkers from
+        accepting ``.like(...)`` on non-string columns; at runtime the method
+        is available on any ``FieldProxy``.
 
         Args:
             pattern: SQL LIKE pattern such as ``"%@example.com"``.
@@ -217,7 +235,9 @@ class FieldProxy:
         """
         return QueryNode(self.column, "LIKE", pattern)
 
-    def __lshift__(self, other: Any) -> QueryNode:
+    def __lshift__(
+        self, other: "list[TField] | tuple[TField, ...] | set[TField]"
+    ) -> QueryNode:
         """Use ``<<`` as shorthand syntax for ``IN`` comparisons
 
         Args:
@@ -236,3 +256,71 @@ class FieldProxy:
     def __repr__(self):
         """Return a developer-friendly representation of the field proxy"""
         return f"FieldProxy(column={self.column!r})"
+
+
+def col(value: TField) -> "FieldProxy[TField]":
+    """Treat a model class attribute as a typed query column.
+
+    At runtime Ferro's metaclass replaces ``Model.field`` with a
+    :class:`FieldProxy`, so ``Model.field`` is already a ``FieldProxy`` when
+    accessed on the class. Static type checkers, however, see the field's
+    Pydantic-annotated type (``bool``, ``int``, ...). That makes expressions
+    like ``Model.archived == False`` resolve to ``bool`` statically, even
+    though the runtime value is a ``QueryNode``.
+
+    ``col()`` is runtime-identity for ``FieldProxy`` inputs and statically
+    narrows the return type to ``FieldProxy[T]``, so ``col(Model.archived) ==
+    False`` type-checks as ``QueryNode``. Use it when a single attribute
+    trips your type checker; for new code, prefer the lambda predicate API
+    on :meth:`Query.where`.
+
+    Args:
+        value: A model class attribute (already a ``FieldProxy`` at runtime).
+
+    Returns:
+        The same object, statically typed as ``FieldProxy[T]``.
+
+    Raises:
+        TypeError: If ``value`` is not a ``FieldProxy``. This guards against
+            calling ``col()`` on a literal (e.g., ``col(False)``), which is
+            almost certainly a bug.
+
+    Examples:
+        >>> rows = await User.where(col(User.archived) == False).all()  # noqa: E712
+    """
+    if not isinstance(value, FieldProxy):
+        raise TypeError(
+            f"col() expects a model column reference (FieldProxy), got {type(value).__name__}"
+        )
+    return value  # type: ignore[return-value]
+
+
+class QueryProxy(Generic[TModel]):
+    """Lazy attribute proxy used by lambda predicates passed to ``Query.where``.
+
+    A fresh ``QueryProxy`` is constructed each time a lambda predicate is
+    evaluated. Any attribute access returns a :class:`FieldProxy` for the
+    accessed name, so ``lambda t: t.archived == False`` builds a
+    :class:`QueryNode` without ever asking the model class what type
+    ``archived`` is. The ``TModel`` type parameter exists so user-supplied
+    lambdas can narrow ``t`` to a specific model in static analysis; the
+    proxy itself ignores the parameter at runtime.
+
+    The proxy attribute return type is intentionally ``FieldProxy[Any]`` for
+    now — wiring per-field types through a lambda parameter requires
+    ``@dataclass_transform`` plumbing on the metaclass, which is outside this
+    feature's scope.
+
+    Examples:
+        >>> rows = await User.where(lambda t: t.archived == False).all()  # noqa: E712
+    """
+
+    __slots__ = ()
+
+    def __getattr__(self, name: str) -> "FieldProxy[Any]":
+        """Return a fresh ``FieldProxy`` for any attribute name."""
+        return FieldProxy(name)
+
+
+Predicate: TypeAlias = Callable[[QueryProxy[TModel]], QueryNode]
+"""Type alias for lambda predicates accepted by :meth:`Query.where`."""

--- a/tests/test_query_typing.py
+++ b/tests/test_query_typing.py
@@ -1,0 +1,285 @@
+"""Integration tests for typed query predicates.
+
+Covers the three predicate styles accepted by ``Query.where`` and
+``Relation.where`` — operator (``Model.field == value``), ``col()`` wrapper,
+and lambda predicate (``lambda t: t.field == value``) — plus the AE5
+mixed-style chain from the requirements doc.
+"""
+
+from typing import TYPE_CHECKING, Annotated
+
+import pytest
+
+import ferro
+from ferro import (
+    BackRef,
+    FerroField,
+    ForeignKey,
+    Model,
+    Relation,
+    clear_registry,
+    reset_engine,
+)
+from ferro.query import FieldProxy, Predicate, Query, QueryNode, QueryProxy, col
+
+pytestmark = pytest.mark.sqlite_only
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    """Reset model registry and engine between typing tests."""
+    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    reset_engine()
+    clear_registry()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# col() runtime behavior
+# ---------------------------------------------------------------------------
+
+
+class TestColWrapper:
+    def test_col_returns_same_field_proxy(self):
+        """col(FieldProxy) is identity at runtime."""
+
+        class ColUser(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            archived: bool = False
+
+        assert col(ColUser.archived) is ColUser.archived  # type: ignore[arg-type]
+
+    def test_col_eq_builds_query_node(self):
+        """col(field) == value builds a QueryNode with the right shape."""
+
+        class ColUser(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            archived: bool = False
+
+        node = col(ColUser.archived) == False  # noqa: E712
+        assert isinstance(node, QueryNode)
+        assert node.column == "archived"
+        assert node.operator == "=="
+        assert node.value is False
+
+    def test_col_rejects_literal_bool(self):
+        """col(False) raises TypeError naming the bad type."""
+        with pytest.raises(TypeError, match="bool"):
+            col(False)  # type: ignore[arg-type]
+
+    def test_col_rejects_string(self):
+        """col('archived') raises TypeError naming the bad type."""
+        with pytest.raises(TypeError, match="str"):
+            col("archived")  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_col_query_round_trips(self, db_url):
+        """col() predicates execute against the real backend."""
+
+        class ColUser(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            username: str
+            archived: bool = False
+
+        await ferro.connect(db_url, auto_migrate=True)
+        await ColUser(id=1, username="alice", archived=False).save()
+        await ColUser(id=2, username="bob", archived=True).save()
+
+        active = await ColUser.where(col(ColUser.archived) == False).all()  # noqa: E712
+        assert {u.username for u in active} == {"alice"}
+
+
+# ---------------------------------------------------------------------------
+# Lambda predicate runtime behavior
+# ---------------------------------------------------------------------------
+
+
+class TestLambdaPredicates:
+    def test_lambda_simple_appends_one_node(self):
+        """A lambda predicate appends exactly one QueryNode."""
+
+        class LamUser(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            archived: bool = False
+
+        q: Query[LamUser] = Query(LamUser).where(lambda t: t.id == 1)
+        assert len(q.where_clause) == 1
+        assert q.where_clause[0].column == "id"
+        assert q.where_clause[0].operator == "=="
+        assert q.where_clause[0].value == 1
+
+    def test_lambda_compound_predicate(self):
+        """Compound predicates produce one is_compound=True node."""
+
+        class LamUser(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            role: str = "user"
+            active: bool = True
+
+        q = Query(LamUser).where(
+            lambda t: (t.role == "admin") & (t.active == True)  # noqa: E712
+        )
+        assert len(q.where_clause) == 1
+        assert q.where_clause[0].is_compound is True
+        assert q.where_clause[0].operator == "AND"
+
+    def test_lambda_returning_non_query_node_raises(self):
+        """Predicates that don't return a QueryNode are rejected."""
+
+        class LamUser(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+
+        with pytest.raises(TypeError, match="must return QueryNode"):
+            Query(LamUser).where(lambda t: True)  # type: ignore[arg-type, return-value]  # ty: ignore[no-matching-overload]
+
+    def test_where_rejects_non_node_non_callable(self):
+        """A bare value (not a QueryNode and not callable) is rejected."""
+
+        class LamUser(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+
+        with pytest.raises(TypeError, match="QueryNode or predicate callable"):
+            Query(LamUser).where(123)  # type: ignore[arg-type]  # ty: ignore[no-matching-overload]
+
+    def test_query_proxy_attribute_returns_field_proxy(self):
+        """QueryProxy attribute access yields a FieldProxy at runtime."""
+        proxy = QueryProxy()
+        f = proxy.archived
+        assert isinstance(f, FieldProxy)
+        assert f.column == "archived"
+
+    @pytest.mark.asyncio
+    async def test_lambda_query_round_trips(self, db_url):
+        """Lambda predicates execute against the real backend."""
+
+        class LamUser(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            username: str
+            archived: bool = False
+
+        await ferro.connect(db_url, auto_migrate=True)
+        await LamUser(id=1, username="alice", archived=False).save()
+        await LamUser(id=2, username="bob", archived=True).save()
+
+        active = await LamUser.where(lambda t: t.archived == False).all()  # noqa: E712
+        assert {u.username for u in active} == {"alice"}
+
+
+# ---------------------------------------------------------------------------
+# Operator path (regression — must keep working unchanged)
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorPathUnchanged:
+    @pytest.mark.asyncio
+    async def test_operator_eq_still_works(self, db_url):
+        """The original ``Model.field == value`` form is unchanged at runtime.
+
+        This is the exact static-typing scenario that motivates ``col()`` and
+        the lambda predicate API — ``OpUser.email == "a@b.com"`` resolves to
+        ``bool`` statically, so ``ty`` rejects it. The runtime path is
+        unaffected; the ``ty: ignore`` documents the trade-off rather than
+        hiding it.
+        """
+
+        class OpUser(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            email: str
+
+        await ferro.connect(db_url, auto_migrate=True)
+        await OpUser(id=1, email="a@b.com").save()
+        await OpUser(id=2, email="c@d.com").save()
+
+        rows = await OpUser.where(OpUser.email == "a@b.com").all()  # ty: ignore[no-matching-overload]
+        assert len(rows) == 1
+        assert rows[0].email == "a@b.com"
+
+
+# ---------------------------------------------------------------------------
+# AE5 — mixed chain
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedStyles:
+    @pytest.mark.asyncio
+    async def test_mixed_chain_executes(self, db_url):
+        """Operator + col() + lambda chained together filter correctly."""
+
+        class MixUser(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            role: str = "user"
+            archived: bool = False
+
+        await ferro.connect(db_url, auto_migrate=True)
+        await MixUser(id=1, role="admin", archived=False).save()
+        await MixUser(id=1_001, role="admin", archived=True).save()
+        await MixUser(id=2, role="user", archived=False).save()
+
+        rows = await (
+            MixUser.where(MixUser.id == 1)  # ty: ignore[no-matching-overload]
+            .where(col(MixUser.archived) == False)  # noqa: E712
+            .where(lambda t: t.role == "admin")
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].id == 1
+
+
+# ---------------------------------------------------------------------------
+# Relation.where parity
+# ---------------------------------------------------------------------------
+
+
+class TestRelationLambda:
+    @pytest.mark.asyncio
+    async def test_relation_where_accepts_lambda(self, db_url):
+        """Relation.where accepts a lambda predicate (parity with Query)."""
+
+        class RelAuthor(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            name: str
+            posts: Relation[list["RelPost"]] = BackRef()
+
+        class RelPost(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            title: str
+            published: bool = False
+            author: Annotated[RelAuthor, ForeignKey(related_name="posts")]
+
+        await ferro.connect(db_url, auto_migrate=True)
+        author = RelAuthor(id=1, name="taylor")
+        await author.save()
+        await RelPost(id=10, title="draft", published=False, author=author).save()
+        await RelPost(id=11, title="live", published=True, author=author).save()
+
+        published = await author.posts.where(lambda t: t.published == True).all()  # noqa: E712
+        assert {p.title for p in published} == {"live"}
+
+
+# ---------------------------------------------------------------------------
+# Static-typing snippets for Pyright/`ty` to consume.
+#
+# These never execute at runtime; they exist so type checkers exercise the
+# new generic types and confirm they resolve as advertised.
+# ---------------------------------------------------------------------------
+
+if TYPE_CHECKING:
+    from typing import assert_type
+
+    class _StaticUser(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        archived: bool = False
+        email: str = ""
+
+    # col() narrows back to FieldProxy[T]
+    assert_type(col(_StaticUser.archived), FieldProxy[bool])
+
+    # col(field) == value resolves to QueryNode (not bool)
+    assert_type(col(_StaticUser.archived) == False, QueryNode)  # noqa: E712
+
+    # Lambda predicates type-check as Predicate[Model]
+    _pred: Predicate[_StaticUser] = lambda t: t.archived == False  # noqa: E712
+    assert_type(_pred(QueryProxy[_StaticUser]()), QueryNode)

--- a/uv.lock
+++ b/uv.lock
@@ -537,7 +537,7 @@ wheels = [
 
 [[package]]
 name = "ferro-orm"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Pyright and `ty` previously rejected `Model.archived == False` (and any other boolean / value-type comparison on a model attribute) because static checkers see your Pydantic annotations, not the `FieldProxy` instances Ferro's metaclass installs at class-creation time. Real queries had to be sprinkled with `# ty: ignore` to compile.

This PR makes the existing operator path generic, adds two opt-in predicate styles (`col()` and lambda), and threads the new overloads through the entire `where` surface — `Query.where`, `Relation.where`, and `Model.where`. The runtime path is unchanged; existing operator-style code keeps working without edits.

## The three styles

```python
# Operator (unchanged at runtime; still trips type checkers on bool columns)
await User.where(User.id == 1).all()

# col() — runtime identity, statically narrows back to FieldProxy[T]
await User.where(col(User.archived) == False).all()

# Lambda — receives a QueryProxy whose attributes return FieldProxy
await User.where(lambda t: t.archived == False).all()
```

All three styles are interchangeable and can be mixed on a single chain. They funnel through one dispatcher (`_resolve_where_node`) so adding a third path is a one-place change in the future.

## Key decisions

- **`FieldProxy` is now generic (`FieldProxy[TField]`).** Operator overloads accept `TField | FieldProxy[TField]` so column-vs-column comparisons type-check, and `.like(...)` is gated to `FieldProxy[str]` via the `self:`-binding pattern so non-string columns can't statically reach it.
- **`col()` is runtime-identity, not a wrapper.** It returns its argument unchanged for `FieldProxy` inputs, raises `TypeError` for anything else, and exists purely so type checkers see `FieldProxy[T]` instead of `bool` / `int` / `str`. No allocation, no indirection.
- **The lambda proxy is `FieldProxy[Any]` for now.** Wiring per-field types through the lambda parameter requires `@dataclass_transform` plumbing on the metaclass, which is deliberately out of scope. If `t.archived` ever resolves too loosely for your taste, drop back to `col(...)` for that one comparison — that's the role it plays.
- **Lambda overload added to `Model.where` too.** `Query.where` and `Relation.where` are the layered API; `Model.where` is the user-facing entry point. Surfacing the lambda only on the lower layers would have left `User.where(lambda t: ...)` failing to type-check, which defeats the goal.
- **No metaclass, Pydantic, or Rust FFI changes.** Everything is in `src/ferro/query/` and the one `Model.where` overload in `models.py`.

## Test plan

`tests/test_query_typing.py` is new and covers:

- `col()` runtime identity, `TypeError` paths, and DB round-trip
- Lambda runtime: simple, compound (`(t.role == "admin") & (t.active == True)`), invalid-return-value, non-callable rejection
- Operator path unchanged (regression — runtime works, with a documented `ty: ignore` showing the exact scenario that motivates the new styles)
- AE5 mixed chain: `User.where(...).where(col(...) == ...).where(lambda t: ...)` against SQLite
- `Relation.where` accepting a lambda predicate via a `BackRef` collection
- A `TYPE_CHECKING` block with `assert_type` so static checkers exercise the generic types

The full pre-existing suite is untouched and still green: 346 passed, 26 skipped, 1 xfailed.

`uvx ty check src/ferro/query/ tests/test_query_typing.py` is clean except for one pre-existing `_fix_types` diagnostic unrelated to this PR (verified by stashing the diff).

## Documentation

- `docs/concepts/query-typing.md` — user-facing concept page covering the three styles, when to use each, combined usage, and the explicit scope boundaries.
- `docs/brainstorms/2026-05-08-typed-query-predicates-requirements.md` — origin requirements doc (R-IDs and AE-IDs traced through the plan).
- `docs/plans/2026-05-08-001-feat-typed-query-predicates-plan.md` — implementation plan with U1–U5 unit decomposition.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor](https://img.shields.io/badge/Opus_4.7-D97757?logo=claude&logoColor=white)