### PR TITLE
feat: complete Phase 6 sessionized runtime state

### DIFF
--- a/docs/pages/api/connection.md
+++ b/docs/pages/api/connection.md
@@ -1,6 +1,6 @@
 # Connection & Registry
 
-Functions for managing database connections and the global model registry. `connect()` registers a (optionally named) connection pool; `reset_engine()` tears everything down; the registry helpers control schema creation and the identity map. See the [Connections & Databases guide](../guide/connections.md).
+Functions for managing database connections and the global model registry. `connect()` registers a (optionally named) connection pool; `reset_engine()` tears everything down; the registry helpers control schema creation and the identity map. Sessionized routing is exposed via `ferro.engines.session(name)` / `ferro.Session`. See the [Connections & Databases guide](../guide/connections.md).
 
 ::: ferro.connect
 

--- a/docs/pages/api/transactions.md
+++ b/docs/pages/api/transactions.md
@@ -1,6 +1,6 @@
 # Transactions
 
-`transaction()` is an async context manager that runs everything inside the block on one connection, committing on exit and rolling back on exception. It yields a `Transaction` handle for raw SQL that must run on the transaction's connection. See the [Transactions guide](../guide/transactions.md) for semantics and patterns.
+`transaction()` is an async context manager that runs everything inside the block on one connection, committing on exit and rolling back on exception. It yields a `Transaction` handle for raw SQL that must run on the transaction's connection. It can route by `using=` or by an explicit/ambient session (`ferro.engines.session(...)`). See the [Transactions guide](../guide/transactions.md) for semantics and patterns.
 
 ::: ferro.transaction
 

--- a/docs/pages/concepts/identity-map.md
+++ b/docs/pages/concepts/identity-map.md
@@ -1,10 +1,10 @@
 # Identity Map
 
-Ferro keeps an identity map: within a single process and connection, the same database row always resolves to the same Python object.
+Ferro keeps an identity map: within a single session and connection, the same database row resolves to the same Python object.
 
 ## What It Is
 
-The identity map is a per-connection cache in the Rust engine, keyed by `(model name, primary key)`. When a query hydrates a row whose primary key is already in the map, Ferro returns the existing instance instead of building a duplicate.
+The identity map is a session-scoped cache in the Rust engine, keyed by `(connection, model name, primary key)`. When a query hydrates a row whose primary key is already in the session map, Ferro returns the existing instance instead of building a duplicate.
 
 ```mermaid
 graph LR
@@ -13,7 +13,7 @@ graph LR
     IM --> Same[Same Python instance]
 ```
 
-Each named connection has its own map — instances loaded through `using("replica")` are tracked separately from instances loaded through the default connection.
+Each active session keeps its own map. Within a session, connection routing is deterministic and tracked independently from other concurrent sessions.
 
 ## Why It Matters
 

--- a/docs/pages/guide/connections.md
+++ b/docs/pages/guide/connections.md
@@ -101,6 +101,21 @@ Raw SQL routes the same way via `using=`: `await ferro.execute("...", using="ana
 
 Ferro does not provide automatic router policies, read/write splitting, distributed transactions, or cross-connection joins — route each operation explicitly. See [Multiple Databases](../howto/multiple-databases.md) for fuller patterns.
 
+## Sessions (recommended)
+
+Session-scoped routing is now the preferred runtime model:
+
+```python
+import ferro
+
+async with ferro.engines.session("analytics") as s:
+    rows = await s.query(User).where(lambda t: t.active == True).all()  # noqa: E712
+```
+
+Inside an active session context, convenience APIs (`User.all()`, `User.where(...)`, `ferro.execute(...)`) automatically bind to that session's connection.
+
+Legacy implicit default-connection routing (calling unqualified operations outside a session) is still temporarily supported for compatibility, but now emits a deprecation warning and is on the `v0.13.0` removal track.
+
 ## The Default Connection
 
 Unqualified operations (`User.all()`, top-level `execute(...)`) use the default connection. It is established three ways:

--- a/docs/pages/guide/transactions.md
+++ b/docs/pages/guide/transactions.md
@@ -26,6 +26,20 @@ A transaction is pinned to one connection. Open it against a [named connection](
 --8<-- "docs/examples/multiple_databases.py:transaction"
 ```
 
+## Sessions + Transactions
+
+`transaction()` composes with sessions. If a session is active, transactions inherit that session route by default:
+
+```python
+import ferro
+
+async with ferro.engines.session("analytics"):
+    async with ferro.transaction():
+        await Metric.create(name="requests", value=1)
+```
+
+You can also pass an explicit session handle (`transaction(session=my_session)`) when ambient context is different and you need a deterministic override.
+
 ## Raw SQL Inside a Transaction
 
 `transaction()` yields a `Transaction` handle exposing `execute` / `fetch_all` / `fetch_one` for raw SQL on the transaction's own connection — useful for Postgres GUCs (`set_config`, `SET LOCAL`), advisory locks, or any one-off statement that doesn't fit a model:

--- a/docs/pages/howto/multiple-databases.md
+++ b/docs/pages/howto/multiple-databases.md
@@ -22,6 +22,15 @@ Everything runs on the default connection unless routed. `Model.using(name)` ret
 
 Routing is per-call: `using()` doesn't change any global state, so two coroutines can talk to different databases concurrently without interfering.
 
+For session-first workflows, use `engines.session(name)` to pin a full block:
+
+```python
+import ferro
+
+async with ferro.engines.session("analytics") as s:
+    metrics = await s.query(Metric).where(lambda t: t.value > 0).all()
+```
+
 ## Transactions on Named Connections
 
 `transaction(using=...)` pins a transaction to one named connection:

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -88,7 +88,7 @@ Definition of done addition:
 ## Program status
 
 - Overall status: `In progress`
-- Current phase: `Phase 6`
+- Current phase: `Phase 7`
 - Last updated: `2026-06-22`
 - Roadmap owner: `@syn54x`
 
@@ -350,7 +350,7 @@ Issue references:
 
 ### Phase 6 - Sessionized runtime state
 
-Status: `Not started`
+Status: `Complete`
 
 Issue references:
 
@@ -361,13 +361,24 @@ Issue references:
 - Replace global mutable registries in hot paths with explicit session/engine scoped state.
 
 **Deliverables**
-- [ ] Session/UnitOfWork abstraction for identity map + transaction state.
-- [ ] Engine-scoped registries replace global lookups in core operations.
-- [ ] Temporary compatibility shim for legacy call sites.
+- [x] Session/UnitOfWork abstraction for identity map + transaction state.
+- [x] Engine-scoped registries replace global lookups in core operations.
+- [x] Temporary compatibility shim for legacy call sites.
 
 **Exit gate**
-- [ ] Core CRUD/query paths no longer require global registries.
-- [ ] Session lifecycle and concurrency semantics documented.
+- [x] Core CRUD/query paths no longer require global registries.
+- [x] Session lifecycle and concurrency semantics documented.
+
+**Evidence (working branch; pending merge to `feat/ir-first`)**
+- Session API + ambient context routing: `src/ferro/session.py`, `src/ferro/state.py`, `src/ferro/models.py`, `src/ferro/query/builder.py`, `src/ferro/raw.py`, `src/ferro/__init__.py`, `src/ferro/_core.pyi`
+- Session-scoped Rust runtime state for tx/identity-map hot paths: `src/state.rs`, `src/operations.rs`, `src/connection.rs`, `src/lib.rs`
+- Session lifecycle/concurrency + compatibility coverage: `tests/test_session.py`, `tests/test_connection.py`, `tests/test_transactions.py`, `tests/test_named_connections_integration.py`
+- Docs/migration/invariant updates for sessionized runtime and compatibility shim: `docs/pages/guide/connections.md`, `docs/pages/guide/transactions.md`, `docs/pages/howto/multiple-databases.md`, `docs/pages/concepts/identity-map.md`, `docs/pages/api/connection.md`, `docs/pages/api/transactions.md`, `docs/plans/ir-first-migration-guide.md`, `docs/solutions/patterns/ir-invariants.md`
+- Verification commands:
+  - `cargo check`
+  - `cargo test` (fails in local environment due missing Python symbol linkage for PyO3 test target; non-blocking for Phase 6 code paths)
+  - `cargo test -p ferro-schema-ir -p ferro-migrate`
+  - `uv run pytest tests/test_session.py tests/test_connection.py tests/test_transactions.py tests/test_named_connections_integration.py tests/test_query_builder.py tests/test_raw_sql.py tests/test_crud.py tests/test_deletion.py tests/test_bulk_update.py tests/test_hydration.py tests/test_ir_vectors_contract.py tests/test_shadow_reports.py -q`
 
 ---
 
@@ -557,6 +568,7 @@ Append updates as concise entries.
 - `2026-06-19` - Phase 8 issue set created and linked: epic [#107](https://github.com/syn54x/ferro-orm/issues/107) with sub-issues [#108](https://github.com/syn54x/ferro-orm/issues/108), [#109](https://github.com/syn54x/ferro-orm/issues/109), [#110](https://github.com/syn54x/ferro-orm/issues/110).
 - `2026-06-19` - Phase 4 working-branch implementation landed: added `ferro-migrate` (`SchemaIR(old,new)` diff + SQL emission entrypoint), expanded SchemaIR fidelity (enum/check/join-table coverage), switched Alembic metadata derivation to SchemaIR, and added deprecation warnings for superseded JSON-only Alembic helpers (target removal `v0.13.0`).
 - `2026-06-22` - Phase 5 working-branch implementation landed: added unified codec registry module (`src/codec.rs`) across insert/update/filter/m2m/fetch paths, extracted single hydration ABI helper (`src/hydration.rs`) with required Pydantic slot initialization, and expanded codec conformance vectors/tests for null/uuid/decimal/temporal/enum semantics.
+- `2026-06-22` - Phase 6 working-branch implementation landed: introduced sessionized runtime API (`engines.session` / `Session`) and ambient session routing, moved transaction/identity-map hot-path state to session scope in Rust with compatibility fallback + deprecation warnings, added session lifecycle tests, and synchronized migration/guide/API/invariant docs.
 
 ## Immediate next actions
 

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -87,7 +87,17 @@ Phase 4 deprecation note:
 
 ### Phase 6
 
-_TBD_
+| Issue | Change | Impact | User action | Notes |
+| --- | --- | --- | --- | --- |
+| [#97](https://github.com/syn54x/ferro-orm/issues/97) | Add explicit `Session`/`engines.session(name)` runtime boundary for ambient model/query/raw routing | minor | Prefer `async with ferro.engines.session(\"name\")` around request/task work; use `session=` explicit overrides when needed | Adds deterministic nested-session shadow/restore semantics |
+| [#98](https://github.com/syn54x/ferro-orm/issues/98) | Core CRUD/query/transaction hot paths now support session-scoped transaction + identity-map state in Rust | minor | No call-site change required if you use sessions; behavior is now isolated per session under concurrent workloads | Legacy global fallback remains only for compatibility paths |
+| [#99](https://github.com/syn54x/ferro-orm/issues/99) | Temporary compatibility shim keeps implicit default-connection routing but emits deprecation warnings | minor | Migrate unqualified operations (`Model.*`, `ferro.execute/fetch_*`) to run inside sessions; keep `using=` for explicit one-off routing | Deprecation warning points to removal target `v0.13.0` |
+
+Phase 6 deprecation note:
+
+- Deprecated: implicit default-connection routing outside an active session context.
+- Replacement: `async with ferro.engines.session(\"name\")` (ambient routing) or explicit `session=` arguments.
+- Removal target: `v0.13.0`.
 
 ### Phase 7
 

--- a/docs/solutions/patterns/ir-invariants.md
+++ b/docs/solutions/patterns/ir-invariants.md
@@ -34,6 +34,7 @@ Treat these as non-negotiable IR invariants:
 1. **Cross-emitter parity**: every schema artifact name/type/default/nullability must match across emitters.
 2. **Hydration ABI**: zero-copy hydration must initialize required Pydantic slots exactly.
 3. **Typed null/bind correctness**: schema-driven paths must emit type-correct binds, including typed NULLs.
+4. **Session-scoped runtime state**: hot-path identity and transaction state is scoped to explicit/ambient sessions, not hidden globals.
 
 Every IR contract change must preserve or explicitly version these invariants.
 
@@ -124,3 +125,29 @@ When updating `SchemaIR`, `QueryIR`, or `CodecIR`:
 - New IR field appears in one emitter path but not another.
 
 If any appears, treat it as a correctness bug, not a warning-level mismatch.
+
+## Invariant IV: Session-scoped runtime state
+
+### Contract
+
+Core CRUD/query/raw operation routing must derive mutable runtime state from explicit or ambient session context.
+
+- Transaction state is session-scoped.
+- Identity map state is session-scoped.
+- Nested sessions shadow and restore deterministically.
+- Legacy implicit default routing is compatibility-only and on a declared removal timeline.
+
+### Why it exists
+
+Global mutable runtime state in hot paths makes concurrent multi-DB behavior fragile and creates hidden coupling between unrelated tasks.
+
+### Enforcement anchors
+
+- `src/ferro/session.py`
+- `src/ferro/state.py`
+- `src/ferro/models.py`
+- `src/ferro/query/builder.py`
+- `src/ferro/raw.py`
+- `src/state.rs`
+- `src/operations.rs`
+- `tests/test_session.py`

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -5,7 +5,10 @@
 
 use crate::backend::{BackendKind, EngineHandle, PoolSpec};
 use crate::migrate::{MigrateOptions, internal_migrate};
-use crate::state::{CONNECTION_REGISTRY, DEFAULT_CONNECTION_NAME, ENGINE, IDENTITY_MAP};
+use crate::state::{
+    CONNECTION_REGISTRY, DEFAULT_CONNECTION_NAME, ENGINE, IDENTITY_MAP, SESSION_REGISTRY,
+    TRANSACTION_REGISTRY,
+};
 use pyo3::prelude::*;
 use std::sync::Arc;
 
@@ -313,6 +316,8 @@ pub fn reset_engine() -> PyResult<()> {
         pyo3::exceptions::PyRuntimeError::new_err("Failed to lock Default Connection")
     })? = None;
     IDENTITY_MAP.clear();
+    TRANSACTION_REGISTRY.clear();
+    SESSION_REGISTRY.clear();
     Ok(())
 }
 

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -28,6 +28,7 @@ from .fields import BackRef, Field, ManyToMany
 from .models import Model, transaction
 from .query import Relation
 from .raw import Transaction, execute, fetch_all, fetch_one
+from .session import Session, engines
 
 # Set up the Ferro logger
 _logger = logging.getLogger("ferro")
@@ -154,4 +155,6 @@ __all__ = [
     "fetch_all",
     "fetch_one",
     "Transaction",
+    "Session",
+    "engines",
 ]

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -62,49 +62,59 @@ def _shadow_compare_query_plan_for_test(
     ...
 
 async def fetch_all(
-    cls: object, tx_id: Optional[str] = None, using: Optional[str] = None
+    cls: object,
+    tx_id: Optional[str] = None,
+    using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> list[Any]: ...
 async def fetch_filtered(
     cls: object,
     query_ir_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> list[Any]: ...
 async def count_filtered(
     name: str,
     query_ir_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> int: ...
 async def fetch_one(
     cls: object,
     pk_val: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> Any | None: ...
 async def save_record(
     name: str,
     data: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> int | None: ...
 async def save_bulk_records(
     name: str,
     data_list_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> int: ...
 async def delete_record(
     name: str,
     pk_val: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> bool: ...
 async def delete_filtered(
     name: str,
     query_ir_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> int: ...
 async def update_filtered(
     name: str,
@@ -112,6 +122,7 @@ async def update_filtered(
     update_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> int: ...
 async def add_m2m_links(
     join_table: str,
@@ -121,6 +132,7 @@ async def add_m2m_links(
     target_ids: list[Any],
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> None: ...
 async def remove_m2m_links(
     join_table: str,
@@ -130,6 +142,7 @@ async def remove_m2m_links(
     target_ids: list[Any],
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> None: ...
 async def clear_m2m_links(
     join_table: str,
@@ -137,35 +150,49 @@ async def clear_m2m_links(
     source_id: Any,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> None: ...
 async def begin_transaction(
-    parent_tx_id: Optional[str] = None, using: Optional[str] = None
+    parent_tx_id: Optional[str] = None,
+    using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> str: ...
-async def commit_transaction(tx_id: str) -> None: ...
-def transaction_connection_name(tx_id: str) -> str: ...
-async def rollback_transaction(tx_id: str) -> None: ...
+async def commit_transaction(tx_id: str, session_id: Optional[str] = None) -> None: ...
+def transaction_connection_name(tx_id: str, session_id: Optional[str] = None) -> str: ...
+async def rollback_transaction(tx_id: str, session_id: Optional[str] = None) -> None: ...
+def open_session(using: Optional[str] = None) -> str: ...
+def close_session(session_id: str) -> None: ...
 async def raw_execute(
     sql: str,
     args: list[Any],
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> int: ...
 async def raw_fetch_all(
     sql: str,
     args: list[Any],
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> list[dict[str, Any]]: ...
 async def raw_fetch_one(
     sql: str,
     args: list[Any],
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> dict[str, Any] | None: ...
 def register_instance(
-    name: str, pk: str, obj: object, using: Optional[str] = None
+    name: str,
+    pk: str,
+    obj: object,
+    using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> None: ...
-def evict_instance(name: str, pk: str, using: Optional[str] = None) -> None: ...
+def evict_instance(
+    name: str, pk: str, using: Optional[str] = None, session_id: Optional[str] = None
+) -> None: ...
 def reset_engine() -> None: ...
 def set_default_connection(name: str) -> None: ...
 def clear_registry() -> None: ...

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -13,6 +13,7 @@ from typing import (
 
 if TYPE_CHECKING:
     from .query import Predicate
+    from .session import Session
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -31,44 +32,39 @@ from .base import ForeignKey, foreign_key_allows_none
 from .exceptions import ModelDoesNotExist
 from .metaclass import ModelMetaclass
 from .query import Query, QueryNode
-from .state import _CURRENT_TRANSACTION, _CURRENT_TRANSACTION_CONNECTION
+from .state import (
+    _CURRENT_TRANSACTION,
+    _CURRENT_TRANSACTION_CONNECTION,
+    resolve_operation_scope,
+    resolve_transaction_scope,
+)
 
 
 _FERRO_CONNECTION_ATTR = "__ferro_connection_name"
 
 
-def _transaction_or_using(using: str | None) -> tuple[str | None, str | None]:
-    tx_id = _CURRENT_TRANSACTION.get()
-    if tx_id is not None and using is not None:
-        tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
-        if using == tx_connection:
-            return tx_id, None
-        raise ValueError(
-            "ORM operations inside a transaction inherit the transaction connection"
-        )
-    return tx_id, using
+def _transaction_or_using(
+    using: str | None, session: "Session | None"
+) -> tuple[str | None, str | None, str | None]:
+    return resolve_operation_scope(
+        using=using, session=session, allow_legacy_default=True
+    )
 
 
 def _instance_transaction_route(
-    instance: object, using: str | None
-) -> tuple[str | None, str | None, str | None]:
+    instance: object, using: str | None, session: "Session | None"
+) -> tuple[str | None, str | None, str | None, str | None]:
     origin = _instance_origin(instance)
     if using is not None and origin is not None and using != origin:
         raise ValueError("Instance is already bound to a different connection")
 
-    tx_id = _CURRENT_TRANSACTION.get()
+    tx_id, route_using, session_id = _transaction_or_using(using, session)
     if tx_id is not None:
         tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
-        if using is not None:
-            if using == tx_connection:
-                return tx_id, None, origin or tx_connection
-            raise ValueError(
-                "ORM operations inside a transaction inherit the transaction connection"
-            )
-        return tx_id, None, origin or tx_connection
+        return tx_id, route_using, origin or tx_connection, session_id
 
-    effective_using = using or origin
-    return None, effective_using, effective_using
+    effective_using = route_using or origin
+    return None, effective_using, effective_using, session_id
 
 
 def _instance_origin(instance: object) -> str | None:
@@ -82,7 +78,7 @@ def _set_instance_origin(instance: object, using: str | None) -> None:
 
 
 @asynccontextmanager
-async def transaction(using: str | None = None):
+async def transaction(using: str | None = None, *, session: "Session | None" = None):
     """Run database operations inside a transaction context.
 
     Yields a :class:`~ferro.raw.Transaction` handle bound to this transaction's
@@ -107,16 +103,18 @@ async def transaction(using: str | None = None):
     """
     from .raw import Transaction
 
-    parent_tx_id = _CURRENT_TRANSACTION.get()
-    tx_id = await begin_transaction(parent_tx_id, using)
-    connection_name = transaction_connection_name(tx_id)
+    parent_tx_id, effective_using, session_id = resolve_transaction_scope(
+        using=using, session=session, allow_legacy_default=True
+    )
+    tx_id = await begin_transaction(parent_tx_id, effective_using, session_id=session_id)
+    connection_name = transaction_connection_name(tx_id, session_id=session_id)
     token = _CURRENT_TRANSACTION.set(tx_id)
     connection_token = _CURRENT_TRANSACTION_CONNECTION.set(connection_name)
     try:
-        yield Transaction(tx_id)
-        await commit_transaction(tx_id)
+        yield Transaction(tx_id, session_id=session_id)
+        await commit_transaction(tx_id, session_id=session_id)
     except Exception:
-        await rollback_transaction(tx_id)
+        await rollback_transaction(tx_id, session_id=session_id)
         raise
     finally:
         _CURRENT_TRANSACTION.reset(token)
@@ -216,7 +214,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                     raise ValueError(f"{field_name} is required")
         return self
 
-    async def save(self, *, using: str | None = None) -> None:
+    async def save(
+        self, *, using: str | None = None, session: "Session | None" = None
+    ) -> None:
         """Persist the current model instance
 
         Returns:
@@ -226,11 +226,15 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> user = User(name="Taylor")
             >>> await user.save()
         """
-        tx_id, operation_using, identity_using = _instance_transaction_route(
-            self, using
+        tx_id, operation_using, identity_using, session_id = _instance_transaction_route(
+            self, using, session
         )
         new_id = await save_record(
-            self.__class__.__name__, self.model_dump_json(), tx_id, operation_using
+            self.__class__.__name__,
+            self.model_dump_json(),
+            tx_id,
+            operation_using,
+            session_id=session_id,
         )
 
         pk_val = None
@@ -256,11 +260,17 @@ class Model(BaseModel, metaclass=ModelMetaclass):
 
         if pk_val is not None:
             register_instance(
-                self.__class__.__name__, str(pk_val), self, identity_using
+                self.__class__.__name__,
+                str(pk_val),
+                self,
+                identity_using,
+                session_id=session_id,
             )
             _set_instance_origin(self, identity_using)
 
-    async def delete(self, *, using: str | None = None) -> None:
+    async def delete(
+        self, *, using: str | None = None, session: "Session | None" = None
+    ) -> None:
         """Delete the current model instance from storage
 
         Returns:
@@ -273,8 +283,8 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         """
         pk_field_name = self.__class__._primary_key_field_name()
         pk_val = getattr(self, pk_field_name) if pk_field_name is not None else None
-        _tx_id, operation_using, identity_using = _instance_transaction_route(
-            self, using
+        _tx_id, operation_using, identity_using, session_id = _instance_transaction_route(
+            self, using, session
         )
 
         if pk_val is not None:
@@ -287,7 +297,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                     getattr(self.__class__, pk_field_name) == pk_val
                 )
             await query.delete()
-            evict_instance(name, str(pk_val), identity_using)
+            evict_instance(
+                name, str(pk_val), identity_using, session_id=session_id
+            )
 
     @classmethod
     def _primary_key_field_name(cls) -> str | None:
@@ -320,7 +332,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                     pass
 
     @classmethod
-    async def all(cls, *, using: str | None = None) -> list[Self]:
+    async def all(
+        cls, *, using: str | None = None, session: "Session | None" = None
+    ) -> list[Self]:
         """Fetch all records for this model class
 
         Returns:
@@ -331,14 +345,14 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> isinstance(users, list)
             True
         """
-        tx_id, using = _transaction_or_using(using)
-        results = await fetch_all(cls, tx_id, using)
+        tx_id, using, session_id = _transaction_or_using(using, session)
+        results = await fetch_all(cls, tx_id, using, session_id=session_id)
         for instance in results:
             cls._fix_types(instance)
         return results
 
     @classmethod
-    async def get(cls, pk: Any) -> Self:
+    async def get(cls, pk: Any, *, session: "Session | None" = None) -> Self:
         """Fetch one record by primary key value.
 
         Args:
@@ -356,13 +370,15 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> isinstance(user, User)
             True
         """
-        instance = await cls.get_or_none(pk)
+        instance = await cls.get_or_none(pk, session=session)
         if instance is None:
             raise ModelDoesNotExist(cls, pk)
         return instance
 
     @classmethod
-    async def get_or_none(cls, pk: Any) -> Self | None:
+    async def get_or_none(
+        cls, pk: Any, *, session: "Session | None" = None
+    ) -> Self | None:
         """Fetch one record by primary key, or return None if no row exists.
 
         Args:
@@ -375,12 +391,14 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         if pk_field_name is None:
             raise RuntimeError(f"Model {cls.__name__} does not define a primary key")
 
-        instance = await cls.where(getattr(cls, pk_field_name) == pk).first()
+        instance = await cls.where(getattr(cls, pk_field_name) == pk, session=session).first()
         if instance:
             cls._fix_types(instance)
         return instance
 
-    async def refresh(self, *, using: str | None = None) -> None:
+    async def refresh(
+        self, *, using: str | None = None, session: "Session | None" = None
+    ) -> None:
         """Reload this instance from storage using its primary key
 
         Returns:
@@ -400,11 +418,11 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             raise RuntimeError("Cannot refresh a model without a primary key")
 
         name = self.__class__.__name__
-        _tx_id, operation_using, identity_using = _instance_transaction_route(
-            self, using
+        _tx_id, operation_using, identity_using, session_id = _instance_transaction_route(
+            self, using, session
         )
 
-        evict_instance(name, str(pk_val), identity_using)
+        evict_instance(name, str(pk_val), identity_using, session_id=session_id)
         query = self.__class__.where(getattr(self.__class__, pk_field_name) == pk_val)
         if operation_using is not None:
             query = Query(self.__class__, using=operation_using).where(
@@ -416,7 +434,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             raise RuntimeError(f"Instance not found in database: {name}({pk_val})")
 
         self.__dict__.update(fresh_instance.__dict__)
-        register_instance(name, str(pk_val), self, identity_using)
+        register_instance(
+            name, str(pk_val), self, identity_using, session_id=session_id
+        )
         _set_instance_origin(self, identity_using)
         self.__class__._fix_types(self)
 
@@ -429,7 +449,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
     def where(cls, node: "Predicate[Self]") -> Query[Self]: ...
 
     @classmethod
-    def where(cls, node: "QueryNode | Predicate[Self]") -> Query[Self]:
+    def where(
+        cls, node: "QueryNode | Predicate[Self]", *, session: "Session | None" = None
+    ) -> Query[Self]:
         """Start a fluent query with an initial condition.
 
         The recommended style is a lambda predicate of shape
@@ -460,10 +482,10 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> isinstance(q1, Query) and isinstance(q2, Query)
             True
         """
-        return Query(cls).where(node)
+        return Query(cls, session=session).where(node)
 
     @classmethod
-    def select(cls) -> Query[Self]:
+    def select(cls, *, session: "Session | None" = None) -> Query[Self]:
         """Start an empty fluent query for this model class
 
         Returns:
@@ -474,7 +496,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> isinstance(query, Query)
             True
         """
-        return Query(cls)
+        return Query(cls, session=session)
 
     @classmethod
     def using(cls, name: str) -> "ModelConnection[Self]":
@@ -482,7 +504,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         return ModelConnection(cls, name)
 
     @classmethod
-    async def create(cls, **fields) -> Self:
+    async def create(cls, *, session: "Session | None" = None, **fields) -> Self:
         """Create and persist a new model instance
 
         Args:
@@ -497,12 +519,16 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             True
         """
         instance = cls(**fields)
-        await instance.save()
+        await instance.save(session=session)
         return instance
 
     @classmethod
     async def bulk_create(
-        cls, instances: list[Self], *, using: str | None = None
+        cls,
+        instances: list[Self],
+        *,
+        using: str | None = None,
+        session: "Session | None" = None,
     ) -> int:
         """Persist multiple instances in a single bulk operation
 
@@ -521,12 +547,18 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             return 0
         # Use mode="json" to ensure Decimals, UUIDs, etc. are serialized correctly
         data = [i.model_dump(mode="json") for i in instances]
-        tx_id, using = _transaction_or_using(using)
-        return await save_bulk_records(cls.__name__, json.dumps(data), tx_id, using)
+        tx_id, using, session_id = _transaction_or_using(using, session)
+        return await save_bulk_records(
+            cls.__name__, json.dumps(data), tx_id, using, session_id=session_id
+        )
 
     @classmethod
     async def get_or_create(
-        cls, defaults: dict[str, Any] | None = None, **fields
+        cls,
+        defaults: dict[str, Any] | None = None,
+        *,
+        session: "Session | None" = None,
+        **fields,
     ) -> tuple[Self, bool]:
         """Fetch a record by filters or create one when missing
 
@@ -542,7 +574,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> isinstance(created, bool)
             True
         """
-        query = Query(cls)
+        query = Query(cls, session=session)
         for key, val in fields.items():
             query = query.where(getattr(cls, key) == val)
 
@@ -551,11 +583,15 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             return instance, False
 
         params = {**fields, **(defaults or {})}
-        return await cls.create(**params), True
+        return await cls.create(session=session, **params), True
 
     @classmethod
     async def update_or_create(
-        cls, defaults: dict[str, Any] | None = None, **fields
+        cls,
+        defaults: dict[str, Any] | None = None,
+        *,
+        session: "Session | None" = None,
+        **fields,
     ) -> tuple[Self, bool]:
         """Update a matched record or create one when missing
 
@@ -566,7 +602,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         Returns:
             A tuple of ``(instance, created)`` where ``created`` is True for new records.
         """
-        query = Query(cls)
+        query = Query(cls, session=session)
         for key, val in fields.items():
             query = query.where(getattr(cls, key) == val)
 
@@ -574,11 +610,11 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         if instance:
             for key, val in (defaults or {}).items():
                 setattr(instance, key, val)
-            await instance.save()
+            await instance.save(session=session)
             return instance, False
 
         params = {**fields, **(defaults or {})}
-        return await cls.create(**params), True
+        return await cls.create(session=session, **params), True
 
 
 class ModelConnection[M: Model]:

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -92,7 +92,9 @@ class Query(Generic[T]):
         order_by_clause: Sort definitions sent to the Rust core.
     """
 
-    def __init__(self, model_cls: Type[T], using: str | None = None):
+    def __init__(
+        self, model_cls: Type[T], using: str | None = None, session: Any | None = None
+    ):
         """Initialize a query for a model class.
 
         Args:
@@ -105,23 +107,19 @@ class Query(Generic[T]):
         """
         self.model_cls = model_cls
         self._using = using
+        self._session = session
         self.where_clause: list["QueryNode"] = []
         self.order_by_clause: list[dict[str, str]] = []
         self._limit: int | None = None
         self._offset: int | None = None
         self._m2m_context: dict[str, Any] | None = None
 
-    def _transaction_or_using(self) -> tuple[str | None, str | None]:
-        from ..state import _CURRENT_TRANSACTION, _CURRENT_TRANSACTION_CONNECTION
+    def _transaction_or_using(self) -> tuple[str | None, str | None, str | None]:
+        from ..state import resolve_operation_scope
 
-        tx_id = _CURRENT_TRANSACTION.get()
-        if tx_id is not None and self._using is not None:
-            if self._using == _CURRENT_TRANSACTION_CONNECTION.get():
-                return tx_id, None
-            raise ValueError(
-                "ORM queries inside a transaction inherit the transaction connection"
-            )
-        return tx_id, self._using
+        return resolve_operation_scope(
+            using=self._using, session=self._session, allow_legacy_default=True
+        )
 
     def _m2m(
         self, join_table: str, source_col: str, target_col: str, source_id: Any
@@ -257,9 +255,13 @@ class Query(Generic[T]):
             "offset": self._offset,
             "m2m": self._m2m_context,
         }
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         results = await fetch_filtered(
-            self.model_cls, _query_ir_payload_to_json(query_def), tx_id, using
+            self.model_cls,
+            _query_ir_payload_to_json(query_def),
+            tx_id,
+            using,
+            session_id=session_id,
         )
         for instance in results:
             if hasattr(self.model_cls, "_fix_types"):
@@ -285,9 +287,13 @@ class Query(Generic[T]):
             "offset": None,
             "m2m": self._m2m_context,
         }
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         return await count_filtered(
-            self.model_cls.__name__, _query_ir_payload_to_json(query_def), tx_id, using
+            self.model_cls.__name__,
+            _query_ir_payload_to_json(query_def),
+            tx_id,
+            using,
+            session_id=session_id,
         )
 
     async def update(self, **fields) -> int:
@@ -314,7 +320,7 @@ class Query(Generic[T]):
         }
         from pydantic_core import to_json
 
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         # Use pydantic_core.to_json to handle Decimals, UUIDs, etc. in kwargs
         return await update_filtered(
             self.model_cls.__name__,
@@ -322,6 +328,7 @@ class Query(Generic[T]):
             to_json(fields).decode(),
             tx_id,
             using,
+            session_id=session_id,
         )
 
     async def first(self) -> T | None:
@@ -362,9 +369,13 @@ class Query(Generic[T]):
             "offset": self._offset,
             "m2m": None,
         }
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         return await delete_filtered(
-            self.model_cls.__name__, _query_ir_payload_to_json(query_def), tx_id, using
+            self.model_cls.__name__,
+            _query_ir_payload_to_json(query_def),
+            tx_id,
+            using,
+            session_id=session_id,
         )
 
     async def exists(self) -> bool:
@@ -407,7 +418,7 @@ class Query(Generic[T]):
 
         from ..state import _CURRENT_TRANSACTION
 
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         await add_m2m_links(
             self._m2m_context["join_table"],
             self._m2m_context["source_col"],
@@ -416,6 +427,7 @@ class Query(Generic[T]):
             ids,
             tx_id,
             using,
+            session_id=session_id,
         )
 
     async def remove(self, *instances: Any) -> None:
@@ -443,7 +455,7 @@ class Query(Generic[T]):
 
         from ..state import _CURRENT_TRANSACTION
 
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         await remove_m2m_links(
             self._m2m_context["join_table"],
             self._m2m_context["source_col"],
@@ -452,6 +464,7 @@ class Query(Generic[T]):
             ids,
             tx_id,
             using,
+            session_id=session_id,
         )
 
     async def clear(self) -> None:
@@ -471,13 +484,14 @@ class Query(Generic[T]):
 
         from ..state import _CURRENT_TRANSACTION
 
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         await clear_m2m_links(
             self._m2m_context["join_table"],
             self._m2m_context["source_col"],
             self._m2m_context["source_id"],
             tx_id,
             using,
+            session_id=session_id,
         )
 
     def __repr__(self):

--- a/src/ferro/raw.py
+++ b/src/ferro/raw.py
@@ -31,7 +31,7 @@ from typing import Any
 from ._core import raw_execute as _raw_execute
 from ._core import raw_fetch_all as _raw_fetch_all
 from ._core import raw_fetch_one as _raw_fetch_one
-from .state import _CURRENT_TRANSACTION, _CURRENT_TRANSACTION_CONNECTION
+from .state import resolve_operation_scope
 
 __all__ = ["execute", "fetch_all", "fetch_one", "Transaction"]
 
@@ -68,16 +68,17 @@ def _check_sql(sql: str) -> None:
         raise ValueError("sql must be a non-empty statement")
 
 
-def _transaction_or_using(using: str | None) -> tuple[str | None, str | None]:
-    tx_id = _CURRENT_TRANSACTION.get()
-    if tx_id is not None and using is not None:
-        if using == _CURRENT_TRANSACTION_CONNECTION.get():
-            return tx_id, None
-        raise ValueError("Raw SQL inside a transaction inherits the transaction connection")
-    return tx_id, using
+def _transaction_or_using(
+    using: str | None, session: Any | None
+) -> tuple[str | None, str | None, str | None]:
+    return resolve_operation_scope(
+        using=using, session=session, allow_legacy_default=True
+    )
 
 
-async def execute(sql: str, *args: Any, using: str | None = None) -> int:
+async def execute(
+    sql: str, *args: Any, using: str | None = None, session: Any | None = None
+) -> int:
     """Run a raw SQL statement, returning rows affected.
 
     Honors the active ``transaction()`` block via the ``_CURRENT_TRANSACTION``
@@ -88,12 +89,12 @@ async def execute(sql: str, *args: Any, using: str | None = None) -> int:
     """
     _check_sql(sql)
     marshalled = [_marshal(a) for a in args]
-    tx_id, using = _transaction_or_using(using)
-    return await _raw_execute(sql, marshalled, tx_id, using)
+    tx_id, using, session_id = _transaction_or_using(using, session)
+    return await _raw_execute(sql, marshalled, tx_id, using, session_id=session_id)
 
 
 async def fetch_all(
-    sql: str, *args: Any, using: str | None = None
+    sql: str, *args: Any, using: str | None = None, session: Any | None = None
 ) -> list[dict[str, Any]]:
     """Run a raw SQL query and return all rows as a list of dicts.
 
@@ -102,12 +103,12 @@ async def fetch_all(
     """
     _check_sql(sql)
     marshalled = [_marshal(a) for a in args]
-    tx_id, using = _transaction_or_using(using)
-    return await _raw_fetch_all(sql, marshalled, tx_id, using)
+    tx_id, using, session_id = _transaction_or_using(using, session)
+    return await _raw_fetch_all(sql, marshalled, tx_id, using, session_id=session_id)
 
 
 async def fetch_one(
-    sql: str, *args: Any, using: str | None = None
+    sql: str, *args: Any, using: str | None = None, session: Any | None = None
 ) -> dict[str, Any] | None:
     """Run a raw SQL query and return the first row as a dict, or ``None``.
 
@@ -115,8 +116,8 @@ async def fetch_one(
     """
     _check_sql(sql)
     marshalled = [_marshal(a) for a in args]
-    tx_id, using = _transaction_or_using(using)
-    return await _raw_fetch_one(sql, marshalled, tx_id, using)
+    tx_id, using, session_id = _transaction_or_using(using, session)
+    return await _raw_fetch_one(sql, marshalled, tx_id, using, session_id=session_id)
 
 
 class Transaction:
@@ -132,22 +133,27 @@ class Transaction:
     subsequent call raises :class:`RuntimeError`.
     """
 
-    __slots__ = ("_tx_id",)
+    __slots__ = ("_tx_id", "_session_id")
 
-    def __init__(self, tx_id: str) -> None:
+    def __init__(self, tx_id: str, session_id: str | None = None) -> None:
         self._tx_id = tx_id
+        self._session_id = session_id
 
     async def execute(self, sql: str, *args: Any) -> int:
         _check_sql(sql)
         marshalled = [_marshal(a) for a in args]
-        return await _raw_execute(sql, marshalled, self._tx_id)
+        return await _raw_execute(sql, marshalled, self._tx_id, session_id=self._session_id)
 
     async def fetch_all(self, sql: str, *args: Any) -> list[dict[str, Any]]:
         _check_sql(sql)
         marshalled = [_marshal(a) for a in args]
-        return await _raw_fetch_all(sql, marshalled, self._tx_id)
+        return await _raw_fetch_all(
+            sql, marshalled, self._tx_id, session_id=self._session_id
+        )
 
     async def fetch_one(self, sql: str, *args: Any) -> dict[str, Any] | None:
         _check_sql(sql)
         marshalled = [_marshal(a) for a in args]
-        return await _raw_fetch_one(sql, marshalled, self._tx_id)
+        return await _raw_fetch_one(
+            sql, marshalled, self._tx_id, session_id=self._session_id
+        )

--- a/src/ferro/session.py
+++ b/src/ferro/session.py
@@ -1,0 +1,44 @@
+"""Session-scoped runtime state for Ferro operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ._core import close_session as _core_close_session
+from ._core import open_session as _core_open_session
+from .state import _CURRENT_SESSION
+
+
+@dataclass(slots=True)
+class Session:
+    connection_name: str | None = None
+    session_id: str | None = None
+    _token: Any = None
+
+    async def __aenter__(self) -> "Session":
+        self.session_id = _core_open_session(self.connection_name)
+        self._token = _CURRENT_SESSION.set(self)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._token is not None:
+            _CURRENT_SESSION.reset(self._token)
+            self._token = None
+        if self.session_id is not None:
+            _core_close_session(self.session_id)
+            self.session_id = None
+
+    def query(self, model_cls):
+        from .query import Query
+
+        return Query(model_cls, session=self)
+
+
+class EngineManager:
+    def session(self, name: str | None = None) -> Session:
+        return Session(connection_name=name)
+
+
+engines = EngineManager()
+

--- a/src/ferro/session.py
+++ b/src/ferro/session.py
@@ -41,4 +41,3 @@ class EngineManager:
 
 
 engines = EngineManager()
-

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -1,5 +1,6 @@
 from contextvars import ContextVar
-from typing import Any
+import warnings
+from typing import Any, Protocol
 
 # Context variable to store the active transaction ID for the current task
 _CURRENT_TRANSACTION: ContextVar[str | None] = ContextVar(
@@ -8,6 +9,23 @@ _CURRENT_TRANSACTION: ContextVar[str | None] = ContextVar(
 
 _CURRENT_TRANSACTION_CONNECTION: ContextVar[str | None] = ContextVar(
     "current_transaction_connection", default=None
+)
+
+
+class SessionLike(Protocol):
+    session_id: str
+    connection_name: str
+
+
+_CURRENT_SESSION: ContextVar[SessionLike | None] = ContextVar(
+    "current_session", default=None
+)
+
+
+_LEGACY_DEFAULT_CONNECTION_DEPRECATION = (
+    "Implicit default-connection routing without an active session is deprecated; "
+    "use `async with ferro.engines.session(\"name\")` (or pass `session=...`) for "
+    "ORM/raw operations. Planned removal: v0.13.0."
 )
 
 # Global registry for models (Python side)
@@ -26,3 +44,85 @@ _SCHEMA_IR_MODELSET_FINGERPRINT: str | None = None
 # Per-model compiled SchemaIR artifacts and fingerprints.
 _SCHEMA_IR_BY_MODEL: dict[str, dict[str, Any]] = {}
 _SCHEMA_IR_FINGERPRINT_BY_MODEL: dict[str, str] = {}
+
+
+def resolve_operation_scope(
+    *,
+    using: str | None,
+    session: SessionLike | None,
+    allow_legacy_default: bool,
+) -> tuple[str | None, str | None, str | None]:
+    """Resolve `(tx_id, using, session_id)` for ORM/raw operations."""
+    tx_id = _CURRENT_TRANSACTION.get()
+    tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
+
+    ambient_session = _CURRENT_SESSION.get()
+    explicit_session = session
+    effective_session = explicit_session or ambient_session
+
+    # Explicit `using` can override ambient sessions for compatibility, but not
+    # explicitly supplied `session=...`.
+    if effective_session is not None and using is not None:
+        if explicit_session is not None and using != effective_session.connection_name:
+            raise ValueError(
+                "Explicit `using` conflicts with explicit `session` connection"
+            )
+        if explicit_session is None and using != effective_session.connection_name:
+            effective_session = None
+
+    session_id = effective_session.session_id if effective_session is not None else None
+
+    if tx_id is not None:
+        if using is not None and using != tx_connection:
+            raise ValueError(
+                "Operations inside a transaction inherit the transaction connection"
+            )
+        if effective_session is not None and tx_connection is not None:
+            if effective_session.connection_name != tx_connection:
+                raise ValueError(
+                    "Active transaction is bound to a different connection than session"
+                )
+        return tx_id, None, session_id
+
+    effective_using = using or (
+        effective_session.connection_name if effective_session is not None else None
+    )
+    if effective_using is None and allow_legacy_default:
+        warnings.warn(_LEGACY_DEFAULT_CONNECTION_DEPRECATION, DeprecationWarning, stacklevel=3)
+    return None, effective_using, session_id
+
+
+def resolve_transaction_scope(
+    *,
+    using: str | None,
+    session: SessionLike | None,
+    allow_legacy_default: bool,
+) -> tuple[str | None, str | None, str | None]:
+    parent_tx_id = _CURRENT_TRANSACTION.get()
+    tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
+    ambient_session = _CURRENT_SESSION.get()
+    explicit_session = session
+    effective_session = explicit_session or ambient_session
+
+    if effective_session is not None and using is not None:
+        if explicit_session is not None and using != effective_session.connection_name:
+            raise ValueError(
+                "Explicit `using` conflicts with explicit `session` connection"
+            )
+        if explicit_session is None and using != effective_session.connection_name:
+            effective_session = None
+
+    if parent_tx_id is not None:
+        # Nested tx route is always inherited from parent.
+        return parent_tx_id, None, (
+            effective_session.session_id if effective_session is not None else None
+        )
+
+    effective_using = using or (
+        effective_session.connection_name if effective_session is not None else None
+    )
+    if effective_using is None and allow_legacy_default:
+        warnings.warn(_LEGACY_DEFAULT_CONNECTION_DEPRECATION, DeprecationWarning, stacklevel=3)
+    return None, effective_using, (
+        effective_session.session_id if effective_session is not None else None
+    )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,8 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m
     )?)?;
     m.add_function(wrap_pyfunction!(operations::rollback_transaction, m)?)?;
+    m.add_function(wrap_pyfunction!(operations::open_session, m)?)?;
+    m.add_function(wrap_pyfunction!(operations::close_session, m)?)?;
     m.add_function(wrap_pyfunction!(operations::raw_execute, m)?)?;
     m.add_function(wrap_pyfunction!(operations::raw_fetch_all, m)?)?;
     m.add_function(wrap_pyfunction!(operations::raw_fetch_one, m)?)?;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -8,8 +8,9 @@ use crate::backend::{
 };
 use crate::query::{QueryDef, query_def_from_ir_payload};
 use crate::state::{
-    IDENTITY_MAP, MODEL_REGISTRY, SqlDialect, TRANSACTION_REGISTRY, TransactionConnection,
-    TransactionHandle, connection_for_route, engine_for_connection,
+    IDENTITY_MAP, MODEL_REGISTRY, SqlDialect, TRANSACTION_REGISTRY,
+    TransactionConnection, TransactionHandle, connection_for_route, engine_for_connection,
+    register_session, session_state, unregister_session,
 };
 use ferro_schema_ir::{IrEnvelope, QueryIrPayload};
 use pyo3::prelude::*;
@@ -21,40 +22,77 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-fn get_transaction_connection(tx_id: Option<String>) -> Option<TransactionConnection> {
-    tx_id.and_then(|id| {
-        TRANSACTION_REGISTRY
+fn get_transaction_connection(
+    tx_id: Option<String>,
+    session_id: Option<&str>,
+) -> PyResult<Option<TransactionConnection>> {
+    if let Some(id) = tx_id {
+        if let Some(session_id) = session_id {
+            let session = session_state(session_id)?;
+            return Ok(session
+                .transaction_registry
+                .get(&id)
+                .map(|tx| tx.value().conn.clone()));
+        }
+        return Ok(TRANSACTION_REGISTRY
             .get(&id)
-            .map(|tx| tx.value().conn.clone())
-    })
+            .map(|tx| tx.value().conn.clone()));
+    }
+    Ok(None)
 }
 
-fn get_transaction_route(tx_id: Option<String>) -> Option<(String, TransactionConnection)> {
-    tx_id.and_then(|id| {
-        TRANSACTION_REGISTRY
+fn get_transaction_route(
+    tx_id: Option<String>,
+    session_id: Option<&str>,
+) -> PyResult<Option<(String, TransactionConnection)>> {
+    if let Some(id) = tx_id {
+        if let Some(session_id) = session_id {
+            let session = session_state(session_id)?;
+            return Ok(session
+                .transaction_registry
+                .get(&id)
+                .map(|tx| (tx.value().connection_name.clone(), tx.value().conn.clone())));
+        }
+        return Ok(TRANSACTION_REGISTRY
             .get(&id)
-            .map(|tx| (tx.value().connection_name.clone(), tx.value().conn.clone()))
-    })
+            .map(|tx| (tx.value().connection_name.clone(), tx.value().conn.clone())));
+    }
+    Ok(None)
 }
 
-fn active_engine_for_connection(using: Option<String>) -> PyResult<Arc<EngineHandle>> {
+fn active_engine_for_connection(
+    using: Option<String>,
+    session_id: Option<&str>,
+) -> PyResult<Arc<EngineHandle>> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        let connection_name = using.unwrap_or_else(|| session.connection_name.clone());
+        return engine_for_connection(Some(connection_name));
+    }
     engine_for_connection(using)
 }
 
 fn active_route_for_operation(
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<(
     String,
     Arc<EngineHandle>,
     Option<TransactionConnection>,
     BackendKind,
 )> {
-    let tx_route = get_transaction_route(tx_id);
+    let tx_route = get_transaction_route(tx_id, session_id.as_deref())?;
+    let session_connection = if let Some(ref sid) = session_id {
+        Some(session_state(sid)?.connection_name.clone())
+    } else {
+        None
+    };
     let route_using = tx_route
         .as_ref()
         .map(|(connection_name, _)| connection_name.clone())
-        .or(using);
+        .or(using)
+        .or(session_connection);
     let (connection_name, engine) = active_connection_for_route(route_using)?;
     let backend = engine.backend();
     let tx_conn = tx_route.map(|(_, conn)| conn);
@@ -63,6 +101,101 @@ fn active_route_for_operation(
 
 fn active_connection_for_route(using: Option<String>) -> PyResult<(String, Arc<EngineHandle>)> {
     connection_for_route(using)
+}
+
+fn identity_map_get(
+    session_id: Option<&str>,
+    key: &(String, String, String),
+) -> PyResult<Option<Py<PyAny>>> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        return Ok(session.identity_map.get(key).map(|entry| {
+            Python::attach(|py| entry.value().clone_ref(py))
+        }));
+    }
+    Ok(IDENTITY_MAP
+        .get(key)
+        .map(|entry| Python::attach(|py| entry.value().clone_ref(py))))
+}
+
+fn identity_map_insert(
+    session_id: Option<&str>,
+    key: (String, String, String),
+    value: Py<PyAny>,
+) -> PyResult<()> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        session.identity_map.insert(key, value);
+        return Ok(());
+    }
+    IDENTITY_MAP.insert(key, value);
+    Ok(())
+}
+
+fn identity_map_remove(session_id: Option<&str>, key: &(String, String, String)) -> PyResult<()> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        session.identity_map.remove(key);
+        return Ok(());
+    }
+    IDENTITY_MAP.remove(key);
+    Ok(())
+}
+
+fn identity_map_retain_model(session_id: Option<&str>, model_name: &str) -> PyResult<()> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        session
+            .identity_map
+            .retain(|(_, m_name, _), _| m_name != model_name);
+        return Ok(());
+    }
+    IDENTITY_MAP.retain(|(_, m_name, _), _| m_name != model_name);
+    Ok(())
+}
+
+fn identity_map_clear(session_id: Option<&str>) -> PyResult<()> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        session.identity_map.clear();
+        return Ok(());
+    }
+    IDENTITY_MAP.clear();
+    Ok(())
+}
+
+fn tx_get(session_id: Option<&str>, tx_id: &str) -> PyResult<Option<TransactionHandle>> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        return Ok(session
+            .transaction_registry
+            .get(tx_id)
+            .map(|entry| entry.value().clone()));
+    }
+    Ok(TRANSACTION_REGISTRY
+        .get(tx_id)
+        .map(|entry| entry.value().clone()))
+}
+
+fn tx_insert(session_id: Option<&str>, tx_id: String, handle: TransactionHandle) -> PyResult<()> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        session.transaction_registry.insert(tx_id, handle);
+        return Ok(());
+    }
+    TRANSACTION_REGISTRY.insert(tx_id, handle);
+    Ok(())
+}
+
+fn tx_remove(session_id: Option<&str>, tx_id: &str) -> PyResult<Option<TransactionHandle>> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        return Ok(session
+            .transaction_registry
+            .remove(tx_id)
+            .map(|(_, handle)| handle));
+    }
+    Ok(TRANSACTION_REGISTRY.remove(tx_id).map(|(_, handle)| handle))
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -533,11 +666,12 @@ fn backend_column_value_expr(
 }
 
 #[pyfunction]
-#[pyo3(signature = (parent_tx_id=None, using=None))]
+#[pyo3(signature = (parent_tx_id=None, using=None, session_id=None))]
 pub fn begin_transaction(
     py: Python<'_>,
     parent_tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let tx_id = uuid::Uuid::new_v4().to_string();
@@ -548,12 +682,10 @@ pub fn begin_transaction(
                 ));
             }
 
-            let parent = TRANSACTION_REGISTRY.get(&parent_tx_id).ok_or_else(|| {
-                pyo3::exceptions::PyRuntimeError::new_err("Parent transaction not found")
-            })?;
+            let parent = tx_get(session_id.as_deref(), &parent_tx_id)?
+                .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Parent transaction not found"))?;
             let conn = parent.conn.clone();
             let connection_name = parent.connection_name.clone();
-            drop(parent);
 
             let savepoint_name = format!("sp_{}", tx_id.replace('-', "_"));
             execute_transaction_sql(&conn, &format!("SAVEPOINT {savepoint_name}"))
@@ -565,20 +697,27 @@ pub fn begin_transaction(
                     ))
                 })?;
 
-            TRANSACTION_REGISTRY.insert(
+            tx_insert(
+                session_id.as_deref(),
                 tx_id.clone(),
                 TransactionHandle::nested(conn, savepoint_name, connection_name),
-            );
+            )?;
         } else {
-            let (connection_name, engine) = active_connection_for_route(using)?;
+            let (connection_name, engine) = active_route_for_operation(
+                None,
+                using,
+                session_id.clone(),
+            )
+            .map(|(name, engine, _, _)| (name, engine))?;
             let conn = engine.begin_transaction_connection().await.map_err(|e| {
                 pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to BEGIN: {}", e))
             })?;
 
-            TRANSACTION_REGISTRY.insert(
+            tx_insert(
+                session_id.as_deref(),
                 tx_id.clone(),
                 TransactionHandle::root(conn, connection_name),
-            );
+            )?;
         }
 
         Ok(tx_id)
@@ -586,12 +725,15 @@ pub fn begin_transaction(
 }
 
 #[pyfunction]
-pub fn commit_transaction(py: Python<'_>, tx_id: String) -> PyResult<Bound<'_, PyAny>> {
+#[pyo3(signature = (tx_id, session_id=None))]
+pub fn commit_transaction(
+    py: Python<'_>,
+    tx_id: String,
+    session_id: Option<String>,
+) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let tx_handle = TRANSACTION_REGISTRY
-            .remove(&tx_id)
-            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Transaction not found"))?
-            .1;
+        let tx_handle = tx_remove(session_id.as_deref(), &tx_id)?
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Transaction not found"))?;
 
         if let Some(savepoint_name) = tx_handle.savepoint_name {
             execute_transaction_sql(
@@ -618,20 +760,23 @@ pub fn commit_transaction(py: Python<'_>, tx_id: String) -> PyResult<Bound<'_, P
 }
 
 #[pyfunction]
-pub fn transaction_connection_name(tx_id: String) -> PyResult<String> {
-    TRANSACTION_REGISTRY
-        .get(&tx_id)
-        .map(|tx| tx.value().connection_name.clone())
+#[pyo3(signature = (tx_id, session_id=None))]
+pub fn transaction_connection_name(tx_id: String, session_id: Option<String>) -> PyResult<String> {
+    tx_get(session_id.as_deref(), &tx_id)?
+        .map(|tx| tx.connection_name)
         .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Transaction not found"))
 }
 
 #[pyfunction]
-pub fn rollback_transaction(py: Python<'_>, tx_id: String) -> PyResult<Bound<'_, PyAny>> {
+#[pyo3(signature = (tx_id, session_id=None))]
+pub fn rollback_transaction(
+    py: Python<'_>,
+    tx_id: String,
+    session_id: Option<String>,
+) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let tx_handle = TRANSACTION_REGISTRY
-            .remove(&tx_id)
-            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Transaction not found"))?
-            .1;
+        let tx_handle = tx_remove(session_id.as_deref(), &tx_id)?
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Transaction not found"))?;
 
         if let Some(savepoint_name) = tx_handle.savepoint_name {
             execute_transaction_sql(
@@ -664,9 +809,27 @@ pub fn rollback_transaction(py: Python<'_>, tx_id: String) -> PyResult<Bound<'_,
                 })?;
         }
 
-        IDENTITY_MAP.clear();
+        identity_map_clear(session_id.as_deref())?;
         Ok(())
     })
+}
+
+#[pyfunction]
+#[pyo3(signature = (using=None))]
+pub fn open_session(using: Option<String>) -> PyResult<String> {
+    let (connection_name, _) = active_connection_for_route(using)?;
+    Ok(register_session(connection_name))
+}
+
+#[pyfunction]
+pub fn close_session(session_id: String) -> PyResult<()> {
+    if !unregister_session(&session_id) {
+        return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "Session '{}' is not active",
+            session_id
+        )));
+    }
+    Ok(())
 }
 
 /// Fetches all records for a given model class.
@@ -683,18 +846,19 @@ pub fn rollback_transaction(py: Python<'_>, tx_id: String) -> PyResult<Bound<'_,
 /// # Errors
 /// Returns a `PyErr` if the engine is not initialized or if the query fails.
 #[pyfunction]
-#[pyo3(signature = (cls, tx_id=None, using=None))]
+#[pyo3(signature = (cls, tx_id=None, using=None, session_id=None))]
 pub fn fetch_all<'py>(
     py: Python<'py>,
     cls: Bound<'py, PyAny>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let name = cls.getattr("__name__")?.extract::<String>()?;
     let cls_py = cls.unbind();
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
         let use_identity_map = engine.is_identity_map_enabled();
 
         let table_name = name.to_lowercase();
@@ -774,10 +938,12 @@ pub fn fetch_all<'py>(
             for (row_pk_val, fields) in parsed_data {
                 if use_identity_map
                     && let Some(ref pk_val) = row_pk_val
-                    && let Some(existing_obj) =
-                        IDENTITY_MAP.get(&(connection_name.clone(), name.clone(), pk_val.clone()))
+                    && let Some(existing_obj) = identity_map_get(
+                        session_id.as_deref(),
+                        &(connection_name.clone(), name.clone(), pk_val.clone()),
+                    )?
                 {
-                    results.append(existing_obj.value().clone_ref(py))?;
+                    results.append(existing_obj.clone_ref(py))?;
                     continue;
                 }
 
@@ -790,10 +956,11 @@ pub fn fetch_all<'py>(
                 )?;
 
                 if use_identity_map && let Some(pk_val) = row_pk_val {
-                    IDENTITY_MAP.insert(
+                    identity_map_insert(
+                        session_id.as_deref(),
                         (connection_name.clone(), name.clone(), pk_val),
                         instance.clone().unbind(),
-                    );
+                    )?;
                 }
 
                 results.append(instance)?;
@@ -818,29 +985,32 @@ pub fn fetch_all<'py>(
 /// # Errors
 /// Returns a `PyErr` if the engine is not initialized or if the query fails.
 #[pyfunction]
-#[pyo3(signature = (cls, pk_val, tx_id=None, using=None))]
+#[pyo3(signature = (cls, pk_val, tx_id=None, using=None, session_id=None))]
 pub fn fetch_one<'py>(
     py: Python<'py>,
     cls: Bound<'py, PyAny>,
     pk_val: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let name = cls.getattr("__name__")?.extract::<String>()?;
     let cls_py = cls.unbind();
-    let (connection_name, engine) = active_connection_for_route(using.clone())?;
+    let (connection_name, engine) = active_route_for_operation(tx_id.clone(), using.clone(), session_id.clone()).map(|(c,e,_,_)|(c,e))?;
 
     // Check Identity Map first (if no transaction, or even with transaction, IM is usually safe)
     if engine.is_identity_map_enabled()
-        && let Some(existing_obj) =
-            IDENTITY_MAP.get(&(connection_name.clone(), name.clone(), pk_val.clone()))
+        && let Some(existing_obj) = identity_map_get(
+            session_id.as_deref(),
+            &(connection_name.clone(), name.clone(), pk_val.clone()),
+        )?
     {
-        let obj = existing_obj.value().clone_ref(py);
+        let obj = existing_obj.clone_ref(py);
         return pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(obj) });
     }
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
         let use_identity_map = engine.is_identity_map_enabled();
 
         let table_name = name.to_lowercase();
@@ -942,10 +1112,11 @@ pub fn fetch_one<'py>(
                     &py_col_names,
                 )?;
                 if use_identity_map {
-                    IDENTITY_MAP.insert(
+                    identity_map_insert(
+                        session_id.as_deref(),
                         (connection_name.clone(), name.clone(), pk_val),
                         instance.clone().unbind(),
-                    );
+                    )?;
                 }
                 Ok(instance.into_any().unbind())
             }),
@@ -965,17 +1136,18 @@ pub fn fetch_one<'py>(
 /// # Errors
 /// Returns a `PyErr` if the engine is not initialized or if the save fails.
 #[pyfunction]
-#[pyo3(signature = (name, data, tx_id=None, using=None))]
+#[pyo3(signature = (name, data, tx_id=None, using=None, session_id=None))]
 pub fn save_record(
     py: Python<'_>,
     name: String,
     data: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (_connection_name, engine, tx_conn, backend) =
-            active_route_for_operation(tx_id, using)?;
+            active_route_for_operation(tx_id, using, session_id.clone())?;
 
         // ... schema and record logic ...
         let (schema, record_obj) = {
@@ -1138,17 +1310,18 @@ pub fn save_record(
 
 /// Persists multiple model instances in a single batch operation.
 #[pyfunction]
-#[pyo3(signature = (name, data_list_json, tx_id=None, using=None))]
+#[pyo3(signature = (name, data_list_json, tx_id=None, using=None, session_id=None))]
 pub fn save_bulk_records(
     py: Python<'_>,
     name: String,
     data_list_json: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (_connection_name, engine, tx_conn, backend) =
-            active_route_for_operation(tx_id, using)?;
+            active_route_for_operation(tx_id, using, session_id.clone())?;
 
         let schema = {
             let registry = MODEL_REGISTRY.read().map_err(|_| {
@@ -1274,13 +1447,14 @@ pub fn save_bulk_records(
 /// Returns:
 ///     list[PyAny]: A list of hydrated model instances.
 #[pyfunction]
-#[pyo3(signature = (cls, query_ir_json, tx_id=None, using=None))]
+#[pyo3(signature = (cls, query_ir_json, tx_id=None, using=None, session_id=None))]
 pub fn fetch_filtered<'py>(
     py: Python<'py>,
     cls: Bound<'py, PyAny>,
     query_ir_json: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let name = cls.getattr("__name__")?.extract::<String>()?;
     let cls_py = cls.unbind();
@@ -1288,7 +1462,7 @@ pub fn fetch_filtered<'py>(
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
         let use_identity_map = engine.is_identity_map_enabled();
 
         let table_name = name.to_lowercase();
@@ -1420,10 +1594,12 @@ pub fn fetch_filtered<'py>(
             for (row_pk_val, fields) in parsed_data {
                 if use_identity_map
                     && let Some(ref pk_val) = row_pk_val
-                    && let Some(existing_obj) =
-                        IDENTITY_MAP.get(&(connection_name.clone(), name.clone(), pk_val.clone()))
+                    && let Some(existing_obj) = identity_map_get(
+                        session_id.as_deref(),
+                        &(connection_name.clone(), name.clone(), pk_val.clone()),
+                    )?
                 {
-                    results.append(existing_obj.value().clone_ref(py))?;
+                    results.append(existing_obj.clone_ref(py))?;
                     continue;
                 }
 
@@ -1436,10 +1612,11 @@ pub fn fetch_filtered<'py>(
                 )?;
 
                 if use_identity_map && let Some(pk_val) = row_pk_val {
-                    IDENTITY_MAP.insert(
+                    identity_map_insert(
+                        session_id.as_deref(),
                         (connection_name.clone(), name.clone(), pk_val),
                         instance.clone().unbind(),
-                    );
+                    )?;
                 }
 
                 results.append(instance)?;
@@ -1451,18 +1628,19 @@ pub fn fetch_filtered<'py>(
 
 /// Returns the number of records matching a filtered query.
 #[pyfunction]
-#[pyo3(signature = (name, query_ir_json, tx_id=None, using=None))]
+#[pyo3(signature = (name, query_ir_json, tx_id=None, using=None, session_id=None))]
 pub fn count_filtered(
     py: Python<'_>,
     name: String,
     query_ir_json: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
 
         let table_name = name.to_lowercase();
         query_def.postgres_enum_udt =
@@ -1563,43 +1741,60 @@ pub fn count_filtered(
 
 /// Registers a live Python object in the global Identity Map.
 #[pyfunction]
-#[pyo3(signature = (name, pk, obj, using=None))]
+#[pyo3(signature = (name, pk, obj, using=None, session_id=None))]
 pub fn register_instance(
     name: String,
     pk: String,
     obj: Py<PyAny>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<()> {
-    let (connection_name, engine) = active_connection_for_route(using)?;
+    let (connection_name, engine) = active_route_for_operation(
+        None,
+        using,
+        session_id.clone(),
+    )
+    .map(|(name, engine, _, _)| (name, engine))?;
     if engine.is_identity_map_enabled() {
-        IDENTITY_MAP.insert((connection_name, name, pk), obj);
+        identity_map_insert(session_id.as_deref(), (connection_name, name, pk), obj)?;
     }
     Ok(())
 }
 
 /// Evicts a specific model instance from the global Identity Map.
 #[pyfunction]
-#[pyo3(signature = (name, pk, using=None))]
-pub fn evict_instance(name: String, pk: String, using: Option<String>) -> PyResult<()> {
-    let (connection_name, engine) = active_connection_for_route(using)?;
+#[pyo3(signature = (name, pk, using=None, session_id=None))]
+pub fn evict_instance(
+    name: String,
+    pk: String,
+    using: Option<String>,
+    session_id: Option<String>,
+) -> PyResult<()> {
+    let (connection_name, engine) = active_route_for_operation(
+        None,
+        using,
+        session_id.clone(),
+    )
+    .map(|(name, engine, _, _)| (name, engine))?;
     if engine.is_identity_map_enabled() {
-        IDENTITY_MAP.remove(&(connection_name, name, pk));
+        identity_map_remove(session_id.as_deref(), &(connection_name, name, pk))?;
     }
     Ok(())
 }
 
 /// Deletes a record by its primary key.
 #[pyfunction]
-#[pyo3(signature = (name, pk_val, tx_id=None, using=None))]
+#[pyo3(signature = (name, pk_val, tx_id=None, using=None, session_id=None))]
 pub fn delete_record(
     py: Python<'_>,
     name: String,
     pk_val: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
 
         let table_name = name.to_lowercase();
         // ... sql ...
@@ -1659,18 +1854,19 @@ pub fn delete_record(
 
 /// Deletes records matching a filtered query.
 #[pyfunction]
-#[pyo3(signature = (name, query_ir_json, tx_id=None, using=None))]
+#[pyo3(signature = (name, query_ir_json, tx_id=None, using=None, session_id=None))]
 pub fn delete_filtered(
     py: Python<'_>,
     name: String,
     query_ir_json: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
 
         let table_name = name.to_lowercase();
         query_def.postgres_enum_udt =
@@ -1699,7 +1895,7 @@ pub fn delete_filtered(
 
         // After bulk delete, we MUST clear the Identity Map for this model to avoid stale objects
         if engine.is_identity_map_enabled() {
-            IDENTITY_MAP.retain(|(_, m_name, _), _| m_name != &name);
+            identity_map_retain_model(session_id.as_deref(), &name)?;
         }
 
         Ok(rows_affected)
@@ -1708,7 +1904,7 @@ pub fn delete_filtered(
 
 /// Updates records matching a filtered query with provided values.
 #[pyfunction]
-#[pyo3(signature = (name, query_ir_json, update_json, tx_id=None, using=None))]
+#[pyo3(signature = (name, query_ir_json, update_json, tx_id=None, using=None, session_id=None))]
 pub fn update_filtered(
     py: Python<'_>,
     name: String,
@@ -1716,6 +1912,7 @@ pub fn update_filtered(
     update_json: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
@@ -1728,7 +1925,7 @@ pub fn update_filtered(
     })?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
 
         let table_name = name.to_lowercase();
         let enum_udt = postgres_enum_udt_by_column(&table_name, &engine, &tx_conn, backend).await?;
@@ -1782,7 +1979,7 @@ pub fn update_filtered(
 
         // After bulk update, we MUST clear the Identity Map for this model to avoid stale objects
         if engine.is_identity_map_enabled() {
-            IDENTITY_MAP.retain(|(_, m_name, _), _| m_name != &name);
+            identity_map_retain_model(session_id.as_deref(), &name)?;
         }
 
         Ok(rows_affected)
@@ -1790,7 +1987,7 @@ pub fn update_filtered(
 }
 
 #[pyfunction]
-#[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None))]
+#[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None, session_id=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn add_m2m_links<'py>(
     py: Python<'py>,
@@ -1801,6 +1998,7 @@ pub fn add_m2m_links<'py>(
     target_ids: Vec<Bound<'py, PyAny>>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let s_id = python_to_sea_value(source_id)?;
     let t_ids: Vec<sea_query::Value> = target_ids
@@ -1809,7 +2007,7 @@ pub fn add_m2m_links<'py>(
         .collect::<PyResult<Vec<_>>>()?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
         let uuid_columns =
             postgres_uuid_column_names(&join_table, &engine, &tx_conn, backend).await?;
 
@@ -1846,7 +2044,7 @@ pub fn add_m2m_links<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None))]
+#[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None, session_id=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn remove_m2m_links<'py>(
     py: Python<'py>,
@@ -1857,6 +2055,7 @@ pub fn remove_m2m_links<'py>(
     target_ids: Vec<Bound<'py, PyAny>>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let s_id = python_to_sea_value(source_id)?;
     let t_ids: Vec<sea_query::Value> = target_ids
@@ -1865,7 +2064,7 @@ pub fn remove_m2m_links<'py>(
         .collect::<PyResult<Vec<_>>>()?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
         let uuid_columns =
             postgres_uuid_column_names(&join_table, &engine, &tx_conn, backend).await?;
 
@@ -1904,7 +2103,7 @@ pub fn remove_m2m_links<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (join_table, source_col, source_id, tx_id=None, using=None))]
+#[pyo3(signature = (join_table, source_col, source_id, tx_id=None, using=None, session_id=None))]
 pub fn clear_m2m_links<'py>(
     py: Python<'py>,
     join_table: String,
@@ -1912,14 +2111,15 @@ pub fn clear_m2m_links<'py>(
     source_id: Bound<'py, PyAny>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let s_id = python_to_sea_value(source_id)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (engine, tx_conn, backend) = {
-            let engine = active_engine_for_connection(using)?;
+            let engine = active_engine_for_connection(using, session_id.as_deref())?;
             let backend = engine.backend();
-            let tx_conn = get_transaction_connection(tx_id);
+            let tx_conn = get_transaction_connection(tx_id, session_id.as_deref())?;
             (engine, tx_conn, backend)
         };
         let uuid_columns =
@@ -2031,12 +2231,14 @@ fn python_to_engine_bind_value(
 /// Look up a transaction connection by id, returning a sharper error than the
 /// CRUD path's "Transaction not found" — this surface is reachable by users
 /// who hold a `Transaction` handle past the end of `async with transaction():`.
-fn get_raw_tx_conn(tx_id: Option<String>) -> PyResult<Option<TransactionConnection>> {
+fn get_raw_tx_conn(
+    tx_id: Option<String>,
+    session_id: Option<&str>,
+) -> PyResult<Option<TransactionConnection>> {
     match tx_id {
         Some(id) => {
-            let conn = TRANSACTION_REGISTRY
-                .get(&id)
-                .map(|tx| tx.value().conn.clone())
+            let conn = tx_get(session_id, &id)?
+                .map(|tx| tx.conn)
                 .ok_or_else(|| {
                     pyo3::exceptions::PyRuntimeError::new_err(
                         "Transaction has already been closed or never existed",
@@ -2060,19 +2262,20 @@ fn get_raw_tx_conn(tx_id: Option<String>) -> PyResult<Option<TransactionConnecti
 ///   not a supported primitive (the Python `_marshal` wrapper guarantees this
 ///   never trips in normal use).
 #[pyfunction]
-#[pyo3(signature = (sql, args, tx_id=None, using=None))]
+#[pyo3(signature = (sql, args, tx_id=None, using=None, session_id=None))]
 pub fn raw_execute<'py>(
     py: Python<'py>,
     sql: String,
     args: Vec<Bound<'py, PyAny>>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let bind_values: Vec<EngineBindValue> = args
         .iter()
         .map(python_to_engine_bind_value)
         .collect::<PyResult<_>>()?;
-    let tx_conn = get_raw_tx_conn(tx_id)?;
+    let tx_conn = get_raw_tx_conn(tx_id, session_id.as_deref())?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let rows_affected = match tx_conn {
@@ -2081,7 +2284,7 @@ pub fn raw_execute<'py>(
                 conn.execute_sql_with_binds(&sql, &bind_values).await
             }
             None => {
-                let engine = active_engine_for_connection(using)?;
+                let engine = active_engine_for_connection(using, session_id.as_deref())?;
                 engine.execute_sql_with_binds(&sql, &bind_values).await
             }
         }
@@ -2099,19 +2302,20 @@ pub fn raw_execute<'py>(
 /// UUID/datetime/JSON columns come back as strings — Ferro does not decode them
 /// for raw SQL. If you want typed rows, use the ORM.
 #[pyfunction]
-#[pyo3(signature = (sql, args, tx_id=None, using=None))]
+#[pyo3(signature = (sql, args, tx_id=None, using=None, session_id=None))]
 pub fn raw_fetch_all<'py>(
     py: Python<'py>,
     sql: String,
     args: Vec<Bound<'py, PyAny>>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let bind_values: Vec<EngineBindValue> = args
         .iter()
         .map(python_to_engine_bind_value)
         .collect::<PyResult<_>>()?;
-    let tx_conn = get_raw_tx_conn(tx_id)?;
+    let tx_conn = get_raw_tx_conn(tx_id, session_id.as_deref())?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let rows = match tx_conn {
@@ -2120,7 +2324,7 @@ pub fn raw_fetch_all<'py>(
                 conn.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
             None => {
-                let engine = active_engine_for_connection(using)?;
+                let engine = active_engine_for_connection(using, session_id.as_deref())?;
                 engine.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
         }
@@ -2140,19 +2344,20 @@ pub fn raw_fetch_all<'py>(
 
 /// Run a raw SQL query and return the first row as a dict, or `None`.
 #[pyfunction]
-#[pyo3(signature = (sql, args, tx_id=None, using=None))]
+#[pyo3(signature = (sql, args, tx_id=None, using=None, session_id=None))]
 pub fn raw_fetch_one<'py>(
     py: Python<'py>,
     sql: String,
     args: Vec<Bound<'py, PyAny>>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let bind_values: Vec<EngineBindValue> = args
         .iter()
         .map(python_to_engine_bind_value)
         .collect::<PyResult<_>>()?;
-    let tx_conn = get_raw_tx_conn(tx_id)?;
+    let tx_conn = get_raw_tx_conn(tx_id, session_id.as_deref())?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let rows = match tx_conn {
@@ -2161,7 +2366,7 @@ pub fn raw_fetch_one<'py>(
                 conn.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
             None => {
-                let engine = active_engine_for_connection(using)?;
+                let engine = active_engine_for_connection(using, session_id.as_deref())?;
                 engine.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -154,6 +154,51 @@ pub static TRANSACTION_REGISTRY: Lazy<DashMap<String, TransactionHandle>> = Lazy
 pub static IDENTITY_MAP: Lazy<DashMap<(String, String, String), Py<PyAny>>> =
     Lazy::new(DashMap::new);
 
+/// Session-scoped runtime state for Phase 6 sessionized execution.
+///
+/// A session pins connection routing and keeps transactional/identity state local
+/// to that session so concurrent sessions do not bleed mutable runtime state.
+pub struct SessionState {
+    pub connection_name: String,
+    pub transaction_registry: DashMap<String, TransactionHandle>,
+    pub identity_map: DashMap<(String, String, String), Py<PyAny>>,
+}
+
+impl SessionState {
+    pub fn new(connection_name: String) -> Self {
+        Self {
+            connection_name,
+            transaction_registry: DashMap::new(),
+            identity_map: DashMap::new(),
+        }
+    }
+}
+
+/// Global registry of active sessions.
+pub static SESSION_REGISTRY: Lazy<DashMap<String, Arc<SessionState>>> = Lazy::new(DashMap::new);
+
+pub fn register_session(connection_name: String) -> String {
+    let session_id = uuid::Uuid::new_v4().to_string();
+    SESSION_REGISTRY.insert(session_id.clone(), Arc::new(SessionState::new(connection_name)));
+    session_id
+}
+
+pub fn unregister_session(session_id: &str) -> bool {
+    SESSION_REGISTRY.remove(session_id).is_some()
+}
+
+pub fn session_state(session_id: &str) -> PyResult<Arc<SessionState>> {
+    SESSION_REGISTRY
+        .get(session_id)
+        .map(|entry| entry.value().clone())
+        .ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "Session '{}' is not active",
+                session_id
+            ))
+        })
+}
+
 /// A Rust-native representation of database values.
 ///
 /// Used during the GIL-free parsing phase to move data from the database

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,99 @@
+from typing import Annotated
+
+import pytest
+
+import ferro
+
+
+pytestmark = pytest.mark.sqlite_only
+
+
+class SessionMarker(ferro.Model):
+    id: Annotated[int | None, ferro.FerroField(primary_key=True)] = None
+    label: str
+
+
+@pytest.fixture(autouse=True)
+def _ensure_models_registered():
+    from ferro.state import _MODEL_REGISTRY_PY
+
+    SessionMarker._reregister_ferro()
+    _MODEL_REGISTRY_PY[SessionMarker.__name__] = SessionMarker
+    yield
+
+
+@pytest.mark.asyncio
+async def test_session_query_api_routes_to_bound_connection(tmp_path):
+    app_db = tmp_path / "app.db"
+    analytics_db = tmp_path / "analytics.db"
+
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.connect(f"sqlite:{analytics_db}?mode=rwc", name="analytics")
+    await ferro.create_tables()
+    await ferro.create_tables(using="analytics")
+
+    async with ferro.engines.session("analytics") as session:
+        created = await SessionMarker.create(id=1, label="analytics")
+        fetched = await session.query(SessionMarker).where(lambda t: t.id == 1).first()
+
+    assert created.id == 1
+    assert fetched is not None
+    assert fetched.label == "analytics"
+
+    with pytest.warns(DeprecationWarning, match="Implicit default-connection routing"):
+        default_rows = await SessionMarker.all()
+    assert default_rows == []
+
+
+@pytest.mark.asyncio
+async def test_nested_sessions_shadow_and_restore(tmp_path):
+    app_db = tmp_path / "app.db"
+    analytics_db = tmp_path / "analytics.db"
+
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.connect(f"sqlite:{analytics_db}?mode=rwc", name="analytics")
+    await ferro.create_tables()
+    await ferro.create_tables(using="analytics")
+
+    async with ferro.engines.session("app"):
+        await SessionMarker.create(id=1, label="app")
+        async with ferro.engines.session("analytics"):
+            await SessionMarker.create(id=1, label="analytics")
+            inner_rows = await SessionMarker.all()
+            assert [row.label for row in inner_rows] == ["analytics"]
+        outer_rows = await SessionMarker.all()
+        assert [row.label for row in outer_rows] == ["app"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_session_override_beats_ambient(tmp_path):
+    app_db = tmp_path / "app.db"
+    analytics_db = tmp_path / "analytics.db"
+
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.connect(f"sqlite:{analytics_db}?mode=rwc", name="analytics")
+    await ferro.create_tables()
+    await ferro.create_tables(using="analytics")
+
+    async with ferro.engines.session("app") as app_session:
+        await SessionMarker.create(id=1, label="app")
+        async with ferro.engines.session("analytics"):
+            await SessionMarker.create(id=1, label="analytics")
+            rows = await SessionMarker.all(session=app_session)
+            assert [row.label for row in rows] == ["app"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_unqualified_operation_warns(tmp_path):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.create_tables()
+
+    with pytest.warns(DeprecationWarning, match="Implicit default-connection routing"):
+        created = await SessionMarker.create(id=10, label="legacy")
+    with pytest.warns(DeprecationWarning, match="Implicit default-connection routing"):
+        loaded = await SessionMarker.get(10)
+
+    assert created.id == 10
+    assert loaded.label == "legacy"
+

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -96,4 +96,3 @@ async def test_legacy_unqualified_operation_warns(tmp_path):
 
     assert created.id == 10
     assert loaded.label == "legacy"
-


### PR DESCRIPTION
## Summary
- add explicit session/UoW runtime API (`engines.session(...)`, `Session.query(...)`) and thread session scope through Python ORM/query/raw routing
- move Rust hot-path transaction + identity-map state to session scope while keeping a temporary legacy compatibility path with deprecation warnings
- synchronize Phase 6 roadmap, migration guide, and runtime invariant docs; add session lifecycle coverage in `tests/test_session.py`

## Test plan
- [x] `cargo check`
- [x] `cargo test -p ferro-schema-ir -p ferro-migrate`
- [x] `uv run pytest tests/test_session.py tests/test_connection.py tests/test_transactions.py tests/test_named_connections_integration.py tests/test_query_builder.py tests/test_raw_sql.py tests/test_crud.py tests/test_deletion.py tests/test_bulk_update.py tests/test_hydration.py tests/test_ir_vectors_contract.py tests/test_shadow_reports.py -q`
- [ ] `cargo test` (currently fails in this environment on PyO3 Python symbol linkage for `ferro` lib test target)

## Issue closure
Closes #96
Closes #97
Closes #98
Closes #99

Made with [Cursor](https://cursor.com)