### PR TITLE
feat: extend auto_migrate with column updates and destructive drops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,3 +147,13 @@ search this directory before starting work.
 `docs/solutions/issues/` — debugging stories and known footguns.
 
 See `docs/solutions/README.md` for the frontmatter conventions.
+
+---
+
+## I-6: No AI attribution in commits or PRs
+
+Never sign commits or pull requests with AI/agent attribution. No
+`Co-Authored-By: Claude ...` trailers, no "Generated with Claude Code"
+footers, no robot emoji bylines — in commit messages, PR titles, or PR
+bodies. This applies even when an agent's default behavior is to add them:
+this rule overrides those defaults for this repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ For a single model, every emitter must agree on:
    includes the canonical `db_type` vocabulary (`text`, `varchar(N)`,
    `smallint`, `int`, `bigint`, `uuid`, `timestamp`, `timestamptz`, `date`,
    `time`) — duplicated in `_db_type_to_sa_type` (Python) and
-   `apply_db_type_to_column_def` (Rust), pinned by
+   `db_type_token_to_canonical` (Rust), pinned by
    `tests/test_db_type_cross_emitter_parity.py`.
 4. **Index names** — `idx_<table>_<col>` for single-column indexes,
    `idx_<table>_<col1>_<col2>...` for composite indexes.

--- a/docs/coming-soon.md
+++ b/docs/coming-soon.md
@@ -410,37 +410,12 @@ Document the exception hierarchy and import paths:
 
 ### Many-to-Many Join Table Creation
 
-**Status:** Partially Implemented
+**Status:** Implemented
 
-**Documentation References:**
-- `docs/guide/relationships.md` (lines 176-289)
-
-**Description:**
-Many-to-many relationships are defined with `ManyToMany(...)`, but the join tables are not automatically created during `auto_migrate=True`.
-
-**Example (Partially Working):**
-```python
-from typing import Annotated
-
-from ferro import BackRef, Field, ManyToMany, Model, Relation
-
-class Post(Model):
-    id: int | None = Field(default=None, primary_key=True)
-    tags: Relation[list["Tag"]] = ManyToMany(related_name="posts")
-
-class Tag(Model):
-    id: int | None = Field(default=None, primary_key=True)
-    posts: Relation[list["Post"]] = BackRef()
-
-# Models created, but join table 'post_tags' is NOT auto-created
-# This causes errors when trying to use M2M methods:
-await post.tags.add(tag)  # RuntimeError: no such table: post_tags
-```
-
-**Workaround:**
-Manual join table creation may be required, or use Alembic migrations. Further investigation needed.
-
-**Test Status:** 4 tests skipped in `tests/test_documentation_features.py`
+Many-to-many join tables are registered alongside their models and created by
+`auto_migrate=True` / `create_tables()` like any other table (they also
+participate in `migrate_updates` diffing). Covered by
+`tests/test_auto_migrate.py::test_m2m_join_table_created_during_auto_migrate`.
 
 ---
 

--- a/docs/guide/database.md
+++ b/docs/guide/database.md
@@ -133,8 +133,53 @@ During development, automatically align the database schema with your models:
 await ferro.connect("sqlite:dev.db?mode=rwc", auto_migrate=True)
 ```
 
+`auto_migrate=True` creates missing tables (including many-to-many join tables) and never touches existing ones. Two opt-in flags extend it:
+
+```python
+await ferro.connect(
+    "sqlite:dev.db?mode=rwc",
+    auto_migrate=True,
+    migrate_updates=True,      # update existing tables to match the models
+    migrate_destructive=True,  # also drop columns removed from the models
+)
+```
+
+The flags form a ladder — `migrate_destructive` implies `migrate_updates`, which implies `auto_migrate` — so passing just the strongest flag you want is enough.
+
+#### Schema updates with `migrate_updates`
+
+When a model gains fields between releases, `migrate_updates=True` reconciles the live table on connect. What it can do is capability-relative per backend:
+
+| Change | SQLite | Postgres |
+|---|---|---|
+| Add missing column | ✅ `ADD COLUMN` | ✅ `ADD COLUMN` |
+| Add missing column's index (`index=True`) | ✅ `CREATE INDEX` | ✅ `CREATE INDEX` |
+| Add unique column (`unique=True`) | ✅ via explicit `uq_` unique index + warning | ✅ inline `UNIQUE` |
+| Add foreign-key column | ✅ column only, no FK constraint + warning | ✅ column + FK constraint |
+| Change column type | ⚠️ warning, no DDL (type affinity makes drift mostly cosmetic) | ✅ `ALTER COLUMN ... TYPE ... USING` cast |
+| Change nullability | ⚠️ warning, no DDL | ✅ `SET NOT NULL` / `DROP NOT NULL` |
+| Drop removed column (`migrate_destructive`) | ✅ dependency-aware | ✅ |
+| Rename column/table, change primary key, drop table | ❌ never — [Alembic](migrations.md) territory | ❌ never |
+
+Rules to know:
+
+- **NOT NULL additions need a literal default.** Existing rows must be backfilled, so a new required field without a literal default fails the connect with a clear error. Make the field nullable, give it a default, or use Alembic. On Postgres the backfill default is dropped immediately after the add (a fresh `CREATE TABLE` carries no server default); SQLite cannot drop a column default, so it remains — harmless, and invisible to Alembic autogenerate's defaults.
+- **Added columns reuse the exact `CREATE TABLE` DDL.** A database brought forward by `migrate_updates` is byte-identical to one created fresh, so `alembic revision --autogenerate` stays clean (this is pinned by the cross-emitter parity tests).
+- **Destructive drops are dependency-aware and fail loudly.** Explicit indexes covering a dropped column are dropped first (they are orphaned anyway). Columns that are primary keys, enforced by UNIQUE/CHECK constraints, or referenced by other tables' foreign keys abort the migration with an error pointing at Alembic — nothing is skipped silently. Tables are never dropped.
+- **Postgres native enum columns are left alone.** They only exist via Alembic, which remains their owner.
+- **Postgres type changes take an exclusive lock** and fail the connect if existing data does not cast cleanly — acceptable for a development flag, but worth knowing.
+- **The pool refreshes after any schema change.** No connection can serve a statement prepared against the pre-migration schema (on SQLite stale statements panic the sqlx worker and silently return zero rows; on Postgres they raise `cached plan must not change result type`), and identity-mapped instances hydrated before the migration are evicted so loads return fresh, complete objects.
+
+The same pass can be run explicitly on a live connection instead of at connect time:
+
+```python
+await ferro.migrate()                    # create + update (default)
+await ferro.migrate(destructive=True)    # also drop removed columns
+await ferro.migrate(using="service")     # against a named connection
+```
+
 !!! danger "Production Warning"
-    `auto_migrate=True` is intended for development only. For production, use [Alembic migrations](migrations.md).
+    `auto_migrate=True` and its extension flags are intended for development and local-first apps whose schema is still moving. For production, use [Alembic migrations](migrations.md) — renames, primary-key changes, and data transforms are deliberately out of auto-migrate's scope.
 
 ## Manual Table Creation
 

--- a/docs/solutions/patterns/configurable-column-storage-types.md
+++ b/docs/solutions/patterns/configurable-column-storage-types.md
@@ -109,8 +109,9 @@ Two emitters, two dispatch tables, one parity test:
 
 - **Python:** `_db_type_to_sa_type(token)` in
   `src/ferro/migrations/alembic.py` returns an SA type.
-- **Rust:** `apply_db_type_to_column_def(col_def, token, backend)` in
-  `src/schema.rs` mutates a `ColumnDef`.
+- **Rust:** `db_type_token_to_canonical(token, backend)` in
+  `src/schema.rs` resolves a `CanonicalType`, which `apply_canonical_type`
+  applies to a `ColumnDef`.
 - **Parity test:**
   `tests/test_db_type_cross_emitter_parity.py::test_column_type_parity_across_emitters`
   walks every `(token × dialect)` pair, renders both emitters via
@@ -132,10 +133,11 @@ truncation guard.
    `src/ferro/_annotation_utils.py`, plus its compatibility predicate.
 2. Add an arm in `_db_type_to_sa_type` (Python, `migrations/alembic.py`)
    returning the appropriate `sa.types.TypeEngine`.
-3. Add an arm in `apply_db_type_to_column_def` (Rust, `src/schema.rs`)
-   calling the matching `ColumnDef::*` method, with per-backend rendering
-   chosen to byte-match the Python side's `CreateTable.compile(dialect)`
-   output.
+3. Add an arm in `db_type_token_to_canonical` (Rust, `src/schema.rs`)
+   returning the matching `CanonicalType` variant (add one if needed, with
+   its `ColumnDef::*` mapping in `apply_canonical_type`), with per-backend
+   resolution chosen to byte-match the Python side's
+   `CreateTable.compile(dialect)` output.
 4. Extend `_TOKEN_CASES` in `tests/test_db_type_cross_emitter_parity.py`
    with the new token and expected keywords for both `postgres` and `sqlite`.
 5. Add a positive validation test and at least one negative

--- a/docs/solutions/patterns/ddl-on-live-engine.md
+++ b/docs/solutions/patterns/ddl-on-live-engine.md
@@ -1,0 +1,68 @@
+---
+title: DDL on a live engine — pool refresh, unprepared SQL, identity-map eviction
+type: pattern
+tags: [invariant, rust, sqlx, pool, statement-cache, auto-migrate, identity-map]
+related_files:
+  - src/backend.rs
+  - src/migrate.rs
+  - src/introspect.rs
+  - tests/test_auto_migrate.py
+related_issues: [67, 68]
+captured: 2026-06-11
+---
+
+## Problem
+
+Running `ALTER TABLE` against a pool that has already served queries leaves
+three kinds of stale state, each producing a different failure:
+
+1. **sqlx statement caches (SQLite):** a cached prepared statement carries the
+   pre-DDL column count. Re-executing it after the table widens panics the
+   sqlx worker thread (`row.rs index out of bounds`) and the query **silently
+   returns zero rows** — no exception reaches Python (issue #67).
+2. **Prepared statements (Postgres):** the server raises
+   `cached plan must not change result type`.
+3. **Ferro's identity map:** instances hydrated before the DDL lack fields the
+   migration added. A later load returns the same cached instance, so the new
+   field falls through to the class-level `FieldProxy` instead of its value.
+
+## Pattern
+
+Auto-migrate (`src/migrate.rs::internal_migrate`) treats DDL as a
+schema-epoch event with three guarantees, in order:
+
+1. **Migration SQL never populates caches.** All introspection and DDL go
+   through `EngineHandle::execute_sql_unprepared` /
+   `fetch_all_sql_unprepared*` (`sqlx ... .persistent(false)`), so the
+   migration cannot poison the connection it borrowed.
+2. **`EngineHandle::refresh_pool()` after any ALTER/DROP.** The pool lives
+   behind `Arc<RwLock<BackendPool>>` with an owned `PoolSpec` (URL,
+   search_path, sizing), so the engine atomically swaps in a freshly built
+   pool and gracefully closes the old one. No connection — idle or checked
+   out — can serve a statement prepared against the pre-DDL schema afterward.
+   * In-memory SQLite databases live inside their connections; swapping the
+     pool would destroy the database. There, refresh acquires **every**
+     connection (waiting for outstanding work to drain) and calls
+     `clear_cached_statements()` on each — same guarantee, data intact.
+   * Handles wrapped around externally built pools (`new_sqlite` /
+     `new_postgres`, test-only) have no `PoolSpec` and fail loudly.
+3. **`IDENTITY_MAP.clear()` after any ALTER/DROP.** The schema lives in the
+   database, which any number of named connections may share, so the whole
+   map is invalidated. Eviction is always safe — instances re-hydrate on the
+   next load.
+
+The connect path gets guarantee zero for free: migration runs immediately
+after pool creation, before the connection can serve ORM queries.
+
+## Gotchas
+
+- `refresh_pool` is the primitive for any future DDL surface (e.g. detecting
+  DDL in `ferro.raw.execute` for the rest of issue #67). Do not reinvent
+  partial cache flushes — draining "idle" connections only is exactly the
+  stop-gap this design replaced.
+- The regression tests are
+  `tests/test_auto_migrate.py::test_migrate_updates_adds_missing_columns_and_hydrates`
+  (#67 repro shape: narrow table → connect with `migrate_updates=True` → rows
+  hydrate) and
+  `::test_manual_migrate_on_live_pool_refreshes_cached_statements`
+  (statement cached pre-migrate, correct rows post-migrate).

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,8 +1,10 @@
 use sqlx::ColumnIndex;
 use sqlx::pool::PoolConnection;
-use sqlx::{Column, PgPool, Postgres, Row, Sqlite, SqlitePool, ValueRef};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::{Column, Connection, PgPool, Postgres, Row, Sqlite, SqlitePool, ValueRef};
 use std::fmt;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 /// Ferro's currently supported runtime database backends.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -25,11 +27,79 @@ impl BackendKind {
     }
 }
 
+/// Everything needed to (re)build a connection pool. Owned by `EngineHandle`
+/// so the engine can atomically replace its pool after schema-changing DDL
+/// (see [`EngineHandle::refresh_pool`]).
+#[derive(Clone, Debug)]
+pub struct PoolSpec {
+    pub backend: BackendKind,
+    pub url: String,
+    /// Postgres `SET search_path` applied to every new connection
+    /// (the `ferro_search_path` URL parameter).
+    pub search_path: Option<String>,
+    pub max_connections: u32,
+    pub min_connections: u32,
+}
+
+impl PoolSpec {
+    /// Build a fresh pool from this spec.
+    async fn build(&self) -> Result<BackendPool, sqlx::Error> {
+        match self.backend {
+            BackendKind::Sqlite => {
+                let pool = SqlitePoolOptions::new()
+                    .max_connections(self.max_connections)
+                    .min_connections(self.min_connections)
+                    .connect(&self.url)
+                    .await?;
+                Ok(BackendPool::Sqlite(Arc::new(pool)))
+            }
+            BackendKind::Postgres => {
+                let mut pool_options = PgPoolOptions::new()
+                    .max_connections(self.max_connections)
+                    .min_connections(self.min_connections);
+                if let Some(search_path) = &self.search_path {
+                    let set_search_path_sql =
+                        Arc::new(format!("SET search_path TO {}", search_path));
+                    pool_options = pool_options.after_connect(move |conn, _meta| {
+                        let set_search_path_sql = set_search_path_sql.clone();
+                        Box::pin(async move {
+                            sqlx::query(set_search_path_sql.as_str())
+                                .execute(conn)
+                                .await?;
+                            Ok(())
+                        })
+                    });
+                }
+                let pool = pool_options.connect(&self.url).await?;
+                Ok(BackendPool::Postgres(Arc::new(pool)))
+            }
+        }
+    }
+
+    /// In-memory SQLite databases live inside their connections: replacing the
+    /// pool would discard the database itself, so refresh must clear statement
+    /// caches in place instead of rebuilding.
+    fn is_ephemeral_sqlite(&self) -> bool {
+        if self.backend != BackendKind::Sqlite {
+            return false;
+        }
+        let url = self.url.to_ascii_lowercase();
+        url.contains(":memory:") || url.contains("mode=memory")
+    }
+}
+
 /// Persistent runtime engine state for the currently connected backend.
+///
+/// The pool lives behind a shared `RwLock` so [`EngineHandle::refresh_pool`]
+/// can atomically swap in a fresh pool after schema-changing DDL; clones of a
+/// handle observe the swap because they share the same slot.
 #[derive(Clone, Debug)]
 pub struct EngineHandle {
     backend: BackendKind,
-    pool: BackendPool,
+    pool: Arc<RwLock<BackendPool>>,
+    /// How to rebuild the pool. `None` for handles wrapped around an
+    /// externally built pool (test-only constructors), which cannot refresh.
+    spec: Option<PoolSpec>,
     /// When false, Ferro skips the identity map for this connection (no lookup/register on load).
     identity_map_enabled: bool,
 }
@@ -38,6 +108,15 @@ pub struct EngineHandle {
 enum BackendPool {
     Sqlite(Arc<SqlitePool>),
     Postgres(Arc<PgPool>),
+}
+
+impl BackendPool {
+    async fn close(&self) {
+        match self {
+            BackendPool::Sqlite(pool) => pool.close().await,
+            BackendPool::Postgres(pool) => pool.close().await,
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -114,20 +193,119 @@ impl EngineValue {
 }
 
 impl EngineHandle {
+    /// Connect a new engine from a [`PoolSpec`]. This is the canonical
+    /// constructor: handles built this way know how to rebuild their pool and
+    /// therefore support [`EngineHandle::refresh_pool`].
+    pub async fn connect(spec: PoolSpec) -> Result<Self, sqlx::Error> {
+        let backend = spec.backend;
+        let pool = spec.build().await?;
+        Ok(Self {
+            backend,
+            pool: Arc::new(RwLock::new(pool)),
+            spec: Some(spec),
+            identity_map_enabled: true,
+        })
+    }
+
+    /// Wrap an externally built SQLite pool. The handle cannot rebuild the
+    /// pool, so `refresh_pool` fails loudly. Test-only: production code must
+    /// construct engines via [`EngineHandle::connect`].
+    #[cfg(test)]
     pub fn new_sqlite(pool: SqlitePool) -> Self {
         Self {
             backend: BackendKind::Sqlite,
-            pool: BackendPool::Sqlite(Arc::new(pool)),
+            pool: Arc::new(RwLock::new(BackendPool::Sqlite(Arc::new(pool)))),
+            spec: None,
             identity_map_enabled: true,
         }
     }
 
+    /// Wrap an externally built Postgres pool. The handle cannot rebuild the
+    /// pool, so `refresh_pool` fails loudly. Test-only: production code must
+    /// construct engines via [`EngineHandle::connect`].
+    #[cfg(test)]
     pub fn new_postgres(pool: PgPool) -> Self {
         Self {
             backend: BackendKind::Postgres,
-            pool: BackendPool::Postgres(Arc::new(pool)),
+            pool: Arc::new(RwLock::new(BackendPool::Postgres(Arc::new(pool)))),
+            spec: None,
             identity_map_enabled: true,
         }
+    }
+
+    /// Snapshot the current pool. Cheap: `sqlx::Pool` is a reference-counted
+    /// handle. Poisoning is recovered rather than propagated — the pool value
+    /// itself is always valid (writers only ever replace it wholesale) and
+    /// panicking here would cross the FFI boundary (AGENTS.md § I-3).
+    fn pool_snapshot(&self) -> BackendPool {
+        match self.pool.read() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+
+    /// Atomically swap in a freshly built pool and gracefully close the old
+    /// one. After this returns, no future query can be served by a connection
+    /// whose statement cache predates the swap — the engine-level guarantee
+    /// that makes DDL on a live engine safe (sqlx's SQLite worker panics and
+    /// silently returns zero rows on stale cached statements; Postgres raises
+    /// "cached plan must not change result type").
+    ///
+    /// In-memory SQLite databases live inside their connections, so the pool
+    /// cannot be replaced without losing the database. For those, every
+    /// connection is acquired (waiting for outstanding work to drain) and its
+    /// statement cache cleared in place — the same guarantee, data intact.
+    pub async fn refresh_pool(&self) -> Result<(), sqlx::Error> {
+        let Some(spec) = &self.spec else {
+            return Err(sqlx::Error::Configuration(
+                "this EngineHandle wraps an externally built pool and cannot rebuild it; \
+                 construct it via EngineHandle::connect to enable refresh_pool"
+                    .into(),
+            ));
+        };
+
+        if spec.is_ephemeral_sqlite() {
+            return self.clear_all_statement_caches(spec).await;
+        }
+
+        let new_pool = spec.build().await?;
+        let old_pool = {
+            let mut guard = match self.pool.write() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            std::mem::replace(&mut *guard, new_pool)
+        };
+        old_pool.close().await;
+        Ok(())
+    }
+
+    /// Acquire every pool connection and clear its statement cache. Holding
+    /// all connections simultaneously guarantees none escapes the sweep;
+    /// acquisition waits for checked-out connections to be returned, so
+    /// outstanding work drains before the caches are cleared.
+    async fn clear_all_statement_caches(&self, spec: &PoolSpec) -> Result<(), sqlx::Error> {
+        match &self.pool_snapshot() {
+            BackendPool::Sqlite(pool) => {
+                let mut held = Vec::with_capacity(spec.max_connections as usize);
+                for _ in 0..spec.max_connections {
+                    held.push(pool.acquire().await?);
+                }
+                for conn in &mut held {
+                    conn.clear_cached_statements().await?;
+                }
+            }
+            BackendPool::Postgres(pool) => {
+                let mut held = Vec::with_capacity(spec.max_connections as usize);
+                for _ in 0..spec.max_connections {
+                    held.push(pool.acquire().await?);
+                }
+                for conn in &mut held {
+                    conn.clear_cached_statements().await?;
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Returns whether this connection uses the identity map (singleton instances per PK).
@@ -149,7 +327,7 @@ impl EngineHandle {
 
     #[allow(dead_code)]
     pub fn sqlite_pool(&self) -> Option<Arc<SqlitePool>> {
-        match &self.pool {
+        match &self.pool_snapshot() {
             BackendPool::Sqlite(pool) => Some(pool.clone()),
             BackendPool::Postgres(_) => None,
         }
@@ -157,14 +335,14 @@ impl EngineHandle {
 
     #[allow(dead_code)]
     pub fn postgres_pool(&self) -> Option<Arc<PgPool>> {
-        match &self.pool {
+        match &self.pool_snapshot() {
             BackendPool::Postgres(pool) => Some(pool.clone()),
             BackendPool::Sqlite(_) => None,
         }
     }
 
     pub async fn execute_sql(&self, sql: &str) -> Result<u64, sqlx::Error> {
-        match &self.pool {
+        match &self.pool_snapshot() {
             BackendPool::Sqlite(pool) => {
                 let result = sqlx::query(sql).execute(pool.as_ref()).await?;
                 Ok(result.rows_affected())
@@ -172,6 +350,61 @@ impl EngineHandle {
             BackendPool::Postgres(pool) => {
                 let result = sqlx::query(sql).execute(pool.as_ref()).await?;
                 Ok(result.rows_affected())
+            }
+        }
+    }
+
+    /// Execute without entering any connection's prepared-statement cache.
+    /// Migration DDL and schema introspection must use this: caching a
+    /// statement against a schema that the very same migration is about to
+    /// change would poison the connection it ran on.
+    pub async fn execute_sql_unprepared(&self, sql: &str) -> Result<u64, sqlx::Error> {
+        match &self.pool_snapshot() {
+            BackendPool::Sqlite(pool) => {
+                let result = sqlx::query(sql)
+                    .persistent(false)
+                    .execute(pool.as_ref())
+                    .await?;
+                Ok(result.rows_affected())
+            }
+            BackendPool::Postgres(pool) => {
+                let result = sqlx::query(sql)
+                    .persistent(false)
+                    .execute(pool.as_ref())
+                    .await?;
+                Ok(result.rows_affected())
+            }
+        }
+    }
+
+    /// Fetch without entering any connection's prepared-statement cache.
+    /// See [`EngineHandle::execute_sql_unprepared`].
+    pub async fn fetch_all_sql_unprepared(&self, sql: &str) -> Result<Vec<EngineRow>, sqlx::Error> {
+        self.fetch_all_sql_unprepared_with_binds(sql, &[]).await
+    }
+
+    /// Bind-supporting variant of [`EngineHandle::fetch_all_sql_unprepared`].
+    pub async fn fetch_all_sql_unprepared_with_binds(
+        &self,
+        sql: &str,
+        values: &[EngineBindValue],
+    ) -> Result<Vec<EngineRow>, sqlx::Error> {
+        match &self.pool_snapshot() {
+            BackendPool::Sqlite(pool) => {
+                let mut query = sqlx::query(sql).persistent(false);
+                for value in values {
+                    query = bind_engine_value(query, value);
+                }
+                let rows = query.fetch_all(pool.as_ref()).await?;
+                Ok(rows.iter().map(materialize_engine_row).collect())
+            }
+            BackendPool::Postgres(pool) => {
+                let mut query = sqlx::query(sql).persistent(false);
+                for value in values {
+                    query = bind_engine_value(query, value);
+                }
+                let rows = query.fetch_all(pool.as_ref()).await?;
+                Ok(rows.iter().map(materialize_engine_row).collect())
             }
         }
     }
@@ -192,7 +425,7 @@ impl EngineHandle {
         sql: &str,
         values: &[EngineBindValue],
     ) -> Result<EngineExecuteResult, sqlx::Error> {
-        match &self.pool {
+        match &self.pool_snapshot() {
             BackendPool::Sqlite(pool) => {
                 let mut query = sqlx::query(sql);
                 for value in values {
@@ -223,7 +456,7 @@ impl EngineHandle {
         sql: &str,
         values: &[EngineBindValue],
     ) -> Result<Vec<EngineRow>, sqlx::Error> {
-        match &self.pool {
+        match &self.pool_snapshot() {
             BackendPool::Sqlite(pool) => {
                 let mut query = sqlx::query(sql);
                 for value in values {
@@ -245,7 +478,7 @@ impl EngineHandle {
 
     #[allow(dead_code)]
     pub async fn begin_transaction_connection(&self) -> Result<EngineConnection, sqlx::Error> {
-        match &self.pool {
+        match &self.pool_snapshot() {
             BackendPool::Sqlite(pool) => {
                 let mut conn = pool.acquire().await?;
                 sqlx::query("BEGIN").execute(&mut *conn).await?;
@@ -469,6 +702,7 @@ mod tests {
     use super::EngineBindValue;
     use super::EngineHandle;
     use super::EngineValue;
+    use super::PoolSpec;
     use sqlx::postgres::PgPoolOptions;
     use sqlx::sqlite::SqlitePoolOptions;
 
@@ -838,6 +1072,110 @@ mod tests {
         assert!(
             debug_repr.contains("I64"),
             "Debug should mention NullKind::I64: {debug_repr}"
+        );
+    }
+
+    fn file_backed_spec(path: &std::path::Path) -> PoolSpec {
+        PoolSpec {
+            backend: BackendKind::Sqlite,
+            url: format!("sqlite://{}?mode=rwc", path.display()),
+            search_path: None,
+            max_connections: 2,
+            min_connections: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_pool_survives_alter_table_on_file_backed_sqlite() {
+        let dir = std::env::temp_dir().join(format!("ferro_refresh_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db_path = dir.join("refresh_swap.db");
+        let _ = std::fs::remove_file(&db_path);
+
+        let engine = EngineHandle::connect(file_backed_spec(&db_path))
+            .await
+            .unwrap();
+        engine
+            .execute_sql("CREATE TABLE swap_check (id INTEGER PRIMARY KEY, a TEXT)")
+            .await
+            .unwrap();
+        engine
+            .execute_sql("INSERT INTO swap_check (id, a) VALUES (1, 'x')")
+            .await
+            .unwrap();
+
+        // Prepare (and cache) a statement against the pre-DDL schema.
+        let rows = engine
+            .fetch_all_sql_with_binds("SELECT * FROM swap_check", &[])
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+
+        // Widen the table, then refresh. The same SELECT * must now see the
+        // new column instead of panicking on a stale cached statement.
+        engine
+            .execute_sql_unprepared("ALTER TABLE swap_check ADD COLUMN b TEXT")
+            .await
+            .unwrap();
+        engine.refresh_pool().await.unwrap();
+
+        let rows = engine
+            .fetch_all_sql_with_binds("SELECT * FROM swap_check", &[])
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].values.len(),
+            3,
+            "post-refresh row must include the added column"
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[tokio::test]
+    async fn refresh_pool_preserves_in_memory_database() {
+        let spec = PoolSpec {
+            backend: BackendKind::Sqlite,
+            url: "sqlite::memory:".to_string(),
+            search_path: None,
+            max_connections: 1,
+            min_connections: 0,
+        };
+        let engine = EngineHandle::connect(spec).await.unwrap();
+        engine
+            .execute_sql("CREATE TABLE mem_check (id INTEGER PRIMARY KEY)")
+            .await
+            .unwrap();
+        engine
+            .execute_sql("INSERT INTO mem_check (id) VALUES (1)")
+            .await
+            .unwrap();
+
+        // Must clear statement caches in place rather than swapping the pool,
+        // which would discard the in-memory database.
+        engine.refresh_pool().await.unwrap();
+
+        let rows = engine
+            .fetch_all_sql_with_binds("SELECT id FROM mem_check", &[])
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "in-memory data must survive refresh_pool");
+    }
+
+    #[tokio::test]
+    async fn refresh_pool_fails_loudly_for_externally_built_pools() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        let engine = EngineHandle::new_sqlite(pool);
+
+        let err = engine.refresh_pool().await.unwrap_err();
+        assert!(
+            err.to_string().contains("externally built pool"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -3,12 +3,10 @@
 //! This module handles database connections, pool initialization,
 //! and engine resets.
 
-use crate::backend::{BackendKind, EngineHandle};
-use crate::schema::internal_create_tables;
+use crate::backend::{BackendKind, EngineHandle, PoolSpec};
+use crate::migrate::{MigrateOptions, internal_migrate};
 use crate::state::{CONNECTION_REGISTRY, DEFAULT_CONNECTION_NAME, ENGINE, IDENTITY_MAP};
 use pyo3::prelude::*;
-use sqlx::postgres::PgPoolOptions;
-use sqlx::sqlite::SqlitePoolOptions;
 use std::sync::Arc;
 
 fn split_search_path(url: &str) -> (String, Option<String>) {
@@ -143,36 +141,14 @@ async fn connect_engine_handle(
     max_connections: u32,
     min_connections: u32,
 ) -> Result<EngineHandle, sqlx::Error> {
-    match backend {
-        BackendKind::Sqlite => {
-            let pool = SqlitePoolOptions::new()
-                .max_connections(max_connections)
-                .min_connections(min_connections)
-                .connect(connection_url)
-                .await?;
-            Ok(EngineHandle::new_sqlite(pool))
-        }
-        BackendKind::Postgres => {
-            let mut pool_options = PgPoolOptions::new()
-                .max_connections(max_connections)
-                .min_connections(min_connections);
-            if let Some(search_path) = search_path {
-                let set_search_path_sql = Arc::new(format!("SET search_path TO {}", search_path));
-                pool_options = pool_options.after_connect(move |conn, _meta| {
-                    let set_search_path_sql = set_search_path_sql.clone();
-                    Box::pin(async move {
-                        sqlx::query(set_search_path_sql.as_str())
-                            .execute(conn)
-                            .await?;
-                        Ok(())
-                    })
-                });
-            }
-
-            let pool = pool_options.connect(connection_url).await?;
-            Ok(EngineHandle::new_postgres(pool))
-        }
-    }
+    EngineHandle::connect(PoolSpec {
+        backend,
+        url: connection_url.to_string(),
+        search_path,
+        max_connections,
+        min_connections,
+    })
+    .await
 }
 
 /// Initializes the global database connection pool.
@@ -183,11 +159,17 @@ async fn connect_engine_handle(
 ///     url (str): The database connection URL (e.g., "sqlite:test.db").
 ///     auto_migrate (bool): If True, automatically creates tables for all
 ///         registered models on connection. Defaults to False.
+///     migrate_updates (bool): If True, also adds missing model columns to
+///         existing tables (and reconciles type/nullability drift on
+///         Postgres). Implies `auto_migrate`.
+///     migrate_destructive (bool): If True, also drops live columns that no
+///         longer exist on the model. Implies `migrate_updates`.
 ///
 /// # Errors
 /// Returns a `PyErr` if the connection fails or if auto-migration fails.
 #[pyfunction]
-#[pyo3(signature = (url, auto_migrate=false, name=None, default=false, max_connections=5, min_connections=0, identity_map=true))]
+#[pyo3(signature = (url, auto_migrate=false, name=None, default=false, max_connections=5, min_connections=0, identity_map=true, migrate_updates=false, migrate_destructive=false))]
+#[allow(clippy::too_many_arguments)]
 pub fn connect(
     py: Python<'_>,
     url: String,
@@ -197,6 +179,8 @@ pub fn connect(
     max_connections: u32,
     min_connections: u32,
     identity_map: bool,
+    migrate_updates: bool,
+    migrate_destructive: bool,
 ) -> PyResult<Bound<'_, PyAny>> {
     let (connection_url, search_path) = split_search_path(&url);
     let redacted_url = redact_connection_url(&connection_url);
@@ -253,8 +237,13 @@ pub fn connect(
 
         let engine_handle = Arc::new(engine_handle);
 
-        if auto_migrate {
-            internal_create_tables(engine_handle.clone()).await?;
+        // Flag ladder: migrate_destructive ⇒ migrate_updates ⇒ auto_migrate.
+        // There is no coherent "alter existing tables but don't create missing
+        // ones" mode — the diff baseline relies on CREATE TABLE IF NOT EXISTS
+        // having run first.
+        let opts = MigrateOptions::laddered(migrate_updates, migrate_destructive);
+        if auto_migrate || opts.updates {
+            internal_migrate(engine_handle.clone(), opts).await?;
         }
 
         let mut registry = CONNECTION_REGISTRY.write().map_err(|_| {

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -14,6 +14,7 @@ from ._core import (
     clear_registry,
     create_tables,
     evict_instance,
+    migrate,
     reset_engine,
     set_default_connection,
     version,
@@ -63,6 +64,8 @@ async def connect(
     pool: PoolConfig | None = None,
     *,
     identity_map: bool = True,
+    migrate_updates: bool = False,
+    migrate_destructive: bool = False,
 ) -> None:
     """
     Establish a connection to the database.
@@ -70,12 +73,41 @@ async def connect(
     Args:
         url: The database connection string (e.g., "sqlite:example.db?mode=rwc").
         auto_migrate: If True, automatically create tables for all registered models.
+            Existing tables are left untouched unless ``migrate_updates`` /
+            ``migrate_destructive`` are also set.
         name: Optional connection name. Omitted connections register as "default".
         default: If True, make this named connection the default for unqualified operations.
         pool: Optional per-connection pool configuration.
         identity_map: If True (default), keep a per-connection identity map so the same primary
             key maps to a single Python instance. If False, each load returns fresh instances and
             the map is not consulted (lower memory use; no ``a is b`` guarantees across loads).
+        migrate_updates: If True, additionally update existing tables to match the
+            registered models. Implies ``auto_migrate``. What this covers is
+            capability-relative per backend:
+
+            - **Both backends**: ``ALTER TABLE ... ADD COLUMN`` for model fields
+              missing from the live table, using the same column DDL ``CREATE TABLE``
+              would emit (including single-column indexes and, on Postgres, CHECK
+              constraints and foreign keys). NOT NULL fields need a literal default
+              to backfill existing rows — connecting fails with a clear error
+              otherwise.
+            - **Postgres only**: column type changes
+              (``ALTER COLUMN ... TYPE ... USING`` cast) and nullability changes
+              (``SET/DROP NOT NULL``) when the live column disagrees with the model.
+            - **SQLite**: type/nullability drift cannot be changed in place; ferro
+              emits a ``UserWarning`` naming the column and pointing at Alembic.
+              (SQLite's type affinity makes declared-type drift mostly cosmetic.)
+
+            After any schema change, the connection pool is refreshed so no cached
+            statement can observe the pre-migration schema.
+        migrate_destructive: If True, additionally **drop** live columns that no
+            longer exist on the model (never whole tables). Implies
+            ``migrate_updates``. Dropping is dependency-aware: explicit indexes
+            covering the column are dropped first; columns that are primary keys or
+            enforced by table constraints fail with a clear error instead.
+
+    For schema changes beyond these (renames, primary-key changes, complex
+    transforms), use the Alembic bridge — see ``docs/guide/migrations.md``.
     """
     from .relations import resolve_relationships
 
@@ -90,6 +122,8 @@ async def connect(
         max_connections=pool_config.max_connections,
         min_connections=pool_config.min_connections,
         identity_map=identity_map,
+        migrate_updates=migrate_updates,
+        migrate_destructive=migrate_destructive,
     )
 
 
@@ -110,6 +144,7 @@ __all__ = [
     "Relation",
     "version",
     "create_tables",
+    "migrate",
     "reset_engine",
     "set_default_connection",
     "clear_registry",

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -10,8 +10,25 @@ async def connect(
     min_connections: int = 0,
     *,
     identity_map: bool = True,
+    migrate_updates: bool = False,
+    migrate_destructive: bool = False,
 ) -> None: ...
 async def create_tables(using: Optional[str] = None) -> None: ...
+async def migrate(
+    using: Optional[str] = None,
+    updates: bool = True,
+    destructive: bool = False,
+) -> None:
+    """Run the auto-migrate pass against a connected engine.
+
+    Creates missing tables, then (with ``updates``, the default) adds missing
+    model columns to existing tables and reconciles type/nullability drift on
+    Postgres; with ``destructive`` it also drops live columns no longer on the
+    model. ``destructive`` implies ``updates``. The pool is refreshed after any
+    DDL so no cached statement observes the pre-migration schema.
+    """
+    ...
+
 def _render_create_table_sql_for_test(
     name: str, schema_json: str, dialect: str
 ) -> tuple[str, list[str]]:
@@ -21,6 +38,23 @@ def _render_create_table_sql_for_test(
     ``"sqlite"``.
     """
     ...
+
+def _render_migration_sql_for_test(
+    name: str,
+    schema_json: str,
+    live_columns_json: str,
+    dialect: str,
+    updates: bool = True,
+    destructive: bool = False,
+) -> tuple[list[str], list[str]]:
+    """Test-only: render the auto-migrate diff for one table without a database.
+
+    ``live_columns_json`` is a JSON array of objects with the LiveColumn shape
+    (``name``, ``declared_type``, ``is_nullable``, ``is_primary_key``,
+    ``char_max_len``, ``is_enum_udt``). Returns ``(statements, warnings)``.
+    """
+    ...
+
 async def fetch_all(
     cls: object, tx_id: Optional[str] = None, using: Optional[str] = None
 ) -> list[Any]: ...

--- a/src/introspect.rs
+++ b/src/introspect.rs
@@ -1,0 +1,334 @@
+//! Live database schema introspection.
+//!
+//! Reads the structure of existing tables so the auto-migrate diff
+//! (`src/migrate.rs`) can compare them against registered model schemas.
+//! All queries run unprepared — introspection precedes DDL, and neither may
+//! populate a connection's statement cache (see `EngineHandle::execute_sql_unprepared`).
+
+use crate::backend::{EngineBindValue, EngineHandle, EngineRow, EngineValue};
+use crate::state::SqlDialect;
+use pyo3::prelude::*;
+
+fn serde_default_true() -> bool {
+    true
+}
+
+/// One column of a live database table, normalized across backends.
+///
+/// `Deserialize` exists for the `_render_migration_sql_for_test` helper,
+/// which accepts live columns as JSON so the diff can be exercised without a
+/// database.
+#[derive(Clone, Debug, serde::Deserialize)]
+pub struct LiveColumn {
+    pub name: String,
+    /// SQLite: the declared type from `PRAGMA table_info` (e.g. `varchar`,
+    /// `uuid_text`, `datetime_text`). Postgres: `information_schema.data_type`
+    /// (e.g. `character varying`, `timestamp with time zone`).
+    #[serde(default)]
+    pub declared_type: String,
+    #[serde(default = "serde_default_true")]
+    pub is_nullable: bool,
+    #[serde(default)]
+    pub is_primary_key: bool,
+    /// Postgres `character_maximum_length`; always `None` on SQLite (declared
+    /// lengths live inside `declared_type`, e.g. `varchar(40)`).
+    #[serde(default)]
+    pub char_max_len: Option<i64>,
+    /// Postgres: the column's type is a native enum (`pg_type.typtype = 'e'`).
+    /// Such columns are Alembic-managed and excluded from type reconciliation.
+    #[serde(default)]
+    pub is_enum_udt: bool,
+}
+
+/// One live SQLite index covering some column, with enough context to decide
+/// whether it can be dropped ahead of `ALTER TABLE ... DROP COLUMN`.
+#[derive(Clone, Debug)]
+pub struct SqliteIndex {
+    pub name: String,
+    /// `PRAGMA index_list` origin: `"c"` = explicit `CREATE INDEX` (droppable),
+    /// `"u"` = UNIQUE-constraint autoindex, `"pk"` = PRIMARY KEY autoindex
+    /// (neither autoindex can be dropped with `DROP INDEX`).
+    pub origin: String,
+}
+
+fn row_string(row: &EngineRow, column: &str) -> Option<String> {
+    row.values
+        .iter()
+        .find(|(name, _)| name == column)
+        .and_then(|(_, value)| match value {
+            EngineValue::String(value) => Some(value.clone()),
+            EngineValue::I64(value) => Some(value.to_string()),
+            _ => None,
+        })
+}
+
+fn row_bool(row: &EngineRow, column: &str) -> bool {
+    row.values
+        .iter()
+        .find(|(name, _)| name == column)
+        .map(|(_, value)| match value {
+            EngineValue::Bool(value) => *value,
+            EngineValue::I64(value) => *value != 0,
+            _ => false,
+        })
+        .unwrap_or(false)
+}
+
+fn row_opt_i64(row: &EngineRow, column: &str) -> Option<i64> {
+    row.values
+        .iter()
+        .find(|(name, _)| name == column)
+        .and_then(|(_, value)| value.as_i64())
+}
+
+/// Quote an identifier for direct inclusion in SQL (`PRAGMA` arguments cannot
+/// be bound as parameters).
+pub(crate) fn quote_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+fn introspection_error(context: &str, table: &str, err: sqlx::Error) -> PyErr {
+    pyo3::exceptions::PyRuntimeError::new_err(format!(
+        "Schema introspection failed ({context} for table '{table}'): {err}"
+    ))
+}
+
+/// Read the live columns of `table`. Returns `None` when the table does not
+/// exist (a table cannot have zero columns on either backend).
+pub async fn live_table_columns(
+    engine: &EngineHandle,
+    table: &str,
+) -> PyResult<Option<Vec<LiveColumn>>> {
+    let columns = match engine.backend() {
+        SqlDialect::Sqlite => sqlite_table_columns(engine, table).await?,
+        SqlDialect::Postgres => postgres_table_columns(engine, table).await?,
+    };
+    Ok(if columns.is_empty() {
+        None
+    } else {
+        Some(columns)
+    })
+}
+
+async fn sqlite_table_columns(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveColumn>> {
+    let sql = format!("PRAGMA table_info({})", quote_ident(table));
+    let rows = engine
+        .fetch_all_sql_unprepared(&sql)
+        .await
+        .map_err(|e| introspection_error("PRAGMA table_info", table, e))?;
+
+    Ok(rows
+        .iter()
+        .filter_map(|row| {
+            let name = row_string(row, "name")?;
+            Some(LiveColumn {
+                name,
+                declared_type: row_string(row, "type").unwrap_or_default(),
+                is_nullable: row_opt_i64(row, "notnull") == Some(0),
+                // `pk` is the 1-based position within the primary key (0 = not part of it).
+                is_primary_key: row_opt_i64(row, "pk").unwrap_or(0) > 0,
+                char_max_len: None,
+                is_enum_udt: false,
+            })
+        })
+        .collect())
+}
+
+async fn postgres_table_columns(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveColumn>> {
+    let sql = r#"
+        SELECT
+            c.column_name::text AS column_name,
+            c.data_type::text AS data_type,
+            (c.is_nullable = 'YES') AS is_nullable,
+            c.character_maximum_length::bigint AS char_max_len,
+            EXISTS (
+                SELECT 1
+                FROM pg_attribute a
+                JOIN pg_class cl ON a.attrelid = cl.oid
+                JOIN pg_namespace n ON cl.relnamespace = n.oid
+                JOIN pg_type t ON a.atttypid = t.oid
+                WHERE n.nspname = c.table_schema
+                  AND cl.relname = c.table_name
+                  AND a.attname = c.column_name
+                  AND t.typtype = 'e'
+            ) AS is_enum_udt,
+            EXISTS (
+                SELECT 1
+                FROM pg_index i
+                JOIN pg_class cl ON i.indrelid = cl.oid
+                JOIN pg_namespace n ON cl.relnamespace = n.oid
+                JOIN pg_attribute a ON a.attrelid = cl.oid AND a.attnum = ANY(i.indkey)
+                WHERE n.nspname = c.table_schema
+                  AND cl.relname = c.table_name
+                  AND i.indisprimary
+                  AND a.attname = c.column_name
+            ) AS is_primary_key
+        FROM information_schema.columns c
+        WHERE c.table_schema = current_schema()
+          AND c.table_name = $1
+        ORDER BY c.ordinal_position
+        "#;
+
+    let rows = engine
+        .fetch_all_sql_unprepared_with_binds(sql, &[EngineBindValue::String(table.to_string())])
+        .await
+        .map_err(|e| introspection_error("information_schema.columns", table, e))?;
+
+    Ok(rows
+        .iter()
+        .filter_map(|row| {
+            let name = row_string(row, "column_name")?;
+            Some(LiveColumn {
+                name,
+                declared_type: row_string(row, "data_type").unwrap_or_default(),
+                is_nullable: row_bool(row, "is_nullable"),
+                is_primary_key: row_bool(row, "is_primary_key"),
+                char_max_len: row_opt_i64(row, "char_max_len"),
+                is_enum_udt: row_bool(row, "is_enum_udt"),
+            })
+        })
+        .collect())
+}
+
+/// Live SQLite indexes that cover `column` on `table` (any position, including
+/// composite indexes). Used by the destructive-drop path: explicit indexes
+/// (`origin == "c"`) must be dropped before `DROP COLUMN`; constraint
+/// autoindexes cannot be, and their presence makes the drop impossible.
+pub async fn sqlite_indexes_covering_column(
+    engine: &EngineHandle,
+    table: &str,
+    column: &str,
+) -> PyResult<Vec<SqliteIndex>> {
+    let list_sql = format!("PRAGMA index_list({})", quote_ident(table));
+    let index_rows = engine
+        .fetch_all_sql_unprepared(&list_sql)
+        .await
+        .map_err(|e| introspection_error("PRAGMA index_list", table, e))?;
+
+    let mut covering = Vec::new();
+    for index_row in &index_rows {
+        let Some(index_name) = row_string(index_row, "name") else {
+            continue;
+        };
+        let origin = row_string(index_row, "origin").unwrap_or_default();
+
+        let info_sql = format!("PRAGMA index_info({})", quote_ident(&index_name));
+        let column_rows = engine
+            .fetch_all_sql_unprepared(&info_sql)
+            .await
+            .map_err(|e| introspection_error("PRAGMA index_info", table, e))?;
+        let covers = column_rows
+            .iter()
+            .any(|row| row_string(row, "name").as_deref() == Some(column));
+        if covers {
+            covering.push(SqliteIndex {
+                name: index_name,
+                origin,
+            });
+        }
+    }
+    Ok(covering)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::{BackendKind, PoolSpec};
+
+    async fn memory_engine() -> EngineHandle {
+        EngineHandle::connect(PoolSpec {
+            backend: BackendKind::Sqlite,
+            url: "sqlite::memory:".to_string(),
+            search_path: None,
+            max_connections: 1,
+            min_connections: 0,
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn live_table_columns_reads_sqlite_structure() {
+        let engine = memory_engine().await;
+        engine
+            .execute_sql(
+                "CREATE TABLE invoice (\
+                 id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                 number varchar NOT NULL, \
+                 paid_date date_text, \
+                 total real NOT NULL DEFAULT 0)",
+            )
+            .await
+            .unwrap();
+
+        let columns = live_table_columns(&engine, "invoice")
+            .await
+            .unwrap()
+            .expect("table exists");
+        assert_eq!(columns.len(), 4);
+
+        let by_name = |name: &str| columns.iter().find(|c| c.name == name).unwrap();
+        let id = by_name("id");
+        assert!(id.is_primary_key);
+        let number = by_name("number");
+        assert!(!number.is_nullable);
+        assert_eq!(number.declared_type.to_lowercase(), "varchar");
+        let paid_date = by_name("paid_date");
+        assert!(paid_date.is_nullable);
+        assert_eq!(paid_date.declared_type.to_lowercase(), "date_text");
+        let total = by_name("total");
+        assert!(!total.is_nullable);
+    }
+
+    #[tokio::test]
+    async fn live_table_columns_returns_none_for_missing_table() {
+        let engine = memory_engine().await;
+        assert!(
+            live_table_columns(&engine, "no_such_table")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_indexes_covering_column_distinguishes_origin() {
+        let engine = memory_engine().await;
+        engine
+            .execute_sql(
+                "CREATE TABLE doc (id INTEGER PRIMARY KEY, slug TEXT UNIQUE, status TEXT, kind TEXT)",
+            )
+            .await
+            .unwrap();
+        engine
+            .execute_sql("CREATE INDEX idx_doc_status ON doc (status)")
+            .await
+            .unwrap();
+        engine
+            .execute_sql("CREATE INDEX idx_doc_status_kind ON doc (status, kind)")
+            .await
+            .unwrap();
+
+        let status_indexes = sqlite_indexes_covering_column(&engine, "doc", "status")
+            .await
+            .unwrap();
+        let mut names: Vec<_> = status_indexes.iter().map(|i| i.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, ["idx_doc_status", "idx_doc_status_kind"]);
+        assert!(status_indexes.iter().all(|i| i.origin == "c"));
+
+        let slug_indexes = sqlite_indexes_covering_column(&engine, "doc", "slug")
+            .await
+            .unwrap();
+        assert_eq!(slug_indexes.len(), 1);
+        assert_eq!(slug_indexes[0].origin, "u");
+
+        assert!(
+            sqlite_indexes_covering_column(&engine, "doc", "id")
+                .await
+                .unwrap()
+                .is_empty(),
+            "rowid-alias PK has no autoindex"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 
 mod backend;
 mod connection;
+mod introspect;
+mod migrate;
 mod operations;
 mod query;
 mod schema;
@@ -35,6 +37,26 @@ pub fn log_debug(message: String) {
             // If logging fails, silently continue (don't break the application)
             // In production, we might want to log this to stderr, but for now we'll be silent
         }
+    });
+}
+
+/// Emits a Python `UserWarning` through the `warnings` module.
+///
+/// Used by auto-migrate for conditions that are not errors but that the user
+/// must see (e.g. SQLite type drift it cannot reconcile). Safe to call from
+/// async contexts; failures to warn are swallowed so a logging problem can
+/// never break a migration.
+pub fn emit_user_warning(message: &str) {
+    let message = format!("ferro auto-migrate: {}", message);
+    Python::attach(|py| {
+        let _ = (|| -> PyResult<()> {
+            let warnings = py.import("warnings")?;
+            warnings.call_method1(
+                "warn",
+                (message, py.get_type::<pyo3::exceptions::PyUserWarning>()),
+            )?;
+            Ok(())
+        })();
     });
 }
 
@@ -82,7 +104,10 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(operations::clear_m2m_links, m)?)?;
     m.add_function(wrap_pyfunction!(operations::begin_transaction, m)?)?;
     m.add_function(wrap_pyfunction!(operations::commit_transaction, m)?)?;
-    m.add_function(wrap_pyfunction!(operations::transaction_connection_name, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        operations::transaction_connection_name,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(operations::rollback_transaction, m)?)?;
     m.add_function(wrap_pyfunction!(operations::raw_execute, m)?)?;
     m.add_function(wrap_pyfunction!(operations::raw_fetch_all, m)?)?;
@@ -92,7 +117,15 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(clear_registry, m)?)?;
     m.add_function(wrap_pyfunction!(version, m)?)?;
     m.add_function(wrap_pyfunction!(schema::create_tables, m)?)?;
-    m.add_function(wrap_pyfunction!(schema::_render_create_table_sql_for_test, m)?)?;
+    m.add_function(wrap_pyfunction!(migrate::migrate, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        schema::_render_create_table_sql_for_test,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        migrate::_render_migration_sql_for_test,
+        m
+    )?)?;
 
     Ok(())
 }

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,0 +1,1267 @@
+//! Auto-migrate schema diffing and execution.
+//!
+//! Extends `connect(auto_migrate=True)` beyond table creation: with
+//! `migrate_updates`, missing model columns are added to existing tables
+//! (plus, on Postgres, type/nullability reconciliation); with
+//! `migrate_destructive`, live columns that no longer exist on the model are
+//! dropped. Capability matrix and semantics are documented on the Python
+//! `ferro.connect` / `ferro.migrate` APIs.
+//!
+//! Column DDL is produced by the same `build_column_plan` the CREATE TABLE
+//! emitter uses, so an auto-migrated database is byte-identical to a freshly
+//! created one (AGENTS.md § I-1).
+
+use crate::backend::EngineHandle;
+use crate::introspect::{
+    LiveColumn, live_table_columns, quote_ident, sqlite_indexes_covering_column,
+};
+use crate::schema::{
+    CanonicalType, ColumnPlan, apply_canonical_type, build_column_plan, internal_create_tables,
+    order_schemas_for_creation,
+};
+use crate::state::{IDENTITY_MAP, MODEL_REGISTRY, SqlDialect, engine_for_connection};
+use pyo3::prelude::*;
+use sea_query::{
+    Alias, ColumnDef, ForeignKeyAction, Index, PostgresQueryBuilder, SqliteQueryBuilder, Table,
+};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+/// Which migration behaviors beyond table creation are enabled.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct MigrateOptions {
+    /// Add missing model columns to existing tables; on Postgres, also
+    /// reconcile column type and nullability drift.
+    pub updates: bool,
+    /// Drop live columns that no longer exist on the model. Implies `updates`.
+    pub destructive: bool,
+}
+
+impl MigrateOptions {
+    /// Apply the flag ladder: `destructive` ⇒ `updates`.
+    pub fn laddered(updates: bool, destructive: bool) -> Self {
+        Self {
+            updates: updates || destructive,
+            destructive,
+        }
+    }
+}
+
+/// The DDL and diagnostics produced by diffing one table.
+#[derive(Debug)]
+pub struct MigrationPlan {
+    /// Ready-to-execute DDL statements, in order.
+    pub statements: Vec<String>,
+    /// Columns to drop (destructive mode). Kept separate from `statements`
+    /// because the executor must resolve live index dependencies first.
+    pub drop_columns: Vec<String>,
+    /// Human-readable notes emitted as Python `UserWarning`s.
+    pub warnings: Vec<String>,
+}
+
+impl MigrationPlan {
+    fn new() -> Self {
+        Self {
+            statements: Vec::new(),
+            drop_columns: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.statements.is_empty() && self.drop_columns.is_empty()
+    }
+}
+
+/// The `information_schema.data_type` spelling Postgres reports for each
+/// canonical type, used to detect drift between model and live schema.
+fn pg_type_matches(canonical: CanonicalType, live: &LiveColumn) -> bool {
+    let data_type = live.declared_type.as_str();
+    match canonical {
+        CanonicalType::Integer => data_type == "integer",
+        CanonicalType::SmallInt => data_type == "smallint",
+        CanonicalType::BigInt => data_type == "bigint",
+        CanonicalType::Double => data_type == "double precision",
+        CanonicalType::Decimal => data_type == "numeric",
+        CanonicalType::Boolean => data_type == "boolean",
+        CanonicalType::Json => data_type == "json",
+        CanonicalType::Text => data_type == "text",
+        CanonicalType::Varchar(None) => {
+            data_type == "character varying" && live.char_max_len.is_none()
+        }
+        CanonicalType::Varchar(Some(n)) => {
+            data_type == "character varying" && live.char_max_len == Some(i64::from(n))
+        }
+        CanonicalType::Char(n) => {
+            data_type == "character" && live.char_max_len == Some(i64::from(n))
+        }
+        CanonicalType::Uuid => data_type == "uuid",
+        // DateTime is the SQLite rendering of the timestamp tokens; treat it
+        // like a plain timestamp if it ever reaches a Postgres comparison.
+        CanonicalType::DateTime | CanonicalType::Timestamp => {
+            data_type == "timestamp without time zone"
+        }
+        CanonicalType::TimestampTz => data_type == "timestamp with time zone",
+        CanonicalType::Date => data_type == "date",
+        CanonicalType::Time => data_type == "time without time zone",
+        CanonicalType::Blob => data_type == "bytea",
+    }
+}
+
+/// The DDL spelling used in `ALTER TABLE ... ALTER COLUMN ... TYPE <x> USING <col>::<x>`.
+fn pg_alter_type_target(canonical: CanonicalType) -> String {
+    match canonical {
+        CanonicalType::Integer => "integer".to_string(),
+        CanonicalType::SmallInt => "smallint".to_string(),
+        CanonicalType::BigInt => "bigint".to_string(),
+        CanonicalType::Double => "double precision".to_string(),
+        CanonicalType::Decimal => "numeric".to_string(),
+        CanonicalType::Boolean => "boolean".to_string(),
+        CanonicalType::Json => "json".to_string(),
+        CanonicalType::Text => "text".to_string(),
+        CanonicalType::Varchar(None) => "varchar".to_string(),
+        CanonicalType::Varchar(Some(n)) => format!("varchar({n})"),
+        CanonicalType::Char(n) => format!("char({n})"),
+        CanonicalType::Uuid => "uuid".to_string(),
+        CanonicalType::DateTime | CanonicalType::Timestamp => "timestamp".to_string(),
+        CanonicalType::TimestampTz => "timestamptz".to_string(),
+        CanonicalType::Date => "date".to_string(),
+        CanonicalType::Time => "time".to_string(),
+        CanonicalType::Blob => "bytea".to_string(),
+    }
+}
+
+/// The declared-type string sea-query's SQLite builder renders for each
+/// canonical type (pinned by the cross-emitter parity tests).
+fn sqlite_declared_type(canonical: CanonicalType) -> String {
+    match canonical {
+        CanonicalType::Integer => "integer".to_string(),
+        CanonicalType::SmallInt => "smallint".to_string(),
+        CanonicalType::BigInt => "bigint".to_string(),
+        CanonicalType::Double => "double".to_string(),
+        CanonicalType::Decimal => "real".to_string(),
+        CanonicalType::Boolean => "boolean".to_string(),
+        CanonicalType::Json => "json_text".to_string(),
+        CanonicalType::Text => "text".to_string(),
+        CanonicalType::Varchar(None) => "varchar".to_string(),
+        CanonicalType::Varchar(Some(n)) => format!("varchar({n})"),
+        CanonicalType::Char(n) => format!("char({n})"),
+        CanonicalType::Uuid => "uuid_text".to_string(),
+        CanonicalType::DateTime | CanonicalType::Timestamp => "datetime_text".to_string(),
+        CanonicalType::TimestampTz => "timestamp_with_timezone_text".to_string(),
+        CanonicalType::Date => "date_text".to_string(),
+        CanonicalType::Time => "time_text".to_string(),
+        CanonicalType::Blob => "blob".to_string(),
+    }
+}
+
+/// Storage-semantics class of a declared SQLite type. SQLite is dynamically
+/// typed: many declared-type spellings are storage-equivalent (its type
+/// affinity rules), so drift warnings fire only when the *class* changes —
+/// e.g. `integer` vs `varchar` — not for cosmetic spelling differences like
+/// `DATETIME` (Alembic) vs `datetime_text` (sea-query).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SqliteTypeClass {
+    Integer,
+    Text,
+    Blob,
+    Real,
+    Numeric,
+    Temporal,
+}
+
+fn sqlite_type_class(declared: &str) -> SqliteTypeClass {
+    let declared = declared.to_ascii_lowercase();
+    // ISO-text temporal spellings from both emitters (DATE, DATETIME,
+    // TIMESTAMP, date_text, timestamp_with_timezone_text, ...).
+    if declared.contains("date") || declared.contains("time") {
+        return SqliteTypeClass::Temporal;
+    }
+    if declared.contains("json") {
+        return SqliteTypeClass::Text;
+    }
+    if declared.contains("bool") || declared.contains("int") {
+        return SqliteTypeClass::Integer;
+    }
+    if declared.contains("char") || declared.contains("clob") || declared.contains("text") {
+        return SqliteTypeClass::Text;
+    }
+    if declared.is_empty() || declared.contains("blob") {
+        return SqliteTypeClass::Blob;
+    }
+    if declared.contains("real")
+        || declared.contains("floa")
+        || declared.contains("doub")
+        || declared.contains("num")
+        || declared.contains("dec")
+    {
+        return SqliteTypeClass::Real;
+    }
+    SqliteTypeClass::Numeric
+}
+
+/// Single-column unique index name with the 63-char Postgres-identifier
+/// guard; matches the composite `uq_` convention (AGENTS.md § I-1).
+fn single_unique_index_name(table_lower: &str, col_name: &str) -> String {
+    let raw = format!("uq_{}_{}", table_lower, col_name);
+    if raw.chars().count() > 63 {
+        return format!("{}_uq", raw.chars().take(60).collect::<String>());
+    }
+    raw
+}
+
+fn fk_action_sql(action: ForeignKeyAction) -> &'static str {
+    match action {
+        ForeignKeyAction::Restrict => "RESTRICT",
+        ForeignKeyAction::SetNull => "SET NULL",
+        ForeignKeyAction::SetDefault => "SET DEFAULT",
+        ForeignKeyAction::NoAction => "NO ACTION",
+        ForeignKeyAction::Cascade => "CASCADE",
+    }
+}
+
+/// Convert a JSON-schema scalar default into a sea-query literal usable to
+/// backfill a NOT NULL column add. Non-scalars (and `null`) are not usable.
+fn literal_default_value(default: &serde_json::Value) -> Option<sea_query::Value> {
+    match default {
+        serde_json::Value::Bool(value) => Some((*value).into()),
+        serde_json::Value::Number(value) => value
+            .as_i64()
+            .map(sea_query::Value::from)
+            .or_else(|| value.as_f64().map(sea_query::Value::from)),
+        serde_json::Value::String(value) => Some(value.clone().into()),
+        _ => None,
+    }
+}
+
+fn render_alter(stmt: &sea_query::TableAlterStatement, backend: SqlDialect) -> String {
+    match backend {
+        SqlDialect::Sqlite => stmt.to_string(SqliteQueryBuilder),
+        SqlDialect::Postgres => stmt.to_string(PostgresQueryBuilder),
+    }
+}
+
+/// Diff one registered model schema against its live table and produce the
+/// DDL plan. Pure with respect to the database — callers introspect first.
+///
+/// # Errors
+/// Returns a `PyErr` for changes that cannot be applied safely: adding a
+/// primary-key column, or adding a NOT NULL column without a usable literal
+/// default. These abort the migration ("fail loudly").
+pub fn plan_table_migration(
+    table_lower: &str,
+    schema: &serde_json::Value,
+    live: &[LiveColumn],
+    backend: SqlDialect,
+    opts: MigrateOptions,
+) -> PyResult<MigrationPlan> {
+    let mut plan = MigrationPlan::new();
+    if !opts.updates {
+        return Ok(plan);
+    }
+
+    let live_by_name: HashMap<&str, &LiveColumn> =
+        live.iter().map(|col| (col.name.as_str(), col)).collect();
+
+    let mut model_columns: HashSet<&str> = HashSet::new();
+
+    if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
+        for (col_name, raw_col_info) in properties {
+            model_columns.insert(col_name.as_str());
+            let col_plan = build_column_plan(table_lower, col_name, raw_col_info, schema, backend);
+
+            match live_by_name.get(col_name.as_str()) {
+                None => plan_missing_column(table_lower, col_name, &col_plan, backend, &mut plan)?,
+                Some(live_col) => {
+                    plan_existing_column(
+                        table_lower,
+                        col_name,
+                        &col_plan,
+                        live_col,
+                        backend,
+                        &mut plan,
+                    );
+                }
+            }
+        }
+    }
+
+    if opts.destructive {
+        for live_col in live {
+            if model_columns.contains(live_col.name.as_str()) {
+                continue;
+            }
+            if live_col.is_primary_key {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Cannot drop column '{}.{}': it is part of the primary key. \
+                     Primary-key changes must be migrated with Alembic.",
+                    table_lower, live_col.name
+                )));
+            }
+            plan.drop_columns.push(live_col.name.clone());
+        }
+    }
+
+    Ok(plan)
+}
+
+/// Plan the `ADD COLUMN` (and any follow-up DDL) for a model column missing
+/// from the live table.
+fn plan_missing_column(
+    table_lower: &str,
+    col_name: &str,
+    col_plan: &ColumnPlan,
+    backend: SqlDialect,
+    plan: &mut MigrationPlan,
+) -> PyResult<()> {
+    if col_plan.is_primary_key {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "Cannot add column '{}.{}': it is a primary key, and primary keys cannot \
+             be added to existing tables. Use Alembic for this migration.",
+            table_lower, col_name
+        )));
+    }
+
+    // NOT NULL columns need a literal default to backfill existing rows.
+    let backfill_default = if col_plan.is_nullable {
+        None
+    } else {
+        let literal = col_plan
+            .literal_default
+            .as_ref()
+            .and_then(literal_default_value);
+        match literal {
+            Some(value) => Some(value),
+            None => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Cannot add NOT NULL column '{}.{}' to an existing table: it has no \
+                     literal default to backfill existing rows. Make the field nullable, \
+                     give it a literal default, or use Alembic for this migration.",
+                    table_lower, col_name
+                )));
+            }
+        }
+    };
+
+    // SQLite's ADD COLUMN cannot take a UNIQUE constraint; an explicit unique
+    // index provides the same guarantee.
+    let inline_unique = col_plan.is_unique && backend == SqlDialect::Postgres;
+
+    let mut col_def = ColumnDef::new(Alias::new(col_name));
+    apply_canonical_type(&mut col_def, col_plan.canonical);
+    if !col_plan.is_nullable {
+        col_def.not_null();
+    }
+    if inline_unique {
+        col_def.unique_key();
+    }
+    if let Some(default_value) = &backfill_default {
+        col_def.default(default_value.clone());
+    }
+
+    let stmt = Table::alter()
+        .table(Alias::new(table_lower))
+        .add_column(&mut col_def)
+        .to_owned();
+    plan.statements.push(render_alter(&stmt, backend));
+
+    // The DEFAULT above exists only to backfill: a fresh CREATE TABLE emits no
+    // server default, so drop it for parity. SQLite cannot drop a column
+    // default; the leftover is documented (Alembic's compare_server_default
+    // is off by default, so it produces no phantom diff).
+    if backfill_default.is_some() && backend == SqlDialect::Postgres {
+        plan.statements.push(format!(
+            "ALTER TABLE {} ALTER COLUMN {} DROP DEFAULT",
+            quote_ident(table_lower),
+            quote_ident(col_name)
+        ));
+    }
+
+    if col_plan.is_unique && backend == SqlDialect::Sqlite {
+        let index_name = single_unique_index_name(table_lower, col_name);
+        let index_stmt = Index::create()
+            .unique()
+            .name(&index_name)
+            .table(Alias::new(table_lower))
+            .col(Alias::new(col_name))
+            .if_not_exists()
+            .to_owned();
+        plan.statements
+            .push(index_stmt.to_string(SqliteQueryBuilder));
+        plan.warnings.push(format!(
+            "Added unique column '{}.{}' as a unique index '{}' (SQLite cannot add an \
+             inline UNIQUE constraint to an existing table).",
+            table_lower, col_name, index_name
+        ));
+    }
+
+    // Single-column index and db_check constraint, exactly as CREATE TABLE
+    // would emit them.
+    plan.statements.extend(col_plan.index_sqls.iter().cloned());
+
+    if let Some(fk) = &col_plan.fk {
+        match backend {
+            SqlDialect::Postgres => {
+                // Unnamed, so Postgres assigns "<table>_<col>_fkey" — the same
+                // name an inline FK from CREATE TABLE receives.
+                plan.statements.push(format!(
+                    "ALTER TABLE {} ADD FOREIGN KEY ({}) REFERENCES {} (\"id\") ON DELETE {}",
+                    quote_ident(table_lower),
+                    quote_ident(col_name),
+                    quote_ident(&fk.to_table),
+                    fk_action_sql(fk.on_delete)
+                ));
+            }
+            SqlDialect::Sqlite => {
+                plan.warnings.push(format!(
+                    "Added foreign-key column '{}.{}' without its FOREIGN KEY constraint \
+                     (SQLite cannot add table constraints to an existing table). Referential \
+                     integrity for this column is not database-enforced; use Alembic if you \
+                     need the constraint.",
+                    table_lower, col_name
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Reconcile an existing live column with the model definition. Postgres gets
+/// native `ALTER COLUMN` DDL; SQLite cannot alter columns in place, so drift
+/// surfaces as warnings (and is usually cosmetic there thanks to type
+/// affinity).
+fn plan_existing_column(
+    table_lower: &str,
+    col_name: &str,
+    col_plan: &ColumnPlan,
+    live: &LiveColumn,
+    backend: SqlDialect,
+    plan: &mut MigrationPlan,
+) {
+    // Primary keys (incl. autoincrement/serial) are never reconciled.
+    if col_plan.is_primary_key || live.is_primary_key {
+        return;
+    }
+
+    match backend {
+        SqlDialect::Postgres => {
+            // Native enum columns only exist via Alembic; leave them to it.
+            if !live.is_enum_udt && !pg_type_matches(col_plan.canonical, live) {
+                let target = pg_alter_type_target(col_plan.canonical);
+                plan.statements.push(format!(
+                    "ALTER TABLE {table} ALTER COLUMN {col} TYPE {target} USING {col}::{target}",
+                    table = quote_ident(table_lower),
+                    col = quote_ident(col_name),
+                    target = target,
+                ));
+            }
+            if !col_plan.is_nullable && live.is_nullable {
+                plan.statements.push(format!(
+                    "ALTER TABLE {} ALTER COLUMN {} SET NOT NULL",
+                    quote_ident(table_lower),
+                    quote_ident(col_name)
+                ));
+            } else if col_plan.is_nullable && !live.is_nullable {
+                plan.statements.push(format!(
+                    "ALTER TABLE {} ALTER COLUMN {} DROP NOT NULL",
+                    quote_ident(table_lower),
+                    quote_ident(col_name)
+                ));
+            }
+        }
+        SqlDialect::Sqlite => {
+            let expected = sqlite_declared_type(col_plan.canonical);
+            if sqlite_type_class(&live.declared_type) != sqlite_type_class(&expected) {
+                plan.warnings.push(format!(
+                    "Column '{}.{}' is declared '{}' in the database but the model expects \
+                     '{}'. SQLite cannot change column types in place; use Alembic to \
+                     migrate this column.",
+                    table_lower, col_name, live.declared_type, expected
+                ));
+            }
+            if col_plan.is_nullable != live.is_nullable {
+                plan.warnings.push(format!(
+                    "Column '{}.{}' is {} in the database but the model expects {}. SQLite \
+                     cannot change column nullability in place; use Alembic to migrate \
+                     this column.",
+                    table_lower,
+                    col_name,
+                    if live.is_nullable {
+                        "nullable"
+                    } else {
+                        "NOT NULL"
+                    },
+                    if col_plan.is_nullable {
+                        "nullable"
+                    } else {
+                        "NOT NULL"
+                    },
+                ));
+            }
+        }
+    }
+}
+
+/// Drop one column, resolving SQLite index dependencies first.
+///
+/// Explicit indexes covering the column are orphaned by its removal and are
+/// dropped beforehand (SQLite refuses `DROP COLUMN` on an indexed column).
+/// Constraint autoindexes cannot be dropped separately, so their presence is
+/// a hard error, as is any remaining engine refusal (CHECK references,
+/// triggers, views, inbound foreign keys).
+async fn execute_drop_column(
+    engine: &EngineHandle,
+    table_lower: &str,
+    col_name: &str,
+    backend: SqlDialect,
+) -> PyResult<()> {
+    if backend == SqlDialect::Sqlite {
+        let indexes = sqlite_indexes_covering_column(engine, table_lower, col_name).await?;
+        if let Some(blocking) = indexes.iter().find(|index| index.origin != "c") {
+            let constraint = match blocking.origin.as_str() {
+                "u" => "a UNIQUE constraint",
+                "pk" => "the PRIMARY KEY",
+                _ => "a table constraint",
+            };
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Cannot drop column '{}.{}': it is enforced by {} ('{}'), which SQLite \
+                 cannot drop separately from the table definition. Use Alembic for this \
+                 migration.",
+                table_lower, col_name, constraint, blocking.name
+            )));
+        }
+        for index in &indexes {
+            let sql = format!("DROP INDEX IF EXISTS {}", quote_ident(&index.name));
+            engine.execute_sql_unprepared(&sql).await.map_err(|e| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!(
+                    "Auto-migrate failed dropping index '{}' (required to drop column \
+                     '{}.{}'): {}",
+                    index.name, table_lower, col_name, e
+                ))
+            })?;
+        }
+    }
+
+    let sql = format!(
+        "ALTER TABLE {} DROP COLUMN {}",
+        quote_ident(table_lower),
+        quote_ident(col_name)
+    );
+    engine.execute_sql_unprepared(&sql).await.map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "Cannot drop column '{}.{}': {}. Columns referenced by constraints, foreign \
+             keys, triggers, or views must be migrated with Alembic.",
+            table_lower, col_name, e
+        ))
+    })?;
+    Ok(())
+}
+
+/// Run the full auto-migrate pass: create missing tables, then (per
+/// `MigrateOptions`) reconcile existing tables with the registered models.
+///
+/// After any ALTER/DROP executed, the engine pool is refreshed so no
+/// connection can serve a statement prepared against the pre-DDL schema.
+///
+/// # Errors
+/// Returns a `PyErr` if introspection, DDL execution, or the pool refresh
+/// fails, or if the diff contains a change that cannot be applied safely.
+pub async fn internal_migrate(engine: Arc<EngineHandle>, opts: MigrateOptions) -> PyResult<()> {
+    internal_create_tables(engine.clone()).await?;
+    if !opts.updates {
+        return Ok(());
+    }
+
+    let schemas = {
+        let registry = MODEL_REGISTRY.read().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("Failed to lock Model Registry")
+        })?;
+        registry.clone()
+    };
+    let backend = engine.backend();
+
+    let mut warnings = Vec::new();
+    let mut ddl_ran = false;
+
+    for (name, schema) in order_schemas_for_creation(schemas) {
+        let table_lower = name.to_lowercase();
+        let Some(live) = live_table_columns(&engine, &table_lower).await? else {
+            // Freshly created (or otherwise absent) tables have nothing to diff.
+            continue;
+        };
+
+        let mut plan = plan_table_migration(&table_lower, &schema, &live, backend, opts)?;
+        if plan.is_empty() {
+            warnings.append(&mut plan.warnings);
+            continue;
+        }
+
+        for sql in &plan.statements {
+            engine.execute_sql_unprepared(sql).await.map_err(|e| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!(
+                    "Auto-migrate DDL failed for table '{}': {} (statement: {})",
+                    table_lower, e, sql
+                ))
+            })?;
+            ddl_ran = true;
+        }
+        for col_name in &plan.drop_columns {
+            execute_drop_column(&engine, &table_lower, col_name, backend).await?;
+            ddl_ran = true;
+        }
+        warnings.append(&mut plan.warnings);
+
+        crate::log_debug(format!(
+            "✅ Ferro Engine: Table '{}' migrated ({} statement(s), {} column(s) dropped)",
+            table_lower,
+            plan.statements.len(),
+            plan.drop_columns.len()
+        ));
+    }
+
+    if ddl_ran {
+        engine.refresh_pool().await.map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "Auto-migrate applied DDL but failed to refresh the connection pool: {}",
+                e
+            ))
+        })?;
+        // Identity-mapped instances were hydrated against the pre-migration
+        // schema (e.g. a row loaded before a column add lacks the new field).
+        // The schema lives in the database, which any number of named
+        // connections may share, so the whole map is invalidated — eviction is
+        // always safe; instances simply re-hydrate on next load.
+        IDENTITY_MAP.clear();
+    }
+
+    for warning in &warnings {
+        crate::emit_user_warning(warning);
+    }
+
+    Ok(())
+}
+
+/// Manually run the auto-migrate pass against a connected engine.
+///
+/// Mirrors `connect(auto_migrate=True, migrate_updates=..., migrate_destructive=...)`
+/// for consumers that want explicit control over when DDL runs. `updates`
+/// defaults to true — calling `migrate()` and getting create-only behavior
+/// would be surprising; use `create_tables()` for that.
+///
+/// # Errors
+/// Returns a `PyErr` if the engine is not initialized or the migration fails.
+#[pyfunction]
+#[pyo3(signature = (using=None, updates=true, destructive=false))]
+pub fn migrate(
+    py: Python<'_>,
+    using: Option<String>,
+    updates: bool,
+    destructive: bool,
+) -> PyResult<Bound<'_, PyAny>> {
+    let opts = MigrateOptions::laddered(updates, destructive);
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let engine = engine_for_connection(using)?;
+        internal_migrate(engine, opts).await
+    })
+}
+
+/// Test-only helper: run the migration diff for one table against a JSON
+/// description of its live columns, without a database. Returns
+/// `(statements, warnings)`; destructive drops are rendered as plain
+/// `DROP COLUMN` statements (the dependency-aware index handling needs a live
+/// database and is exercised by integration tests).
+///
+/// # Errors
+/// Returns a `PyErr` when the JSON cannot be parsed, the dialect is
+/// unrecognized, or the diff contains an unsafe change.
+#[pyfunction]
+#[pyo3(name = "_render_migration_sql_for_test")]
+#[pyo3(signature = (name, schema_json, live_columns_json, dialect, updates=true, destructive=false))]
+pub fn _render_migration_sql_for_test(
+    name: String,
+    schema_json: String,
+    live_columns_json: String,
+    dialect: String,
+    updates: bool,
+    destructive: bool,
+) -> PyResult<(Vec<String>, Vec<String>)> {
+    let backend = match dialect.as_str() {
+        "postgres" => SqlDialect::Postgres,
+        "sqlite" => SqlDialect::Sqlite,
+        other => {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Unknown dialect {:?}; expected 'postgres' or 'sqlite'",
+                other
+            )));
+        }
+    };
+    let schema: serde_json::Value = serde_json::from_str(&schema_json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("Invalid JSON schema: {}", e))
+    })?;
+    let live: Vec<LiveColumn> = serde_json::from_str(&live_columns_json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("Invalid live-columns JSON: {}", e))
+    })?;
+
+    let table_lower = name.to_lowercase();
+    let opts = MigrateOptions::laddered(updates, destructive);
+    let plan = plan_table_migration(&table_lower, &schema, &live, backend, opts)?;
+
+    let mut statements = plan.statements;
+    for col_name in &plan.drop_columns {
+        statements.push(format!(
+            "ALTER TABLE {} DROP COLUMN {}",
+            quote_ident(&table_lower),
+            quote_ident(col_name)
+        ));
+    }
+    Ok((statements, plan.warnings))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const UPDATES: MigrateOptions = MigrateOptions {
+        updates: true,
+        destructive: false,
+    };
+    const DESTRUCTIVE: MigrateOptions = MigrateOptions {
+        updates: true,
+        destructive: true,
+    };
+
+    fn live(name: &str, declared_type: &str) -> LiveColumn {
+        LiveColumn {
+            name: name.to_string(),
+            declared_type: declared_type.to_string(),
+            is_nullable: true,
+            is_primary_key: false,
+            char_max_len: None,
+            is_enum_udt: false,
+        }
+    }
+
+    fn invoice_schema() -> serde_json::Value {
+        json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true, "autoincrement": true},
+                "number": {"type": "string", "ferro_nullable": false},
+                "paid_date": {"type": "string", "db_type": "date", "ferro_nullable": true},
+            }
+        })
+    }
+
+    #[test]
+    fn adds_missing_nullable_column_on_both_backends() {
+        let schema = invoice_schema();
+        for (backend, varchar_spelling) in [
+            (SqlDialect::Sqlite, "varchar"),
+            (SqlDialect::Postgres, "character varying"),
+        ] {
+            let live_cols = vec![
+                LiveColumn {
+                    is_primary_key: true,
+                    ..live("id", "integer")
+                },
+                LiveColumn {
+                    is_nullable: false,
+                    ..live("number", varchar_spelling)
+                },
+            ];
+            let plan =
+                plan_table_migration("invoice", &schema, &live_cols, backend, UPDATES).unwrap();
+            assert_eq!(
+                plan.statements.len(),
+                1,
+                "{:?}: {:?}",
+                backend,
+                plan.statements
+            );
+            let sql = &plan.statements[0];
+            assert!(sql.contains("ALTER TABLE \"invoice\""), "{sql}");
+            assert!(sql.contains("ADD COLUMN \"paid_date\""), "{sql}");
+            assert!(
+                plan.warnings.is_empty(),
+                "{:?}: {:?}",
+                backend,
+                plan.warnings
+            );
+        }
+    }
+
+    #[test]
+    fn add_column_reuses_create_table_type_spelling() {
+        let schema = invoice_schema();
+        let live_cols = vec![
+            LiveColumn {
+                is_primary_key: true,
+                ..live("id", "integer")
+            },
+            live("number", "varchar"),
+        ];
+        let plan =
+            plan_table_migration("invoice", &schema, &live_cols, SqlDialect::Sqlite, UPDATES)
+                .unwrap();
+        // db_type "date" renders date_text on SQLite — identical to CREATE TABLE.
+        assert!(
+            plan.statements[0].contains("date_text"),
+            "{}",
+            plan.statements[0]
+        );
+    }
+
+    #[test]
+    fn missing_not_null_column_with_literal_default_backfills() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "status": {"type": "string", "ferro_nullable": false, "default": "draft"},
+            }
+        });
+        let live_cols = vec![LiveColumn {
+            is_primary_key: true,
+            ..live("id", "integer")
+        }];
+
+        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
+            .unwrap();
+        assert_eq!(plan.statements.len(), 2, "{:?}", plan.statements);
+        assert!(
+            plan.statements[0].contains("NOT NULL"),
+            "{}",
+            plan.statements[0]
+        );
+        assert!(
+            plan.statements[0].contains("DEFAULT 'draft'"),
+            "{}",
+            plan.statements[0]
+        );
+        assert!(
+            plan.statements[1].contains("DROP DEFAULT"),
+            "Postgres must not keep the backfill default: {}",
+            plan.statements[1]
+        );
+
+        let plan =
+            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+        assert_eq!(
+            plan.statements.len(),
+            1,
+            "SQLite cannot DROP DEFAULT: {:?}",
+            plan.statements
+        );
+        assert!(
+            plan.statements[0].contains("DEFAULT 'draft'"),
+            "{}",
+            plan.statements[0]
+        );
+    }
+
+    #[test]
+    fn missing_not_null_column_without_default_fails_loudly() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "created_at": {"type": "string", "format": "date-time", "ferro_nullable": false},
+            }
+        });
+        let live_cols = vec![LiveColumn {
+            is_primary_key: true,
+            ..live("id", "integer")
+        }];
+
+        for backend in [SqlDialect::Sqlite, SqlDialect::Postgres] {
+            let err =
+                plan_table_migration("doc", &schema, &live_cols, backend, UPDATES).unwrap_err();
+            let message = err.to_string();
+            assert!(message.contains("doc.created_at"), "{message}");
+            assert!(message.contains("Alembic"), "{message}");
+        }
+    }
+
+    #[test]
+    fn missing_primary_key_column_fails_loudly() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "name": {"type": "string"},
+            }
+        });
+        let live_cols = vec![live("name", "varchar")];
+        let err = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES)
+            .unwrap_err();
+        assert!(err.to_string().contains("primary key"), "{err}");
+    }
+
+    #[test]
+    fn unique_column_add_strips_inline_unique_on_sqlite() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "slug": {"type": "string", "unique": true},
+            }
+        });
+        let live_cols = vec![LiveColumn {
+            is_primary_key: true,
+            ..live("id", "integer")
+        }];
+
+        let plan =
+            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+        assert!(
+            !plan.statements[0].to_uppercase().contains("UNIQUE"),
+            "inline UNIQUE must be stripped on SQLite: {}",
+            plan.statements[0]
+        );
+        assert!(
+            plan.statements[1].contains("CREATE UNIQUE INDEX IF NOT EXISTS \"uq_doc_slug\""),
+            "{}",
+            plan.statements[1]
+        );
+        assert_eq!(plan.warnings.len(), 1);
+
+        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
+            .unwrap();
+        assert!(
+            plan.statements[0].to_uppercase().contains("UNIQUE"),
+            "Postgres keeps the inline UNIQUE: {}",
+            plan.statements[0]
+        );
+        assert!(plan.warnings.is_empty());
+    }
+
+    #[test]
+    fn indexed_column_add_emits_index_sql() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "status": {"type": "string", "index": true},
+            }
+        });
+        let live_cols = vec![LiveColumn {
+            is_primary_key: true,
+            ..live("id", "integer")
+        }];
+        let plan =
+            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+        assert_eq!(plan.statements.len(), 2, "{:?}", plan.statements);
+        assert!(
+            plan.statements[1].contains("\"idx_doc_status\""),
+            "{}",
+            plan.statements[1]
+        );
+    }
+
+    #[test]
+    fn fk_shadow_column_add_handles_backend_capabilities() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "client_id": {
+                    "type": "integer",
+                    "foreign_key": {"to_table": "client", "on_delete": "CASCADE"},
+                },
+            }
+        });
+        let live_cols = vec![LiveColumn {
+            is_primary_key: true,
+            ..live("id", "integer")
+        }];
+
+        let plan = plan_table_migration(
+            "invoice",
+            &schema,
+            &live_cols,
+            SqlDialect::Postgres,
+            UPDATES,
+        )
+        .unwrap();
+        assert_eq!(plan.statements.len(), 2, "{:?}", plan.statements);
+        assert_eq!(
+            plan.statements[1],
+            "ALTER TABLE \"invoice\" ADD FOREIGN KEY (\"client_id\") REFERENCES \"client\" (\"id\") ON DELETE CASCADE"
+        );
+
+        let plan =
+            plan_table_migration("invoice", &schema, &live_cols, SqlDialect::Sqlite, UPDATES)
+                .unwrap();
+        assert_eq!(plan.statements.len(), 1, "{:?}", plan.statements);
+        assert_eq!(plan.warnings.len(), 1);
+        assert!(
+            plan.warnings[0].contains("FOREIGN KEY"),
+            "{}",
+            plan.warnings[0]
+        );
+    }
+
+    #[test]
+    fn pg_type_mismatch_emits_alter_with_using_cast() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "total": {"type": "integer", "db_type": "bigint", "ferro_nullable": false},
+            }
+        });
+        let live_cols = vec![
+            LiveColumn {
+                is_primary_key: true,
+                ..live("id", "integer")
+            },
+            LiveColumn {
+                is_nullable: false,
+                ..live("total", "integer")
+            },
+        ];
+        let plan = plan_table_migration(
+            "invoice",
+            &schema,
+            &live_cols,
+            SqlDialect::Postgres,
+            UPDATES,
+        )
+        .unwrap();
+        assert_eq!(plan.statements.len(), 1, "{:?}", plan.statements);
+        assert_eq!(
+            plan.statements[0],
+            "ALTER TABLE \"invoice\" ALTER COLUMN \"total\" TYPE bigint USING \"total\"::bigint"
+        );
+    }
+
+    #[test]
+    fn pg_nullability_mismatch_emits_set_and_drop_not_null() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "a": {"type": "string", "ferro_nullable": false},
+                "b": {"type": "string", "ferro_nullable": true},
+            }
+        });
+        let live_cols = vec![
+            LiveColumn {
+                is_primary_key: true,
+                ..live("id", "integer")
+            },
+            LiveColumn {
+                declared_type: "character varying".to_string(),
+                ..live("a", "character varying")
+            },
+            LiveColumn {
+                is_nullable: false,
+                ..live("b", "character varying")
+            },
+        ];
+        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
+            .unwrap();
+        assert!(
+            plan.statements
+                .contains(&"ALTER TABLE \"doc\" ALTER COLUMN \"a\" SET NOT NULL".to_string()),
+            "{:?}",
+            plan.statements
+        );
+        assert!(
+            plan.statements
+                .contains(&"ALTER TABLE \"doc\" ALTER COLUMN \"b\" DROP NOT NULL".to_string()),
+            "{:?}",
+            plan.statements
+        );
+    }
+
+    #[test]
+    fn pg_enum_udt_columns_are_never_type_reconciled() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "status": {"type": "string"},
+            }
+        });
+        let live_cols = vec![
+            LiveColumn {
+                is_primary_key: true,
+                ..live("id", "integer")
+            },
+            LiveColumn {
+                is_enum_udt: true,
+                declared_type: "USER-DEFINED".to_string(),
+                ..live("status", "USER-DEFINED")
+            },
+        ];
+        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
+            .unwrap();
+        assert!(plan.statements.is_empty(), "{:?}", plan.statements);
+    }
+
+    #[test]
+    fn sqlite_type_drift_warns_only_on_storage_class_change() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "created_at": {"type": "string", "format": "date-time"},
+                "count": {"type": "integer"},
+            }
+        });
+        // DATETIME (Alembic spelling) vs timestamp_with_timezone_text: same
+        // storage class, no warning. varchar vs integer: real drift, warn.
+        let live_cols = vec![
+            LiveColumn {
+                is_primary_key: true,
+                ..live("id", "integer")
+            },
+            live("created_at", "DATETIME"),
+            live("count", "varchar"),
+        ];
+        let plan =
+            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+        assert!(plan.statements.is_empty(), "{:?}", plan.statements);
+        assert_eq!(plan.warnings.len(), 1, "{:?}", plan.warnings);
+        assert!(
+            plan.warnings[0].contains("doc.count"),
+            "{}",
+            plan.warnings[0]
+        );
+        assert!(plan.warnings[0].contains("Alembic"), "{}", plan.warnings[0]);
+    }
+
+    #[test]
+    fn sqlite_nullability_drift_warns() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "name": {"type": "string", "ferro_nullable": false},
+            }
+        });
+        let live_cols = vec![
+            LiveColumn {
+                is_primary_key: true,
+                ..live("id", "integer")
+            },
+            live("name", "varchar"),
+        ];
+        let plan =
+            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+        assert!(plan.statements.is_empty());
+        assert_eq!(plan.warnings.len(), 1);
+        assert!(
+            plan.warnings[0].contains("NOT NULL"),
+            "{}",
+            plan.warnings[0]
+        );
+    }
+
+    #[test]
+    fn destructive_collects_removed_columns_and_protects_pk() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "name": {"type": "string"},
+            }
+        });
+        let live_cols = vec![
+            LiveColumn {
+                is_primary_key: true,
+                ..live("id", "integer")
+            },
+            live("name", "varchar"),
+            live("legacy_notes", "text"),
+        ];
+
+        let plan =
+            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, DESTRUCTIVE)
+                .unwrap();
+        assert_eq!(plan.drop_columns, vec!["legacy_notes".to_string()]);
+
+        // Without the destructive flag the extra column is untouched.
+        let plan =
+            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+        assert!(plan.drop_columns.is_empty());
+
+        // A live PK column missing from the model is a hard error.
+        let schema_without_id = json!({
+            "properties": {
+                "name": {"type": "string"},
+            }
+        });
+        let err = plan_table_migration(
+            "doc",
+            &schema_without_id,
+            &live_cols,
+            SqlDialect::Sqlite,
+            DESTRUCTIVE,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("primary key"), "{err}");
+    }
+
+    #[test]
+    fn no_updates_flag_produces_empty_plan() {
+        let schema = invoice_schema();
+        let live_cols = vec![live("number", "varchar")];
+        let plan = plan_table_migration(
+            "invoice",
+            &schema,
+            &live_cols,
+            SqlDialect::Sqlite,
+            MigrateOptions::default(),
+        )
+        .unwrap();
+        assert!(plan.is_empty());
+        assert!(plan.warnings.is_empty());
+    }
+
+    #[test]
+    fn ladder_implies_updates_from_destructive() {
+        let opts = MigrateOptions::laddered(false, true);
+        assert!(opts.updates);
+        assert!(opts.destructive);
+    }
+
+    #[test]
+    fn sqlite_type_classes_group_storage_equivalent_spellings() {
+        for (a, b) in [
+            ("DATETIME", "timestamp_with_timezone_text"),
+            ("DATE", "date_text"),
+            ("uuid_text", "char(32)"),
+            ("JSON", "json_text"),
+            ("NUMERIC", "real"),
+            ("BOOLEAN", "integer"),
+            ("BIGINT", "integer"),
+            ("VARCHAR(3)", "varchar"),
+        ] {
+            assert_eq!(
+                sqlite_type_class(a),
+                sqlite_type_class(b),
+                "{a} and {b} should be storage-equivalent"
+            );
+        }
+        assert_ne!(sqlite_type_class("integer"), sqlite_type_class("varchar"));
+        assert_ne!(sqlite_type_class("blob"), sqlite_type_class("text"));
+    }
+
+    #[test]
+    fn render_helper_outputs_drop_statements() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+            }
+        });
+        let live_json = json!([
+            {"name": "id", "declared_type": "integer", "is_primary_key": true, "is_nullable": false},
+            {"name": "stale", "declared_type": "varchar"},
+        ]);
+        let (statements, warnings) = _render_migration_sql_for_test(
+            "Doc".to_string(),
+            schema.to_string(),
+            live_json.to_string(),
+            "sqlite".to_string(),
+            true,
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            statements,
+            vec!["ALTER TABLE \"doc\" DROP COLUMN \"stale\"".to_string()]
+        );
+        assert!(warnings.is_empty());
+    }
+}

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -29,12 +29,9 @@ fn get_transaction_connection(tx_id: Option<String>) -> Option<TransactionConnec
 
 fn get_transaction_route(tx_id: Option<String>) -> Option<(String, TransactionConnection)> {
     tx_id.and_then(|id| {
-        TRANSACTION_REGISTRY.get(&id).map(|tx| {
-            (
-                tx.value().connection_name.clone(),
-                tx.value().conn.clone(),
-            )
-        })
+        TRANSACTION_REGISTRY
+            .get(&id)
+            .map(|tx| (tx.value().connection_name.clone(), tx.value().conn.clone()))
     })
 }
 
@@ -45,7 +42,12 @@ fn active_engine_for_connection(using: Option<String>) -> PyResult<Arc<EngineHan
 fn active_route_for_operation(
     tx_id: Option<String>,
     using: Option<String>,
-) -> PyResult<(String, Arc<EngineHandle>, Option<TransactionConnection>, BackendKind)> {
+) -> PyResult<(
+    String,
+    Arc<EngineHandle>,
+    Option<TransactionConnection>,
+    BackendKind,
+)> {
     let tx_route = get_transaction_route(tx_id);
     let route_using = tx_route
         .as_ref()
@@ -231,11 +233,14 @@ fn engine_value_to_rust_value(
     }
 }
 
+/// One parsed row: the primary-key value (when present) plus all column values.
+type ParsedRow = (Option<String>, Vec<(String, RustValue)>);
+
 fn typed_rows_to_parsed_data(
     rows: Vec<EngineRow>,
     schema: &serde_json::Value,
     pk_col: Option<&str>,
-) -> Vec<(Option<String>, Vec<(String, RustValue)>)> {
+) -> Vec<ParsedRow> {
     rows.into_iter()
         .map(|row| {
             let mut row_pk_val = None;
@@ -581,6 +586,7 @@ fn schema_property<'a>(
 /// `uuid_columns` / `ts_cast`). Non-null UUID values on Postgres are parsed
 /// to `uuid::Uuid` and emitted as `Value::Uuid(Some(...))` -- no
 /// `cast_as("uuid")` wrapping. See `docs/solutions/patterns/typed-null-binds.md`.
+#[allow(clippy::too_many_arguments)]
 fn schema_value_expr(
     schema: &serde_json::Value,
     table_name: &str,
@@ -807,7 +813,10 @@ pub fn begin_transaction(
                 pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to BEGIN: {}", e))
             })?;
 
-            TRANSACTION_REGISTRY.insert(tx_id.clone(), TransactionHandle::root(conn, connection_name));
+            TRANSACTION_REGISTRY.insert(
+                tx_id.clone(),
+                TransactionHandle::root(conn, connection_name),
+            );
         }
 
         Ok(tx_id)
@@ -923,8 +932,7 @@ pub fn fetch_all<'py>(
     let cls_py = cls.unbind();
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (connection_name, engine, tx_conn, backend) =
-            active_route_for_operation(tx_id, using)?;
+        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
         let use_identity_map = engine.is_identity_map_enabled();
 
         let table_name = name.to_lowercase();
@@ -1007,17 +1015,13 @@ pub fn fetch_all<'py>(
             let connection_attr_str = pyo3::intern!(py, "__ferro_connection_name");
 
             for (row_pk_val, fields) in parsed_data {
-                if use_identity_map {
-                    if let Some(ref pk_val) = row_pk_val
-                        && let Some(existing_obj) = IDENTITY_MAP.get(&(
-                            connection_name.clone(),
-                            name.clone(),
-                            pk_val.clone(),
-                        ))
-                    {
-                        results.append(existing_obj.value().clone_ref(py))?;
-                        continue;
-                    }
+                if use_identity_map
+                    && let Some(ref pk_val) = row_pk_val
+                    && let Some(existing_obj) =
+                        IDENTITY_MAP.get(&(connection_name.clone(), name.clone(), pk_val.clone()))
+                {
+                    results.append(existing_obj.value().clone_ref(py))?;
+                    continue;
                 }
 
                 let instance = cls.call_method1(new_str, (cls,))?;
@@ -1034,15 +1038,13 @@ pub fn fetch_all<'py>(
                 }
 
                 let _ = instance.setattr(pydantic_fields_set_str, fields_set);
-                set_pydantic_hydration_slots(py, &cls, &instance)?;
+                set_pydantic_hydration_slots(py, cls, &instance)?;
 
-                if use_identity_map {
-                    if let Some(pk_val) = row_pk_val {
-                        IDENTITY_MAP.insert(
-                            (connection_name.clone(), name.clone(), pk_val),
-                            instance.clone().unbind(),
-                        );
-                    }
+                if use_identity_map && let Some(pk_val) = row_pk_val {
+                    IDENTITY_MAP.insert(
+                        (connection_name.clone(), name.clone(), pk_val),
+                        instance.clone().unbind(),
+                    );
                 }
 
                 results.append(instance)?;
@@ -1080,18 +1082,16 @@ pub fn fetch_one<'py>(
     let (connection_name, engine) = active_connection_for_route(using.clone())?;
 
     // Check Identity Map first (if no transaction, or even with transaction, IM is usually safe)
-    if engine.is_identity_map_enabled() {
-        if let Some(existing_obj) =
+    if engine.is_identity_map_enabled()
+        && let Some(existing_obj) =
             IDENTITY_MAP.get(&(connection_name.clone(), name.clone(), pk_val.clone()))
-        {
-            let obj = existing_obj.value().clone_ref(py);
-            return pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(obj) });
-        }
+    {
+        let obj = existing_obj.value().clone_ref(py);
+        return pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(obj) });
     }
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (connection_name, engine, tx_conn, backend) =
-            active_route_for_operation(tx_id, using)?;
+        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
         let use_identity_map = engine.is_identity_map_enabled();
 
         let table_name = name.to_lowercase();
@@ -1201,7 +1201,7 @@ pub fn fetch_one<'py>(
                 }
 
                 let _ = instance.setattr(pyo3::intern!(py, "__pydantic_fields_set__"), fields_set);
-                set_pydantic_hydration_slots(py, &cls, &instance)?;
+                set_pydantic_hydration_slots(py, cls, &instance)?;
                 if use_identity_map {
                     IDENTITY_MAP.insert(
                         (connection_name.clone(), name.clone(), pk_val),
@@ -1551,8 +1551,7 @@ pub fn fetch_filtered<'py>(
     })?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (connection_name, engine, tx_conn, backend) =
-            active_route_for_operation(tx_id, using)?;
+        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
         let use_identity_map = engine.is_identity_map_enabled();
 
         let table_name = name.to_lowercase();
@@ -1681,17 +1680,13 @@ pub fn fetch_filtered<'py>(
             let connection_attr_str = pyo3::intern!(py, "__ferro_connection_name");
 
             for (row_pk_val, fields) in parsed_data {
-                if use_identity_map {
-                    if let Some(ref pk_val) = row_pk_val
-                        && let Some(existing_obj) = IDENTITY_MAP.get(&(
-                            connection_name.clone(),
-                            name.clone(),
-                            pk_val.clone(),
-                        ))
-                    {
-                        results.append(existing_obj.value().clone_ref(py))?;
-                        continue;
-                    }
+                if use_identity_map
+                    && let Some(ref pk_val) = row_pk_val
+                    && let Some(existing_obj) =
+                        IDENTITY_MAP.get(&(connection_name.clone(), name.clone(), pk_val.clone()))
+                {
+                    results.append(existing_obj.value().clone_ref(py))?;
+                    continue;
                 }
 
                 let instance = cls.call_method1(new_str, (cls,))?;
@@ -1708,15 +1703,13 @@ pub fn fetch_filtered<'py>(
                 }
 
                 let _ = instance.setattr(pydantic_fields_set_str, fields_set);
-                set_pydantic_hydration_slots(py, &cls, &instance)?;
+                set_pydantic_hydration_slots(py, cls, &instance)?;
 
-                if use_identity_map {
-                    if let Some(pk_val) = row_pk_val {
-                        IDENTITY_MAP.insert(
-                            (connection_name.clone(), name.clone(), pk_val),
-                            instance.clone().unbind(),
-                        );
-                    }
+                if use_identity_map && let Some(pk_val) = row_pk_val {
+                    IDENTITY_MAP.insert(
+                        (connection_name.clone(), name.clone(), pk_val),
+                        instance.clone().unbind(),
+                    );
                 }
 
                 results.append(instance)?;
@@ -1902,7 +1895,7 @@ pub fn delete_record(
             let no_uuid = HashSet::new();
             let no_ts: HashMap<String, String> = HashMap::new();
             let pk_expr = schema_value_expr(
-                &schema,
+                schema,
                 &table_name,
                 &pk_name,
                 &serde_json::Value::String(pk_val),
@@ -2024,7 +2017,7 @@ pub fn update_filtered(
                 update.value(
                     Alias::new(&key),
                     schema_value_expr(
-                        &schema,
+                        schema,
                         &table_name,
                         &key,
                         &value,
@@ -2056,6 +2049,7 @@ pub fn update_filtered(
 
 #[pyfunction]
 #[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None))]
+#[allow(clippy::too_many_arguments)]
 pub fn add_m2m_links<'py>(
     py: Python<'py>,
     join_table: String,
@@ -2111,6 +2105,7 @@ pub fn add_m2m_links<'py>(
 
 #[pyfunction]
 #[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None))]
+#[allow(clippy::too_many_arguments)]
 pub fn remove_m2m_links<'py>(
     py: Python<'py>,
     join_table: String,
@@ -2287,7 +2282,7 @@ fn python_to_engine_bind_value(
     }
     Err(pyo3::exceptions::PyTypeError::new_err(format!(
         "Unsupported raw SQL bind value: {}",
-        val.repr()?.to_string()
+        val.repr()?
     )))
 }
 
@@ -3088,8 +3083,7 @@ mod engine_value_to_rust_value_tests {
     #[test]
     fn decimal_column_maps_real_and_text() {
         let schema = decimal_schema();
-        let from_real =
-            engine_value_to_rust_value(EngineValue::F64(1.5), &schema, "hours");
+        let from_real = engine_value_to_rust_value(EngineValue::F64(1.5), &schema, "hours");
         assert!(matches!(from_real, RustValue::Decimal(ref s) if s == "1.5"));
         let from_text =
             engine_value_to_rust_value(EngineValue::String("2.25".into()), &schema, "hours");
@@ -3137,7 +3131,8 @@ mod engine_value_to_rust_value_tests {
             "happened_at",
         );
         assert!(matches!(ok, RustValue::DateTime(_)));
-        let from_int = engine_value_to_rust_value(EngineValue::I64(1713984600), &schema, "happened_at");
+        let from_int =
+            engine_value_to_rust_value(EngineValue::I64(1713984600), &schema, "happened_at");
         assert!(matches!(from_int, RustValue::BigInt(1713984600)));
     }
 
@@ -3175,7 +3170,8 @@ mod engine_value_to_rust_value_tests {
             &schema,
             "payload",
         );
-        assert!(matches!(out, RustValue::Json(v) if v.get("k").and_then(|x| x.as_str()) == Some("v")));
+        assert!(
+            matches!(out, RustValue::Json(v) if v.get("k").and_then(|x| x.as_str()) == Some("v"))
+        );
     }
-
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -73,7 +73,7 @@ impl QueryDef {
             // Python `None` becomes JSON `null`, which serde deserializes as
             // `Option<serde_json::Value>::None` (not `Some(Null)`). SQL `col = NULL`
             // is never true — use `IS NULL` / `IS NOT NULL` for `== None` / `!= None`.
-            let rhs_is_json_null = node.value.as_ref().map_or(true, serde_json::Value::is_null);
+            let rhs_is_json_null = node.value.as_ref().is_none_or(serde_json::Value::is_null);
 
             let expr: SimpleExpr = if rhs_is_json_null {
                 match node.operator.as_str() {
@@ -207,9 +207,10 @@ impl QueryDef {
     ) -> SimpleExpr {
         if let Value::String(s) = val {
             if backend == SqlDialect::Postgres {
-                if let Some(tn) =
-                    crate::schema_bind::native_postgres_enum_udt_name(col_name, &self.postgres_enum_udt)
-                {
+                if let Some(tn) = crate::schema_bind::native_postgres_enum_udt_name(
+                    col_name,
+                    &self.postgres_enum_udt,
+                ) {
                     return crate::schema_bind::postgres_enum_string_rhs_expr(s, tn);
                 }
 
@@ -228,7 +229,7 @@ impl QueryDef {
                     return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
                         .cast_as("date");
                 }
-                if model_column_format(&self.model_name, col_name).as_deref() == Some("binary") {
+                if model_column_format(&self.model_name, col_name) == Some("binary") {
                     return Expr::value(sea_query::Value::Bytes(Some(Box::new(
                         s.as_bytes().to_vec(),
                     ))));
@@ -360,15 +361,9 @@ fn model_column_format(model_name: &str, col: &str) -> Option<&'static str> {
     let Ok(registry) = MODEL_REGISTRY.read() else {
         return None;
     };
-    let Some(schema) = registry.get(model_name) else {
-        return None;
-    };
-    let Some(props) = schema.get("properties").and_then(|p| p.as_object()) else {
-        return None;
-    };
-    let Some(col_info) = props.get(col) else {
-        return None;
-    };
+    let schema = registry.get(model_name)?;
+    let props = schema.get("properties").and_then(|p| p.as_object())?;
+    let col_info = props.get(col)?;
     match property_schema_format(col_info) {
         Some("uuid") => Some("uuid"),
         Some("date-time") => Some("date-time"),
@@ -732,7 +727,8 @@ mod tests {
         let sql = Query::select().expr(rhs).to_string(PostgresQueryBuilder);
 
         assert!(
-            !sql.to_lowercase().contains("as \"color\"") && !sql.to_lowercase().contains("as color"),
+            !sql.to_lowercase().contains("as \"color\"")
+                && !sql.to_lowercase().contains("as color"),
             "auto-migrate TEXT enum columns must not cast without catalog UDT: {sql}"
         );
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -88,7 +88,7 @@ fn schema_dependencies(schema: &serde_json::Value) -> Vec<String> {
     deps
 }
 
-fn order_schemas_for_creation(
+pub(crate) fn order_schemas_for_creation(
     schemas: std::collections::HashMap<String, serde_json::Value>,
 ) -> Vec<(String, serde_json::Value)> {
     let mut remaining: Vec<(String, serde_json::Value)> = schemas.into_iter().collect();
@@ -128,38 +128,105 @@ fn order_schemas_for_creation(
     ordered
 }
 
-fn json_type_to_sea_query_for_backend(
-    col_def: &mut ColumnDef,
-    json_type: &str,
-    backend: SqlDialect,
-) {
-    match json_type {
-        "integer" => {
+/// Canonical, backend-resolved column type shared by every Rust DDL path —
+/// CREATE TABLE, ALTER TABLE ADD COLUMN, and schema diffing. The pair
+/// `canonical_column_type` → `apply_canonical_type` is the single source of
+/// truth for "what SQL type does this model field get"; any path that needs a
+/// column type must go through it so emitters cannot drift. See AGENTS.md § I-1.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CanonicalType {
+    Integer,
+    SmallInt,
+    BigInt,
+    Double,
+    Decimal,
+    Boolean,
+    Json,
+    Text,
+    /// `varchar` with optional length (`.string()` / `.string_len(n)`).
+    Varchar(Option<u32>),
+    Char(u32),
+    Uuid,
+    /// SQLite rendering of the `timestamp`/`timestamptz` tokens (`.date_time()`).
+    DateTime,
+    Timestamp,
+    TimestampTz,
+    Date,
+    Time,
+    Blob,
+}
+
+pub(crate) fn apply_canonical_type(col_def: &mut ColumnDef, canonical: CanonicalType) {
+    match canonical {
+        CanonicalType::Integer => {
             col_def.integer();
         }
-        "string" => {
-            col_def.string();
+        CanonicalType::SmallInt => {
+            col_def.small_integer();
         }
-        "number" => {
+        CanonicalType::BigInt => {
+            col_def.big_integer();
+        }
+        CanonicalType::Double => {
             col_def.double();
         }
-        "boolean" => {
-            match backend {
-                SqlDialect::Sqlite => {
-                    // SQLite stores booleans as integers.
-                    col_def.integer();
-                }
-                SqlDialect::Postgres => {
-                    col_def.boolean();
-                }
-            }
+        CanonicalType::Decimal => {
+            col_def.decimal();
         }
-        "object" | "array" => {
+        CanonicalType::Boolean => {
+            col_def.boolean();
+        }
+        CanonicalType::Json => {
             col_def.json();
         }
-        _ => {
+        CanonicalType::Text => {
+            col_def.text();
+        }
+        CanonicalType::Varchar(None) => {
             col_def.string();
         }
+        CanonicalType::Varchar(Some(n)) => {
+            col_def.string_len(n);
+        }
+        CanonicalType::Char(n) => {
+            col_def.char_len(n);
+        }
+        CanonicalType::Uuid => {
+            col_def.uuid();
+        }
+        CanonicalType::DateTime => {
+            col_def.date_time();
+        }
+        CanonicalType::Timestamp => {
+            col_def.timestamp();
+        }
+        CanonicalType::TimestampTz => {
+            col_def.timestamp_with_time_zone();
+        }
+        CanonicalType::Date => {
+            col_def.date();
+        }
+        CanonicalType::Time => {
+            col_def.time();
+        }
+        CanonicalType::Blob => {
+            col_def.blob();
+        }
+    }
+}
+
+fn json_type_to_canonical(json_type: &str, backend: SqlDialect) -> CanonicalType {
+    match json_type {
+        "integer" => CanonicalType::Integer,
+        "string" => CanonicalType::Varchar(None),
+        "number" => CanonicalType::Double,
+        "boolean" => match backend {
+            // SQLite stores booleans as integers.
+            SqlDialect::Sqlite => CanonicalType::Integer,
+            SqlDialect::Postgres => CanonicalType::Boolean,
+        },
+        "object" | "array" => CanonicalType::Json,
+        _ => CanonicalType::Varchar(None),
     }
 }
 
@@ -243,73 +310,71 @@ fn parse_varchar_token(token: &str) -> Option<u32> {
     if n == 0 { None } else { Some(n) }
 }
 
-/// Dispatch a canonical `db_type` token onto a `ColumnDef`. Returns `true` when
-/// the token was recognized. Strict per-class-definition validation runs in
-/// `metaclass._validate_db_type_options`; unknown tokens reaching here are a
-/// programming error and the caller surfaces them as a `PyErr`.
+/// Map a canonical `db_type` token to a [`CanonicalType`]. Returns `None` when
+/// the token is unrecognized (the caller falls back to the JSON-type cascade).
+/// Strict per-class-definition validation runs in
+/// `metaclass._validate_db_type_options`.
 ///
 /// Duplicated on the Python side in `src/ferro/migrations/alembic.py
 /// ::_db_type_to_sa_type`. Add new tokens to both emitters in the same change
 /// and update the parity test. See AGENTS.md § I-1.
-fn apply_db_type_to_column_def(col_def: &mut ColumnDef, token: &str, backend: SqlDialect) -> bool {
-    // Per-dialect rendering is chosen to byte-match SA's compilation in the
+fn db_type_token_to_canonical(token: &str, backend: SqlDialect) -> Option<CanonicalType> {
+    // Per-dialect resolution is chosen to byte-match SA's compilation in the
     // Alembic bridge. SQLite emits the typed keyword (BIGINT, SMALLINT,
     // CHAR(32), DATETIME) and lets SQLite type affinity normalize at
     // runtime; the parity test (U5) pins both sides token-for-token.
     match token {
-        "text" => {
-            col_def.text();
-            true
-        }
-        "smallint" => {
-            col_def.small_integer();
-            true
-        }
-        "int" => {
-            col_def.integer();
-            true
-        }
-        "bigint" => {
-            col_def.big_integer();
-            true
-        }
-        "uuid" => {
-            match backend {
-                SqlDialect::Sqlite => col_def.char_len(32),
-                SqlDialect::Postgres => col_def.uuid(),
-            };
-            true
-        }
-        "timestamp" => {
-            match backend {
-                SqlDialect::Sqlite => col_def.date_time(),
-                SqlDialect::Postgres => col_def.timestamp(),
-            };
-            true
-        }
-        "timestamptz" => {
-            match backend {
-                SqlDialect::Sqlite => col_def.date_time(),
-                SqlDialect::Postgres => col_def.timestamp_with_time_zone(),
-            };
-            true
-        }
-        "date" => {
-            col_def.date();
-            true
-        }
-        "time" => {
-            col_def.time();
-            true
-        }
-        other => {
-            if let Some(n) = parse_varchar_token(other) {
-                col_def.string_len(n);
-                true
-            } else {
-                false
-            }
-        }
+        "text" => Some(CanonicalType::Text),
+        "smallint" => Some(CanonicalType::SmallInt),
+        "int" => Some(CanonicalType::Integer),
+        "bigint" => Some(CanonicalType::BigInt),
+        "uuid" => Some(match backend {
+            SqlDialect::Sqlite => CanonicalType::Char(32),
+            SqlDialect::Postgres => CanonicalType::Uuid,
+        }),
+        "timestamp" => Some(match backend {
+            SqlDialect::Sqlite => CanonicalType::DateTime,
+            SqlDialect::Postgres => CanonicalType::Timestamp,
+        }),
+        "timestamptz" => Some(match backend {
+            SqlDialect::Sqlite => CanonicalType::DateTime,
+            SqlDialect::Postgres => CanonicalType::TimestampTz,
+        }),
+        "date" => Some(CanonicalType::Date),
+        "time" => Some(CanonicalType::Time),
+        other => parse_varchar_token(other).map(|n| CanonicalType::Varchar(Some(n))),
+    }
+}
+
+/// Resolve a model property to its backend-specific [`CanonicalType`].
+///
+/// `db_type` is the canonical user-facing storage knob: when present and
+/// recognized it overrides every other column-type branch. Otherwise the
+/// Pydantic JSON type/format cascade decides.
+pub(crate) fn canonical_column_type(
+    raw_col_info: &serde_json::Value,
+    resolved_col_info: &serde_json::Value,
+    backend: SqlDialect,
+) -> CanonicalType {
+    let db_type_token = raw_col_info
+        .get("db_type")
+        .or_else(|| resolved_col_info.get("db_type"))
+        .and_then(|v| v.as_str());
+    if let Some(token) = db_type_token
+        && let Some(canonical) = db_type_token_to_canonical(token, backend)
+    {
+        return canonical;
+    }
+
+    let (json_type, format) = property_json_type_and_format(resolved_col_info);
+    match (json_type, format) {
+        (Some("string"), Some("date-time")) => CanonicalType::TimestampTz,
+        (Some("string"), Some("date")) => CanonicalType::Date,
+        (Some("string"), Some("uuid")) => CanonicalType::Uuid,
+        (Some(_), Some("decimal")) => CanonicalType::Decimal,
+        (Some("string"), Some("binary")) => CanonicalType::Blob,
+        (Some(t), _) => json_type_to_canonical(t, backend),
+        (None, _) => CanonicalType::Varchar(None),
     }
 }
 
@@ -396,6 +461,134 @@ fn append_composite_index_sqls(
     }
 }
 
+/// Foreign-key metadata for a column, resolved from the model schema.
+#[derive(Clone, Debug)]
+pub(crate) struct FkSpec {
+    pub to_table: String,
+    pub on_delete: ForeignKeyAction,
+}
+
+/// Everything any DDL path needs to know about one model column, built once
+/// so CREATE TABLE and ALTER TABLE ADD COLUMN emit byte-identical column
+/// definitions (AGENTS.md § I-1).
+pub(crate) struct ColumnPlan {
+    /// CREATE-ready column definition: type, then PK/auto-increment, then
+    /// NOT NULL, then UNIQUE — applied in the exact order the CREATE TABLE
+    /// emitter has always used (spec order is part of the rendered SQL).
+    pub col_def: ColumnDef,
+    pub canonical: CanonicalType,
+    pub is_primary_key: bool,
+    pub is_nullable: bool,
+    pub is_unique: bool,
+    /// Post-create SQL owned by this column, in emission order:
+    /// single-column index, then `db_check` CHECK constraint.
+    pub index_sqls: Vec<String>,
+    pub fk: Option<FkSpec>,
+    /// Literal default from the JSON schema (the Pydantic field default).
+    /// CREATE TABLE never emits server defaults; the ALTER path uses this to
+    /// backfill NOT NULL column adds on populated tables.
+    pub literal_default: Option<serde_json::Value>,
+}
+
+pub(crate) fn build_column_plan(
+    table_lower: &str,
+    col_name: &str,
+    raw_col_info: &serde_json::Value,
+    schema: &serde_json::Value,
+    backend: SqlDialect,
+) -> ColumnPlan {
+    let col_info = resolve_ref(schema, raw_col_info);
+    let canonical = canonical_column_type(raw_col_info, col_info, backend);
+
+    let mut col_def = ColumnDef::new(Alias::new(col_name));
+    apply_canonical_type(&mut col_def, canonical);
+
+    let is_primary_key =
+        column_bool_metadata(raw_col_info, col_info, "primary_key").unwrap_or(false);
+    let is_auto = column_bool_metadata(raw_col_info, col_info, "autoincrement").unwrap_or(true);
+    if is_primary_key {
+        col_def.primary_key();
+        if is_auto {
+            col_def.auto_increment();
+        }
+    }
+
+    let is_nullable = column_bool_metadata(raw_col_info, col_info, "ferro_nullable") != Some(false);
+    if !is_nullable {
+        col_def.not_null();
+    }
+
+    let is_unique = column_bool_metadata(raw_col_info, col_info, "unique").unwrap_or(false);
+    if is_unique {
+        col_def.unique_key();
+    }
+
+    let mut index_sqls = Vec::new();
+    if column_bool_metadata(raw_col_info, col_info, "index").unwrap_or(false) {
+        let index_name = format!("idx_{}_{}", table_lower, col_name);
+        let index_stmt = Index::create()
+            .name(&index_name)
+            .table(Alias::new(table_lower))
+            .col(Alias::new(col_name))
+            .if_not_exists()
+            .to_owned();
+        let index_sql = match backend {
+            SqlDialect::Sqlite => index_stmt.to_string(SqliteQueryBuilder),
+            SqlDialect::Postgres => index_stmt.to_string(PostgresQueryBuilder),
+        };
+        index_sqls.push(index_sql);
+    }
+
+    // db_check=True -> single-column CHECK constraint named ck_<table>_<col>.
+    // Emitted as a post-create ALTER TABLE so the name flows through
+    // identically on both backends. SQLite cannot execute ADD CONSTRAINT;
+    // users opting in to db_check are expected to be on Postgres for Phase 1.
+    let db_check = column_bool_metadata(raw_col_info, col_info, "db_check").unwrap_or(false);
+    if db_check
+        && let Some(ck_sql) = build_check_constraint_sql(table_lower, col_name, col_info, backend)
+    {
+        index_sqls.push(ck_sql);
+    }
+
+    let fk = column_object_metadata(raw_col_info, col_info, "foreign_key").map(|fk_info| {
+        let to_table = fk_info
+            .get("to_table")
+            .and_then(|t| t.as_str())
+            .unwrap_or("");
+        let on_delete_str = fk_info
+            .get("on_delete")
+            .and_then(|o| o.as_str())
+            .unwrap_or("CASCADE");
+        let on_delete = match on_delete_str.to_uppercase().as_str() {
+            "RESTRICT" => ForeignKeyAction::Restrict,
+            "SET NULL" => ForeignKeyAction::SetNull,
+            "SET DEFAULT" => ForeignKeyAction::SetDefault,
+            "NO ACTION" => ForeignKeyAction::NoAction,
+            _ => ForeignKeyAction::Cascade, // Default
+        };
+        FkSpec {
+            to_table: to_table.to_string(),
+            on_delete,
+        }
+    });
+
+    let literal_default = raw_col_info
+        .get("default")
+        .or_else(|| col_info.get("default"))
+        .cloned();
+
+    ColumnPlan {
+        col_def,
+        canonical,
+        is_primary_key,
+        is_nullable,
+        is_unique,
+        index_sqls,
+        fk,
+        literal_default,
+    }
+}
+
 fn build_create_table_sqls(
     name: &str,
     schema: &serde_json::Value,
@@ -411,126 +604,17 @@ fn build_create_table_sqls(
 
     if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
         for (col_name, raw_col_info) in properties {
-            let mut col_def = ColumnDef::new(Alias::new(col_name));
-            let col_info = resolve_ref(schema, raw_col_info);
+            let mut plan = build_column_plan(&table_lower, col_name, raw_col_info, schema, backend);
 
-            // `db_type` is the canonical user-facing storage knob. When set it
-            // overrides every other column-type branch. Validation runs at
-            // class-definition time (see metaclass._validate_db_type_options).
-            let db_type_token = raw_col_info
-                .get("db_type")
-                .or_else(|| col_info.get("db_type"))
-                .and_then(|v| v.as_str());
+            table_stmt.col(&mut plan.col_def);
+            index_sqls.append(&mut plan.index_sqls);
 
-            let db_type_handled = match db_type_token {
-                Some(token) => apply_db_type_to_column_def(&mut col_def, token, backend),
-                None => false,
-            };
-
-            if !db_type_handled {
-                let (json_type, format) = property_json_type_and_format(col_info);
-
-                if let Some(t) = json_type {
-                    match (t, format) {
-                        ("string", Some("date-time")) => {
-                            col_def.timestamp_with_time_zone();
-                        }
-                        ("string", Some("date")) => {
-                            col_def.date();
-                        }
-                        ("string", Some("uuid")) => {
-                            col_def.uuid();
-                        }
-                        (_, Some("decimal")) => {
-                            col_def.decimal();
-                        }
-                        ("string", Some("binary")) => {
-                            col_def.blob();
-                        }
-                        _ => json_type_to_sea_query_for_backend(&mut col_def, t, backend),
-                    }
-                } else {
-                    col_def.string();
-                }
-            }
-
-            // Check for primary key and autoincrement from our custom metadata
-            let is_pk =
-                column_bool_metadata(raw_col_info, col_info, "primary_key").unwrap_or(false);
-
-            let is_auto =
-                column_bool_metadata(raw_col_info, col_info, "autoincrement").unwrap_or(true);
-
-            if is_pk {
-                col_def.primary_key();
-                if is_auto {
-                    col_def.auto_increment();
-                }
-            }
-
-            if column_bool_metadata(raw_col_info, col_info, "ferro_nullable") == Some(false) {
-                col_def.not_null();
-            }
-
-            if column_bool_metadata(raw_col_info, col_info, "unique").unwrap_or(false) {
-                col_def.unique_key();
-            }
-
-            if column_bool_metadata(raw_col_info, col_info, "index").unwrap_or(false) {
-                let index_name = format!("idx_{}_{}", table_lower, col_name);
-                let index_stmt = Index::create()
-                    .name(&index_name)
-                    .table(Alias::new(&table_lower))
-                    .col(Alias::new(col_name))
-                    .if_not_exists()
-                    .to_owned();
-                let index_sql = match backend {
-                    SqlDialect::Sqlite => index_stmt.to_string(SqliteQueryBuilder),
-                    SqlDialect::Postgres => index_stmt.to_string(PostgresQueryBuilder),
-                };
-                index_sqls.push(index_sql);
-            }
-
-            table_stmt.col(&mut col_def);
-
-            // db_check=True -> single-column CHECK constraint named
-            // ck_<table>_<col>. Emitted as a post-create ALTER TABLE so the
-            // name flows through identically on both backends. SQLite cannot
-            // execute ADD CONSTRAINT; users opting in to db_check are
-            // expected to be on Postgres for Phase 1.
-            let db_check = column_bool_metadata(raw_col_info, col_info, "db_check")
-                .unwrap_or(false);
-            if db_check
-                && let Some(ck_sql) =
-                    build_check_constraint_sql(&table_lower, col_name, col_info, backend)
-            {
-                index_sqls.push(ck_sql);
-            }
-
-            // Check for Foreign Key from metadata
-            if let Some(fk_info) = column_object_metadata(raw_col_info, col_info, "foreign_key") {
-                let to_table = fk_info
-                    .get("to_table")
-                    .and_then(|t| t.as_str())
-                    .unwrap_or("");
-                let on_delete_str = fk_info
-                    .get("on_delete")
-                    .and_then(|o| o.as_str())
-                    .unwrap_or("CASCADE");
-
-                let action = match on_delete_str.to_uppercase().as_str() {
-                    "RESTRICT" => ForeignKeyAction::Restrict,
-                    "SET NULL" => ForeignKeyAction::SetNull,
-                    "SET DEFAULT" => ForeignKeyAction::SetDefault,
-                    "NO ACTION" => ForeignKeyAction::NoAction,
-                    _ => ForeignKeyAction::Cascade, // Default
-                };
-
+            if let Some(fk) = &plan.fk {
                 let mut fk_stmt = ForeignKey::create();
                 fk_stmt
                     .from(Alias::new(&table_lower), Alias::new(col_name))
-                    .to(Alias::new(to_table), Alias::new("id")) // CX Choice: Assume target PK is 'id' for now
-                    .on_delete(action);
+                    .to(Alias::new(&fk.to_table), Alias::new("id")) // CX Choice: Assume target PK is 'id' for now
+                    .on_delete(fk.on_delete);
 
                 table_stmt.foreign_key(&mut fk_stmt);
             }
@@ -770,7 +854,12 @@ mod tests {
     fn test_db_type_text_emits_text_column() {
         for backend in [SqlDialect::Sqlite, SqlDialect::Postgres] {
             let sql = col_sql("text", "string", backend);
-            assert!(sql.contains("TEXT"), "missing TEXT for {:?}: {}", backend, sql);
+            assert!(
+                sql.contains("TEXT"),
+                "missing TEXT for {:?}: {}",
+                backend,
+                sql
+            );
         }
     }
 
@@ -797,7 +886,11 @@ mod tests {
     #[test]
     fn test_db_type_smallint_sqlite_emits_smallint_keyword() {
         let sql = col_sql("smallint", "integer", SqlDialect::Sqlite);
-        assert!(sql.contains("SMALLINT"), "missing SMALLINT keyword: {}", sql);
+        assert!(
+            sql.contains("SMALLINT"),
+            "missing SMALLINT keyword: {}",
+            sql
+        );
     }
 
     #[test]
@@ -867,9 +960,21 @@ mod tests {
         });
         let (_table_sql, post_sqls) = build_create_table_sqls("doc", &schema, SqlDialect::Postgres);
         let joined = post_sqls.join("\n");
-        assert!(joined.contains("ck_doc_format"), "missing constraint name: {}", joined);
-        assert!(joined.to_uppercase().contains("CHECK"), "missing CHECK: {}", joined);
-        assert!(joined.contains("'pdf'") && joined.contains("'json'"), "missing values: {}", joined);
+        assert!(
+            joined.contains("ck_doc_format"),
+            "missing constraint name: {}",
+            joined
+        );
+        assert!(
+            joined.to_uppercase().contains("CHECK"),
+            "missing CHECK: {}",
+            joined
+        );
+        assert!(
+            joined.contains("'pdf'") && joined.contains("'json'"),
+            "missing values: {}",
+            joined
+        );
     }
 
     #[test]
@@ -885,10 +990,19 @@ mod tests {
                 }
             }
         });
-        let (_table_sql, post_sqls) = build_create_table_sqls("task", &schema, SqlDialect::Postgres);
+        let (_table_sql, post_sqls) =
+            build_create_table_sqls("task", &schema, SqlDialect::Postgres);
         let joined = post_sqls.join("\n");
-        assert!(joined.contains("(1, 2)"), "ints should be unquoted: {}", joined);
-        assert!(!joined.contains("'1'"), "ints should not be quoted: {}", joined);
+        assert!(
+            joined.contains("(1, 2)"),
+            "ints should be unquoted: {}",
+            joined
+        );
+        assert!(
+            !joined.contains("'1'"),
+            "ints should not be quoted: {}",
+            joined
+        );
     }
 
     #[test]
@@ -925,7 +1039,9 @@ mod tests {
         });
         let (_table_sql, post_sqls) = build_create_table_sqls("doc", &schema, SqlDialect::Sqlite);
         assert!(
-            post_sqls.iter().all(|s| !s.to_uppercase().contains("CONSTRAINT")),
+            post_sqls
+                .iter()
+                .all(|s| !s.to_uppercase().contains("CONSTRAINT")),
             "SQLite must not emit ADD CONSTRAINT: {:?}",
             post_sqls
         );
@@ -945,10 +1061,22 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_db_type_unknown_token_returns_false() {
-        let mut col_def = ColumnDef::new(Alias::new("c"));
-        let ok = apply_db_type_to_column_def(&mut col_def, "banana", SqlDialect::Postgres);
-        assert!(!ok);
+    fn test_db_type_unknown_token_maps_to_none() {
+        assert_eq!(
+            db_type_token_to_canonical("banana", SqlDialect::Postgres),
+            None
+        );
+    }
+
+    #[test]
+    fn test_unknown_db_type_token_falls_back_to_json_cascade() {
+        // An unrecognized token must not change behavior: the JSON-type
+        // cascade decides, exactly as before the CanonicalType refactor.
+        let raw = json!({"type": "integer", "db_type": "banana"});
+        assert_eq!(
+            canonical_column_type(&raw, &raw, SqlDialect::Postgres),
+            CanonicalType::Integer
+        );
     }
 
     #[test]

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -198,3 +198,385 @@ async def test_uuid_m2m_relationship_query_serializes_source_id(db_url):
         assert await post.tags.count() == 0
 
     assert await post.tags.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# migrate_updates / migrate_destructive (issue #68)
+# ---------------------------------------------------------------------------
+
+from datetime import date  # noqa: E402
+
+from ferro.raw import execute, fetch_all  # noqa: E402
+
+
+@pytest.fixture
+def clean_registry():
+    from ferro import clear_registry, reset_engine
+    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    reset_engine()
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+    yield
+
+
+def _sqlite_columns(db_url: str, table: str) -> dict[str, tuple]:
+    import sqlite3
+
+    db_path = db_url.removeprefix("sqlite:").split("?", 1)[0]
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(f'PRAGMA table_info("{table}")').fetchall()
+    finally:
+        conn.close()
+    return {row[1]: row for row in rows}
+
+
+def _sqlite_index_names(db_url: str, table: str) -> set[str]:
+    import sqlite3
+
+    db_path = db_url.removeprefix("sqlite:").split("?", 1)[0]
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(f'PRAGMA index_list("{table}")').fetchall()
+    finally:
+        conn.close()
+    return {row[1] for row in rows}
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_migrate_updates_adds_missing_columns_and_hydrates(
+    db_url, db_backend, clean_registry
+):
+    """The issue #67/#68 repro shape: a pre-existing narrow table gains the
+    model's new columns on connect, and the very next ORM query hydrates
+    existing rows with the new fields as None (no panic, no silent empty
+    result)."""
+
+    class MigInvoice(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        number: str
+        paid_date: Annotated[date | None, FerroField(db_type="date")] = None
+        memo: str | None = None
+
+    # Bootstrap the OLD (narrow) schema by hand, as an older release would have.
+    await ferro.connect(db_url)
+    if db_backend == "sqlite":
+        await execute(
+            'CREATE TABLE "miginvoice" '
+            '("id" integer PRIMARY KEY AUTOINCREMENT, "number" varchar NOT NULL)'
+        )
+    else:
+        await execute(
+            'CREATE TABLE "miginvoice" ("id" serial PRIMARY KEY, "number" varchar NOT NULL)'
+        )
+    await execute('INSERT INTO "miginvoice" ("number") VALUES (\'INV-1\')')
+    ferro.reset_engine()
+
+    await ferro.connect(db_url, migrate_updates=True)
+
+    rows = await MigInvoice.all()
+    assert len(rows) == 1
+    assert rows[0].number == "INV-1"
+    assert rows[0].paid_date is None
+    assert rows[0].memo is None
+
+    # The new columns are usable immediately.
+    inv = await MigInvoice.create(
+        number="INV-2", paid_date=date(2026, 1, 15), memo="paid"
+    )
+    fetched = await MigInvoice.get(inv.id)
+    assert fetched.paid_date == date(2026, 1, 15)
+    assert fetched.memo == "paid"
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_manual_migrate_on_live_pool_refreshes_cached_statements(
+    db_url, db_backend, clean_registry
+):
+    """`ferro.migrate()` on a live pool must work even when the same query was
+    already prepared (and cached) against the pre-migration schema — the
+    engine refreshes its pool after DDL (issue #67)."""
+
+    class MigReport(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        title: str
+        summary: str | None = None
+
+    await ferro.connect(db_url)
+    if db_backend == "sqlite":
+        await execute(
+            'CREATE TABLE "migreport" '
+            '("id" integer PRIMARY KEY AUTOINCREMENT, "title" varchar NOT NULL)'
+        )
+    else:
+        await execute(
+            'CREATE TABLE "migreport" ("id" serial PRIMARY KEY, "title" varchar NOT NULL)'
+        )
+    await execute('INSERT INTO "migreport" ("title") VALUES (\'Q1\')')
+
+    # Prepare (and cache) the SELECT against the narrow schema.
+    rows_before = await MigReport.all()
+    assert len(rows_before) == 1
+
+    await ferro.migrate()
+
+    # Same query again: without the pool refresh this panics in the sqlx
+    # worker and silently returns zero rows on SQLite.
+    rows_after = await MigReport.all()
+    assert len(rows_after) == 1
+    assert rows_after[0].title == "Q1"
+    assert rows_after[0].summary is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.sqlite_only
+async def test_migrate_updates_not_null_without_default_fails_loudly(
+    db_url, clean_registry
+):
+    """A new NOT NULL field with no literal default cannot backfill existing
+    rows; connecting must fail with an error naming the field."""
+    import json as _json
+
+    from ferro._core import register_model_schema
+
+    await ferro.connect(db_url)
+    await execute(
+        'CREATE TABLE "migstrict" ("id" integer PRIMARY KEY AUTOINCREMENT, "name" varchar NOT NULL)'
+    )
+    ferro.reset_engine()
+
+    register_model_schema(
+        "MigStrict",
+        _json.dumps(
+            {
+                "properties": {
+                    "id": {"type": "integer", "primary_key": True},
+                    "name": {"type": "string", "ferro_nullable": False},
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "ferro_nullable": False,
+                    },
+                }
+            }
+        ),
+    )
+
+    with pytest.raises(ValueError, match=r"migstrict\.created_at"):
+        await ferro.connect(db_url, migrate_updates=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.sqlite_only
+async def test_sqlite_type_drift_warns_and_leaves_column_untouched(
+    db_url, clean_registry
+):
+    await ferro.connect(db_url)
+    await execute(
+        'CREATE TABLE "migdrift" '
+        '("id" integer PRIMARY KEY AUTOINCREMENT, "count" varchar NOT NULL)'
+    )
+    ferro.reset_engine()
+
+    import json as _json
+
+    from ferro._core import register_model_schema
+
+    register_model_schema(
+        "MigDrift",
+        _json.dumps(
+            {
+                "properties": {
+                    "id": {"type": "integer", "primary_key": True},
+                    "count": {"type": "integer", "ferro_nullable": False},
+                }
+            }
+        ),
+    )
+
+    with pytest.warns(UserWarning, match=r"migdrift\.count.*Alembic"):
+        await ferro.connect(db_url, migrate_updates=True)
+
+    columns = _sqlite_columns(db_url, "migdrift")
+    assert (
+        columns["count"][2].lower() == "varchar"
+    ), "no DDL may run for SQLite type drift"
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_migrate_destructive_drops_removed_columns(
+    db_url, db_backend, clean_registry
+):
+    class MigSlim(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    await ferro.connect(db_url)
+    if db_backend == "sqlite":
+        await execute(
+            'CREATE TABLE "migslim" ("id" integer PRIMARY KEY AUTOINCREMENT, '
+            '"name" varchar NOT NULL, "legacy_notes" text)'
+        )
+    else:
+        await execute(
+            'CREATE TABLE "migslim" ("id" serial PRIMARY KEY, '
+            '"name" varchar NOT NULL, "legacy_notes" text)'
+        )
+    await execute(
+        'INSERT INTO "migslim" ("name", "legacy_notes") VALUES (\'keep\', \'bye\')'
+    )
+    ferro.reset_engine()
+
+    # Without the flag the extra column is untouched.
+    await ferro.connect(db_url, migrate_updates=True)
+    rows = await fetch_all('SELECT * FROM "migslim"')
+    assert "legacy_notes" in rows[0]
+    ferro.reset_engine()
+
+    await ferro.connect(db_url, migrate_destructive=True)
+    rows = await fetch_all('SELECT * FROM "migslim"')
+    assert len(rows) == 1
+    assert rows[0]["name"] == "keep", "surviving data must be intact"
+    assert "legacy_notes" not in rows[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.sqlite_only
+async def test_destructive_drop_of_indexed_column_drops_index_first(
+    db_url, clean_registry
+):
+    class MigIdx(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    await ferro.connect(db_url)
+    await execute(
+        'CREATE TABLE "migidx" ("id" integer PRIMARY KEY AUTOINCREMENT, '
+        '"name" varchar NOT NULL, "old_status" varchar)'
+    )
+    await execute('CREATE INDEX "idx_migidx_old_status" ON "migidx" ("old_status")')
+    await execute(
+        'INSERT INTO "migidx" ("name", "old_status") VALUES (\'keep\', \'x\')'
+    )
+    ferro.reset_engine()
+
+    await ferro.connect(db_url, migrate_destructive=True)
+
+    columns = _sqlite_columns(db_url, "migidx")
+    assert "old_status" not in columns
+    assert "idx_migidx_old_status" not in _sqlite_index_names(db_url, "migidx")
+    rows = await fetch_all('SELECT * FROM "migidx"')
+    assert rows[0]["name"] == "keep"
+
+
+@pytest.mark.asyncio
+@pytest.mark.sqlite_only
+async def test_destructive_refuses_unique_constraint_column_on_sqlite(
+    db_url, clean_registry
+):
+    class MigUq(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    await ferro.connect(db_url)
+    await execute(
+        'CREATE TABLE "miguq" ("id" integer PRIMARY KEY AUTOINCREMENT, '
+        '"name" varchar NOT NULL, "old_code" varchar UNIQUE)'
+    )
+    ferro.reset_engine()
+
+    with pytest.raises(ValueError, match=r"miguq\.old_code.*UNIQUE.*Alembic"):
+        await ferro.connect(db_url, migrate_destructive=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.sqlite_only
+async def test_added_indexed_and_unique_columns_get_their_indexes(
+    db_url, clean_registry
+):
+    class MigIndexed(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+        status: Annotated[str | None, FerroField(index=True)] = None
+        slug: Annotated[str | None, FerroField(unique=True)] = None
+
+    await ferro.connect(db_url)
+    await execute(
+        'CREATE TABLE "migindexed" '
+        '("id" integer PRIMARY KEY AUTOINCREMENT, "name" varchar NOT NULL)'
+    )
+    ferro.reset_engine()
+
+    with pytest.warns(UserWarning, match="uq_migindexed_slug"):
+        await ferro.connect(db_url, migrate_updates=True)
+
+    index_names = _sqlite_index_names(db_url, "migindexed")
+    assert "idx_migindexed_status" in index_names
+    assert "uq_migindexed_slug" in index_names
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
+async def test_postgres_type_and_nullability_reconciliation(db_url, clean_registry):
+    """Postgres gets native ALTER COLUMN: type changes via USING cast (with
+    existing data), SET NOT NULL, and no lingering server default after a
+    backfilled NOT NULL add."""
+    import json as _json
+
+    from ferro._core import register_model_schema
+
+    await ferro.connect(db_url)
+    await execute(
+        'CREATE TABLE "migpg" ("id" serial PRIMARY KEY, '
+        '"total" integer NOT NULL, "note" varchar)'
+    )
+    await execute('INSERT INTO "migpg" ("total", "note") VALUES (41, NULL)')
+    ferro.reset_engine()
+
+    register_model_schema(
+        "MigPg",
+        _json.dumps(
+            {
+                "properties": {
+                    "id": {"type": "integer", "primary_key": True},
+                    "total": {
+                        "type": "integer",
+                        "db_type": "bigint",
+                        "ferro_nullable": False,
+                    },
+                    "note": {"type": "string", "ferro_nullable": True},
+                    "status": {
+                        "type": "string",
+                        "ferro_nullable": False,
+                        "default": "draft",
+                    },
+                }
+            }
+        ),
+    )
+
+    await ferro.connect(db_url, migrate_updates=True)
+
+    rows = await fetch_all(
+        "SELECT column_name, data_type, is_nullable, column_default "
+        "FROM information_schema.columns "
+        "WHERE table_schema = current_schema() AND table_name = 'migpg'"
+    )
+    by_name = {row["column_name"]: row for row in rows}
+    assert by_name["total"]["data_type"] == "bigint", "integer -> bigint via USING cast"
+    assert by_name["status"]["is_nullable"] == "NO"
+    assert (
+        by_name["status"]["column_default"] is None
+    ), "backfill default must not linger"
+
+    data = await fetch_all('SELECT "total", "status" FROM "migpg"')
+    assert data[0]["total"] == 41, "existing data survives the type change"
+    assert (
+        data[0]["status"] == "draft"
+    ), "existing rows backfilled with the literal default"

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -206,7 +206,10 @@ async def test_model_using_routes_helper_writes_to_named_connection(tmp_path):
     assert created_row.label == "created"
     assert updated_created is False
     assert updated_row.label == "updated"
-    assert [(row.id, row.label) for row in await service_model.select().order_by(ConnectionRouteMarker.id).all()] == [
+    assert [
+        (row.id, row.label)
+        for row in await service_model.select().order_by(ConnectionRouteMarker.id).all()
+    ] == [
         (10, "updated"),
         (11, "created"),
     ]
@@ -374,9 +377,7 @@ async def test_forward_fk_load_inherits_source_instance_origin(tmp_path):
     class RouteForwardChild(ferro.Model):
         id: Annotated[int | None, ferro.FerroField(primary_key=True)] = None
         label: str
-        parent: Annotated[
-            RouteForwardParent, ferro.ForeignKey(related_name="children")
-        ]
+        parent: Annotated[RouteForwardParent, ferro.ForeignKey(related_name="children")]
 
     app_db = tmp_path / "app.db"
     service_db = tmp_path / "service.db"
@@ -480,6 +481,8 @@ async def test_connect_passes_pool_config_to_core(monkeypatch):
                 "max_connections": 3,
                 "min_connections": 1,
                 "identity_map": True,
+                "migrate_updates": False,
+                "migrate_destructive": False,
             },
         )
     ]

--- a/tests/test_cross_emitter_parity.py
+++ b/tests/test_cross_emitter_parity.py
@@ -103,9 +103,15 @@ def _is_pk_nullable_relaxation(op_tuple, metadata: sa.MetaData) -> bool:
     """
     if op_tuple[0] != "modify_nullable":
         return False
-    _, _schema, table_name, column_name, _info, new_nullable, existing_nullable = (
-        op_tuple
-    )
+    (
+        _,
+        _schema,
+        table_name,
+        column_name,
+        _info,
+        new_nullable,
+        existing_nullable,
+    ) = op_tuple
     if not (new_nullable is True and existing_nullable is False):
         return False
     table = metadata.tables.get(table_name)
@@ -213,5 +219,95 @@ async def test_alembic_autogen_against_rust_migrated_db_is_idempotent(db_url):
         "a Rust-migrated database returned a non-empty diff. The two emitters "
         "disagree about the schema; running `alembic revision --autogenerate` "
         "against an auto_migrate'd database would produce phantom diffs.\n\n"
+        f"Diff:\n{significant}"
+    )
+
+
+def _build_migration_v1_models() -> None:
+    """The 'old release' shape of the migration-sentinel models."""
+
+    class MigOrg(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        slug: Annotated[str, FerroField(unique=True)]
+        members: Relation[list["MigMember"]] = BackRef()
+
+    class MigMember(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        email: Annotated[str, FerroField(unique=True)]
+        org: Annotated[MigOrg, ForeignKey(related_name="members", index=True)]
+
+    return MigOrg, MigMember
+
+
+def _build_migration_v2_models() -> None:
+    """The 'new release' shape: MigOrg gained two columns since v1."""
+
+    class MigOrg(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        slug: Annotated[str, FerroField(unique=True)]
+        name: Annotated[str | None, FerroField(index=True)] = None
+        motto: str | None = None
+        members: Relation[list["MigMember"]] = BackRef()
+
+    class MigMember(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        email: Annotated[str, FerroField(unique=True)]
+        org: Annotated[MigOrg, ForeignKey(related_name="members", index=True)]
+
+    return MigOrg, MigMember
+
+
+@pytest.mark.asyncio
+@pytest.mark.sqlite_only
+async def test_alembic_autogen_after_migrate_updates_is_idempotent(db_url):
+    """Migration-path parity sentinel: a database bootstrapped on an old model
+    shape and brought forward via ``connect(migrate_updates=True)`` must be
+    indistinguishable to Alembic from one created fresh.
+
+    This pins that ``ALTER TABLE ... ADD COLUMN`` reuses the exact column DDL
+    of the CREATE TABLE emitter — including single-column index names — so the
+    auto-migrate path cannot drift from the Alembic bridge (I-1 in AGENTS.md).
+
+    Scope note: the v1→v2 delta covers a plain nullable column and an indexed
+    nullable column, where byte parity is achievable on SQLite. Unique and
+    foreign-key column adds are deliberately not part of this sentinel on
+    SQLite: the engine cannot add inline UNIQUE/FK constraints to existing
+    tables, so auto-migrate emits the documented equivalent (an explicit
+    ``uq_`` index / a constraint-less column) plus a ``UserWarning`` — visible
+    divergence by design, covered in ``test_auto_migrate.py``.
+    """
+    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    _build_migration_v1_models()
+    await connect(db_url, auto_migrate=True)
+
+    reset_engine()
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+
+    _build_migration_v2_models()
+    await connect(db_url, migrate_updates=True)
+
+    metadata = get_metadata()
+
+    db_path = db_url.replace("sqlite:", "", 1).split("?")[0]
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.connect() as conn:
+            ctx = MigrationContext.configure(
+                conn,
+                opts={"compare_type": True, "compare_server_default": True},
+            )
+            diff = compare_metadata(ctx, metadata)
+    finally:
+        engine.dispose()
+
+    significant = _ignore_unreliable_alembic_diffs(diff, metadata)
+    assert significant == [], (
+        "Cross-emitter DDL parity violation on the migrate_updates path: a "
+        "database migrated forward from an older model shape differs from "
+        "what Alembic expects of the current models.\n\n"
         f"Diff:\n{significant}"
     )

--- a/tests/test_migrate_plan.py
+++ b/tests/test_migrate_plan.py
@@ -1,0 +1,225 @@
+"""Render-level tests for the auto-migrate diff (no live database).
+
+Drives ``_render_migration_sql_for_test`` over both dialects and pins the
+exact DDL and warning text the diff produces. Integration behavior (execution,
+pool refresh, dependency-aware drops) is covered in ``test_auto_migrate.py``.
+"""
+
+import json
+
+import pytest
+
+from ferro._core import _render_migration_sql_for_test
+
+
+def render(schema, live, dialect, *, updates=True, destructive=False, name="Invoice"):
+    return _render_migration_sql_for_test(
+        name, json.dumps(schema), json.dumps(live), dialect, updates, destructive
+    )
+
+
+PK_ONLY_LIVE = [
+    {
+        "name": "id",
+        "declared_type": "integer",
+        "is_primary_key": True,
+        "is_nullable": False,
+    }
+]
+
+
+def schema_with(props):
+    return {"properties": {"id": {"type": "integer", "primary_key": True}, **props}}
+
+
+class TestAddColumn:
+    def test_nullable_column_add_uses_create_table_type_spelling(self):
+        schema = schema_with(
+            {"paid_date": {"type": "string", "db_type": "date", "ferro_nullable": True}}
+        )
+        stmts, warns = render(schema, PK_ONLY_LIVE, "sqlite")
+        assert stmts == ['ALTER TABLE "invoice" ADD COLUMN "paid_date" date_text']
+        assert warns == []
+
+        stmts, warns = render(schema, PK_ONLY_LIVE, "postgres")
+        assert stmts == ['ALTER TABLE "invoice" ADD COLUMN "paid_date" date']
+        assert warns == []
+
+    def test_not_null_with_literal_default_backfills(self):
+        schema = schema_with(
+            {"status": {"type": "string", "ferro_nullable": False, "default": "draft"}}
+        )
+        stmts, _ = render(schema, PK_ONLY_LIVE, "postgres")
+        assert stmts == [
+            'ALTER TABLE "invoice" ADD COLUMN "status" varchar NOT NULL DEFAULT \'draft\'',
+            'ALTER TABLE "invoice" ALTER COLUMN "status" DROP DEFAULT',
+        ]
+
+        # SQLite cannot DROP DEFAULT; the backfill default remains (documented).
+        stmts, _ = render(schema, PK_ONLY_LIVE, "sqlite")
+        assert stmts == [
+            'ALTER TABLE "invoice" ADD COLUMN "status" varchar NOT NULL DEFAULT \'draft\'',
+        ]
+
+    def test_not_null_without_default_fails_loudly(self):
+        schema = schema_with(
+            {
+                "created_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "ferro_nullable": False,
+                }
+            }
+        )
+        for dialect in ("sqlite", "postgres"):
+            with pytest.raises(ValueError, match=r"invoice\.created_at.*Alembic"):
+                render(schema, PK_ONLY_LIVE, dialect)
+
+    def test_adding_primary_key_column_fails_loudly(self):
+        schema = schema_with({})
+        live = [{"name": "name", "declared_type": "varchar"}]
+        with pytest.raises(ValueError, match=r"invoice\.id.*primary key"):
+            render(schema, live, "sqlite")
+
+    def test_unique_column_strips_inline_unique_on_sqlite(self):
+        schema = schema_with({"slug": {"type": "string", "unique": True}})
+        stmts, warns = render(schema, PK_ONLY_LIVE, "sqlite")
+        assert stmts == [
+            'ALTER TABLE "invoice" ADD COLUMN "slug" varchar',
+            'CREATE UNIQUE INDEX IF NOT EXISTS "uq_invoice_slug" ON "invoice" ("slug")',
+        ]
+        assert len(warns) == 1 and "uq_invoice_slug" in warns[0]
+
+        stmts, warns = render(schema, PK_ONLY_LIVE, "postgres")
+        assert stmts == ['ALTER TABLE "invoice" ADD COLUMN "slug" varchar UNIQUE']
+        assert warns == []
+
+    def test_indexed_column_add_emits_create_index(self):
+        schema = schema_with({"kind": {"type": "string", "index": True}})
+        for dialect in ("sqlite", "postgres"):
+            stmts, _ = render(schema, PK_ONLY_LIVE, dialect)
+            assert stmts == [
+                'ALTER TABLE "invoice" ADD COLUMN "kind" varchar',
+                'CREATE INDEX IF NOT EXISTS "idx_invoice_kind" ON "invoice" ("kind")',
+            ]
+
+    def test_fk_shadow_column_is_capability_relative(self):
+        schema = schema_with(
+            {
+                "client_id": {
+                    "type": "integer",
+                    "foreign_key": {"to_table": "client", "on_delete": "CASCADE"},
+                }
+            }
+        )
+        stmts, warns = render(schema, PK_ONLY_LIVE, "postgres")
+        assert stmts == [
+            'ALTER TABLE "invoice" ADD COLUMN "client_id" integer',
+            'ALTER TABLE "invoice" ADD FOREIGN KEY ("client_id") REFERENCES "client" ("id")'
+            " ON DELETE CASCADE",
+        ]
+        assert warns == []
+
+        stmts, warns = render(schema, PK_ONLY_LIVE, "sqlite")
+        assert stmts == ['ALTER TABLE "invoice" ADD COLUMN "client_id" integer']
+        assert len(warns) == 1 and "FOREIGN KEY" in warns[0] and "Alembic" in warns[0]
+
+
+class TestReconcileExisting:
+    def test_pg_type_mismatch_emits_alter_with_using_cast(self):
+        schema = schema_with(
+            {"total": {"type": "integer", "db_type": "bigint", "ferro_nullable": False}}
+        )
+        live = PK_ONLY_LIVE + [
+            {"name": "total", "declared_type": "integer", "is_nullable": False}
+        ]
+        stmts, _ = render(schema, live, "postgres")
+        assert stmts == [
+            'ALTER TABLE "invoice" ALTER COLUMN "total" TYPE bigint USING "total"::bigint'
+        ]
+
+    def test_pg_nullability_mismatch_emits_set_and_drop_not_null(self):
+        schema = schema_with(
+            {
+                "a": {"type": "string", "ferro_nullable": False},
+                "b": {"type": "string", "ferro_nullable": True},
+            }
+        )
+        live = PK_ONLY_LIVE + [
+            {"name": "a", "declared_type": "character varying", "is_nullable": True},
+            {"name": "b", "declared_type": "character varying", "is_nullable": False},
+        ]
+        stmts, _ = render(schema, live, "postgres")
+        assert 'ALTER TABLE "invoice" ALTER COLUMN "a" SET NOT NULL' in stmts
+        assert 'ALTER TABLE "invoice" ALTER COLUMN "b" DROP NOT NULL' in stmts
+
+    def test_pg_native_enum_columns_are_left_to_alembic(self):
+        schema = schema_with({"status": {"type": "string"}})
+        live = PK_ONLY_LIVE + [
+            {"name": "status", "declared_type": "USER-DEFINED", "is_enum_udt": True}
+        ]
+        stmts, warns = render(schema, live, "postgres")
+        assert stmts == []
+        assert warns == []
+
+    def test_sqlite_type_drift_warns_and_emits_no_ddl(self):
+        schema = schema_with({"count": {"type": "integer"}})
+        live = PK_ONLY_LIVE + [{"name": "count", "declared_type": "varchar"}]
+        stmts, warns = render(schema, live, "sqlite")
+        assert stmts == []
+        assert len(warns) == 1
+        assert "invoice.count" in warns[0] and "Alembic" in warns[0]
+
+    def test_sqlite_cosmetic_spelling_differences_do_not_warn(self):
+        # An Alembic-created table spells temporal/uuid types differently than
+        # the runtime emitter; SQLite type affinity makes that equivalent.
+        schema = schema_with(
+            {
+                "created_at": {"type": "string", "format": "date-time"},
+                "ref": {"type": "string", "format": "uuid"},
+            }
+        )
+        live = PK_ONLY_LIVE + [
+            {"name": "created_at", "declared_type": "DATETIME"},
+            {"name": "ref", "declared_type": "CHAR(32)"},
+        ]
+        stmts, warns = render(schema, live, "sqlite")
+        assert stmts == []
+        assert warns == []
+
+
+class TestDestructive:
+    LIVE_WITH_EXTRA = PK_ONLY_LIVE + [{"name": "legacy_notes", "declared_type": "text"}]
+
+    def test_removed_column_drops_only_with_flag(self):
+        schema = schema_with({})
+        stmts, _ = render(schema, self.LIVE_WITH_EXTRA, "sqlite", destructive=True)
+        assert stmts == ['ALTER TABLE "invoice" DROP COLUMN "legacy_notes"']
+
+        stmts, _ = render(schema, self.LIVE_WITH_EXTRA, "sqlite", destructive=False)
+        assert stmts == []
+
+    def test_live_primary_key_missing_from_model_fails_loudly(self):
+        schema = {"properties": {"name": {"type": "string"}}}
+        live = PK_ONLY_LIVE + [{"name": "name", "declared_type": "varchar"}]
+        with pytest.raises(ValueError, match=r"invoice\.id.*primary key.*Alembic"):
+            render(schema, live, "sqlite", destructive=True)
+
+    def test_destructive_implies_updates(self):
+        schema = schema_with({"memo": {"type": "string", "ferro_nullable": True}})
+        stmts, _ = render(
+            schema, PK_ONLY_LIVE, "sqlite", updates=False, destructive=True
+        )
+        assert stmts == ['ALTER TABLE "invoice" ADD COLUMN "memo" varchar']
+
+
+def test_updates_false_produces_no_plan():
+    schema = schema_with({"memo": {"type": "string", "ferro_nullable": True}})
+    stmts, warns = render(schema, PK_ONLY_LIVE, "sqlite", updates=False)
+    assert stmts == []
+    assert warns == []
+
+
+def test_unknown_dialect_is_rejected():
+    with pytest.raises(ValueError, match="Unknown dialect"):
+        render(schema_with({}), PK_ONLY_LIVE, "mysql")

--- a/uv.lock
+++ b/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "ferro-orm"
-version = "0.10.0"
+version = "0.10.5"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Closes #68. Also lands the engine-level fix for the schema class of #67 (DDL run through ferro; raw-DDL detection stays in #67's scope).

- Closes #68
- Closes #67 

## What

`connect()` gains two opt-in flags forming a ladder (each implies the previous):

```python
await ferro.connect(
    "sqlite:app.db?mode=rwc",
    auto_migrate=True,         # create missing tables (unchanged default behavior)
    migrate_updates=True,      # update existing tables to match the models
    migrate_destructive=True,  # also drop columns removed from the models
)
```

plus an explicit `await ferro.migrate(updates=True, destructive=False, using=None)` for consumers that want control over when DDL runs.

### Capability matrix (`migrate_updates`)

| Change | SQLite | Postgres |
|---|---|---|
| Add missing column (+ its index / CHECK) | ✅ | ✅ |
| Add unique column | ✅ explicit `uq_` index + warning | ✅ inline `UNIQUE` |
| Add FK column | ✅ column only + warning (no ADD CONSTRAINT in SQLite) | ✅ column + FK |
| Change type | ⚠️ warning only (type affinity makes drift cosmetic) | ✅ `ALTER COLUMN ... TYPE ... USING` |
| Change nullability | ⚠️ warning only | ✅ `SET/DROP NOT NULL` |
| Drop removed column (`migrate_destructive`) | ✅ dependency-aware | ✅ |
| Renames, PK changes, table drops | ❌ never — Alembic territory | ❌ never |

Fail-loudly rules: NOT NULL adds need a literal default to backfill existing rows (clear error otherwise); destructive drops of PK or constraint-enforced columns abort with an error pointing at Alembic. Nothing is skipped silently.

## How

- **One column-DDL source of truth**: `CanonicalType` + `build_column_plan` extracted from the CREATE TABLE emitter; ALTER reuses them, so a migrated DB is byte-identical to a fresh one. A new cross-emitter sentinel (`test_alembic_autogen_after_migrate_updates_is_idempotent`) pins that Alembic autogenerate sees an auto-migrated DB as up to date (AGENTS.md I-1).
- **DDL as a schema-epoch event**: migration SQL runs unprepared (`persistent(false)`); `EngineHandle::refresh_pool()` atomically swaps in a fresh pool after any ALTER/DROP (in-memory SQLite clears statement caches in place — a swap would destroy the database); the identity map is invalidated so stale instances can't shadow new fields. This eliminates the sqlx stale-statement panic + silent empty results (#67's failure class) and Postgres's `cached plan must not change result type` for all ferro-driven DDL, and `refresh_pool` is the primitive a full #67 fix (raw DDL) can reuse.
- **New modules**: `src/introspect.rs` (live columns via `PRAGMA table_info` / `information_schema` + enum/PK detection; index coverage for dependency-aware drops) and `src/migrate.rs` (pure `plan_table_migration` diff + executor).
- Pattern documented in `docs/solutions/patterns/ddl-on-live-engine.md`; per-backend support matrix in `docs/guide/database.md`.

The first commit is unrelated lint debt: current stable clippy (1.96) flags pre-existing `operations.rs`/`query.rs` code under the CI `-D warnings` gate; fixed separately so the feature diff stays reviewable.

## Tests

- Rust: 119 pass — diff-rule matrix, introspection round-trips, pool-refresh swap / in-memory no-op / fail-loudly.
- Python (SQLite): 476 pass — 17 exact-SQL render tests over both dialects, the #67 repro-shape regression (narrow table → connect with `migrate_updates=True` → rows hydrate with `None` for new fields), `migrate()` on a live pool with a pre-cached statement, NOT NULL error, drift warnings, destructive cases, parity sentinel.
- Postgres integration tests (`postgres_only`) run in CI: `USING` cast with data, `SET/DROP NOT NULL`, no lingering server default after backfilled adds, destructive drop.
