### PR TITLE
fix(query): cast native Postgres enum RHS in `.where()` filters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod connection;
 mod operations;
 mod query;
 mod schema;
+mod schema_bind;
 mod state;
 
 use crate::state::MODEL_REGISTRY;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -560,30 +560,6 @@ async fn postgres_temporal_cast_by_column(
     Ok(out)
 }
 
-fn postgres_enum_type_name_for_column(
-    col_name: &str,
-    enum_udt: &HashMap<String, String>,
-    col_info: Option<&serde_json::Value>,
-) -> Option<String> {
-    // db_type takes precedence over the JSON-schema enum_type_name: when the
-    // user has asked for `text` / `varchar(N)` / etc. storage, the column is
-    // no longer a native Postgres enum UDT and we must not CAST values to a
-    // non-existent type. This mirrors the Alembic-side _map_to_sa_type
-    // override. See AGENTS.md § I-1.
-    if let Some(info) = col_info
-        && info.get("db_type").and_then(|v| v.as_str()).is_some()
-    {
-        return None;
-    }
-
-    enum_udt.get(col_name).cloned().or_else(|| {
-        col_info?
-            .get("enum_type_name")?
-            .as_str()
-            .map(std::string::ToString::to_string)
-    })
-}
-
 fn schema_property<'a>(
     schema: &'a serde_json::Value,
     col_name: &str,
@@ -630,12 +606,10 @@ fn schema_value_expr(
 
     if let serde_json::Value::String(s) = value
         && backend == SqlDialect::Postgres
-        && let Some(tn) = postgres_enum_type_name_for_column(col_name, enum_udt, col_info)
+        && let Some(tn) =
+            crate::schema_bind::postgres_enum_type_name_for_column(col_name, enum_udt, col_info)
     {
-        return Ok(
-            Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
-                .cast_as(Alias::new(tn.as_str())),
-        );
+        return Ok(crate::schema_bind::postgres_enum_string_rhs_expr(s, &tn));
     }
 
     if is_uuid_pg {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1546,7 +1546,7 @@ pub fn fetch_filtered<'py>(
     let name = cls.getattr("__name__")?.extract::<String>()?;
     let cls_py = cls.unbind();
 
-    let query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
+    let mut query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("Invalid query JSON: {}", e))
     })?;
 
@@ -1556,10 +1556,10 @@ pub fn fetch_filtered<'py>(
         let use_identity_map = engine.is_identity_map_enabled();
 
         let table_name = name.to_lowercase();
-        let pg_native_enum_cols: HashSet<String> = {
-            let m = postgres_enum_udt_by_column(&table_name, &engine, &tx_conn, backend).await?;
-            m.keys().cloned().collect()
-        };
+        let postgres_enum_udt =
+            postgres_enum_udt_by_column(&table_name, &engine, &tx_conn, backend).await?;
+        query_def.postgres_enum_udt = postgres_enum_udt.clone();
+        let pg_native_enum_cols: HashSet<String> = postgres_enum_udt.keys().cloned().collect();
         // ...
         let (sql, bind_values, pk_col, schema_for_decode) = {
             let registry = MODEL_REGISTRY.read().map_err(|_| {
@@ -1736,7 +1736,7 @@ pub fn count_filtered(
     tx_id: Option<String>,
     using: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
-    let query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
+    let mut query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("Invalid query JSON: {}", e))
     })?;
 
@@ -1744,6 +1744,8 @@ pub fn count_filtered(
         let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
 
         let table_name = name.to_lowercase();
+        query_def.postgres_enum_udt =
+            postgres_enum_udt_by_column(&table_name, &engine, &tx_conn, backend).await?;
         // ... sql ...
         let (sql, bind_values) = {
             let mut select = Query::select();
@@ -1938,7 +1940,7 @@ pub fn delete_filtered(
     tx_id: Option<String>,
     using: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
-    let query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
+    let mut query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("Invalid query JSON: {}", e))
     })?;
 
@@ -1946,6 +1948,8 @@ pub fn delete_filtered(
         let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
 
         let table_name = name.to_lowercase();
+        query_def.postgres_enum_udt =
+            postgres_enum_udt_by_column(&table_name, &engine, &tx_conn, backend).await?;
         // ... sql ...
         let (sql, bind_values) = {
             let mut delete = Query::delete();
@@ -1982,7 +1986,7 @@ pub fn update_filtered(
     tx_id: Option<String>,
     using: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
-    let query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
+    let mut query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("Invalid query JSON: {}", e))
     })?;
 
@@ -1999,6 +2003,7 @@ pub fn update_filtered(
 
         let table_name = name.to_lowercase();
         let enum_udt = postgres_enum_udt_by_column(&table_name, &engine, &tx_conn, backend).await?;
+        query_def.postgres_enum_udt = enum_udt.clone();
         let uuid_columns =
             postgres_uuid_column_names(&table_name, &engine, &tx_conn, backend).await?;
         let ts_cast =

--- a/src/query.rs
+++ b/src/query.rs
@@ -2,6 +2,7 @@ use crate::state::{MODEL_REGISTRY, SqlDialect};
 use sea_query::{Alias, Condition, Expr, SimpleExpr};
 use serde::Deserialize;
 use serde_json::Value;
+use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]
 pub struct QueryNode {
@@ -38,6 +39,10 @@ pub struct QueryDef {
     pub limit: Option<u64>,
     pub offset: Option<u64>,
     pub m2m: Option<M2mContext>,
+    /// Populated from `pg_catalog` before building filter SQL. Not part of the
+    /// Python query JSON payload.
+    #[serde(skip)]
+    pub postgres_enum_udt: HashMap<String, String>,
 }
 
 impl QueryDef {
@@ -202,19 +207,10 @@ impl QueryDef {
     ) -> SimpleExpr {
         if let Value::String(s) = val {
             if backend == SqlDialect::Postgres {
-                if let Ok(registry) = MODEL_REGISTRY.read()
-                    && let Some(schema) = registry.get(&self.model_name)
-                    && let Some(col_info) = schema
-                        .get("properties")
-                        .and_then(|p| p.as_object())
-                        .and_then(|props| props.get(col_name))
-                    && let Some(tn) = crate::schema_bind::postgres_enum_type_name_for_column(
-                        col_name,
-                        &std::collections::HashMap::new(),
-                        Some(col_info),
-                    )
+                if let Some(tn) =
+                    crate::schema_bind::native_postgres_enum_udt_name(col_name, &self.postgres_enum_udt)
                 {
-                    return crate::schema_bind::postgres_enum_string_rhs_expr(s, &tn);
+                    return crate::schema_bind::postgres_enum_string_rhs_expr(s, tn);
                 }
 
                 if let Ok(parsed) = uuid::Uuid::parse_str(s) {
@@ -454,6 +450,7 @@ mod tests {
             limit: None,
             offset: None,
             m2m: None,
+            postgres_enum_udt: HashMap::new(),
         }
     }
 
@@ -494,6 +491,7 @@ mod tests {
             limit: None,
             offset: None,
             m2m: None,
+            postgres_enum_udt: HashMap::new(),
         };
         let mut select = Query::select();
         select
@@ -523,6 +521,7 @@ mod tests {
             limit: None,
             offset: None,
             m2m: None,
+            postgres_enum_udt: HashMap::new(),
         };
         let mut select = Query::select();
         select
@@ -692,15 +691,10 @@ mod tests {
 
     #[test]
     fn enum_rhs_emits_cast_to_schema_enum_type_on_postgres() {
-        crate::state::MODEL_REGISTRY.write().unwrap().insert(
-            "WidgetColor".to_string(),
-            json!({
-                "properties": {
-                    "color": {"enum_type_name": "color"}
-                }
-            }),
-        );
-        let query_def = empty_query_def("WidgetColor");
+        let mut query_def = empty_query_def("WidgetColor");
+        query_def
+            .postgres_enum_udt
+            .insert("color".to_string(), "color".to_string());
 
         let rhs = query_def.value_rhs_simple_expr_for_backend(
             "color",
@@ -717,7 +711,7 @@ mod tests {
     }
 
     #[test]
-    fn enum_rhs_skips_cast_when_db_type_overrides_storage() {
+    fn enum_rhs_skips_cast_without_native_enum_column() {
         crate::state::MODEL_REGISTRY.write().unwrap().insert(
             "WidgetTextColor".to_string(),
             json!({
@@ -738,7 +732,7 @@ mod tests {
 
         assert!(
             !sql.to_lowercase().contains("as \"color\"") && !sql.to_lowercase().contains("as color"),
-            "db_type=text must not cast to native enum UDT: {sql}"
+            "auto-migrate TEXT enum columns must not cast without catalog UDT: {sql}"
         );
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -202,6 +202,21 @@ impl QueryDef {
     ) -> SimpleExpr {
         if let Value::String(s) = val {
             if backend == SqlDialect::Postgres {
+                if let Ok(registry) = MODEL_REGISTRY.read()
+                    && let Some(schema) = registry.get(&self.model_name)
+                    && let Some(col_info) = schema
+                        .get("properties")
+                        .and_then(|p| p.as_object())
+                        .and_then(|props| props.get(col_name))
+                    && let Some(tn) = crate::schema_bind::postgres_enum_type_name_for_column(
+                        col_name,
+                        &std::collections::HashMap::new(),
+                        Some(col_info),
+                    )
+                {
+                    return crate::schema_bind::postgres_enum_string_rhs_expr(s, &tn);
+                }
+
                 if let Ok(parsed) = uuid::Uuid::parse_str(s) {
                     let schema_uuid = model_column_is_uuid(&self.model_name, col_name);
                     if schema_uuid || infer_uuid_without_schema {
@@ -673,6 +688,58 @@ mod tests {
             SeaValue::Bytes(Some(b)) => assert_eq!(*b, b"some-bytes".to_vec()),
             other => panic!("expected typed Bytes bind, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn enum_rhs_emits_cast_to_schema_enum_type_on_postgres() {
+        crate::state::MODEL_REGISTRY.write().unwrap().insert(
+            "WidgetColor".to_string(),
+            json!({
+                "properties": {
+                    "color": {"enum_type_name": "color"}
+                }
+            }),
+        );
+        let query_def = empty_query_def("WidgetColor");
+
+        let rhs = query_def.value_rhs_simple_expr_for_backend(
+            "color",
+            &json!("red"),
+            false,
+            BackendKind::Postgres,
+        );
+        let sql = Query::select().expr(rhs).to_string(PostgresQueryBuilder);
+
+        assert!(
+            sql.to_lowercase().contains("as \"color\"") || sql.to_lowercase().contains("as color"),
+            "enum filter rhs should CAST to the UDT name, got: {sql}"
+        );
+    }
+
+    #[test]
+    fn enum_rhs_skips_cast_when_db_type_overrides_storage() {
+        crate::state::MODEL_REGISTRY.write().unwrap().insert(
+            "WidgetTextColor".to_string(),
+            json!({
+                "properties": {
+                    "color": {"enum_type_name": "color", "db_type": "text"}
+                }
+            }),
+        );
+        let query_def = empty_query_def("WidgetTextColor");
+
+        let rhs = query_def.value_rhs_simple_expr_for_backend(
+            "color",
+            &json!("red"),
+            false,
+            BackendKind::Postgres,
+        );
+        let sql = Query::select().expr(rhs).to_string(PostgresQueryBuilder);
+
+        assert!(
+            !sql.to_lowercase().contains("as \"color\"") && !sql.to_lowercase().contains("as color"),
+            "db_type=text must not cast to native enum UDT: {sql}"
+        );
     }
 
     #[test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -441,6 +441,7 @@ mod tests {
     use crate::backend::BackendKind;
     use sea_query::{Alias, PostgresQueryBuilder, Query, SqliteQueryBuilder, Value as SeaValue};
     use serde_json::json;
+    use std::collections::HashMap;
 
     fn empty_query_def(model_name: &str) -> QueryDef {
         QueryDef {

--- a/src/schema_bind.rs
+++ b/src/schema_bind.rs
@@ -3,6 +3,19 @@
 use sea_query::{Alias, Expr, SimpleExpr};
 use std::collections::HashMap;
 
+/// Native Postgres enum UDT for `col_name`, from catalog introspection only.
+///
+/// Query-filter predicates use this path so auto-migrate TEXT columns (which
+/// carry `enum_type_name` in schema but are not `typtype = 'e'`) keep plain
+/// text binds. INSERT/UPDATE may still fall back to schema metadata via
+/// [`postgres_enum_type_name_for_column`].
+pub(crate) fn native_postgres_enum_udt_name<'a>(
+    col_name: &str,
+    enum_udt: &'a HashMap<String, String>,
+) -> Option<&'a str> {
+    enum_udt.get(col_name).map(|s| s.as_str())
+}
+
 /// Resolve the Postgres enum UDT name for a column when binding a string RHS.
 ///
 /// `enum_udt` comes from catalog introspection (INSERT/UPDATE). `col_info` is

--- a/src/schema_bind.rs
+++ b/src/schema_bind.rs
@@ -1,0 +1,36 @@
+//! Shared schema-driven bind helpers for INSERT/UPDATE and query-filter paths.
+
+use sea_query::{Alias, Expr, SimpleExpr};
+use std::collections::HashMap;
+
+/// Resolve the Postgres enum UDT name for a column when binding a string RHS.
+///
+/// `enum_udt` comes from catalog introspection (INSERT/UPDATE). `col_info` is
+/// the model field schema fragment (`enum_type_name`, `db_type`, etc.).
+///
+/// When `db_type` is set, native enum casting is suppressed — the column is no
+/// longer stored as a Postgres enum UDT (see AGENTS.md I-1 / Alembic parity).
+pub(crate) fn postgres_enum_type_name_for_column(
+    col_name: &str,
+    enum_udt: &HashMap<String, String>,
+    col_info: Option<&serde_json::Value>,
+) -> Option<String> {
+    if let Some(info) = col_info
+        && info.get("db_type").and_then(|v| v.as_str()).is_some()
+    {
+        return None;
+    }
+
+    enum_udt.get(col_name).cloned().or_else(|| {
+        col_info?
+            .get("enum_type_name")?
+            .as_str()
+            .map(std::string::ToString::to_string)
+    })
+}
+
+/// RHS expression for a non-null string compared against a native Postgres enum column.
+pub(crate) fn postgres_enum_string_rhs_expr(s: &str, enum_type_name: &str) -> SimpleExpr {
+    Expr::value(sea_query::Value::String(Some(Box::new(s.to_string()))))
+        .cast_as(Alias::new(enum_type_name))
+}

--- a/tests/test_structural_types.py
+++ b/tests/test_structural_types.py
@@ -278,6 +278,45 @@ async def test_native_postgres_enum_column_decodes_via_text_cast(
 
 @pytest.mark.asyncio
 @pytest.mark.postgres_only
+async def test_native_postgres_enum_where_lambda_count(db_url, postgres_base_url, db_schema_name):
+    """Regression for #63: filter predicates must cast enum RHS to the PG UDT."""
+
+    class Color(str, Enum):
+        RED = "red"
+        BLUE = "blue"
+
+    class Widget(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        color: Color
+
+    import psycopg
+
+    with psycopg.connect(postgres_base_url) as conn:
+        conn.execute(f'SET search_path TO "{db_schema_name}"')
+        conn.execute("CREATE TYPE color AS ENUM ('red', 'blue')")
+        conn.execute(
+            """
+            CREATE TABLE widget (
+                id integer PRIMARY KEY,
+                color color NOT NULL
+            )
+            """
+        )
+        conn.execute("INSERT INTO widget (id, color) VALUES (1, 'red'), (2, 'blue')")
+        conn.commit()
+
+    await connect(db_url, auto_migrate=False)
+
+    count = await Widget.where(lambda w, c=Color.RED: w.color == c).count()
+    assert count == 1
+
+    rows = await Widget.where(lambda w: w.color != Color.BLUE).all()
+    assert len(rows) == 1
+    assert rows[0].color == Color.RED
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
 async def test_native_postgres_enum_plain_str_column(
     db_url, postgres_base_url, db_schema_name
 ):


### PR DESCRIPTION
## Summary

Fixes #63. Native Postgres `ENUM` columns compared in `.where(lambda ...)` predicates failed with `operator does not exist: <enumtype> = text` because filter RHS values were bound as plain `text`, while INSERT/UPDATE already emitted `CAST(... AS <udt>)` via `enum_type_name` in `__ferro_schema__`.

- Extract shared enum bind helpers into `src/schema_bind.rs`
- Apply the same cast in `value_rhs_simple_expr_for_backend` (query filters and filtered UPDATE WHERE clauses)
- Respect `db_type` overrides (no enum cast when storage is forced to `text`)
- Rust unit tests on generated SQL; Postgres integration regression mirroring the issue repro

## Test plan

- [ ] `cargo test enum_rhs`
- [ ] `pytest tests/test_structural_types.py::test_native_postgres_enum_where_lambda_count -m postgres_only`


Made with [Cursor](https://cursor.com)