### PR TITLE
feat: complete Phase 7 deprecation window and migration guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # CHANGELOG
 
 
+## v0.12.0 (2026-06-22)
+
+### Documentation
+
+- **release**: Publish Phase 7 migration/release guidance for the IR-first public release
+  (`docs/plans/ir-first-migration-guide.md`, `docs/pages/howto/migrating-to-v0-12-0.md`,
+  `docs/plans/ir-first-release-checklist.md`)
+
+### Testing
+
+- **deprecation**: Add inventory contract coverage for `deprecated_operator_path`
+  and enforce `v0.13.0` removal-target assertions across compat warning tests
+
+### Refactoring
+
+- **deprecation**: Centralize compatibility-window warning text to keep
+  `Planned removal: v0.13.0` messaging consistent across query/session/alembic paths
+
+
 ## v0.11.0 (2026-06-11)
 
 ### Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@
 ### Testing
 
 - **deprecation**: Add inventory contract coverage for `deprecated_operator_path`
-  and enforce `v0.13.0` removal-target assertions across compat warning tests
+  and enforce `v0.14.0` removal-target assertions across compat warning tests
 
 ### Refactoring
 
 - **deprecation**: Centralize compatibility-window warning text to keep
-  `Planned removal: v0.13.0` messaging consistent across query/session/alembic paths
+  `Planned removal in v0.14.0` messaging consistent across query/session/alembic paths
 
 
 ## v0.11.0 (2026-06-11)

--- a/docs/examples/predicates.py
+++ b/docs/examples/predicates.py
@@ -33,7 +33,7 @@ async def main() -> None:
     assert len(adults) == 3
 
     # --8<-- [start:operator-style]
-    # Deprecated path (planned removal: v0.13.0).
+    # Deprecated path (planned removal: v0.14.0).
     adults = await User.where(User.age >= 18).all()
     # --8<-- [end:operator-style]
     assert len(adults) == 3

--- a/docs/pages/api/migrations.md
+++ b/docs/pages/api/migrations.md
@@ -2,6 +2,6 @@
 
 The Alembic bridge. `get_metadata()` builds a SQLAlchemy `MetaData` describing all registered Ferro models from the compiled SchemaIR modelset, so Alembic's `--autogenerate` can diff your models against the live database and emit migration scripts. Assign it to `target_metadata` in your Alembic `env.py` (requires the `ferro-orm[alembic]` extra). See the [Schema Migrations guide](../guide/migrations.md) for the full workflow.
 
-Internal JSON-derivation helpers (`_build_sa_table`, `_map_to_sa_type`) are deprecated and scheduled for removal in `v0.13.0`. Replace internal usages with `get_metadata()`; see [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md).
+Internal JSON-derivation helpers (`_build_sa_table`, `_map_to_sa_type`) are deprecated and scheduled for removal in `v0.14.0`. Replace internal usages with `get_metadata()`; see [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md).
 
 ::: ferro.migrations.alembic.get_metadata

--- a/docs/pages/api/migrations.md
+++ b/docs/pages/api/migrations.md
@@ -2,6 +2,6 @@
 
 The Alembic bridge. `get_metadata()` builds a SQLAlchemy `MetaData` describing all registered Ferro models from the compiled SchemaIR modelset, so Alembic's `--autogenerate` can diff your models against the live database and emit migration scripts. Assign it to `target_metadata` in your Alembic `env.py` (requires the `ferro-orm[alembic]` extra). See the [Schema Migrations guide](../guide/migrations.md) for the full workflow.
 
-Internal JSON-derivation helpers (`_build_sa_table`, `_map_to_sa_type`) are deprecated and scheduled for removal in `v0.13.0`.
+Internal JSON-derivation helpers (`_build_sa_table`, `_map_to_sa_type`) are deprecated and scheduled for removal in `v0.13.0`. Replace internal usages with `get_metadata()`; see [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md).
 
 ::: ferro.migrations.alembic.get_metadata

--- a/docs/pages/api/queries.md
+++ b/docs/pages/api/queries.md
@@ -1,6 +1,6 @@
 # Queries
 
-`Model.where(...)` and `Model.select()` return a `Query` — an immutable, chainable builder that executes when awaited via `all()`, `first()`, `count()`, `exists()`, `update()`, or `delete()`. Predicates are lambda-first (`User.where(lambda t: t.age >= 18)`), `col()` is the compatibility bridge for operator-shaped predicates, and direct operator style is deprecated for `v0.13.0` removal. For migration steps, see [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md).
+`Model.where(...)` and `Model.select()` return a `Query` — an immutable, chainable builder that executes when awaited via `all()`, `first()`, `count()`, `exists()`, `update()`, or `delete()`. Predicates are lambda-first (`User.where(lambda t: t.age >= 18)`), `col()` is the compatibility bridge for operator-shaped predicates, and direct operator style is deprecated for `v0.14.0` removal. For migration steps, see [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md).
 
 ::: ferro.query.builder.Query
 

--- a/docs/pages/api/queries.md
+++ b/docs/pages/api/queries.md
@@ -1,6 +1,6 @@
 # Queries
 
-`Model.where(...)` and `Model.select()` return a `Query` — an immutable, chainable builder that executes when awaited via `all()`, `first()`, `count()`, `exists()`, `update()`, or `delete()`. Predicates are lambda-first (`User.where(lambda t: t.age >= 18)`), `col()` is the compatibility bridge for operator-shaped predicates, and direct operator style is deprecated for `v0.13.0` removal.
+`Model.where(...)` and `Model.select()` return a `Query` — an immutable, chainable builder that executes when awaited via `all()`, `first()`, `count()`, `exists()`, `update()`, or `delete()`. Predicates are lambda-first (`User.where(lambda t: t.age >= 18)`), `col()` is the compatibility bridge for operator-shaped predicates, and direct operator style is deprecated for `v0.13.0` removal. For migration steps, see [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md).
 
 ::: ferro.query.builder.Query
 

--- a/docs/pages/concepts/query-typing.md
+++ b/docs/pages/concepts/query-typing.md
@@ -41,7 +41,7 @@ rows = await User.where(User.email.like("%@example.com")).all()
 ```
 
 !!! warning "Operator style is deprecated"
-    The operator style is compatible today but on the `v0.13.0` removal track. It also fails static type checking: checkers read `User.id == 1` through your Pydantic annotations as a `bool`, while `where()` expects a `QueryNode | Predicate`. Use lambda predicates for new code, or `col()` when migrating existing operator-style call sites with minimal diff.
+    The operator style is compatible today but on the `v0.14.0` removal track. It also fails static type checking: checkers read `User.id == 1` through your Pydantic annotations as a `bool`, while `where()` expects a `QueryNode | Predicate`. Use lambda predicates for new code, or `col()` when migrating existing operator-style call sites with minimal diff.
     See [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md) for the Phase 7 migration checklist.
 
 ## When to Use Which

--- a/docs/pages/concepts/query-typing.md
+++ b/docs/pages/concepts/query-typing.md
@@ -42,6 +42,7 @@ rows = await User.where(User.email.like("%@example.com")).all()
 
 !!! warning "Operator style is deprecated"
     The operator style is compatible today but on the `v0.13.0` removal track. It also fails static type checking: checkers read `User.id == 1` through your Pydantic annotations as a `bool`, while `where()` expects a `QueryNode | Predicate`. Use lambda predicates for new code, or `col()` when migrating existing operator-style call sites with minimal diff.
+    See [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md) for the Phase 7 migration checklist.
 
 ## When to Use Which
 

--- a/docs/pages/guide/connections.md
+++ b/docs/pages/guide/connections.md
@@ -114,7 +114,7 @@ async with ferro.engines.session("analytics") as s:
 
 Inside an active session context, convenience APIs (`User.all()`, `User.where(...)`, `ferro.execute(...)`) automatically bind to that session's connection.
 
-Legacy implicit default-connection routing (calling unqualified operations outside a session) is still temporarily supported for compatibility, but now emits a deprecation warning and is on the `v0.13.0` removal track.
+Legacy implicit default-connection routing (calling unqualified operations outside a session) is still temporarily supported for compatibility, but now emits a deprecation warning and is on the `v0.14.0` removal track.
 Follow [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md) to remove these legacy call sites during the compatibility window.
 
 ## The Default Connection

--- a/docs/pages/guide/connections.md
+++ b/docs/pages/guide/connections.md
@@ -115,6 +115,7 @@ async with ferro.engines.session("analytics") as s:
 Inside an active session context, convenience APIs (`User.all()`, `User.where(...)`, `ferro.execute(...)`) automatically bind to that session's connection.
 
 Legacy implicit default-connection routing (calling unqualified operations outside a session) is still temporarily supported for compatibility, but now emits a deprecation warning and is on the `v0.13.0` removal track.
+Follow [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md) to remove these legacy call sites during the compatibility window.
 
 ## The Default Connection
 

--- a/docs/pages/guide/queries.md
+++ b/docs/pages/guide/queries.md
@@ -75,6 +75,7 @@ Both methods also exist on `Model.using("name")` for [named connections](connect
 
     !!! warning "Operator style is deprecated"
         The operator style is compatible today but on the `v0.13.0` removal track. It is also incompatible with static type checkers (ty, mypy, Pyright): they see `User.age >= 18` as a `bool` from your Pydantic annotations, while `where()` expects a `QueryNode | Predicate`. Prefer the lambda style.
+        See [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md) for the compatibility-window migration checklist.
 
 Lambda predicates keep the call site fully type-checked because the proxy's attributes are real `FieldProxy` objects in the type checker's eyes, not your Pydantic annotations. Reach for `col()` only when you want to preserve the operator shape on a single attribute. See [Typed Query Predicates](../concepts/query-typing.md) for the full reasoning.
 

--- a/docs/pages/guide/queries.md
+++ b/docs/pages/guide/queries.md
@@ -74,7 +74,7 @@ Both methods also exist on `Model.using("name")` for [named connections](connect
     ```
 
     !!! warning "Operator style is deprecated"
-        The operator style is compatible today but on the `v0.13.0` removal track. It is also incompatible with static type checkers (ty, mypy, Pyright): they see `User.age >= 18` as a `bool` from your Pydantic annotations, while `where()` expects a `QueryNode | Predicate`. Prefer the lambda style.
+        The operator style is compatible today but on the `v0.14.0` removal track. It is also incompatible with static type checkers (ty, mypy, Pyright): they see `User.age >= 18` as a `bool` from your Pydantic annotations, while `where()` expects a `QueryNode | Predicate`. Prefer the lambda style.
         See [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md) for the compatibility-window migration checklist.
 
 Lambda predicates keep the call site fully type-checked because the proxy's attributes are real `FieldProxy` objects in the type checker's eyes, not your Pydantic annotations. Reach for `col()` only when you want to preserve the operator shape on a single attribute. See [Typed Query Predicates](../concepts/query-typing.md) for the full reasoning.

--- a/docs/pages/howto/migrating-to-v0-12-0.md
+++ b/docs/pages/howto/migrating-to-v0-12-0.md
@@ -1,0 +1,147 @@
+# Migrating to v0.12.0
+
+`v0.12.0` is the first public release built on Ferro's IR-first architecture.
+Query execution, schema/migration planning, codecs, hydration, and connection
+routing now flow through one shared intermediate representation (IR) instead of
+several independent code paths.
+
+## Why this matters
+
+A single source of truth removes whole classes of drift bugs:
+
+- **Predictable schema diffs.** Runtime DDL and the Alembic autogenerate bridge
+  derive from the same IR, so migrations stop proposing phantom changes.
+- **Typed query execution.** Queries compile through typed IR rather than ad-hoc
+  JSON, so bind and null semantics behave the same on SQLite and PostgreSQL.
+- **Explicit runtime state.** Connection and transaction routing are scoped to a
+  session you control, instead of hidden process-global state.
+
+Your model definitions do not change. The migration below is about *how you
+call* a few APIs, not how you declare your data.
+
+## What you need to do
+
+`v0.12.x` ships a **compatibility window**: the older call styles still work,
+but each one now emits a `DeprecationWarning` whose message ends with
+`Planned removal: v0.13.0`. Treat `v0.12.x` as your window to migrate before the
+old surfaces are removed in `v0.13.0`.
+
+Turn deprecation warnings into failures on a migration branch so nothing slips
+through:
+
+```bash
+uv run pytest -W error::DeprecationWarning
+```
+
+Then work through the three changes below.
+
+### 1. Use lambda predicates in `where()`
+
+Operator-style predicates (`Model.field == value`) are deprecated. They never
+type-checked cleanly — static checkers read `User.age >= 18` as a `bool`, while
+`where()` expects a `QueryNode` — and they now warn at runtime. Lambda
+predicates are the recommended style; `col()` is a type-safe bridge when you
+want to keep the operator shape on a single comparison.
+
+=== "Before (deprecated)"
+
+    ```python
+    adults = await User.where(User.age >= 18).all()
+    admins = await User.where(User.role == "admin").all()
+    ```
+
+=== "After (recommended)"
+
+    ```python
+    adults = await User.where(lambda t: t.age >= 18).all()
+    admins = await User.where(lambda t: t.role == "admin").all()
+    ```
+
+=== "After (`col()` bridge)"
+
+    ```python
+    from ferro.query import col
+
+    adults = await User.where(col(User.age) >= 18).all()
+    ```
+
+### 2. Run operations inside a session
+
+Calling unqualified operations (`User.all()`, `ferro.execute(...)`) without an
+active session relied on implicit default-connection routing. That fallback is
+deprecated. Wrap request- or task-scoped work in a session so routing, the
+identity map, and transactions are explicit and isolated under concurrency.
+
+=== "Before (deprecated)"
+
+    ```python
+    import ferro
+
+    # Implicit default-connection routing (now warns).
+    users = await User.where(lambda t: t.active == True).all()  # noqa: E712
+    await ferro.execute("UPDATE users SET active = TRUE")
+    ```
+
+=== "After (ambient session)"
+
+    ```python
+    import ferro
+
+    async with ferro.engines.session("app"):
+        users = await User.where(lambda t: t.active == True).all()  # noqa: E712
+        await ferro.execute("UPDATE users SET active = TRUE")
+    ```
+
+=== "After (explicit handle)"
+
+    ```python
+    import ferro
+
+    async with ferro.engines.session("app") as session:
+        users = await session.query(User).where(lambda t: t.active == True).all()  # noqa: E712
+    ```
+
+Need to target a specific connection from inside another session? Pass
+`session=` explicitly — it overrides the ambient session.
+
+### 3. Build Alembic metadata from `get_metadata()`
+
+The private JSON-derivation helpers `ferro.migrations.alembic._build_sa_table`
+and `ferro.migrations.alembic._map_to_sa_type` are deprecated. Schema metadata
+now derives from the IR through the public `get_metadata()` entry point — use it
+directly in your Alembic `env.py`.
+
+=== "Before (deprecated)"
+
+    ```python
+    from ferro.migrations.alembic import _build_sa_table, _map_to_sa_type
+    ```
+
+=== "After (recommended)"
+
+    ```python
+    from ferro.migrations import get_metadata
+
+    target_metadata = get_metadata()
+    ```
+
+## Deprecated surfaces at a glance
+
+| Deprecated surface | Replacement | Removed in |
+| --- | --- | --- |
+| `Model.where(Model.field OP value)` | `where(lambda t: ...)` or `col(Model.field)` | `v0.13.0` |
+| Unqualified ORM/raw operations outside an active session | `async with ferro.engines.session("name")` or explicit `session=` | `v0.13.0` |
+| `ferro.migrations.alembic._build_sa_table` | `ferro.migrations.get_metadata()` | `v0.13.0` |
+| `ferro.migrations.alembic._map_to_sa_type` | `ferro.migrations.get_metadata()` | `v0.13.0` |
+
+## Verifying your migration
+
+Once your call sites are updated, confirm no deprecation warnings remain on the
+paths you exercise:
+
+```bash
+uv run pytest -W error::DeprecationWarning
+```
+
+A clean run means your codebase is ready for `v0.13.0`, where these
+compatibility shims are removed.

--- a/docs/pages/howto/migrating-to-v0-12-0.md
+++ b/docs/pages/howto/migrating-to-v0-12-0.md
@@ -23,8 +23,8 @@ call* a few APIs, not how you declare your data.
 
 `v0.12.x` ships a **compatibility window**: the older call styles still work,
 but each one now emits a `DeprecationWarning` whose message ends with
-`Planned removal: v0.13.0`. Treat `v0.12.x` as your window to migrate before the
-old surfaces are removed in `v0.13.0`.
+`Planned removal in v0.14.0`. Treat `v0.12.x` and `v0.13.x` as your window to migrate before the
+old surfaces are removed in `v0.14.0`.
 
 Turn deprecation warnings into failures on a migration branch so nothing slips
 through:
@@ -129,10 +129,10 @@ directly in your Alembic `env.py`.
 
 | Deprecated surface | Replacement | Removed in |
 | --- | --- | --- |
-| `Model.where(Model.field OP value)` | `where(lambda t: ...)` or `col(Model.field)` | `v0.13.0` |
-| Unqualified ORM/raw operations outside an active session | `async with ferro.engines.session("name")` or explicit `session=` | `v0.13.0` |
-| `ferro.migrations.alembic._build_sa_table` | `ferro.migrations.get_metadata()` | `v0.13.0` |
-| `ferro.migrations.alembic._map_to_sa_type` | `ferro.migrations.get_metadata()` | `v0.13.0` |
+| `Model.where(Model.field OP value)` | `where(lambda t: ...)` or `col(Model.field)` | `v0.14.0` |
+| Unqualified ORM/raw operations outside an active session | `async with ferro.engines.session("name")` or explicit `session=` | `v0.14.0` |
+| `ferro.migrations.alembic._build_sa_table` | `ferro.migrations.get_metadata()` | `v0.14.0` |
+| `ferro.migrations.alembic._map_to_sa_type` | `ferro.migrations.get_metadata()` | `v0.14.0` |
 
 ## Verifying your migration
 
@@ -143,5 +143,5 @@ paths you exercise:
 uv run pytest -W error::DeprecationWarning
 ```
 
-A clean run means your codebase is ready for `v0.13.0`, where these
+A clean run means your codebase is ready for `v0.14.0`, where these
 compatibility shims are removed.

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -30,7 +30,7 @@ Move Ferro to an IR-first architecture where schema, query, migration, and codec
 - Query execution consumes typed QueryIR (not ad-hoc JSON payloads).
 - Hydration path is single and ABI-defined for Pydantic slot initialization.
 - Global registries are removed from hot-path runtime operations in favor of explicit engine/session state.
-- Legacy compatibility shims are removed in the explicit `v0.13.0` cutover.
+- Legacy compatibility shims are removed in the explicit `v0.14.0` cutover.
 - User-facing migration guidance is continuously updated and release-ready at each phase boundary.
 
 ## Living migration guide requirement
@@ -404,7 +404,7 @@ Issue references:
 **Exit gate**
 - [x] Release branch green across full backend/test matrix.
 - [x] Migration guide validated against at least one real example project.
-- [x] Deprecation warnings explicitly point to `v0.13.0` as the removal release.
+- [x] Deprecation warnings explicitly point to `v0.14.0` as the removal release.
 
 **Evidence (working branch; pending merge to `feat/ir-first`)**
 - Deprecation messaging consistency primitive + call-site adoption: `src/ferro/_deprecations.py`, `src/ferro/query/builder.py`, `src/ferro/state.py`, `src/ferro/migrations/alembic.py`
@@ -424,7 +424,7 @@ Issue references:
 
 ---
 
-### Phase 8 - Compatibility cutover and shim removal (`v0.13.0`)
+### Phase 8 - Compatibility cutover and shim removal (`v0.14.0`)
 
 Status: `Not started`
 
@@ -434,17 +434,17 @@ Issue references:
 - `Sub-issues:` _TBD_
 
 **Objective**
-- Complete migration by removing deprecated compatibility shims in `v0.13.0`.
+- Complete migration by removing deprecated compatibility shims in `v0.14.0`.
 
 **Deliverables**
 - [ ] Legacy compatibility code paths removed.
 - [ ] Deprecated-compat test inventory removed (all `deprecated_operator_path` tests deleted or rewritten).
-- [ ] Final migration-guide cutover notes for `v0.13.0`.
+- [ ] Final migration-guide cutover notes for `v0.14.0`.
 - [ ] Release checklist and changelog entries for shim removal.
 
 **Exit gate**
 - [ ] Full backend/test matrix green with deprecated paths removed.
-- [ ] Migration guide validated against at least one real example project on the `v0.13.0` code path.
+- [ ] Migration guide validated against at least one real example project on the `v0.14.0` code path.
 
 ## Workstreams and ownership
 
@@ -580,12 +580,12 @@ Append updates as concise entries.
 - `2026-06-19` - Phase 2 scaffolding landed on working branch: internal shadow runtime flag/hook wiring, semantic comparison harness, stable SQLite/Postgres shadow report fixtures, and touched-path CI gate for shadow reports.
 - `2026-06-19` - Phase 2 merged via [#105](https://github.com/syn54x/ferro-orm/pull/105); issues [#80](https://github.com/syn54x/ferro-orm/issues/80), [#81](https://github.com/syn54x/ferro-orm/issues/81), [#82](https://github.com/syn54x/ferro-orm/issues/82), [#83](https://github.com/syn54x/ferro-orm/issues/83) synchronized and closed.
 - `2026-06-19` - Phase 3 working-branch implementation landed: QueryIR envelope hot-path cutover for query operations, operator-style deprecation warnings, and synchronized query docs/migration guidance updates.
-- `2026-06-19` - Sequencing update: Phase 7 is now public release with deprecated compatibility support; hard removal moved to Phase 8 (`v0.13.0`).
+- `2026-06-19` - Sequencing update: Phase 7 is now public release with deprecated compatibility support; hard removal moved to Phase 8 (`v0.14.0`).
 - `2026-06-19` - Phase 8 issue set created and linked: epic [#107](https://github.com/syn54x/ferro-orm/issues/107) with sub-issues [#108](https://github.com/syn54x/ferro-orm/issues/108), [#109](https://github.com/syn54x/ferro-orm/issues/109), [#110](https://github.com/syn54x/ferro-orm/issues/110).
-- `2026-06-19` - Phase 4 working-branch implementation landed: added `ferro-migrate` (`SchemaIR(old,new)` diff + SQL emission entrypoint), expanded SchemaIR fidelity (enum/check/join-table coverage), switched Alembic metadata derivation to SchemaIR, and added deprecation warnings for superseded JSON-only Alembic helpers (target removal `v0.13.0`).
+- `2026-06-19` - Phase 4 working-branch implementation landed: added `ferro-migrate` (`SchemaIR(old,new)` diff + SQL emission entrypoint), expanded SchemaIR fidelity (enum/check/join-table coverage), switched Alembic metadata derivation to SchemaIR, and added deprecation warnings for superseded JSON-only Alembic helpers (target removal `v0.14.0`).
 - `2026-06-22` - Phase 5 working-branch implementation landed: added unified codec registry module (`src/codec.rs`) across insert/update/filter/m2m/fetch paths, extracted single hydration ABI helper (`src/hydration.rs`) with required Pydantic slot initialization, and expanded codec conformance vectors/tests for null/uuid/decimal/temporal/enum semantics.
 - `2026-06-22` - Phase 6 working-branch implementation landed: introduced sessionized runtime API (`engines.session` / `Session`) and ambient session routing, moved transaction/identity-map hot-path state to session scope in Rust with compatibility fallback + deprecation warnings, added session lifecycle tests, and synchronized migration/guide/API/invariant docs.
-- `2026-06-22` - Phase 7 working-branch implementation landed: completed version-centric public migration guidance (`Migrating to v0.12.0`), added release checklist + changelog entries, centralized `v0.13.0` deprecation-target messaging across compatibility paths, added deprecated-path inventory tests, and validated full Rust/Python/docs/release verification matrix.
+- `2026-06-22` - Phase 7 working-branch implementation landed: completed version-centric public migration guidance (`Migrating to v0.12.0`), added release checklist + changelog entries, centralized `v0.14.0` deprecation-target messaging across compatibility paths, added deprecated-path inventory tests, and validated full Rust/Python/docs/release verification matrix.
 
 ## Immediate next actions
 

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -384,7 +384,7 @@ Issue references:
 
 ### Phase 7 - Major-version public release with compatibility window
 
-Status: `Not started`
+Status: `Complete`
 
 Issue references:
 
@@ -395,16 +395,32 @@ Issue references:
 - Release the IR-first upgrade publicly while keeping deprecated compatibility paths available through a defined migration window.
 
 **Deliverables**
-- [ ] Public upgrade release shipped with migration guide and deprecation messaging.
-- [ ] Deprecated compatibility paths remain available during the migration window.
-- [ ] Deprecated-compat test inventory is tagged and tracked for removal (`pytest.mark.deprecated_operator_path`).
-- [ ] Migration guide and upgrade checklist.
-- [ ] Final release checklist and changelog entries.
+- [x] Public upgrade release shipped with migration guide and deprecation messaging.
+- [x] Deprecated compatibility paths remain available during the migration window.
+- [x] Deprecated-compat test inventory is tagged and tracked for removal (`pytest.mark.deprecated_operator_path`).
+- [x] Migration guide and upgrade checklist.
+- [x] Final release checklist and changelog entries.
 
 **Exit gate**
-- [ ] Release branch green across full backend/test matrix.
-- [ ] Migration guide validated against at least one real example project.
-- [ ] Deprecation warnings explicitly point to `v0.13.0` as the removal release.
+- [x] Release branch green across full backend/test matrix.
+- [x] Migration guide validated against at least one real example project.
+- [x] Deprecation warnings explicitly point to `v0.13.0` as the removal release.
+
+**Evidence (working branch; pending merge to `feat/ir-first`)**
+- Deprecation messaging consistency primitive + call-site adoption: `src/ferro/_deprecations.py`, `src/ferro/query/builder.py`, `src/ferro/state.py`, `src/ferro/migrations/alembic.py`
+- Deprecated inventory and warning-target coverage: `tests/test_deprecated_operator_inventory.py`, `tests/test_query_builder.py`, `tests/test_query_typing.py`, `tests/test_session.py`, `tests/test_alembic_bridge.py`
+- Phase 7 migration/release docs: `docs/plans/ir-first-migration-guide.md`, `docs/pages/howto/migrating-to-v0-12-0.md`, `docs/plans/ir-first-release-checklist.md`, `docs/pages/guide/queries.md`, `docs/pages/concepts/query-typing.md`, `docs/pages/api/queries.md`, `docs/pages/guide/connections.md`, `docs/pages/api/migrations.md`, `zensical.toml`, `CHANGELOG.md`
+- Migration-guide validation against real example project surface: `uv run pytest -v tests/test_docs_examples.py` (includes `docs/examples/*.py` scripts and migration guide code snippet validation)
+- Verification commands:
+  - `cargo test --no-default-features --features testing`
+  - `cargo test -p ferro-schema-ir -p ferro-migrate`
+  - `uv run pytest -v tests/test_ir_vectors_contract.py`
+  - `uv run pytest -v --cov=src --cov-report=xml --cov-report=term`
+  - `uv run pytest -v -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres`
+  - `uv run pytest -v -m deprecated_operator_path`
+  - `uv run pytest -v tests/test_query_builder.py tests/test_query_typing.py tests/test_session.py tests/test_alembic_bridge.py tests/test_docs_examples.py`
+  - `uv run zensical build --clean`
+  - `uv run maturin build --release`
 
 ---
 
@@ -569,6 +585,7 @@ Append updates as concise entries.
 - `2026-06-19` - Phase 4 working-branch implementation landed: added `ferro-migrate` (`SchemaIR(old,new)` diff + SQL emission entrypoint), expanded SchemaIR fidelity (enum/check/join-table coverage), switched Alembic metadata derivation to SchemaIR, and added deprecation warnings for superseded JSON-only Alembic helpers (target removal `v0.13.0`).
 - `2026-06-22` - Phase 5 working-branch implementation landed: added unified codec registry module (`src/codec.rs`) across insert/update/filter/m2m/fetch paths, extracted single hydration ABI helper (`src/hydration.rs`) with required Pydantic slot initialization, and expanded codec conformance vectors/tests for null/uuid/decimal/temporal/enum semantics.
 - `2026-06-22` - Phase 6 working-branch implementation landed: introduced sessionized runtime API (`engines.session` / `Session`) and ambient session routing, moved transaction/identity-map hot-path state to session scope in Rust with compatibility fallback + deprecation warnings, added session lifecycle tests, and synchronized migration/guide/API/invariant docs.
+- `2026-06-22` - Phase 7 working-branch implementation landed: completed version-centric public migration guidance (`Migrating to v0.12.0`), added release checklist + changelog entries, centralized `v0.13.0` deprecation-target messaging across compatibility paths, added deprecated-path inventory tests, and validated full Rust/Python/docs/release verification matrix.
 
 ## Immediate next actions
 

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -101,7 +101,35 @@ Phase 6 deprecation note:
 
 ### Phase 7
 
-_TBD_
+Public release phase for the IR-first architecture with a defined compatibility
+window. Deprecated paths remain supported in `v0.12.x` and are removed in
+`v0.13.0`.
+
+| Issue | Change | Impact | User action | Notes |
+| --- | --- | --- | --- | --- |
+| [#100](https://github.com/syn54x/ferro-orm/issues/100) | Coordinate public IR-first release readiness and compatibility window evidence | minor | Follow the `v0.12.0` migration checklist before upgrading production workloads | Phase-level coordination/evidence issue |
+| [#101](https://github.com/syn54x/ferro-orm/issues/101) | Ship public IR-first release while keeping compatibility paths during migration window | minor | Keep legacy call sites working short-term, but migrate off deprecated surfaces immediately | Deprecated paths stay live only through the compatibility window |
+| [#102](https://github.com/syn54x/ferro-orm/issues/102) | Publish version-centric migration guide and upgrade checklist | minor | Follow [Migrating to v0.12.0](../pages/howto/migrating-to-v0-12-0.md) step-by-step | Includes IR-first rationale and concrete migration actions |
+| [#103](https://github.com/syn54x/ferro-orm/issues/103) | Finalize release checklist/changelog and validate deprecation target consistency | minor | Validate that internal/private deprecated usage has been removed from your codebase | All Phase 7 deprecation warnings explicitly target `v0.13.0` removal |
+
+Deprecated compatibility inventory for the Phase 7 window:
+
+- Operator-style predicates (`Model.field OP value`) are deprecated.
+  - Replacement: `where(lambda t: ...)` (official) or `col(Model.field)`.
+  - Removal target: `v0.13.0`.
+- Implicit default-connection routing outside an active session is deprecated.
+  - Replacement: `async with ferro.engines.session("name")` or explicit `session=`.
+  - Removal target: `v0.13.0`.
+- Private Alembic JSON helper APIs are deprecated:
+  - `ferro.migrations.alembic._build_sa_table`
+  - `ferro.migrations.alembic._map_to_sa_type`
+  - Replacement: `ferro.migrations.get_metadata()`.
+  - Removal target: `v0.13.0`.
+
+Phase 7 migration artifacts:
+
+- User migration checklist: [Migrating to v0.12.0](../pages/howto/migrating-to-v0-12-0.md)
+- Maintainer release checklist: [IR-first release checklist](ir-first-release-checklist.md)
 
 ### Phase 8
 

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -56,12 +56,12 @@ No user-facing runtime behavior changes expected. Shadow planning is internal-on
 | Issue | Change | Impact | User action | Notes |
 | --- | --- | --- | --- | --- |
 | [#85](https://github.com/syn54x/ferro-orm/issues/85) | Runtime query compilation now consumes QueryIR envelopes on core execution paths | minor | No API change for lambda/`col()` query callers; if you rely on internal `_core` query payload shape, migrate to QueryIR envelope (`ir_kind`, `ir_version`, `payload`) | Internal JSON `QueryDef` payload contract is no longer the core hot-path boundary |
-| [#86](https://github.com/syn54x/ferro-orm/issues/86) | Operator-style predicates (`Model.field OP value`) are deprecated with runtime warnings | minor | Migrate call sites to `where(lambda t: ...)` (recommended) or `col(Model.field)` | Deprecation message includes replacement + removal target (`v0.13.0`) |
+| [#86](https://github.com/syn54x/ferro-orm/issues/86) | Operator-style predicates (`Model.field OP value`) are deprecated with runtime warnings | minor | Migrate call sites to `where(lambda t: ...)` (recommended) or `col(Model.field)` | Deprecation message includes replacement + removal target (`v0.14.0`) |
 | [#87](https://github.com/syn54x/ferro-orm/issues/87) | Python query builder now emits QueryIR envelope payloads to Rust runtime | minor | No action for public `Model.where`/`Query.where` usage; update internal tests/tools that serialized legacy `where_clause` JSON | Compatibility behavior remains documented in query typing docs during deprecation window |
 
 Phase 3 test-migration note:
 
-- Tests that exist only to verify temporary operator-style compatibility are tagged `deprecated_operator_path` and scheduled for removal/rewrite at `v0.13.0`.
+- Tests that exist only to verify temporary operator-style compatibility are tagged `deprecated_operator_path` and scheduled for removal/rewrite at `v0.14.0`.
 
 ### Phase 4
 
@@ -69,13 +69,13 @@ Phase 3 test-migration note:
 | --- | --- | --- | --- | --- |
 | [#89](https://github.com/syn54x/ferro-orm/issues/89) | SchemaIR compiler fidelity extended for `db_check` expressions, enum metadata, and join-table model inclusion | minor | No API changes for model declaration; if you consume internal SchemaIR fixtures, refresh snapshots to include join-table and enum/check artifacts | Artifacts: `src/ferro/ir/compiler.py`, `tests/test_ir_vectors_contract.py` |
 | [#90](https://github.com/syn54x/ferro-orm/issues/90) | Introduce `crates/ferro-migrate` with typed `SchemaIR(old,new)` diff operations and backend SQL emission entrypoint | minor | No user API change; maintainers/tools consuming migration internals should move to `ferro-migrate` plan ops | Artifacts: `crates/ferro-migrate/`, `src/migrate.rs` |
-| [#91](https://github.com/syn54x/ferro-orm/issues/91) | Alembic `get_metadata()` now derives from SchemaIR modelset; legacy JSON-lowering helpers deprecated | minor | Keep using `get_metadata()`; if you directly import private `ferro.migrations.alembic._build_sa_table` / `_map_to_sa_type`, migrate away now | Deprecated helpers emit `DeprecationWarning` with planned removal `v0.13.0` |
+| [#91](https://github.com/syn54x/ferro-orm/issues/91) | Alembic `get_metadata()` now derives from SchemaIR modelset; legacy JSON-lowering helpers deprecated | minor | Keep using `get_metadata()`; if you directly import private `ferro.migrations.alembic._build_sa_table` / `_map_to_sa_type`, migrate away now | Deprecated helpers emit `DeprecationWarning` with planned removal `v0.14.0` |
 
 Phase 4 deprecation note:
 
 - Deprecated: `ferro.migrations.alembic._build_sa_table()` and `ferro.migrations.alembic._map_to_sa_type()`
 - Replacement: `get_metadata()` (SchemaIR-backed) and internal IR lowering via `_sa_type_from_ir_column()`
-- Removal target: `v0.13.0`
+- Removal target: `v0.14.0`
 
 ### Phase 5
 
@@ -91,40 +91,40 @@ Phase 4 deprecation note:
 | --- | --- | --- | --- | --- |
 | [#97](https://github.com/syn54x/ferro-orm/issues/97) | Add explicit `Session`/`engines.session(name)` runtime boundary for ambient model/query/raw routing | minor | Prefer `async with ferro.engines.session(\"name\")` around request/task work; use `session=` explicit overrides when needed | Adds deterministic nested-session shadow/restore semantics |
 | [#98](https://github.com/syn54x/ferro-orm/issues/98) | Core CRUD/query/transaction hot paths now support session-scoped transaction + identity-map state in Rust | minor | No call-site change required if you use sessions; behavior is now isolated per session under concurrent workloads | Legacy global fallback remains only for compatibility paths |
-| [#99](https://github.com/syn54x/ferro-orm/issues/99) | Temporary compatibility shim keeps implicit default-connection routing but emits deprecation warnings | minor | Migrate unqualified operations (`Model.*`, `ferro.execute/fetch_*`) to run inside sessions; keep `using=` for explicit one-off routing | Deprecation warning points to removal target `v0.13.0` |
+| [#99](https://github.com/syn54x/ferro-orm/issues/99) | Temporary compatibility shim keeps implicit default-connection routing but emits deprecation warnings | minor | Migrate unqualified operations (`Model.*`, `ferro.execute/fetch_*`) to run inside sessions; keep `using=` for explicit one-off routing | Deprecation warning points to removal target `v0.14.0` |
 
 Phase 6 deprecation note:
 
 - Deprecated: implicit default-connection routing outside an active session context.
 - Replacement: `async with ferro.engines.session(\"name\")` (ambient routing) or explicit `session=` arguments.
-- Removal target: `v0.13.0`.
+- Removal target: `v0.14.0`.
 
 ### Phase 7
 
 Public release phase for the IR-first architecture with a defined compatibility
 window. Deprecated paths remain supported in `v0.12.x` and are removed in
-`v0.13.0`.
+`v0.14.0`.
 
 | Issue | Change | Impact | User action | Notes |
 | --- | --- | --- | --- | --- |
 | [#100](https://github.com/syn54x/ferro-orm/issues/100) | Coordinate public IR-first release readiness and compatibility window evidence | minor | Follow the `v0.12.0` migration checklist before upgrading production workloads | Phase-level coordination/evidence issue |
 | [#101](https://github.com/syn54x/ferro-orm/issues/101) | Ship public IR-first release while keeping compatibility paths during migration window | minor | Keep legacy call sites working short-term, but migrate off deprecated surfaces immediately | Deprecated paths stay live only through the compatibility window |
 | [#102](https://github.com/syn54x/ferro-orm/issues/102) | Publish version-centric migration guide and upgrade checklist | minor | Follow [Migrating to v0.12.0](../pages/howto/migrating-to-v0-12-0.md) step-by-step | Includes IR-first rationale and concrete migration actions |
-| [#103](https://github.com/syn54x/ferro-orm/issues/103) | Finalize release checklist/changelog and validate deprecation target consistency | minor | Validate that internal/private deprecated usage has been removed from your codebase | All Phase 7 deprecation warnings explicitly target `v0.13.0` removal |
+| [#103](https://github.com/syn54x/ferro-orm/issues/103) | Finalize release checklist/changelog and validate deprecation target consistency | minor | Validate that internal/private deprecated usage has been removed from your codebase | All Phase 7 deprecation warnings explicitly target `v0.14.0` removal |
 
 Deprecated compatibility inventory for the Phase 7 window:
 
 - Operator-style predicates (`Model.field OP value`) are deprecated.
   - Replacement: `where(lambda t: ...)` (official) or `col(Model.field)`.
-  - Removal target: `v0.13.0`.
+  - Removal target: `v0.14.0`.
 - Implicit default-connection routing outside an active session is deprecated.
   - Replacement: `async with ferro.engines.session("name")` or explicit `session=`.
-  - Removal target: `v0.13.0`.
+  - Removal target: `v0.14.0`.
 - Private Alembic JSON helper APIs are deprecated:
   - `ferro.migrations.alembic._build_sa_table`
   - `ferro.migrations.alembic._map_to_sa_type`
   - Replacement: `ferro.migrations.get_metadata()`.
-  - Removal target: `v0.13.0`.
+  - Removal target: `v0.14.0`.
 
 Phase 7 migration artifacts:
 
@@ -135,7 +135,7 @@ Phase 7 migration artifacts:
 
 _TBD_
 
-Planned cutover checklist (target: `v0.13.0`):
+Planned cutover checklist (target: `v0.14.0`):
 
 - Remove deprecated operator-style predicate support.
 - Remove or rewrite all tests tagged `deprecated_operator_path`.

--- a/docs/plans/ir-first-release-checklist.md
+++ b/docs/plans/ir-first-release-checklist.md
@@ -1,0 +1,46 @@
+# IR-first release checklist
+
+Phase 7 release checklist for the public `v0.12.0` IR-first release with a
+compatibility window through `v0.12.x`.
+
+## Pre-release checklist
+
+- [ ] All Phase 7 scoped issues are complete and synchronized:
+  - [#100](https://github.com/syn54x/ferro-orm/issues/100)
+  - [#101](https://github.com/syn54x/ferro-orm/issues/101)
+  - [#102](https://github.com/syn54x/ferro-orm/issues/102)
+  - [#103](https://github.com/syn54x/ferro-orm/issues/103)
+- [ ] Deprecation warnings consistently include `Planned removal: v0.13.0`.
+- [ ] Deprecated-compat inventory is still tracked via
+      `pytest.mark.deprecated_operator_path`.
+- [ ] User migration docs are complete:
+  - `docs/plans/ir-first-migration-guide.md`
+  - `docs/pages/howto/migrating-to-v0-12-0.md`
+- [ ] Changelog release notes for `v0.12.0` are finalized.
+
+## Verification matrix
+
+- [ ] `cargo test --no-default-features --features testing`
+- [ ] `cargo test -p ferro-schema-ir -p ferro-migrate`
+- [ ] `uv run pytest -v tests/test_ir_vectors_contract.py`
+- [ ] `uv run pytest -v --cov=src --cov-report=xml --cov-report=term`
+- [ ] `uv run pytest -v -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres`
+- [ ] `uv run pytest -v -m deprecated_operator_path`
+- [ ] `uv run pytest -v tests/test_query_builder.py tests/test_query_typing.py tests/test_session.py tests/test_alembic_bridge.py tests/test_docs_examples.py`
+- [ ] `uv run zensical build --clean`
+- [ ] `uv run maturin build --release`
+
+## Exit-gate evidence
+
+- [ ] Roadmap Phase 7 exit-gate checklist is updated with command evidence links.
+- [ ] Migration guide is validated against at least one real example project.
+- [ ] Issue comments contain verification summary and links to docs/evidence.
+
+## PR closure requirements
+
+If a PR is opened for Phase 7 completion, include explicit auto-close lines:
+
+- `Closes #100`
+- `Closes #101`
+- `Closes #102`
+- `Closes #103`

--- a/docs/plans/ir-first-release-checklist.md
+++ b/docs/plans/ir-first-release-checklist.md
@@ -10,7 +10,7 @@ compatibility window through `v0.12.x`.
   - [#101](https://github.com/syn54x/ferro-orm/issues/101)
   - [#102](https://github.com/syn54x/ferro-orm/issues/102)
   - [#103](https://github.com/syn54x/ferro-orm/issues/103)
-- [ ] Deprecation warnings consistently include `Planned removal: v0.13.0`.
+- [ ] Deprecation warnings consistently include `Planned removal in v0.14.0`.
 - [ ] Deprecated-compat inventory is still tracked via
       `pytest.mark.deprecated_operator_path`.
 - [ ] User migration docs are complete:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dev = [
 [tool.pytest.ini_options]
 addopts = "--cov=src"
 markers = [
-    "deprecated_operator_path: tests that assert temporary operator-style predicate compatibility and are scheduled for removal in v0.13.0",
+    "deprecated_operator_path: tests that assert temporary operator-style predicate compatibility and are scheduled for removal in v0.14.0",
 ]
 
 [tool.commitizen]

--- a/scripts/demo_queries.py
+++ b/scripts/demo_queries.py
@@ -1,16 +1,23 @@
 # /// script
+# requires-python = ">=3.12"
 # dependencies = [
 #     "pydantic>=2.0",
 #     "ferro-orm",
 #     "rich",
 # ]
+#
+# [tool.uv.sources]
+# ferro-orm = { path = "..", editable = true }
 # ///
+"""Ferro query demo for v0.12+ (lambda predicates, session-scoped routing).
+
+Run: uv run scripts/demo_queries.py
+"""
 
 import os
 from datetime import datetime, timezone
 from typing import Annotated
 
-from pydantic import Field
 from rich.console import Console
 from rich.panel import Panel
 from rich.syntax import Syntax
@@ -18,11 +25,13 @@ from rich.syntax import Syntax
 from ferro import (
     BackRef,
     FerroField,
+    Field,
     ForeignKey,
     ManyToMany,
     Model,
     Relation,
     connect,
+    engines,
     transaction,
 )
 
@@ -36,11 +45,10 @@ def show_step(title: str, code: str):
     console.print(Panel(syntax, expand=False, border_style="dim"))
 
 
-# 1. Define relationship-aware models
+# 1. Define relationship-aware models (Field assignment + FerroField Annotated)
 class Category(Model):
-    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    id: int | None = Field(default=None, primary_key=True)
     name: str
-    # Reverse lookup marker (Zero-Boilerplate)
     products: Relation[list["Product"]] = BackRef()
 
 
@@ -48,7 +56,6 @@ class Product(Model):
     id: Annotated[int | None, FerroField(primary_key=True, autoincrement=True)] = None
     name: Annotated[str, FerroField(index=True)]
     price: float
-    # Foreign Key linking to Category
     category: Annotated[
         Category, ForeignKey(related_name="products", on_delete="CASCADE")
     ]
@@ -58,192 +65,202 @@ class Product(Model):
 
 
 class Actor(Model):
-    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    id: int | None = Field(default=None, primary_key=True)
     name: str
     movies: Relation[list["Movie"]] = ManyToMany(related_name="actors")
 
 
 class Movie(Model):
     id: Annotated[int | None, FerroField(primary_key=True)] = None
-    title: str
+    title: Annotated[str, FerroField(index=True)]
     actors: Relation[list[Actor]] = BackRef()
 
 
 async def run_demo():
     # Use a file-based SQLite DB for demo stability
-    db_file = "demo.db"
+    db_file = "demo_v012.db"
     if os.path.exists(db_file):
         os.remove(db_file)
 
     console.print(
         Panel.fit(
-            "[bold green]🚀 Ferro High-Performance ORM Demo[/bold green]",
+            "[bold green]🚀 Ferro High-Performance ORM Demo (v0.12+)[/bold green]",
             border_style="bold green",
         )
     )
 
     console.print(f"🚀 Connecting to Ferro Engine ({db_file})...")
-    # connect() automatically resolves relationships and creates tables
     await connect(f"sqlite:{db_file}?mode=rwc", auto_migrate=True)
 
-    # 2. Seeding with Relationships
-    console.print("📦 Seeding initial data...")
+    async with engines.session("default"):
+        # 2. Seeding with Relationships
+        console.print("📦 Seeding initial data...")
 
-    electronics = await Category.create(name="Electronics")
-    appliances = await Category.create(name="Appliances")
-    furniture = await Category.create(name="Furniture")
+        electronics = await Category.create(name="Electronics")
+        appliances = await Category.create(name="Appliances")
+        furniture = await Category.create(name="Furniture")
 
-    data = [
-        ("Laptop", 1200.0, electronics, True, "LPT-001"),
-        ("Smartphone", 800.0, electronics, True, "PHN-001"),
-        ("Headphones", 150.0, electronics, True, "HDP-001"),
-        ("Monitor", 300.0, electronics, False, "MON-001"),
-        ("Coffee Maker", 80.0, appliances, True, "COF-001"),
-        ("Toaster", 30.0, appliances, True, "TST-001"),
-        ("Desk Chair", 250.0, furniture, True, "CHR-001"),
-        ("Bookshelf", 120.0, furniture, True, "BSH-001"),
-        ("Mechanical Keyboard", 120.0, electronics, True, "KBD-001"),
-        ("Gaming Mouse", 60.0, electronics, True, "MSE-001"),
-    ]
+        data = [
+            ("Laptop", 1200.0, electronics, True, "LPT-001"),
+            ("Smartphone", 800.0, electronics, True, "PHN-001"),
+            ("Headphones", 150.0, electronics, True, "HDP-001"),
+            ("Monitor", 300.0, electronics, False, "MON-001"),
+            ("Coffee Maker", 80.0, appliances, True, "COF-001"),
+            ("Toaster", 30.0, appliances, True, "TST-001"),
+            ("Desk Chair", 250.0, furniture, True, "CHR-001"),
+            ("Bookshelf", 120.0, furniture, True, "BSH-001"),
+            ("Mechanical Keyboard", 120.0, electronics, True, "KBD-001"),
+            ("Gaming Mouse", 60.0, electronics, True, "MSE-001"),
+        ]
 
-    for name, price, cat, stock, sku in data:
-        await Product(
-            name=name, price=price, category=cat, in_stock=stock, sku=sku
-        ).save()
+        for name, price, cat, stock, sku in data:
+            await Product(
+                name=name, price=price, category=cat, in_stock=stock, sku=sku
+            ).save()
 
-    console.print("\n[bold yellow]--- 🔍 Running Fluent Queries ---[/bold yellow]")
+        console.print("\n[bold yellow]--- 🔍 Running Fluent Queries ---[/bold yellow]")
 
-    # 3. Filtering through relationships
-    show_step(
-        "Filter by Relationship ID",
-        "results = await Product.where(Product.category_id == electronics.id).all()",
-    )
-    electronics_products = await Product.where(
-        Product.category_id == electronics.id
-    ).all()
-    console.print(
-        f"✅ Found [bold green]{len(electronics_products)}[/bold green] Electronics products."
-    )
-
-    # 4. Basic Filter (Operators)
-    show_step(
-        "Range Queries (>=)",
-        "expensive = await Product.where(Product.price >= 500).all()",
-    )
-    expensive = await Product.where(Product.price >= 500).all()
-    console.print(
-        f"💰 Expensive items (>= 500): [cyan]{[p.name for p in expensive]}[/cyan]"
-    )
-
-    # 5. Chaining & Pagination
-    show_step(
-        "Pagination & Ordering",
-        'ordered = await Product.select().order_by(Product.price, "desc").limit(3).all()',
-    )
-    top_3 = await Product.select().order_by(Product.price, "desc").limit(3).all()
-    for p in top_3:
-        console.print(f"🔝 [cyan]{p.name}[/cyan]: ${p.price}")
-
-    # 6. RELATIONSHIP POWER
-    console.print("\n[bold yellow]--- 🔗 Relationship Features ---[/bold yellow]")
-
-    show_step(
-        "Lazy Loading (Forward)",
-        'laptop = await Product.where(Product.name == "Laptop").first()\n'
-        "category = await laptop.category  # Fetched on demand",
-    )
-    laptop = await Product.where(Product.name == "Laptop").first()
-    category = await laptop.category
-    console.print(f"💻 Laptop Category: [bold green]{category.name}[/bold green]")
-
-    show_step(
-        "Reverse Lookup (Zero-Boilerplate)",
-        'cat = await Category.where(Category.name == "Appliances").first()\n'
-        "products = await cat.products.all()  # .products returns a Query object!",
-    )
-    app_cat = await Category.where(Category.name == "Appliances").first()
-    app_products = await app_cat.products.all()
-    console.print(f"🏠 Appliances found: [cyan]{[p.name for p in app_products]}[/cyan]")
-
-    show_step(
-        "Reverse Lookup with Filtering",
-        "electronics_in_stock = await electronics.products.where(Product.in_stock == True).all()",
-    )
-    stock_electronics = await electronics.products.where(Product.in_stock == True).all()  # noqa
-    console.print(
-        f"📱 In-stock Electronics: [bold green]{len(stock_electronics)}[/bold green]"
-    )
-
-    # 7. MANY-TO-MANY (M2M)
-    console.print("\n[bold yellow]--- 🤝 Many-to-Many Relationships ---[/bold yellow]")
-
-    show_step(
-        "M2M Setup & Mutation",
-        'keanu = await Actor.create(name="Keanu Reeves")\n'
-        'laurence = await Actor.create(name="Laurence Fishburne")\n'
-        'matrix = await Movie.create(title="The Matrix")\n'
-        "await keanu.movies.add(matrix)\n"
-        "await laurence.movies.add(matrix)",
-    )
-
-    keanu = await Actor.create(name="Keanu Reeves")
-    laurence = await Actor.create(name="Laurence Fishburne")
-    matrix = await Movie.create(title="The Matrix")
-
-    await keanu.movies.add(matrix)
-    await laurence.movies.add(matrix)
-
-    show_step(
-        "M2M Querying (Bi-directional)",
-        "keanu_movies = await keanu.movies.all()\n"
-        "matrix_actors = await matrix.actors.all()",
-    )
-
-    keanu_movies = await keanu.movies.all()
-    matrix_actors = await matrix.actors.all()
-
-    console.print(f"🎬 Keanu's Movies: [cyan]{[m.title for m in keanu_movies]}[/cyan]")
-    console.print(f"👥 Matrix Actors: [cyan]{[a.name for a in matrix_actors]}[/cyan]")
-
-    # 8. Transactions
-    console.print("\n[bold yellow]--- ⚛️ Transaction Support ---[/bold yellow]")
-
-    show_step(
-        "Atomic Transaction",
-        "async with ferro.transaction():\n"
-        '    new_cat = await Category.create(name="New Category")\n'
-        '    await Product.create(name="Atomic Item", category=new_cat, ...)',
-    )
-
-    async with transaction():
-        new_cat = await Category.create(name="Gaming")
-        await Product.create(
-            name="RTX 5090",
-            price=1999.99,
-            category=new_cat,
-            in_stock=True,
-            sku="GPU-5090",
+        # 3. Filtering through relationships
+        show_step(
+            "Filter by Relationship ID",
+            "results = await Product.where(lambda t: t.category_id == electronics.id).all()",
+        )
+        electronics_products = await Product.where(
+            lambda t: t.category_id == electronics.id
+        ).all()
+        console.print(
+            f"✅ Found [bold green]{len(electronics_products)}[/bold green] Electronics products."
         )
 
-    gpu = await Product.where(Product.name == "RTX 5090").first()
-    gpu_cat = await gpu.category
-    console.print(
-        f"✅ Transaction Committed: [bold green]{gpu.name}[/bold green] in [bold green]{gpu_cat.name}[/bold green]"
-    )
+        # 4. Basic Filter (lambda predicates)
+        show_step(
+            "Range Queries (>=)",
+            "expensive = await Product.where(lambda t: t.price >= 500).all()",
+        )
+        expensive = await Product.where(lambda t: t.price >= 500).all()
+        console.print(
+            f"💰 Expensive items (>= 500): [cyan]{[p.name for p in expensive]}[/cyan]"
+        )
 
-    # 9. Instance Refreshing
-    console.print("\n[bold yellow]--- 🔄 Instance Refreshing ---[/bold yellow]")
-    show_step(
-        "Refreshing an instance",
-        "await Product.where(Product.id == laptop.id).update(price=50.0)\n"
-        "await laptop.refresh()",
-    )
+        # 5. Chaining & Pagination
+        show_step(
+            "Pagination & Ordering",
+            'ordered = await Product.select().order_by(Product.price, "desc").limit(3).all()',
+        )
+        top_3 = await Product.select().order_by(Product.price, "desc").limit(3).all()
+        for p in top_3:
+            console.print(f"🔝 [cyan]{p.name}[/cyan]: ${p.price}")
 
-    await Product.where(Product.id == laptop.id).update(price=50.0)
-    await laptop.refresh()
-    console.print(
-        f"🔄 Laptop price after refresh: [bold green]${laptop.price}[/bold green]"
-    )
+        # 6. RELATIONSHIP POWER
+        console.print("\n[bold yellow]--- 🔗 Relationship Features ---[/bold yellow]")
+
+        show_step(
+            "Lazy Loading (Forward)",
+            'laptop = await Product.where(lambda t: t.name == "Laptop").first()\n'
+            "category = await laptop.category  # Fetched on demand",
+        )
+        laptop = await Product.where(lambda t: t.name == "Laptop").first()
+        category = await laptop.category
+        console.print(f"💻 Laptop Category: [bold green]{category.name}[/bold green]")
+
+        show_step(
+            "Reverse Lookup (Zero-Boilerplate)",
+            'cat = await Category.where(lambda t: t.name == "Appliances").first()\n'
+            "products = await cat.products.all()  # .products returns a Query object!",
+        )
+        app_cat = await Category.where(lambda t: t.name == "Appliances").first()
+        app_products = await app_cat.products.all()
+        console.print(
+            f"🏠 Appliances found: [cyan]{[p.name for p in app_products]}[/cyan]"
+        )
+
+        show_step(
+            "Reverse Lookup with Filtering",
+            "electronics_in_stock = await electronics.products.where("
+            "lambda t: t.in_stock == True).all()",
+        )
+        stock_electronics = await electronics.products.where(
+            lambda t: t.in_stock == True  # noqa: E712
+        ).all()
+        console.print(
+            f"📱 In-stock Electronics: [bold green]{len(stock_electronics)}[/bold green]"
+        )
+
+        # 7. MANY-TO-MANY (M2M)
+        console.print("\n[bold yellow]--- 🤝 Many-to-Many Relationships ---[/bold yellow]")
+
+        show_step(
+            "M2M Setup & Mutation",
+            'keanu = await Actor.create(name="Keanu Reeves")\n'
+            'laurence = await Actor.create(name="Laurence Fishburne")\n'
+            'matrix = await Movie.create(title="The Matrix")\n'
+            "await keanu.movies.add(matrix)\n"
+            "await laurence.movies.add(matrix)",
+        )
+
+        keanu = await Actor.create(name="Keanu Reeves")
+        laurence = await Actor.create(name="Laurence Fishburne")
+        matrix = await Movie.create(title="The Matrix")
+
+        await keanu.movies.add(matrix)
+        await laurence.movies.add(matrix)
+
+        show_step(
+            "M2M Querying (Bi-directional)",
+            "keanu_movies = await keanu.movies.all()\n"
+            "matrix_actors = await matrix.actors.all()",
+        )
+
+        keanu_movies = await keanu.movies.all()
+        matrix_actors = await matrix.actors.all()
+
+        console.print(
+            f"🎬 Keanu's Movies: [cyan]{[m.title for m in keanu_movies]}[/cyan]"
+        )
+        console.print(
+            f"👥 Matrix Actors: [cyan]{[a.name for a in matrix_actors]}[/cyan]"
+        )
+
+        # 8. Transactions
+        console.print("\n[bold yellow]--- ⚛️ Transaction Support ---[/bold yellow]")
+
+        show_step(
+            "Atomic Transaction",
+            "async with transaction():\n"
+            '    new_cat = await Category.create(name="Gaming")\n'
+            '    await Product.create(name="RTX 5090", category=new_cat, ...)',
+        )
+
+        async with transaction():
+            new_cat = await Category.create(name="Gaming")
+            await Product.create(
+                name="RTX 5090",
+                price=1999.99,
+                category=new_cat,
+                in_stock=True,
+                sku="GPU-5090",
+            )
+
+        gpu = await Product.where(lambda t: t.name == "RTX 5090").first()
+        gpu_cat = await gpu.category
+        console.print(
+            f"✅ Transaction Committed: [bold green]{gpu.name}[/bold green] in "
+            f"[bold green]{gpu_cat.name}[/bold green]"
+        )
+
+        # 9. Instance Refreshing
+        console.print("\n[bold yellow]--- 🔄 Instance Refreshing ---[/bold yellow]")
+        show_step(
+            "Refreshing an instance",
+            "await Product.where(lambda t: t.id == laptop.id).update(price=50.0)\n"
+            "await laptop.refresh()",
+        )
+
+        await Product.where(lambda t: t.id == laptop.id).update(price=50.0)
+        await laptop.refresh()
+        console.print(
+            f"🔄 Laptop price after refresh: [bold green]${laptop.price}[/bold green]"
+        )
 
     console.print("\n[bold green]🏁 Demo Complete![/bold green]")
 

--- a/scripts/demo_queries_pre_v012.py
+++ b/scripts/demo_queries_pre_v012.py
@@ -1,0 +1,252 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "pydantic>=2.0",
+#     "ferro-orm",
+#     "rich",
+# ]
+#
+# [tool.uv.sources]
+# ferro-orm = { path = "..", editable = true }
+# ///
+"""Ferro query demo for releases before v0.12 (operator predicates, ambient routing).
+
+Run: uv run scripts/demo_queries_pre_v012.py
+"""
+
+import os
+from datetime import datetime, timezone
+from typing import Annotated
+
+from pydantic import Field as PydanticField
+from rich.console import Console
+from rich.panel import Panel
+from rich.syntax import Syntax
+
+from ferro import (
+    BackRef,
+    FerroField,
+    ForeignKey,
+    ManyToMany,
+    Model,
+    Relation,
+    connect,
+    transaction,
+)
+
+console = Console()
+
+
+def show_step(title: str, code: str):
+    """Utility to display a code snippet and its title."""
+    console.print(f"\n[bold blue]>>> {title}[/bold blue]")
+    syntax = Syntax(code, "python", theme="monokai", line_numbers=False)
+    console.print(Panel(syntax, expand=False, border_style="dim"))
+
+
+class Category(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str
+    products: Relation[list["Product"]] = BackRef()
+
+
+class Product(Model):
+    id: Annotated[int | None, FerroField(primary_key=True, autoincrement=True)] = None
+    name: Annotated[str, FerroField(index=True)]
+    price: float
+    category: Annotated[
+        Category, ForeignKey(related_name="products", on_delete="CASCADE")
+    ]
+    in_stock: bool
+    sku: Annotated[str | None, FerroField(unique=True)] = None
+    created_at: datetime = PydanticField(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+
+class Actor(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str
+    movies: Relation[list["Movie"]] = ManyToMany(related_name="actors")
+
+
+class Movie(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    title: str
+    actors: Relation[list[Actor]] = BackRef()
+
+
+async def run_demo():
+    db_file = "demo_pre_v012.db"
+    if os.path.exists(db_file):
+        os.remove(db_file)
+
+    console.print(
+        Panel.fit(
+            "[bold green]🚀 Ferro ORM Demo (pre-v0.12 patterns)[/bold green]",
+            border_style="bold green",
+        )
+    )
+
+    console.print(f"🚀 Connecting to Ferro Engine ({db_file})...")
+    await connect(f"sqlite:{db_file}?mode=rwc", auto_migrate=True)
+
+    console.print("📦 Seeding initial data...")
+
+    electronics = await Category.create(name="Electronics")
+    appliances = await Category.create(name="Appliances")
+    furniture = await Category.create(name="Furniture")
+
+    data = [
+        ("Laptop", 1200.0, electronics, True, "LPT-001"),
+        ("Smartphone", 800.0, electronics, True, "PHN-001"),
+        ("Headphones", 150.0, electronics, True, "HDP-001"),
+        ("Monitor", 300.0, electronics, False, "MON-001"),
+        ("Coffee Maker", 80.0, appliances, True, "COF-001"),
+        ("Toaster", 30.0, appliances, True, "TST-001"),
+        ("Desk Chair", 250.0, furniture, True, "CHR-001"),
+        ("Bookshelf", 120.0, furniture, True, "BSH-001"),
+        ("Mechanical Keyboard", 120.0, electronics, True, "KBD-001"),
+        ("Gaming Mouse", 60.0, electronics, True, "MSE-001"),
+    ]
+
+    for name, price, cat, stock, sku in data:
+        await Product(
+            name=name, price=price, category=cat, in_stock=stock, sku=sku
+        ).save()
+
+    console.print("\n[bold yellow]--- 🔍 Running Fluent Queries ---[/bold yellow]")
+
+    show_step(
+        "Filter by Relationship ID",
+        "results = await Product.where(Product.category_id == electronics.id).all()",
+    )
+    electronics_products = await Product.where(
+        Product.category_id == electronics.id
+    ).all()
+    console.print(
+        f"✅ Found [bold green]{len(electronics_products)}[/bold green] Electronics products."
+    )
+
+    show_step(
+        "Range Queries (>=)",
+        "expensive = await Product.where(Product.price >= 500).all()",
+    )
+    expensive = await Product.where(Product.price >= 500).all()
+    console.print(
+        f"💰 Expensive items (>= 500): [cyan]{[p.name for p in expensive]}[/cyan]"
+    )
+
+    show_step(
+        "Pagination & Ordering",
+        'ordered = await Product.select().order_by(Product.price, "desc").limit(3).all()',
+    )
+    top_3 = await Product.select().order_by(Product.price, "desc").limit(3).all()
+    for p in top_3:
+        console.print(f"🔝 [cyan]{p.name}[/cyan]: ${p.price}")
+
+    console.print("\n[bold yellow]--- 🔗 Relationship Features ---[/bold yellow]")
+
+    show_step(
+        "Lazy Loading (Forward)",
+        'laptop = await Product.where(Product.name == "Laptop").first()\n'
+        "category = await laptop.category  # Fetched on demand",
+    )
+    laptop = await Product.where(Product.name == "Laptop").first()
+    category = await laptop.category
+    console.print(f"💻 Laptop Category: [bold green]{category.name}[/bold green]")
+
+    show_step(
+        "Reverse Lookup (Zero-Boilerplate)",
+        'cat = await Category.where(Category.name == "Appliances").first()\n'
+        "products = await cat.products.all()  # .products returns a Query object!",
+    )
+    app_cat = await Category.where(Category.name == "Appliances").first()
+    app_products = await app_cat.products.all()
+    console.print(f"🏠 Appliances found: [cyan]{[p.name for p in app_products]}[/cyan]")
+
+    show_step(
+        "Reverse Lookup with Filtering",
+        "electronics_in_stock = await electronics.products.where(Product.in_stock == True).all()",
+    )
+    stock_electronics = await electronics.products.where(Product.in_stock == True).all()  # noqa: E712
+    console.print(
+        f"📱 In-stock Electronics: [bold green]{len(stock_electronics)}[/bold green]"
+    )
+
+    console.print("\n[bold yellow]--- 🤝 Many-to-Many Relationships ---[/bold yellow]")
+
+    show_step(
+        "M2M Setup & Mutation",
+        'keanu = await Actor.create(name="Keanu Reeves")\n'
+        'laurence = await Actor.create(name="Laurence Fishburne")\n'
+        'matrix = await Movie.create(title="The Matrix")\n'
+        "await keanu.movies.add(matrix)\n"
+        "await laurence.movies.add(matrix)",
+    )
+
+    keanu = await Actor.create(name="Keanu Reeves")
+    laurence = await Actor.create(name="Laurence Fishburne")
+    matrix = await Movie.create(title="The Matrix")
+
+    await keanu.movies.add(matrix)
+    await laurence.movies.add(matrix)
+
+    show_step(
+        "M2M Querying (Bi-directional)",
+        "keanu_movies = await keanu.movies.all()\n"
+        "matrix_actors = await matrix.actors.all()",
+    )
+
+    keanu_movies = await keanu.movies.all()
+    matrix_actors = await matrix.actors.all()
+
+    console.print(f"🎬 Keanu's Movies: [cyan]{[m.title for m in keanu_movies]}[/cyan]")
+    console.print(f"👥 Matrix Actors: [cyan]{[a.name for a in matrix_actors]}[/cyan]")
+
+    console.print("\n[bold yellow]--- ⚛️ Transaction Support ---[/bold yellow]")
+
+    show_step(
+        "Atomic Transaction",
+        "async with transaction():\n"
+        '    new_cat = await Category.create(name="Gaming")\n'
+        '    await Product.create(name="RTX 5090", category=new_cat, ...)',
+    )
+
+    async with transaction():
+        new_cat = await Category.create(name="Gaming")
+        await Product.create(
+            name="RTX 5090",
+            price=1999.99,
+            category=new_cat,
+            in_stock=True,
+            sku="GPU-5090",
+        )
+
+    gpu = await Product.where(Product.name == "RTX 5090").first()
+    gpu_cat = await gpu.category
+    console.print(
+        f"✅ Transaction Committed: [bold green]{gpu.name}[/bold green] in "
+        f"[bold green]{gpu_cat.name}[/bold green]"
+    )
+
+    console.print("\n[bold yellow]--- 🔄 Instance Refreshing ---[/bold yellow]")
+    show_step(
+        "Refreshing an instance",
+        "await Product.where(Product.id == laptop.id).update(price=50.0)\n"
+        "await laptop.refresh()",
+    )
+
+    await Product.where(Product.id == laptop.id).update(price=50.0)
+    await laptop.refresh()
+    console.print(
+        f"🔄 Laptop price after refresh: [bold green]${laptop.price}[/bold green]"
+    )
+
+    console.print("\n[bold green]🏁 Demo Complete![/bold green]")
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(run_demo())

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -7,6 +7,8 @@ to provide a seamless, high-performance database experience.
 
 import logging
 
+from . import _deprecations as _deprecations  # noqa: F401 — enable deprecation visibility
+
 from pydantic import BaseModel, ConfigDict, model_validator
 from pydantic import Field as PydanticField
 

--- a/src/ferro/_deprecations.py
+++ b/src/ferro/_deprecations.py
@@ -11,7 +11,7 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 # Canonical IR-first compatibility window.
 IR_FIRST_DEPRECATION_SINCE = "v0.12.0"
-IR_FIRST_DEPRECATION_REMOVE_IN = "v0.13.0"
+IR_FIRST_DEPRECATION_REMOVE_IN = "v0.14.0"
 
 # Back-compat alias used by inventory/docs.
 REMOVAL_RELEASE = IR_FIRST_DEPRECATION_REMOVE_IN

--- a/src/ferro/_deprecations.py
+++ b/src/ferro/_deprecations.py
@@ -1,0 +1,100 @@
+"""Shared deprecation helpers for Ferro compatibility-window features."""
+
+from __future__ import annotations
+
+import functools
+import warnings
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+# Canonical IR-first compatibility window.
+IR_FIRST_DEPRECATION_SINCE = "v0.12.0"
+IR_FIRST_DEPRECATION_REMOVE_IN = "v0.13.0"
+
+# Back-compat alias used by inventory/docs.
+REMOVAL_RELEASE = IR_FIRST_DEPRECATION_REMOVE_IN
+
+# Published migration guide (see zensical.toml site_url + nav).
+IR_FIRST_MIGRATION_GUIDE = "https://syn54x.github.io/ferro-orm/howto/migrating-to-v0-12-0/"
+IR_FIRST_MIGRATION_GUIDE_PREDICATES = (
+    f"{IR_FIRST_MIGRATION_GUIDE}#1-use-lambda-predicates-in-where"
+)
+IR_FIRST_MIGRATION_GUIDE_SESSIONS = (
+    f"{IR_FIRST_MIGRATION_GUIDE}#2-run-operations-inside-a-session"
+)
+IR_FIRST_MIGRATION_GUIDE_ALEMBIC = (
+    f"{IR_FIRST_MIGRATION_GUIDE}#3-build-alembic-metadata-from-get_metadata"
+)
+
+
+def deprecation_message(
+    *,
+    reason: str,
+    since: str,
+    remove_in: str | None = None,
+    reference: str | None = None,
+) -> str:
+    """Build a canonical Ferro deprecation warning message."""
+    message = f"{reason.rstrip()} Deprecated since {since}."
+    if remove_in is not None:
+        message = f"{message} Planned removal in {remove_in}."
+    if reference is not None:
+        message = f"{message} See {reference.rstrip()}."
+    return message
+
+
+def warn_deprecated(
+    *,
+    reason: str,
+    since: str,
+    remove_in: str | None = None,
+    reference: str | None = None,
+    stacklevel: int = 2,
+) -> None:
+    """Emit a :class:`DeprecationWarning` for non-decorator call sites."""
+    warnings.warn(
+        deprecation_message(
+            reason=reason,
+            since=since,
+            remove_in=remove_in,
+            reference=reference,
+        ),
+        DeprecationWarning,
+        stacklevel=stacklevel + 1,
+    )
+
+
+def deprecated(
+    *,
+    reason: str,
+    since: str,
+    remove_in: str | None = None,
+    reference: str | None = None,
+) -> Callable[[F], F]:
+    """Mark a callable as deprecated and warn on each invocation."""
+    message = deprecation_message(
+        reason=reason,
+        since=since,
+        remove_in=remove_in,
+        reference=reference,
+    )
+
+    def decorate(obj: F) -> F:
+        @functools.wraps(obj)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            return obj(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorate
+
+
+def enable_deprecation_warnings() -> None:
+    """Show :class:`DeprecationWarning` emitted from library code by default."""
+    warnings.simplefilter("default", DeprecationWarning)
+
+
+enable_deprecation_warnings()

--- a/src/ferro/migrations/alembic.py
+++ b/src/ferro/migrations/alembic.py
@@ -9,6 +9,12 @@ except ImportError:
     sa = None
 
 from .._annotation_utils import _VARCHAR_RE
+from .._deprecations import (
+    IR_FIRST_DEPRECATION_REMOVE_IN,
+    IR_FIRST_DEPRECATION_SINCE,
+    IR_FIRST_MIGRATION_GUIDE_ALEMBIC,
+    deprecated,
+)
 from ..ir import compile_registry_schema_ir
 from ..schema_metadata import build_model_schema
 from ..state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY
@@ -321,6 +327,15 @@ def _resolve_sa_column_nullable(
     return _infer_nullable_join_table(col_name, col_info, required_fields)
 
 
+@deprecated(
+    reason=(
+        "_build_sa_table() is deprecated. Alembic metadata now derives from "
+        "SchemaIR. Use get_metadata() / IR-backed helpers instead."
+    ),
+    since=IR_FIRST_DEPRECATION_SINCE,
+    remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+    reference=IR_FIRST_MIGRATION_GUIDE_ALEMBIC,
+)
 def _build_sa_table(
     metadata: "sa.MetaData",
     table_name: str,
@@ -328,12 +343,6 @@ def _build_sa_table(
     model_cls: type[Any] | None = None,
 ):
     """Build a SQLAlchemy Table object from a Ferro JSON schema."""
-    warnings.warn(
-        "_build_sa_table() is deprecated. Alembic metadata now derives from SchemaIR. "
-        "Use get_metadata() / IR-backed helpers instead. Planned removal: v0.13.0.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     columns = []
 
     properties = schema.get("properties", {})
@@ -458,6 +467,15 @@ def _db_type_to_sa_type(token: str) -> "sa.types.TypeEngine | None":
     return None
 
 
+@deprecated(
+    reason=(
+        "_map_to_sa_type() is deprecated. Type lowering now flows through "
+        "SchemaIR and _sa_type_from_ir_column()."
+    ),
+    since=IR_FIRST_DEPRECATION_SINCE,
+    remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+    reference=IR_FIRST_MIGRATION_GUIDE_ALEMBIC,
+)
 def _map_to_sa_type(
     schema: Dict[str, Any],
     col_info: Dict[str, Any],
@@ -476,12 +494,6 @@ def _map_to_sa_type(
     every other branch -- it is the canonical user-facing storage knob and is
     validated at class-definition time (see ``metaclass._validate_db_type_options``).
     """
-    warnings.warn(
-        "_map_to_sa_type() is deprecated. Type lowering now flows through SchemaIR "
-        "and _sa_type_from_ir_column(). Planned removal: v0.13.0.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     # Resolve $ref if present
     col_info = _resolve_ref(schema, col_info)
 

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -463,7 +463,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         :func:`ferro.query.col` (the type-safe escape hatch that preserves
         operator shape) or with operator syntax on class attributes. The
         bare operator form (``User.where(User.age >= 18)``) is deprecated and
-        on the v0.13.0 removal track. It does not
+        on the v0.14.0 removal track. It does not
         type-check statically:
         the class attribute types as the field type, so the comparison
         resolves to ``bool``, not ``QueryNode``. See

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -1,8 +1,13 @@
 """Build fluent query objects that serialize QueryIR payloads for the Rust core."""
 
-import warnings
 from typing import TYPE_CHECKING, Any, Generic, Type, TypeVar, overload
 
+from .._deprecations import (
+    IR_FIRST_DEPRECATION_REMOVE_IN,
+    IR_FIRST_DEPRECATION_SINCE,
+    IR_FIRST_MIGRATION_GUIDE_PREDICATES,
+    deprecated,
+)
 from .._core import (
     add_m2m_links,
     clear_m2m_links,
@@ -21,21 +26,6 @@ T = TypeVar("T")
 E = TypeVar("E")
 
 
-try:
-    from warnings import deprecated as _warnings_deprecated
-except ImportError:
-
-    def _warnings_deprecated(message: str, **_: Any):
-        def _decorate(func):
-            def _wrapped(*args, **kwargs):
-                warnings.warn(message, DeprecationWarning, stacklevel=3)
-                return func(*args, **kwargs)
-
-            return _wrapped
-
-        return _decorate
-
-
 def _query_ir_payload_to_json(query_payload: dict[str, Any]) -> str:
     """Serialize a QueryIR payload into a versioned IR envelope JSON string."""
     import json
@@ -49,10 +39,14 @@ def _query_ir_payload_to_json(query_payload: dict[str, Any]) -> str:
     )
 
 
-@_warnings_deprecated(
-    "Operator predicate style (Model.field OP value) is deprecated; use lambda "
-    "predicates (`where(lambda t: ...)`) or col(Model.field) instead. Planned "
-    "removal: v0.13.0."
+@deprecated(
+    reason=(
+        "Operator predicate style (Model.field OP value) is deprecated; use lambda "
+        "predicates (`where(lambda t: ...)`) or col(Model.field) instead."
+    ),
+    since=IR_FIRST_DEPRECATION_SINCE,
+    remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+    reference=IR_FIRST_MIGRATION_GUIDE_PREDICATES,
 )
 def _deprecated_operator_query_node(node: QueryNode) -> QueryNode:
     return node

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -145,7 +145,7 @@ class Query(Generic[T]):
         :func:`ferro.query.col` (the type-safe escape hatch that preserves
         operator shape) or with operator syntax on class attributes. The
         bare operator form (``User.where(User.age >= 18)``) is deprecated and
-        on the v0.13.0 removal track. It does not
+        on the v0.14.0 removal track. It does not
         type-check statically:
         the class attribute types as the field type, so the comparison
         resolves to ``bool``, not ``QueryNode``.

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -1,6 +1,13 @@
 from contextvars import ContextVar
-import warnings
+
 from typing import Any, Protocol
+
+from ._deprecations import (
+    IR_FIRST_DEPRECATION_REMOVE_IN,
+    IR_FIRST_DEPRECATION_SINCE,
+    IR_FIRST_MIGRATION_GUIDE_SESSIONS,
+    warn_deprecated,
+)
 
 # Context variable to store the active transaction ID for the current task
 _CURRENT_TRANSACTION: ContextVar[str | None] = ContextVar(
@@ -21,11 +28,10 @@ _CURRENT_SESSION: ContextVar[SessionLike | None] = ContextVar(
     "current_session", default=None
 )
 
-
-_LEGACY_DEFAULT_CONNECTION_DEPRECATION = (
+_LEGACY_DEFAULT_CONNECTION_REASON = (
     "Implicit default-connection routing without an active session is deprecated; "
     "use `async with ferro.engines.session(\"name\")` (or pass `session=...`) for "
-    "ORM/raw operations. Planned removal: v0.13.0."
+    "ORM/raw operations."
 )
 
 # Global registry for models (Python side)
@@ -88,7 +94,13 @@ def resolve_operation_scope(
         effective_session.connection_name if effective_session is not None else None
     )
     if effective_using is None and allow_legacy_default:
-        warnings.warn(_LEGACY_DEFAULT_CONNECTION_DEPRECATION, DeprecationWarning, stacklevel=3)
+        warn_deprecated(
+            reason=_LEGACY_DEFAULT_CONNECTION_REASON,
+            since=IR_FIRST_DEPRECATION_SINCE,
+            remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+            reference=IR_FIRST_MIGRATION_GUIDE_SESSIONS,
+            stacklevel=2,
+        )
     return None, effective_using, session_id
 
 
@@ -122,7 +134,13 @@ def resolve_transaction_scope(
         effective_session.connection_name if effective_session is not None else None
     )
     if effective_using is None and allow_legacy_default:
-        warnings.warn(_LEGACY_DEFAULT_CONNECTION_DEPRECATION, DeprecationWarning, stacklevel=3)
+        warn_deprecated(
+            reason=_LEGACY_DEFAULT_CONNECTION_REASON,
+            since=IR_FIRST_DEPRECATION_SINCE,
+            remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+            reference=IR_FIRST_MIGRATION_GUIDE_SESSIONS,
+            stacklevel=2,
+        )
     return None, effective_using, (
         effective_session.session_id if effective_session is not None else None
     )

--- a/tests/test_alembic_bridge.py
+++ b/tests/test_alembic_bridge.py
@@ -15,7 +15,7 @@ from ferro import (
     clear_registry,
     reset_engine,
 )
-from ferro.migrations.alembic import _build_sa_table
+from ferro.migrations.alembic import _build_sa_table, _map_to_sa_type
 from ferro.migrations import get_metadata
 from ferro.schema_metadata import build_model_schema
 
@@ -78,10 +78,20 @@ def test_legacy_json_table_builder_emits_deprecation_warning():
         }
     }
     with pytest.deprecated_call(
-        match="_build_sa_table\\(\\) is deprecated.*Planned removal: v0\\.13\\.0"
+        match="_build_sa_table\\(\\) is deprecated.*Planned removal in v0\\.13\\.0"
     ):
         _build_sa_table(md, "legacydoc", schema, model_cls=None)
     assert "legacydoc" in md.tables
+
+
+def test_legacy_map_to_sa_type_emits_deprecation_warning():
+    schema = {"properties": {}}
+    col_info = {"type": "string"}
+    with pytest.deprecated_call(
+        match="_map_to_sa_type\\(\\) is deprecated.*Planned removal in v0\\.13\\.0"
+    ):
+        resolved = _map_to_sa_type(schema, col_info, "legacy_field")
+    assert isinstance(resolved, sa.String)
 
 
 def test_foreign_key_unique_true_propagates_to_shadow_column():

--- a/tests/test_alembic_bridge.py
+++ b/tests/test_alembic_bridge.py
@@ -78,7 +78,7 @@ def test_legacy_json_table_builder_emits_deprecation_warning():
         }
     }
     with pytest.deprecated_call(
-        match="_build_sa_table\\(\\) is deprecated.*Planned removal in v0\\.13\\.0"
+        match="_build_sa_table\\(\\) is deprecated.*Planned removal in v0\\.14\\.0"
     ):
         _build_sa_table(md, "legacydoc", schema, model_cls=None)
     assert "legacydoc" in md.tables
@@ -88,7 +88,7 @@ def test_legacy_map_to_sa_type_emits_deprecation_warning():
     schema = {"properties": {}}
     col_info = {"type": "string"}
     with pytest.deprecated_call(
-        match="_map_to_sa_type\\(\\) is deprecated.*Planned removal in v0\\.13\\.0"
+        match="_map_to_sa_type\\(\\) is deprecated.*Planned removal in v0\\.14\\.0"
     ):
         resolved = _map_to_sa_type(schema, col_info, "legacy_field")
     assert isinstance(resolved, sa.String)

--- a/tests/test_deprecated_operator_inventory.py
+++ b/tests/test_deprecated_operator_inventory.py
@@ -1,0 +1,51 @@
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+from tests import test_query_builder, test_query_typing
+
+
+def _marker_names(obj: object) -> set[str]:
+    marks = getattr(obj, "pytestmark", [])
+    if not isinstance(marks, list):
+        marks = [marks]
+    return {mark.name for mark in marks if hasattr(mark, "name")}
+
+
+def test_deprecated_operator_inventory_is_tracked():
+    expected_builder_tests = {
+        "test_model_where_clause",
+        "test_query_chaining_placeholders",
+    }
+    expected_typing_classes = {
+        "TestOperatorPathUnchanged",
+        "TestCombinedStyles",
+    }
+
+    marked_builder_tests = {
+        name
+        for name, value in vars(test_query_builder).items()
+        if name.startswith("test_")
+        and callable(value)
+        and "deprecated_operator_path" in _marker_names(value)
+    }
+    assert marked_builder_tests == expected_builder_tests
+
+    marked_typing_classes = {
+        name
+        for name, value in vars(test_query_typing).items()
+        if inspect.isclass(value) and "deprecated_operator_path" in _marker_names(value)
+    }
+    assert marked_typing_classes == expected_typing_classes
+
+
+def test_pytest_marker_documents_v013_removal_target():
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    content = pyproject.read_text(encoding="utf-8")
+    marker_entry = re.search(
+        r'deprecated_operator_path:[^"]*v0\.13\.0[^"]*',
+        content,
+    )
+    assert marker_entry is not None

--- a/tests/test_deprecated_operator_inventory.py
+++ b/tests/test_deprecated_operator_inventory.py
@@ -45,7 +45,7 @@ def test_pytest_marker_documents_v013_removal_target():
     pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
     content = pyproject.read_text(encoding="utf-8")
     marker_entry = re.search(
-        r'deprecated_operator_path:[^"]*v0\.13\.0[^"]*',
+        r'deprecated_operator_path:[^"]*v0\.14\.0[^"]*',
         content,
     )
     assert marker_entry is not None

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -43,13 +43,13 @@ def test_deprecated_decorator_emits_warning():
         return "ok"
 
     with pytest.deprecated_call(
-        match=r"Legacy helper is deprecated\..*v0\.12\.0.*v0\.13\.0"
+        match=r"Legacy helper is deprecated\..*v0\.12\.0.*v0\.14\.0"
     ):
         assert legacy_helper() == "ok"
 
 
 def test_warn_deprecated_emits_warning():
-    with pytest.deprecated_call(match="Inline legacy path is deprecated.*v0\\.13\\.0"):
+    with pytest.deprecated_call(match="Inline legacy path is deprecated.*v0\\.14\\.0"):
         warn_deprecated(
             reason="Inline legacy path is deprecated.",
             since=IR_FIRST_DEPRECATION_SINCE,

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,74 @@
+import warnings
+
+import pytest
+
+from ferro._deprecations import (
+    IR_FIRST_DEPRECATION_REMOVE_IN,
+    IR_FIRST_DEPRECATION_SINCE,
+    deprecated,
+    deprecation_message,
+    enable_deprecation_warnings,
+    warn_deprecated,
+)
+
+
+def test_deprecation_message_includes_since_and_remove_in():
+    message = deprecation_message(
+        reason="Example API is deprecated.",
+        since=IR_FIRST_DEPRECATION_SINCE,
+        remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+    )
+    assert "Example API is deprecated." in message
+    assert f"Deprecated since {IR_FIRST_DEPRECATION_SINCE}." in message
+    assert f"Planned removal in {IR_FIRST_DEPRECATION_REMOVE_IN}." in message
+
+
+def test_deprecation_message_includes_reference_link():
+    message = deprecation_message(
+        reason="Example API is deprecated.",
+        since=IR_FIRST_DEPRECATION_SINCE,
+        remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+        reference="https://example.com/migrate",
+    )
+    assert message.endswith("See https://example.com/migrate.")
+
+
+def test_deprecated_decorator_emits_warning():
+    @deprecated(
+        reason="Legacy helper is deprecated.",
+        since=IR_FIRST_DEPRECATION_SINCE,
+        remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+    )
+    def legacy_helper() -> str:
+        return "ok"
+
+    with pytest.deprecated_call(
+        match=r"Legacy helper is deprecated\..*v0\.12\.0.*v0\.13\.0"
+    ):
+        assert legacy_helper() == "ok"
+
+
+def test_warn_deprecated_emits_warning():
+    with pytest.deprecated_call(match="Inline legacy path is deprecated.*v0\\.13\\.0"):
+        warn_deprecated(
+            reason="Inline legacy path is deprecated.",
+            since=IR_FIRST_DEPRECATION_SINCE,
+            remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+        )
+
+
+def test_enable_deprecation_warnings_surfaces_library_deprecations():
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.resetwarnings()
+        enable_deprecation_warnings()
+
+        def _library_emitter() -> None:
+            warnings.warn("library deprecation", DeprecationWarning, stacklevel=1)
+
+        _library_emitter()
+
+    assert any(
+        issubclass(item.category, DeprecationWarning)
+        and str(item.message) == "library deprecation"
+        for item in captured
+    )

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -123,7 +123,7 @@ def test_model_where_clause():
         id: int = Field(json_schema_extra={"primary_key": True})
         age: int
 
-    with pytest.deprecated_call(match="Operator predicate style.*v0\\.13\\.0"):
+    with pytest.deprecated_call(match="Operator predicate style.*v0\\.14\\.0"):
         query = QueryUser.where(QueryUser.age >= 21)
 
     assert isinstance(query, Query)
@@ -143,7 +143,7 @@ def test_query_chaining_placeholders():
         id: int = Field(json_schema_extra={"primary_key": True})
         age: int
 
-    with pytest.deprecated_call(match="Operator predicate style.*v0\\.13\\.0"):
+    with pytest.deprecated_call(match="Operator predicate style.*v0\\.14\\.0"):
         query = QueryUser.where(QueryUser.age >= 18).limit(10).offset(5)
 
     assert query._limit == 10

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -123,7 +123,7 @@ def test_model_where_clause():
         id: int = Field(json_schema_extra={"primary_key": True})
         age: int
 
-    with pytest.deprecated_call(match="Operator predicate style"):
+    with pytest.deprecated_call(match="Operator predicate style.*v0\\.13\\.0"):
         query = QueryUser.where(QueryUser.age >= 21)
 
     assert isinstance(query, Query)
@@ -143,7 +143,7 @@ def test_query_chaining_placeholders():
         id: int = Field(json_schema_extra={"primary_key": True})
         age: int
 
-    with pytest.deprecated_call(match="Operator predicate style"):
+    with pytest.deprecated_call(match="Operator predicate style.*v0\\.13\\.0"):
         query = QueryUser.where(QueryUser.age >= 18).limit(10).offset(5)
 
     assert query._limit == 10

--- a/tests/test_query_typing.py
+++ b/tests/test_query_typing.py
@@ -197,7 +197,7 @@ class TestOperatorPathUnchanged:
         await OpUser(id=1, email="a@b.com").save()
         await OpUser(id=2, email="c@d.com").save()
 
-        with pytest.deprecated_call(match="Operator predicate style.*v0\\.13\\.0"):
+        with pytest.deprecated_call(match="Operator predicate style.*v0\\.14\\.0"):
             rows = await OpUser.where(
                 OpUser.email == "a@b.com"
             ).all()  # ty: ignore[no-matching-overload]
@@ -227,7 +227,7 @@ class TestCombinedStyles:
         await MixUser(id=1_001, role="admin", archived=True).save()
         await MixUser(id=2, role="user", archived=False).save()
 
-        with pytest.deprecated_call(match="Operator predicate style.*v0\\.13\\.0"):
+        with pytest.deprecated_call(match="Operator predicate style.*v0\\.14\\.0"):
             rows = await (
                 MixUser.where(MixUser.id == 1)  # ty: ignore[no-matching-overload]
                 .where(col(MixUser.archived) == False)  # noqa: E712

--- a/tests/test_query_typing.py
+++ b/tests/test_query_typing.py
@@ -197,7 +197,7 @@ class TestOperatorPathUnchanged:
         await OpUser(id=1, email="a@b.com").save()
         await OpUser(id=2, email="c@d.com").save()
 
-        with pytest.deprecated_call(match="Operator predicate style"):
+        with pytest.deprecated_call(match="Operator predicate style.*v0\\.13\\.0"):
             rows = await OpUser.where(
                 OpUser.email == "a@b.com"
             ).all()  # ty: ignore[no-matching-overload]
@@ -227,7 +227,7 @@ class TestCombinedStyles:
         await MixUser(id=1_001, role="admin", archived=True).save()
         await MixUser(id=2, role="user", archived=False).save()
 
-        with pytest.deprecated_call(match="Operator predicate style"):
+        with pytest.deprecated_call(match="Operator predicate style.*v0\\.13\\.0"):
             rows = await (
                 MixUser.where(MixUser.id == 1)  # ty: ignore[no-matching-overload]
                 .where(col(MixUser.archived) == False)  # noqa: E712

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -41,7 +41,7 @@ async def test_session_query_api_routes_to_bound_connection(tmp_path):
     assert fetched.label == "analytics"
 
     with pytest.warns(
-        DeprecationWarning, match="Implicit default-connection routing.*v0\\.13\\.0"
+        DeprecationWarning, match="Implicit default-connection routing.*v0\\.14\\.0"
     ):
         default_rows = await SessionMarker.all()
     assert default_rows == []
@@ -92,11 +92,11 @@ async def test_legacy_unqualified_operation_warns(tmp_path):
     await ferro.create_tables()
 
     with pytest.warns(
-        DeprecationWarning, match="Implicit default-connection routing.*v0\\.13\\.0"
+        DeprecationWarning, match="Implicit default-connection routing.*v0\\.14\\.0"
     ):
         created = await SessionMarker.create(id=10, label="legacy")
     with pytest.warns(
-        DeprecationWarning, match="Implicit default-connection routing.*v0\\.13\\.0"
+        DeprecationWarning, match="Implicit default-connection routing.*v0\\.14\\.0"
     ):
         loaded = await SessionMarker.get(10)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -40,7 +40,9 @@ async def test_session_query_api_routes_to_bound_connection(tmp_path):
     assert fetched is not None
     assert fetched.label == "analytics"
 
-    with pytest.warns(DeprecationWarning, match="Implicit default-connection routing"):
+    with pytest.warns(
+        DeprecationWarning, match="Implicit default-connection routing.*v0\\.13\\.0"
+    ):
         default_rows = await SessionMarker.all()
     assert default_rows == []
 
@@ -89,9 +91,13 @@ async def test_legacy_unqualified_operation_warns(tmp_path):
     await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
     await ferro.create_tables()
 
-    with pytest.warns(DeprecationWarning, match="Implicit default-connection routing"):
+    with pytest.warns(
+        DeprecationWarning, match="Implicit default-connection routing.*v0\\.13\\.0"
+    ):
         created = await SessionMarker.create(id=10, label="legacy")
-    with pytest.warns(DeprecationWarning, match="Implicit default-connection routing"):
+    with pytest.warns(
+        DeprecationWarning, match="Implicit default-connection routing.*v0\\.13\\.0"
+    ):
         loaded = await SessionMarker.get(10)
 
     assert created.id == 10

--- a/zensical.toml
+++ b/zensical.toml
@@ -30,6 +30,7 @@ nav = [
     { "Schema Migrations" = "guide/migrations.md" },
   ] },
   { "How-To" = [
+    { "Migrating to v0.12.0" = "howto/migrating-to-v0-12-0.md" },
     { "Testing" = "howto/testing.md" },
     { "Pagination" = "howto/pagination.md" },
     { "Timestamps" = "howto/timestamps.md" },


### PR DESCRIPTION
## Summary

v0.12 now ships a consistent compatibility window: legacy operator predicates, ambient connection routing, and Alembic JSON helpers still work but emit structured `DeprecationWarning`s with `since`, `remove_in`, and migration-guide links. Library warnings are visible by default without `-W`, and user-facing migration docs plus demo scripts document both legacy and recommended call styles.

## Changes

- Add `ferro._deprecations` (`@deprecated`, `warn_deprecated`, `enable_deprecation_warnings`) with migration-guide reference URLs
- Wire deprecations through query builder, session routing, and Alembic legacy helpers
- Publish `docs/pages/howto/migrating-to-v0-12-0.md`, release checklist, roadmap evidence, and cross-links
- Add `scripts/demo_queries.py` (v0.12+) and `scripts/demo_queries_pre_v012.py` (legacy patterns smoke test)
- Add deprecation inventory and message contract tests

## Test plan

- [x] `tests/test_deprecations.py`
- [x] `tests/test_deprecated_operator_inventory.py`
- [x] `tests/test_query_builder.py`, `tests/test_session.py`, `tests/test_query_typing.py`, `tests/test_alembic_bridge.py`
- [x] `uv run scripts/demo_queries.py`
- [x] `uv run scripts/demo_queries_pre_v012.py` (deprecation warnings visible without `-W`)

## Issue closure

Closes #100
Closes #101
Closes #102
Closes #103

- [x] Issue status updates encoded in PR body before merge
