### PR TITLE
docs: compound SQLite hydration learnings (#56, #58)

### DIFF
--- a/docs/solutions/issues/sqlite-integer-decimal-hydrates-as-none.md
+++ b/docs/solutions/issues/sqlite-integer-decimal-hydrates-as-none.md
@@ -1,0 +1,87 @@
+---
+title: SQLite INTEGER-backed NUMERIC Decimal hydrates as None after reconnect
+type: issue
+tags: [gotcha, sqlite, hydration, bridge, rust, sqlalchemy, alembic, decimal, ffi]
+related_files:
+  - src/operations.rs
+  - src/backend.rs
+  - tests/test_sqlite_alembic_reconnect_hydration.py
+related_issues: [58]
+related_prs: [59]
+captured: 2026-05-18
+---
+
+## Problem
+
+Non-null `Decimal` fields can appear as Python `None` after `ferro.reset_engine()`,
+a new CLI process, or any fetch on a fresh connection — even though `sqlite3`
+shows the value in the row (often with `typeof(column) = 'integer'` for whole
+numbers). Same-session `create()` still returns `Decimal('3')`.
+
+## Takeaway
+
+`engine_value_to_rust_value` in `src/operations.rs` must map `EngineValue::I64`
+to `RustValue::Decimal` for decimal schema columns, not only `F64` and `String`.
+SQLite stores whole-number NUMERIC values with INTEGER affinity; fractional
+values use REAL and already worked.
+
+## Explanation
+
+**Causal chain**
+
+1. Alembic/SQLAlchemy maps Python `Decimal` to `sa.Numeric()`; SQLite often
+   stores `Decimal(3)` with INTEGER affinity and `Decimal("1.5")` with REAL.
+2. `materialize_engine_row` (`src/backend.rs`) correctly decodes non-null
+   INTEGER as `EngineValue::I64(3)` (after the #56 NULL-first fix).
+3. `engine_value_to_rust_value` handled decimal columns only for `F64` and
+   `String`; `I64` hit `_ => RustValue::None`.
+4. Python hydration saw `None`, so `e.hours` formatting crashed downstream.
+
+**Why same-session `create()` looked fine**
+
+The identity map returns the in-memory instance from insert without re-reading
+the row from SQLite (same masking pattern as issue #56).
+
+**Fix (PR #59)**
+
+```rust
+if is_decimal {
+    return match value {
+        EngineValue::I64(v) => RustValue::Decimal(v.to_string()),
+        EngineValue::F64(v) => RustValue::Decimal(v.to_string()),
+        EngineValue::String(v) => RustValue::Decimal(v),
+        _ => RustValue::None,
+    };
+}
+```
+
+**Tests**
+
+- Rust: `engine_value_to_rust_value_tests` in `src/operations.rs` (decimal I64/F64/String).
+- Python: `tests/test_sqlite_alembic_reconnect_hydration.py` — Alembic
+  `create_all`, `auto_migrate=False`, `reset_engine()`, then fetch. Covers
+  integer/real/zero/null decimal, plus datetime/date/bool/uuid/json regressions.
+- Requires `aiosqlite` and `greenlet` in `ci-test` / `dev` so CI does not skip.
+
+## How to recognize
+
+- Bug only on **SQLite**, often with **Alembic-created** schema (`auto_migrate=False`).
+- Raw SQL shows a non-null numeric value; Python attribute is `None` after reconnect.
+- `typeof(column)` is `integer` for whole numbers; fractional values often work.
+- Same process right after `create()` is correct; `reset_engine()` or new process fails.
+- Distinct from #56: there the DB value is SQL `NULL` but Python saw `int(0)`.
+
+## Prevention
+
+- Any change to `engine_value_to_rust_value` decimal branch: add Rust tests for
+  every `EngineValue` variant SQLite can emit (`I64`, `F64`, `String`, `Null`).
+- Add Alembic + reconnect integration tests for typed columns — not only
+  `auto_migrate=True` same-session CRUD (see `tests/test_sqlite_alembic_reconnect_hydration.py`).
+- Do not paper over `None` in Python for `Decimal` fields; fix bridge mapping.
+
+## Related
+
+- GitHub issue: https://github.com/syn54x/ferro-orm/issues/58
+- PR: https://github.com/syn54x/ferro-orm/pull/59
+- `docs/solutions/issues/sqlite-null-hydrates-as-int-zero.md` — sibling SQLite fetch bug (#56)
+- `docs/solutions/patterns/typed-null-binds.md` — NULL on the write path (distinct layer)

--- a/docs/solutions/issues/sqlite-null-hydrates-as-int-zero.md
+++ b/docs/solutions/issues/sqlite-null-hydrates-as-int-zero.md
@@ -89,4 +89,5 @@ by treating `0` as missing.
 - GitHub issue: https://github.com/syn54x/ferro-orm/issues/56
 - PR: https://github.com/syn54x/ferro-orm/pull/57
 - `docs/solutions/patterns/typed-null-binds.md` — NULL on the **write** path
+- `docs/solutions/issues/sqlite-integer-decimal-hydrates-as-none.md` — non-null INTEGER Decimal → `None` (#58)
 - `docs/solutions/issues/pydantic-slots-missing-after-ferro-hydration.md` — other hydration footguns

--- a/docs/solutions/patterns/sqlite-alembic-reconnect-hydration-tests.md
+++ b/docs/solutions/patterns/sqlite-alembic-reconnect-hydration-tests.md
@@ -1,0 +1,58 @@
+---
+title: Alembic SQLite schema + reconnect integration tests for hydration
+type: pattern
+tags: [convention, sqlite, hydration, pytest, alembic, sqlalchemy, testing]
+related_files:
+  - tests/test_sqlite_alembic_reconnect_hydration.py
+  - src/backend.rs
+  - src/operations.rs
+related_issues: [56, 58]
+related_prs: [57, 59]
+captured: 2026-05-18
+---
+
+## Problem
+
+Most Ferro integration tests use `auto_migrate=True` (Rust DDL) and often read
+rows on the same connection that inserted them. SQLite hydration bugs tied to
+Alembic column affinities and the identity map only appear after a fresh
+`ferro.connect()`.
+
+## Takeaway
+
+For SQLite fetch/hydration regressions, add tests that use Alembic
+`get_metadata().create_all`, `auto_migrate=False`, `reset_engine()`, then
+re-fetch — see `tests/test_sqlite_alembic_reconnect_hydration.py`.
+
+## Explanation
+
+**Failure mode the harness catches**
+
+1. Schema from SQLAlchemy/Alembic (`sa.Numeric()`, `sa.DateTime()`, etc.) —
+   SQLite storage affinity differs from Rust `auto_migrate` DDL.
+2. Same-session `create()` returns the identity-map instance (no DB re-read).
+3. `reset_engine()` + reconnect forces `materialize_engine_row` and
+   `engine_value_to_rust_value` to run on stored affinities.
+
+**Harness shape**
+
+- `pytest.mark.sqlite_only` so CI always runs SQLite even when Postgres is off.
+- `aiosqlite` + `greenlet` in `ci-test` / `dev` — `importorskip` otherwise hides regressions.
+- Assert both Python attribute and raw `sqlite3` `typeof()` when affinity matters.
+
+**When to extend the matrix**
+
+Add a case when a typed column has a narrow `match` in `engine_value_to_rust_value`
+or only handles `EngineValue::String` while SQLite may emit `I64` / `F64` / `Bytes`.
+
+## When to apply
+
+- New bridge mapping in `engine_value_to_rust_value` or `materialize_engine_row`.
+- User reports "works after insert, wrong after new process / CLI command".
+- Bug repro mentions Alembic, `auto_migrate=False`, or `typeof(...) = 'integer'`.
+
+## Related
+
+- `docs/solutions/issues/sqlite-null-hydrates-as-int-zero.md` (#56)
+- `docs/solutions/issues/sqlite-integer-decimal-hydrates-as-none.md` (#58)
+- `docs/solutions/patterns/typed-null-binds.md` — write-path NULL typing (separate layer)

--- a/docs/solutions/patterns/typed-null-binds.md
+++ b/docs/solutions/patterns/typed-null-binds.md
@@ -114,6 +114,13 @@ typed `try_get`. Non-null integer `0` is unchanged; only SQL `NULL` is affected.
 Rust regression: `engine_handle_fetches_sqlite_null_columns_as_null_not_zero`.
 Integration: `tests/test_sqlite_alembic_reconnect_hydration.py` (Alembic schema + reconnect).
 
+After `materialize_engine_row` produces `EngineValue::I64`, schema-aware mapping in
+`engine_value_to_rust_value` (`src/operations.rs`) must accept that variant for
+each logical type. Decimal columns previously matched only `F64` and `String`,
+so INTEGER-backed NUMERIC values hydrated as Python `None` after reconnect —
+see issue [#58] and `docs/solutions/issues/sqlite-integer-decimal-hydrates-as-none.md`.
+
+
 ## Raw-SQL boundary (explicit exception)
 
 The raw-SQL bind path (`src/operations.rs::python_to_engine_bind_value`,
@@ -145,6 +152,9 @@ Ferro itself.
 - On SQLite, optional fields are `NULL` in the DB but Python sees `int(0)`
   after reconnect — check `materialize_engine_row`, not bind typing alone
   ([#56]).
+- On SQLite, non-null `Decimal` fields are `NULL` in Python after reconnect while
+  raw SQL shows a value — check the decimal branch in `engine_value_to_rust_value`
+  ([#58]).
 
 ## Recipe: adding a new schema-driven emitter
 
@@ -191,9 +201,12 @@ Ferro itself.
   plan with the unit-by-unit breakdown.
 - `docs/solutions/issues/sqlite-null-hydrates-as-int-zero.md`: fetch-time
   NULL → `int(0)` on SQLite (issue [#56]).
+- `docs/solutions/issues/sqlite-integer-decimal-hydrates-as-none.md`: INTEGER
+  NUMERIC Decimal → `None` on reconnect (issue [#58]).
 - Issue [#38]: the original bug report.
 - Issue [#40]: temporal typed binds (deferred follow-up).
 
 [#38]: https://github.com/syn54x/ferro-orm/issues/38
 [#40]: https://github.com/syn54x/ferro-orm/issues/40
 [#56]: https://github.com/syn54x/ferro-orm/issues/56
+[#58]: https://github.com/syn54x/ferro-orm/issues/58


### PR DESCRIPTION
## Description

Captures institutional memory from SQLite Alembic reconnect hydration work (issues #56 and #58): documents the INTEGER-backed `Decimal` → `None` bug (#58), adds a reconnect integration-test pattern, and cross-links existing #56 / typed-null-binds docs.

## Changes

- Add `docs/solutions/issues/sqlite-integer-decimal-hydrates-as-none.md` (#58)
- Add `docs/solutions/patterns/sqlite-alembic-reconnect-hydration-tests.md` (test harness pattern)
- Cross-link #58 from `sqlite-null-hydrates-as-int-zero.md` and `typed-null-binds.md`

## Bridge and Schema Impact

- [x] No Rust/Python bridge changes
- [ ] Python model/schema changed
- [ ] Rust core or SQL generation changed
- [ ] `src/ferro/_core.pyi` updated (if needed)
- [ ] Integration test added first for new behavior

## Migration / Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes included (details below)

## Documentation and Changelog

- [ ] No docs update needed
- [x] Docs updated (README/docs/inline docs)
- [ ] Changelog entry needed

## Related Issues

Relates to #56, #58
