### PR TITLE
fix(sqlite): hydrate SQL NULL as None instead of int 0

### DIFF
--- a/docs/solutions/issues/sqlite-null-hydrates-as-int-zero.md
+++ b/docs/solutions/issues/sqlite-null-hydrates-as-int-zero.md
@@ -1,0 +1,92 @@
+---
+title: SQLite NULL columns hydrate as int 0 after reconnect (Alembic DATETIME)
+type: issue
+tags: [gotcha, sqlite, hydration, bridge, rust, sqlalchemy, alembic, datetime, ffi]
+related_files:
+  - src/backend.rs
+  - src/operations.rs
+  - tests/test_sqlite_null_hydration.py
+related_issues: [56]
+related_prs: [57]
+captured: 2026-05-18
+---
+
+## Problem
+
+Optional fields that are `NULL` in a SQLite database (for example
+`archived_at: datetime | None`) sometimes appear as Python `int(0)` after a
+**new connection** — `ferro.reset_engine()`, a new CLI process, or any fetch
+that does not hit the identity map. The same row shows `None` on the connection
+that just inserted it, and `sqlite3` confirms the column is `NULL`.
+
+## Takeaway
+
+`materialize_engine_row` in `src/backend.rs` must call `ValueRef::is_null()` on
+the raw column **before** typed `try_get` decoding. On SQLite, `try_get::<i64>`
+on SQL `NULL` often succeeds with `0` for INTEGER/NUMERIC-affinity columns
+(including Alembic `DateTime()` → `DATETIME`). That is not limited to datetimes:
+`INTEGER`, `REAL`, `TEXT`, and `NUMERIC` NULLs were all misread as `0` before
+the fix.
+
+## Explanation
+
+**Causal chain**
+
+1. Alembic/SQLAlchemy creates nullable `archived_at` as `DATETIME` (numeric
+   affinity on SQLite).
+2. Insert leaves the column SQL `NULL`.
+3. Fetch uses `materialize_engine_row`, which tried `try_get::<i64>` first.
+4. sqlx returns `Ok(0)` for NULL on those affinities instead of an error.
+5. `engine_value_to_rust_value` maps `EngineValue::I64` to `RustValue::BigInt`
+   (date-time `format` only applies to `EngineValue::String`).
+6. Python sees `0`, so `archived_at is None` filters fail.
+
+**Why same-session `create()` looked fine**
+
+The identity map returns the in-memory instance from insert without re-reading
+the row from SQLite.
+
+**Fix (PR #57)**
+
+```rust
+let value = match row.try_get_raw(ordinal) {
+    Ok(raw) if raw.is_null() => EngineValue::Null,
+    Ok(_) | Err(_) => decode_non_null_engine_value(row, ordinal),
+};
+```
+
+Legitimate integer `0` is unchanged: SQL `NULL` is detected via `is_null()`, not
+by treating `0` as missing.
+
+**Tests**
+
+- Rust: `engine_handle_fetches_sqlite_null_columns_as_null_not_zero`,
+  `engine_handle_fetches_sqlite_non_null_zero_integer` in `src/backend.rs`.
+- Python: `tests/test_sqlite_null_hydration.py` (Alembic `create_all` + reconnect).
+  Requires `aiosqlite` and `greenlet` in `ci-test` / `dev` so CI does not skip.
+
+## How to recognize
+
+- Bug only on **SQLite**, often with **Alembic-created** schema (`auto_migrate=False`).
+- `field is None` checks fail while raw SQL shows `NULL`.
+- Same process right after `create()` is correct; new connection or `reset_engine()` is wrong.
+- Affected value is `0` (int), not a datetime string or `AttributeError`.
+- Raw `ferro.raw.fetch_all` shows the same `0` — failure is in row materialization, not Pydantic coercion alone.
+
+## Prevention
+
+- Any change to `materialize_engine_row` or `EngineValue` decoding: add a Rust
+  test that inserts `DEFAULT VALUES` into a nullable column and asserts
+  `EngineValue::Null`.
+- Do not “fix” optional datetimes in Python by treating `0` as unset — fix NULL
+  detection at the bridge.
+- Related but distinct: typed **bind** NULLs for Postgres are documented in
+  `docs/solutions/patterns/typed-null-binds.md` (`NullKind`, insert/update paths).
+  Fetch-time NULL handling is separate; both layers need correct typing.
+
+## Related
+
+- GitHub issue: https://github.com/syn54x/ferro-orm/issues/56
+- PR: https://github.com/syn54x/ferro-orm/pull/57
+- `docs/solutions/patterns/typed-null-binds.md` — NULL on the **write** path
+- `docs/solutions/issues/pydantic-slots-missing-after-ferro-hydration.md` — other hydration footguns

--- a/docs/solutions/patterns/shadow-fk-columns.md
+++ b/docs/solutions/patterns/shadow-fk-columns.md
@@ -5,7 +5,9 @@ tags: [convention, schema, relationships, pydantic]
 related_files:
   - src/ferro/base.py
   - src/ferro/schema_metadata.py
-  - src/ferro/relations.py
+  - src/ferro/metaclass.py
+  - src/ferro/_shadow_fk_types.py
+  - src/ferro/relations/__init__.py
 related_issues: [32]
 related_prs: [36]
 captured: 2026-04-28

--- a/docs/solutions/patterns/typed-null-binds.md
+++ b/docs/solutions/patterns/typed-null-binds.md
@@ -1,13 +1,14 @@
 ---
 title: Typed-null binds at the SQLx boundary
 type: pattern
-tags: [convention, invariant, bridge, ffi, rust, sea-query, sqlx, postgres]
+tags: [convention, invariant, bridge, ffi, rust, sea-query, sqlx, postgres, sqlite]
 related_files:
   - src/backend.rs
   - src/operations.rs
   - src/query.rs
   - tests/test_typed_null_binds.py
-related_issues: [38, 40]
+  - tests/test_sqlite_null_hydration.py
+related_issues: [38, 40, 56]
 related_prs: []
 captured: 2026-04-29
 ---
@@ -92,6 +93,27 @@ are deferred (see plan §3 Scope Boundaries).
 \*\* Temporal types continue to use `cast_as` until issue [#40] picks a
    datetime crate (`chrono` vs `time`).
 
+## Fetch-time row materialization (read path)
+
+Typed binds fix **outbound** NULL parameters. A separate failure mode is
+**inbound** row decoding in `materialize_engine_row` (`src/backend.rs`).
+
+On SQLite, `row.try_get::<i64>` on SQL `NULL` often returns `Ok(0)` for
+INTEGER/NUMERIC-affinity columns (including Alembic `DateTime()` → `DATETIME`)
+if you decode before checking nullness. Ferro then hydrates Python `int(0)`
+instead of `None` — see issue [#56].
+
+**Rule:** call `row.try_get_raw(ordinal)` and test `raw.is_null()` before any
+typed `try_get`. Non-null integer `0` is unchanged; only SQL `NULL` is affected.
+
+| Layer            | Function / path              | NULL concern                          |
+|------------------|------------------------------|---------------------------------------|
+| Bind (write)     | `bind_engine_value`          | `NullKind` → `Option::<T>::None`      |
+| Fetch (read)     | `materialize_engine_row`     | `is_null()` before `decode_non_null_*`|
+
+Rust regression: `engine_handle_fetches_sqlite_null_columns_as_null_not_zero`.
+Integration: `tests/test_sqlite_null_hydration.py` (Alembic schema + reconnect).
+
 ## Raw-SQL boundary (explicit exception)
 
 The raw-SQL bind path (`src/operations.rs::python_to_engine_bind_value`,
@@ -120,6 +142,9 @@ Ferro itself.
   to `Null(Untyped)` -- non-null data goes out as a text-typed null, and
   Postgres reports `expression is of type text` rather than the actual
   type mismatch. Always pair `Some` and `None` arms when adding a type.
+- On SQLite, optional fields are `NULL` in the DB but Python sees `int(0)`
+  after reconnect — check `materialize_engine_row`, not bind typing alone
+  ([#56]).
 
 ## Recipe: adding a new schema-driven emitter
 
@@ -164,8 +189,11 @@ Ferro itself.
 - AGENTS.md I-3: no `unwrap()` across the FFI boundary.
 - `docs/plans/2026-04-29-001-typed-null-binds-plan.md`: the implementation
   plan with the unit-by-unit breakdown.
+- `docs/solutions/issues/sqlite-null-hydrates-as-int-zero.md`: fetch-time
+  NULL → `int(0)` on SQLite (issue [#56]).
 - Issue [#38]: the original bug report.
 - Issue [#40]: temporal typed binds (deferred follow-up).
 
 [#38]: https://github.com/syn54x/ferro-orm/issues/38
 [#40]: https://github.com/syn54x/ferro-orm/issues/40
+[#56]: https://github.com/syn54x/ferro-orm/issues/56

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ ci-test = [
     "pytest-cov>=7.0.0",
     "pytest-examples>=0.0.18",
     "pytest-postgresql>=8.0.0",
+    "aiosqlite>=0.22.1",
+    "greenlet>=3.3.1",
 ]
 docs = [
     "mkdocs-material>=9.5.0",
@@ -74,6 +76,8 @@ dev = [
     "psycopg[binary]>=3.3.3",
     "pytest-postgresql>=8.0.0",
     "pytest-xdist>=3.8.0",
+    "aiosqlite>=0.22.1",
+    "greenlet>=3.3.1",
 ]
 
 [tool.pytest.ini_options]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,6 +1,6 @@
 use sqlx::ColumnIndex;
 use sqlx::pool::PoolConnection;
-use sqlx::{Column, PgPool, Postgres, Row, Sqlite, SqlitePool};
+use sqlx::{Column, PgPool, Postgres, Row, Sqlite, SqlitePool, ValueRef};
 use std::fmt;
 use std::sync::Arc;
 
@@ -360,26 +360,47 @@ where
         .iter()
         .map(|column| {
             let name = column.name().to_string();
-            let value = if let Ok(value) = row.try_get::<i64, _>(column.ordinal()) {
-                EngineValue::I64(value)
-            } else if let Ok(value) = row.try_get::<i32, _>(column.ordinal()) {
-                EngineValue::I64(i64::from(value))
-            } else if let Ok(value) = row.try_get::<f64, _>(column.ordinal()) {
-                EngineValue::F64(value)
-            } else if let Ok(value) = row.try_get::<String, _>(column.ordinal()) {
-                EngineValue::String(value)
-            } else if let Ok(value) = row.try_get::<Vec<u8>, _>(column.ordinal()) {
-                EngineValue::Bytes(value)
-            } else if let Ok(value) = row.try_get::<bool, _>(column.ordinal()) {
-                EngineValue::Bool(value)
-            } else {
-                EngineValue::Null
+            let ordinal = column.ordinal();
+            // SQLite (and some drivers) let `try_get::<i64>` succeed with 0 on SQL
+            // NULL when the column has INTEGER/NUMERIC affinity (including Alembic
+            // `DATETIME`). Always consult the raw value before typed decode.
+            let value = match row.try_get_raw(ordinal) {
+                Ok(raw) if raw.is_null() => EngineValue::Null,
+                Ok(_) | Err(_) => decode_non_null_engine_value(row, ordinal),
             };
             (name, value)
         })
         .collect();
 
     EngineRow { values }
+}
+
+fn decode_non_null_engine_value<R>(row: &R, ordinal: usize) -> EngineValue
+where
+    R: Row,
+    for<'r> i32: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> i64: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> f64: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> Vec<u8>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> String: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> bool: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    usize: ColumnIndex<R>,
+{
+    if let Ok(value) = row.try_get::<i64, _>(ordinal) {
+        EngineValue::I64(value)
+    } else if let Ok(value) = row.try_get::<i32, _>(ordinal) {
+        EngineValue::I64(i64::from(value))
+    } else if let Ok(value) = row.try_get::<f64, _>(ordinal) {
+        EngineValue::F64(value)
+    } else if let Ok(value) = row.try_get::<String, _>(ordinal) {
+        EngineValue::String(value)
+    } else if let Ok(value) = row.try_get::<Vec<u8>, _>(ordinal) {
+        EngineValue::Bytes(value)
+    } else if let Ok(value) = row.try_get::<bool, _>(ordinal) {
+        EngineValue::Bool(value)
+    } else {
+        EngineValue::Null
+    }
 }
 
 fn bind_engine_value<'q, DB>(
@@ -566,6 +587,64 @@ mod tests {
             .unwrap();
 
         assert_eq!(inserted, 1);
+    }
+
+    #[tokio::test]
+    async fn engine_handle_fetches_sqlite_null_columns_as_null_not_zero() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        let engine = EngineHandle::new_sqlite(pool);
+
+        for (table, ddl) in [
+            ("null_int", "CREATE TABLE null_int (v INTEGER)"),
+            ("null_real", "CREATE TABLE null_real (v REAL)"),
+            ("null_text", "CREATE TABLE null_text (v TEXT)"),
+            ("null_datetime", "CREATE TABLE null_datetime (v DATETIME)"),
+        ] {
+            engine.execute_sql(ddl).await.unwrap();
+            engine
+                .execute_sql(&format!("INSERT INTO {table} DEFAULT VALUES"))
+                .await
+                .unwrap();
+            let rows = engine
+                .fetch_all_sql_with_binds(&format!("SELECT v FROM {table}"), &[])
+                .await
+                .unwrap();
+            assert_eq!(
+                rows[0].values[0].1,
+                EngineValue::Null,
+                "SQL NULL in {table} must not decode as integer zero"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn engine_handle_fetches_sqlite_non_null_zero_integer() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        let engine = EngineHandle::new_sqlite(pool);
+
+        engine
+            .execute_sql("CREATE TABLE zero_int (v INTEGER NOT NULL)")
+            .await
+            .unwrap();
+        engine
+            .execute_sql("INSERT INTO zero_int (v) VALUES (0)")
+            .await
+            .unwrap();
+
+        let rows = engine
+            .fetch_all_sql_with_binds("SELECT v FROM zero_int", &[])
+            .await
+            .unwrap();
+
+        assert_eq!(rows[0].values[0].1, EngineValue::I64(0));
     }
 
     #[tokio::test]

--- a/tests/test_sqlite_null_hydration.py
+++ b/tests/test_sqlite_null_hydration.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 import ferro
 import pytest
-from ferro import Field, Model
+from ferro import Field, Model, clear_registry, reset_engine
 from ferro.migrations.alembic import get_metadata
 from sqlalchemy import pool
 from sqlalchemy.engine.url import URL
@@ -20,10 +20,16 @@ pytest.importorskip("aiosqlite")
 pytest.importorskip("greenlet")
 
 
-class Client(Model):
-    id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True, db_type="text")
-    name: str
-    archived_at: datetime | None = None
+@pytest.fixture(autouse=True)
+def cleanup():
+    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+    reset_engine()
+    clear_registry()
+    yield
 
 
 def _sqlite_url(path: Path) -> str:
@@ -36,6 +42,12 @@ def _sqlite_url(path: Path) -> str:
 @pytest.mark.asyncio
 async def test_sqlite_null_optional_datetime_hydrates_as_none_after_reconnect() -> None:
     """Alembic-created DATETIME NULL must not become int(0) on a fresh connection."""
+
+    class Client(Model):
+        id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True, db_type="text")
+        name: str
+        archived_at: datetime | None = None
+
     with tempfile.TemporaryDirectory() as tmp:
         db_path = Path(tmp) / "app.db"
         uri = f"sqlite:{db_path}?mode=rwc"

--- a/tests/test_sqlite_null_hydration.py
+++ b/tests/test_sqlite_null_hydration.py
@@ -1,0 +1,59 @@
+"""SQLite NULL columns must hydrate as None, not int 0 (issue #56)."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from uuid import uuid4
+
+import ferro
+import pytest
+from ferro import Field, Model
+from ferro.migrations.alembic import get_metadata
+from sqlalchemy import pool
+from sqlalchemy.engine.url import URL
+from sqlalchemy.ext.asyncio import create_async_engine
+
+pytest.importorskip("aiosqlite")
+pytest.importorskip("greenlet")
+
+
+class Client(Model):
+    id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True, db_type="text")
+    name: str
+    archived_at: datetime | None = None
+
+
+def _sqlite_url(path: Path) -> str:
+    return URL.create(
+        drivername="sqlite+aiosqlite",
+        database=str(path.resolve()),
+    ).render_as_string(hide_password=False)
+
+
+@pytest.mark.asyncio
+async def test_sqlite_null_optional_datetime_hydrates_as_none_after_reconnect() -> None:
+    """Alembic-created DATETIME NULL must not become int(0) on a fresh connection."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "app.db"
+        uri = f"sqlite:{db_path}?mode=rwc"
+
+        engine = create_async_engine(_sqlite_url(db_path), poolclass=pool.NullPool)
+        async with engine.begin() as conn:
+            await conn.run_sync(lambda sync_conn: get_metadata().create_all(sync_conn))
+        await engine.dispose()
+
+        await ferro.connect(uri, auto_migrate=False)
+        await Client.create(name="Acme")
+        ferro.reset_engine()
+
+        await ferro.connect(uri, auto_migrate=False)
+        row = (await Client.all())[0]
+
+        with sqlite3.connect(db_path) as conn:
+            raw = conn.execute("SELECT archived_at FROM client").fetchone()[0]
+
+    assert raw is None
+    assert row.archived_at is None

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.1"
 source = { registry = "https://pypi.org/simple" }
@@ -537,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "ferro-orm"
-version = "0.8.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -554,6 +563,8 @@ ci-lint = [
     { name = "prek" },
 ]
 ci-test = [
+    { name = "aiosqlite" },
+    { name = "greenlet" },
     { name = "maturin" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
@@ -563,8 +574,10 @@ ci-test = [
     { name = "pytest-postgresql" },
 ]
 dev = [
+    { name = "aiosqlite" },
     { name = "alembic" },
     { name = "commitizen" },
+    { name = "greenlet" },
     { name = "jupyter" },
     { name = "maturin" },
     { name = "mkdocs-llmstxt" },
@@ -605,6 +618,8 @@ provides-extras = ["alembic"]
 [package.metadata.requires-dev]
 ci-lint = [{ name = "prek", specifier = ">=0.2.25" }]
 ci-test = [
+    { name = "aiosqlite", specifier = ">=0.22.1" },
+    { name = "greenlet", specifier = ">=3.3.1" },
     { name = "maturin", specifier = ">=1.11.5" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
     { name = "pytest", specifier = ">=8.0.0" },
@@ -614,8 +629,10 @@ ci-test = [
     { name = "pytest-postgresql", specifier = ">=8.0.0" },
 ]
 dev = [
+    { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "alembic", specifier = ">=1.18.1" },
     { name = "commitizen", specifier = ">=3.13.0" },
+    { name = "greenlet", specifier = ">=3.3.1" },
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "maturin", specifier = ">=1.11.5" },
     { name = "mkdocs-llmstxt", specifier = ">=0.3.0" },
@@ -699,6 +716,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/ab/d26750f2b7242c2b90ea2ad71de70cfcd73a948a49513188a0fc0d6fc15a/greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3", size = 275205, upload-time = "2026-01-23T15:30:24.556Z" },
     { url = "https://files.pythonhosted.org/packages/10/d3/be7d19e8fad7c5a78eeefb2d896a08cd4643e1e90c605c4be3b46264998f/greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac", size = 599284, upload-time = "2026-01-23T16:00:58.584Z" },
     { url = "https://files.pythonhosted.org/packages/ae/21/fe703aaa056fdb0f17e5afd4b5c80195bbdab701208918938bd15b00d39b/greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd", size = 610274, upload-time = "2026-01-23T16:05:29.312Z" },
+    { url = "https://files.pythonhosted.org/packages/06/00/95df0b6a935103c0452dad2203f5be8377e551b8466a29650c4c5a5af6cc/greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e", size = 624375, upload-time = "2026-01-23T16:15:55.915Z" },
     { url = "https://files.pythonhosted.org/packages/cb/86/5c6ab23bb3c28c21ed6bebad006515cfe08b04613eb105ca0041fecca852/greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3", size = 612904, upload-time = "2026-01-23T15:32:52.317Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f3/7949994264e22639e40718c2daf6f6df5169bf48fb038c008a489ec53a50/greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951", size = 1567316, upload-time = "2026-01-23T16:04:23.316Z" },
     { url = "https://files.pythonhosted.org/packages/8d/6e/d73c94d13b6465e9f7cd6231c68abde838bb22408596c05d9059830b7872/greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2", size = 1636549, upload-time = "2026-01-23T15:33:48.643Z" },
@@ -707,6 +725,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/fb/011c7c717213182caf78084a9bea51c8590b0afda98001f69d9f853a495b/greenlet-3.3.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bd59acd8529b372775cd0fcbc5f420ae20681c5b045ce25bd453ed8455ab99b5", size = 275737, upload-time = "2026-01-23T15:32:16.889Z" },
     { url = "https://files.pythonhosted.org/packages/41/2e/a3a417d620363fdbb08a48b1dd582956a46a61bf8fd27ee8164f9dfe87c2/greenlet-3.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b31c05dd84ef6871dd47120386aed35323c944d86c3d91a17c4b8d23df62f15b", size = 646422, upload-time = "2026-01-23T16:01:00.354Z" },
     { url = "https://files.pythonhosted.org/packages/b4/09/c6c4a0db47defafd2d6bab8ddfe47ad19963b4e30f5bed84d75328059f8c/greenlet-3.3.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:02925a0bfffc41e542c70aa14c7eda3593e4d7e274bfcccca1827e6c0875902e", size = 658219, upload-time = "2026-01-23T16:05:30.956Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/89/b95f2ddcc5f3c2bc09c8ee8d77be312df7f9e7175703ab780f2014a0e781/greenlet-3.3.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3e0f3878ca3a3ff63ab4ea478585942b53df66ddde327b59ecb191b19dbbd62d", size = 671455, upload-time = "2026-01-23T16:15:57.232Z" },
     { url = "https://files.pythonhosted.org/packages/80/38/9d42d60dffb04b45f03dbab9430898352dba277758640751dc5cc316c521/greenlet-3.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34a729e2e4e4ffe9ae2408d5ecaf12f944853f40ad724929b7585bca808a9d6f", size = 660237, upload-time = "2026-01-23T15:32:53.967Z" },
     { url = "https://files.pythonhosted.org/packages/96/61/373c30b7197f9e756e4c81ae90a8d55dc3598c17673f91f4d31c3c689c3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:aec9ab04e82918e623415947921dea15851b152b822661cce3f8e4393c3df683", size = 1615261, upload-time = "2026-01-23T16:04:25.066Z" },
     { url = "https://files.pythonhosted.org/packages/fd/d3/ca534310343f5945316f9451e953dcd89b36fe7a19de652a1dc5a0eeef3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:71c767cf281a80d02b6c1bdc41c9468e1f5a494fb11bc8688c360524e273d7b1", size = 1683719, upload-time = "2026-01-23T15:33:50.61Z" },
@@ -715,6 +734,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/24/cbbec49bacdcc9ec652a81d3efef7b59f326697e7edf6ed775a5e08e54c2/greenlet-3.3.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3e63252943c921b90abb035ebe9de832c436401d9c45f262d80e2d06cc659242", size = 282706, upload-time = "2026-01-23T15:33:05.525Z" },
     { url = "https://files.pythonhosted.org/packages/86/2e/4f2b9323c144c4fe8842a4e0d92121465485c3c2c5b9e9b30a52e80f523f/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76e39058e68eb125de10c92524573924e827927df5d3891fbc97bd55764a8774", size = 651209, upload-time = "2026-01-23T16:01:01.517Z" },
     { url = "https://files.pythonhosted.org/packages/d9/87/50ca60e515f5bb55a2fbc5f0c9b5b156de7d2fc51a0a69abc9d23914a237/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9f9d5e7a9310b7a2f416dd13d2e3fd8b42d803968ea580b7c0f322ccb389b97", size = 654300, upload-time = "2026-01-23T16:05:32.199Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/25/c51a63f3f463171e09cb586eb64db0861eb06667ab01a7968371a24c4f3b/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b9721549a95db96689458a1e0ae32412ca18776ed004463df3a9299c1b257ab", size = 662574, upload-time = "2026-01-23T16:15:58.364Z" },
     { url = "https://files.pythonhosted.org/packages/1d/94/74310866dfa2b73dd08659a3d18762f83985ad3281901ba0ee9a815194fb/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92497c78adf3ac703b57f1e3813c2d874f27f71a178f9ea5887855da413cd6d2", size = 653842, upload-time = "2026-01-23T15:32:55.671Z" },
     { url = "https://files.pythonhosted.org/packages/97/43/8bf0ffa3d498eeee4c58c212a3905dd6146c01c8dc0b0a046481ca29b18c/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53", size = 1614917, upload-time = "2026-01-23T16:04:26.276Z" },
     { url = "https://files.pythonhosted.org/packages/89/90/a3be7a5f378fc6e84abe4dcfb2ba32b07786861172e502388b4c90000d1b/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249", size = 1676092, upload-time = "2026-01-23T15:33:52.176Z" },


### PR DESCRIPTION
## Description

Fixes #56: on SQLite, optional `datetime | None` columns that are `NULL` in the database were hydrated as Python `int(0)` after a new connection (e.g. `ferro.reset_engine()`, new CLI process), breaking filters like `archived_at is None`. Same-session reads after `create()` were fine because the identity map returned the in-memory instance.

Root cause: `materialize_engine_row` tried `try_get::<i64>` before checking SQL `NULL`. SQLite/sqlx often coerces `NULL` in INTEGER/NUMERIC-affinity columns (including Alembic `DATETIME`) to `0`.

## Changes

- Check `ValueRef::is_null()` before typed row decode in `materialize_engine_row` (`src/backend.rs`)
- Add Rust regression tests for NULL columns and non-null integer `0`
- Add integration test reproducing Alembic-created schema + reconnect (`tests/test_sqlite_null_hydration.py`)
- Add `aiosqlite` and `greenlet` to `dev` and `ci-test` so the integration test runs in CI (not skipped)

## Bridge and Schema Impact

- [ ] No Rust/Python bridge changes
- [ ] Python model/schema changed
- [x] Rust core or SQL generation changed
- [ ] `src/ferro/_core.pyi` updated (if needed)
- [x] Integration test added first for new behavior

## Migration / Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes included (details below)

## Documentation and Changelog

- [x] No docs update needed
- [ ] Docs updated (README/docs/inline docs)
- [ ] Changelog entry needed

## Related Issues

Closes #56

Made with [Cursor](https://cursor.com)