### PR TITLE
feat: IR-first architecture program (Phases 0–7)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,4 +33,12 @@
 
 ## Related Issues
 
-<!-- Example: Closes #123 -->
+- Closes #
+- Closes #
+
+<!-- Use one line per completed issue: Closes #123 / Fixes #123 / Resolves #123 -->
+
+## Exit Steps
+
+- [ ] Related completed issues are linked above with Closes/Fixes/Resolves
+- [ ] Issue statuses are updated/auto-close on merge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   workflow_call:
   pull_request:
-    branches: [main]
+    branches: [main, feat/ir-first]
   push:
-    branches: [main]
+    branches: [main, feat/ir-first]
   workflow_dispatch:
 
 concurrency:
@@ -126,6 +126,10 @@ jobs:
         run: |
           uv run maturin develop
 
+      - name: Run IR vector contract harness
+        run: |
+          uv run pytest -v tests/test_ir_vectors_contract.py
+
       - name: Run pytest
         run: |
           uv run pytest -v --cov=src --cov-report=xml --cov-report=term
@@ -168,6 +172,10 @@ jobs:
       - name: Build Rust extension
         run: |
           uv run maturin develop
+
+      - name: Run IR vector contract harness
+        run: |
+          uv run pytest -v tests/test_ir_vectors_contract.py
 
       - name: Run pytest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,33 @@ permissions:
   contents: read
 
 jobs:
+  changed-shadow-paths:
+    name: Detect Shadow-Report Paths
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      requires_shadow_reports: ${{ steps.filter.outputs.shadow }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Detect planner/IR path changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            shadow:
+              - 'src/operations.rs'
+              - 'src/query.rs'
+              - 'src/schema.rs'
+              - 'src/migrate.rs'
+              - 'src/backend.rs'
+              - 'src/connection.rs'
+              - 'src/ferro/ir/**'
+              - 'crates/ferro-schema-ir/**'
+              - 'tests/test_shadow_reports.py'
+              - 'tests/fixtures/shadow_reports/**'
+
   lint-and-format:
     name: Lint & Format (Pre-commit / Prek)
     runs-on: ubuntu-latest
@@ -244,6 +271,64 @@ jobs:
         run: |
           uv run pytest -v -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres
 
+  test-shadow-reports-pr:
+    name: Shadow reports (touched paths)
+    runs-on: ubuntu-latest
+    needs: [changed-shadow-paths]
+    if: github.event_name == 'pull_request' && needs.changed-shadow-paths.outputs.requires_shadow_reports == 'true'
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: ferro
+          POSTGRES_PASSWORD: ferro
+          POSTGRES_DB: ferro
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U ferro -d ferro"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      FERRO_SUPABASE_URL: postgresql://ferro:ferro@127.0.0.1:5432/ferro?sslmode=disable
+      FERRO_SHADOW_RUNTIME: "1"
+      FERRO_SHADOW_RUNTIME_STRICT: "1"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1
+          cache-on-failure: true
+
+      - name: Install dependencies
+        run: |
+          uv sync --only-group ci-test --no-install-project --python 3.13
+
+      - name: Build Rust extension
+        run: |
+          uv run maturin develop
+
+      - name: Verify stable shadow reports
+        run: |
+          uv run pytest -v tests/test_shadow_reports.py::test_shadow_report_fixture_stable --db-backends=sqlite,postgres
+
   check-conventional-commits:
     name: Check Conventional Commits
     runs-on: ubuntu-latest
@@ -293,7 +378,7 @@ jobs:
 
   all-checks:
     name: All Checks Passed
-    needs: [lint-and-format, test-python-pr, test-python-main, test-python-backend-matrix, test-rust]
+    needs: [changed-shadow-paths, lint-and-format, test-python-pr, test-python-main, test-python-backend-matrix, test-shadow-reports-pr, test-rust]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -306,6 +391,7 @@ jobs:
           if ! ok "${{ needs.test-python-pr.result }}"; then exit 1; fi
           if ! ok "${{ needs.test-python-main.result }}"; then exit 1; fi
           if ! ok "${{ needs.test-python-backend-matrix.result }}"; then exit 1; fi
+          if ! ok "${{ needs.test-shadow-reports-pr.result }}"; then exit 1; fi
           if ! ok "${{ needs.test-rust.result }}"; then exit 1; fi
 
           echo "All checks passed!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,10 @@ jobs:
         run: |
           ok() { [[ "$1" == "success" || "$1" == "skipped" ]]; }
 
+          if [[ "${{ needs.changed-shadow-paths.result }}" == "failure" ]]; then
+            echo "Shadow path detection failed; refusing to treat shadow gate as passed."
+            exit 1
+          fi
           if ! ok "${{ needs.lint-and-format.result }}"; then exit 1; fi
           if ! ok "${{ needs.test-python-pr.result }}"; then exit 1; fi
           if ! ok "${{ needs.test-python-main.result }}"; then exit 1; fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,3 +258,21 @@ Rules:
 The canonical comparisons live in `docs/pages/guide/queries.md`
 ("Predicate Styles") and `docs/pages/concepts/query-typing.md`; everywhere
 else uses lambda without restating the trade-offs.
+
+---
+
+## I-10: PRs must close scoped issues explicitly
+
+Issue closure is part of feature completion, not optional cleanup.
+
+Rules:
+
+- Every PR that completes scoped work **must** include GitHub auto-close
+  keywords in the PR body for each completed issue, e.g.
+  `Closes #89`, `Fixes #90`, `Resolves #91`.
+- Do not rely on manual post-merge issue triage when the work is already done
+  in the PR; encode closure directly in the PR body.
+- PRs must include an explicit exit-steps checklist item confirming issue status
+  updates are complete before merge.
+- AI agents and human contributors follow the same requirement. If issue status
+  closure is missing, the PR is not done.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,6 @@
 # CHANGELOG
 
 
-## v0.12.0 (2026-06-22)
-
-### Documentation
-
-- **release**: Publish Phase 7 migration/release guidance for the IR-first public release
-  (`docs/plans/ir-first-migration-guide.md`, `docs/pages/howto/migrating-to-v0-12-0.md`,
-  `docs/plans/ir-first-release-checklist.md`)
-
-### Testing
-
-- **deprecation**: Add inventory contract coverage for `deprecated_operator_path`
-  and enforce `v0.14.0` removal-target assertions across compat warning tests
-
-### Refactoring
-
-- **deprecation**: Centralize compatibility-window warning text to keep
-  `Planned removal in v0.14.0` messaging consistent across query/session/alembic paths
-
-
 ## v0.11.0 (2026-06-11)
 
 ### Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # CHANGELOG
 
 
+## v0.12.0 (2026-06-22)
+
+### Documentation
+
+- **release**: Publish Phase 7 migration/release guidance for the IR-first public release
+  (`docs/plans/ir-first-migration-guide.md`, `docs/pages/howto/migrating-to-v0-12-0.md`,
+  `docs/plans/ir-first-release-checklist.md`)
+
+### Testing
+
+- **deprecation**: Add inventory contract coverage for `deprecated_operator_path`
+  and enforce `v0.14.0` removal-target assertions across compat warning tests
+
+### Refactoring
+
+- **deprecation**: Centralize compatibility-window warning text to keep
+  `Planned removal in v0.14.0` messaging consistent across query/session/alembic paths
+
+
 ## v0.11.0 (2026-06-11)
 
 ### Chores

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/ferro-schema-ir"]
+members = [".", "crates/ferro-schema-ir", "crates/ferro-migrate"]
 
 [package]
 name = "ferro"
@@ -35,3 +35,4 @@ tokio = { version = "1.49", features = ["full"] }
 pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }
 uuid = { version = "1.11", features = ["v4"] }
 ferro-schema-ir = { path = "crates/ferro-schema-ir" }
+ferro-migrate = { path = "crates/ferro-migrate" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "crates/ferro-schema-ir"]
+
 [package]
 name = "ferro"
 version = "0.11.0"
@@ -31,3 +34,4 @@ sea-query = { version = "0.32", features = ["with-uuid"] }
 tokio = { version = "1.49", features = ["full"] }
 pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }
 uuid = { version = "1.11", features = ["v4"] }
+ferro-schema-ir = { path = "crates/ferro-schema-ir" }

--- a/crates/ferro-migrate/Cargo.toml
+++ b/crates/ferro-migrate/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "ferro-migrate"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+ferro-schema-ir = { path = "../ferro-schema-ir" }

--- a/crates/ferro-migrate/src/lib.rs
+++ b/crates/ferro-migrate/src/lib.rs
@@ -1,0 +1,271 @@
+use ferro_schema_ir::{IrEnvelope, SchemaIrPayload, SchemaModel};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BackendDialect {
+    Sqlite,
+    Postgres,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MigrationOp {
+    AddTable { table: String },
+    DropTable { table: String },
+    AddColumn { table: String, column: String },
+    DropColumn { table: String, column: String },
+    AlterColumnType { table: String, column: String },
+    AlterColumnNullability { table: String, column: String },
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MigrationPlan {
+    pub operations: Vec<MigrationOp>,
+    pub warnings: Vec<String>,
+}
+
+impl MigrationPlan {
+    pub fn is_empty(&self) -> bool {
+        self.operations.is_empty()
+    }
+}
+
+pub fn emit_sql(plan: &MigrationPlan, dialect: BackendDialect) -> Vec<String> {
+    let mut sql = Vec::new();
+    for operation in &plan.operations {
+        match operation {
+            MigrationOp::AddTable { table } => {
+                sql.push(format!("-- table '{}' must be created via schema emitter", table));
+            }
+            MigrationOp::DropTable { table } => {
+                sql.push(format!("DROP TABLE \"{}\"", table));
+            }
+            MigrationOp::AddColumn { table, column } => {
+                sql.push(format!(
+                    "-- column '{}.{}' requires typed ADD COLUMN planning",
+                    table, column
+                ));
+            }
+            MigrationOp::DropColumn { table, column } => {
+                sql.push(format!(
+                    "ALTER TABLE \"{}\" DROP COLUMN \"{}\"",
+                    table, column
+                ));
+            }
+            MigrationOp::AlterColumnType { table, column } => match dialect {
+                BackendDialect::Postgres => sql.push(format!(
+                    "-- alter type for '{}.{}' resolved by backend planner",
+                    table, column
+                )),
+                BackendDialect::Sqlite => sql.push(format!(
+                    "-- sqlite cannot alter type in place for '{}.{}'",
+                    table, column
+                )),
+            },
+            MigrationOp::AlterColumnNullability { table, column } => match dialect {
+                BackendDialect::Postgres => sql.push(format!(
+                    "-- alter nullability for '{}.{}' resolved by backend planner",
+                    table, column
+                )),
+                BackendDialect::Sqlite => sql.push(format!(
+                    "-- sqlite cannot alter nullability in place for '{}.{}'",
+                    table, column
+                )),
+            },
+        }
+    }
+    sql
+}
+
+pub fn plan_from_ir(
+    old_ir: &IrEnvelope<SchemaIrPayload>,
+    new_ir: &IrEnvelope<SchemaIrPayload>,
+) -> MigrationPlan {
+    let old_models = index_models(&old_ir.payload.models);
+    let new_models = index_models(&new_ir.payload.models);
+    let mut plan = MigrationPlan::default();
+
+    let old_tables: BTreeSet<&str> = old_models.keys().map(String::as_str).collect();
+    let new_tables: BTreeSet<&str> = new_models.keys().map(String::as_str).collect();
+
+    for table in new_tables.difference(&old_tables) {
+        plan.operations.push(MigrationOp::AddTable {
+            table: (*table).to_string(),
+        });
+    }
+    for table in old_tables.difference(&new_tables) {
+        plan.operations.push(MigrationOp::DropTable {
+            table: (*table).to_string(),
+        });
+    }
+
+    for table in new_tables.intersection(&old_tables) {
+        let Some(old_model) = old_models.get(*table) else {
+            continue;
+        };
+        let Some(new_model) = new_models.get(*table) else {
+            continue;
+        };
+        diff_model_columns(*table, old_model, new_model, &mut plan);
+    }
+
+    plan
+}
+
+fn index_models<'a>(models: &'a [SchemaModel]) -> BTreeMap<String, &'a SchemaModel> {
+    let mut indexed = BTreeMap::new();
+    for model in models {
+        indexed.insert(model.table_name.clone(), model);
+    }
+    indexed
+}
+
+fn diff_model_columns(
+    table: &str,
+    old_model: &SchemaModel,
+    new_model: &SchemaModel,
+    plan: &mut MigrationPlan,
+) {
+    let old_cols: BTreeMap<&str, _> = old_model
+        .columns
+        .iter()
+        .map(|column| (column.name.as_str(), column))
+        .collect();
+    let new_cols: BTreeMap<&str, _> = new_model
+        .columns
+        .iter()
+        .map(|column| (column.name.as_str(), column))
+        .collect();
+
+    let old_names: BTreeSet<&str> = old_cols.keys().copied().collect();
+    let new_names: BTreeSet<&str> = new_cols.keys().copied().collect();
+
+    for col in new_names.difference(&old_names) {
+        plan.operations.push(MigrationOp::AddColumn {
+            table: table.to_string(),
+            column: (*col).to_string(),
+        });
+    }
+    for col in old_names.difference(&new_names) {
+        plan.operations.push(MigrationOp::DropColumn {
+            table: table.to_string(),
+            column: (*col).to_string(),
+        });
+    }
+
+    for col in new_names.intersection(&old_names) {
+        let Some(old_col) = old_cols.get(*col) else {
+            continue;
+        };
+        let Some(new_col) = new_cols.get(*col) else {
+            continue;
+        };
+        if old_col.db_type != new_col.db_type {
+            plan.operations.push(MigrationOp::AlterColumnType {
+                table: table.to_string(),
+                column: (*col).to_string(),
+            });
+        }
+        if old_col.nullable != new_col.nullable {
+            plan.operations.push(MigrationOp::AlterColumnNullability {
+                table: table.to_string(),
+                column: (*col).to_string(),
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferro_schema_ir::{
+        SchemaCheck, SchemaColumn, SchemaForeignKey, SchemaIndex, SchemaUnique,
+    };
+
+    fn envelope(model: SchemaModel) -> IrEnvelope<SchemaIrPayload> {
+        IrEnvelope {
+            ir_kind: "schema".to_string(),
+            ir_version: 1,
+            payload: SchemaIrPayload {
+                dialect_agnostic: true,
+                models: vec![model],
+            },
+        }
+    }
+
+    fn schema_model(table: &str, cols: Vec<SchemaColumn>) -> SchemaModel {
+        SchemaModel {
+            model_name: table.to_string(),
+            table_name: table.to_string(),
+            columns: cols,
+            foreign_keys: Vec::<SchemaForeignKey>::new(),
+            indexes: Vec::<SchemaIndex>::new(),
+            uniques: Vec::<SchemaUnique>::new(),
+            checks: Vec::<SchemaCheck>::new(),
+        }
+    }
+
+    fn col(name: &str, db_type: &str, nullable: bool) -> SchemaColumn {
+        SchemaColumn {
+            name: name.to_string(),
+            logical_type: "string".to_string(),
+            db_type: db_type.to_string(),
+            db_type_explicit: None,
+            nullable,
+            primary_key: false,
+            autoincrement: false,
+            unique: false,
+            index: false,
+            default: None,
+            format: None,
+            enum_values: None,
+            enum_type_name: None,
+        }
+    }
+
+    #[test]
+    fn plan_from_ir_detects_add_drop_and_alter_ops() {
+        let old_ir = envelope(schema_model(
+            "doc",
+            vec![col("name", "text", false), col("legacy", "text", true)],
+        ));
+        let new_ir = envelope(schema_model(
+            "doc",
+            vec![col("name", "varchar(120)", true), col("status", "text", false)],
+        ));
+
+        let plan = plan_from_ir(&old_ir, &new_ir);
+        assert!(
+            plan.operations
+                .contains(&MigrationOp::AddColumn { table: "doc".to_string(), column: "status".to_string() })
+        );
+        assert!(
+            plan.operations
+                .contains(&MigrationOp::DropColumn { table: "doc".to_string(), column: "legacy".to_string() })
+        );
+        assert!(
+            plan.operations.contains(&MigrationOp::AlterColumnType {
+                table: "doc".to_string(),
+                column: "name".to_string()
+            })
+        );
+        assert!(
+            plan.operations.contains(&MigrationOp::AlterColumnNullability {
+                table: "doc".to_string(),
+                column: "name".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn emit_sql_renders_drop_column() {
+        let plan = MigrationPlan {
+            operations: vec![MigrationOp::DropColumn {
+                table: "doc".to_string(),
+                column: "legacy".to_string(),
+            }],
+            warnings: Vec::new(),
+        };
+        let sql = emit_sql(&plan, BackendDialect::Postgres);
+        assert_eq!(sql, vec!["ALTER TABLE \"doc\" DROP COLUMN \"legacy\"".to_string()]);
+    }
+}

--- a/crates/ferro-schema-ir/Cargo.toml
+++ b/crates/ferro-schema-ir/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ferro-schema-ir"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -141,7 +141,8 @@ mod tests {
 
     #[test]
     fn schema_fixture_roundtrip() {
-        let fixture = include_str!("../../../tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json");
+        let fixture =
+            include_str!("../../../tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("schema fixture must parse");
         let ir = parsed
@@ -156,7 +157,8 @@ mod tests {
 
     #[test]
     fn query_fixture_roundtrip() {
-        let fixture = include_str!("../../../tests/fixtures/ir_vectors/query_user_compound_v1.json");
+        let fixture =
+            include_str!("../../../tests/fixtures/ir_vectors/query_user_compound_v1.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query fixture must parse");
         let ir = parsed
@@ -171,7 +173,8 @@ mod tests {
 
     #[test]
     fn codec_fixture_roundtrip() {
-        let fixture = include_str!("../../../tests/fixtures/ir_vectors/codec_registry_core_v1.json");
+        let fixture =
+            include_str!("../../../tests/fixtures/ir_vectors/codec_registry_core_v1.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("codec fixture must parse");
         let ir = parsed

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -30,6 +30,8 @@ pub struct SchemaColumn {
     pub name: String,
     pub logical_type: String,
     pub db_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub db_type_explicit: Option<bool>,
     pub nullable: bool,
     pub primary_key: bool,
     pub autoincrement: bool,
@@ -37,6 +39,10 @@ pub struct SchemaColumn {
     pub index: bool,
     pub default: Option<Value>,
     pub format: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enum_values: Option<Vec<Value>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enum_type_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -1,0 +1,186 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IrEnvelope<T> {
+    pub ir_kind: String,
+    pub ir_version: u32,
+    pub payload: T,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SchemaIrPayload {
+    pub dialect_agnostic: bool,
+    pub models: Vec<SchemaModel>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SchemaModel {
+    pub model_name: String,
+    pub table_name: String,
+    pub columns: Vec<SchemaColumn>,
+    pub foreign_keys: Vec<SchemaForeignKey>,
+    pub indexes: Vec<SchemaIndex>,
+    pub uniques: Vec<SchemaUnique>,
+    pub checks: Vec<SchemaCheck>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SchemaColumn {
+    pub name: String,
+    pub logical_type: String,
+    pub db_type: String,
+    pub nullable: bool,
+    pub primary_key: bool,
+    pub autoincrement: bool,
+    pub unique: bool,
+    pub index: bool,
+    pub default: Option<Value>,
+    pub format: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SchemaForeignKey {
+    pub column: String,
+    pub to_table: String,
+    pub to_column: String,
+    pub on_delete: Option<String>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SchemaIndex {
+    pub name: String,
+    pub columns: Vec<String>,
+    pub unique: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SchemaUnique {
+    pub name: String,
+    pub columns: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SchemaCheck {
+    pub name: String,
+    pub expression: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueryIrPayload {
+    pub model_name: String,
+    #[serde(rename = "where")]
+    pub where_clause: Vec<QueryNode>,
+    pub order_by: Vec<QueryOrderBy>,
+    pub limit: Option<u64>,
+    pub offset: Option<u64>,
+    pub m2m: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueryOrderBy {
+    pub column: String,
+    pub direction: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "node_kind")]
+pub enum QueryNode {
+    #[serde(rename = "leaf")]
+    Leaf {
+        operator: String,
+        column: String,
+        value: QueryValue,
+    },
+    #[serde(rename = "compound")]
+    Compound {
+        operator: String,
+        left: Box<QueryNode>,
+        right: Box<QueryNode>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueryValue {
+    pub kind: String,
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CodecIrPayload {
+    pub bind_rules: Vec<CodecBindRule>,
+    pub fetch_rules: Vec<CodecFetchRule>,
+    pub hydration_abi: HydrationAbi,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CodecBindRule {
+    pub logical_type: String,
+    pub db_type: String,
+    pub non_null_wire_kind: String,
+    pub null_wire_kind: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CodecFetchRule {
+    pub db_type: String,
+    pub wire_kind: String,
+    pub python_kind: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HydrationAbi {
+    pub constructor_mode: String,
+    pub required_slots: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_fixture_roundtrip() {
+        let fixture = include_str!("../../../tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json");
+        let parsed: serde_json::Value =
+            serde_json::from_str(fixture).expect("schema fixture must parse");
+        let ir = parsed
+            .get("ir")
+            .cloned()
+            .expect("fixture must contain ir envelope");
+        let envelope: IrEnvelope<SchemaIrPayload> =
+            serde_json::from_value(ir.clone()).expect("schema IR must deserialize");
+        let encoded = serde_json::to_value(&envelope).expect("schema IR must serialize");
+        assert_eq!(encoded, ir, "schema round-trip must not drift");
+    }
+
+    #[test]
+    fn query_fixture_roundtrip() {
+        let fixture = include_str!("../../../tests/fixtures/ir_vectors/query_user_compound_v1.json");
+        let parsed: serde_json::Value =
+            serde_json::from_str(fixture).expect("query fixture must parse");
+        let ir = parsed
+            .get("ir")
+            .cloned()
+            .expect("fixture must contain ir envelope");
+        let envelope: IrEnvelope<QueryIrPayload> =
+            serde_json::from_value(ir.clone()).expect("query IR must deserialize");
+        let encoded = serde_json::to_value(&envelope).expect("query IR must serialize");
+        assert_eq!(encoded, ir, "query round-trip must not drift");
+    }
+
+    #[test]
+    fn codec_fixture_roundtrip() {
+        let fixture = include_str!("../../../tests/fixtures/ir_vectors/codec_registry_core_v1.json");
+        let parsed: serde_json::Value =
+            serde_json::from_str(fixture).expect("codec fixture must parse");
+        let ir = parsed
+            .get("ir")
+            .cloned()
+            .expect("fixture must contain ir envelope");
+        let envelope: IrEnvelope<CodecIrPayload> =
+            serde_json::from_value(ir.clone()).expect("codec IR must deserialize");
+        let encoded = serde_json::to_value(&envelope).expect("codec IR must serialize");
+        assert_eq!(encoded, ir, "codec round-trip must not drift");
+    }
+}

--- a/docs/examples/predicates.py
+++ b/docs/examples/predicates.py
@@ -33,6 +33,7 @@ async def main() -> None:
     assert len(adults) == 3
 
     # --8<-- [start:operator-style]
+    # Deprecated path (planned removal: v0.13.0).
     adults = await User.where(User.age >= 18).all()
     # --8<-- [end:operator-style]
     assert len(adults) == 3

--- a/docs/examples/predicates.py
+++ b/docs/examples/predicates.py
@@ -33,7 +33,7 @@ async def main() -> None:
     assert len(adults) == 3
 
     # --8<-- [start:operator-style]
-    # Deprecated path (planned removal: v0.13.0).
+    # Deprecated path (planned removal: v0.14.0).
     adults = await User.where(User.age >= 18).all()
     # --8<-- [end:operator-style]
     assert len(adults) == 3

--- a/docs/pages/api/connection.md
+++ b/docs/pages/api/connection.md
@@ -1,6 +1,6 @@
 # Connection & Registry
 
-Functions for managing database connections and the global model registry. `connect()` registers a (optionally named) connection pool; `reset_engine()` tears everything down; the registry helpers control schema creation and the identity map. See the [Connections & Databases guide](../guide/connections.md).
+Functions for managing database connections and the global model registry. `connect()` registers a (optionally named) connection pool; `reset_engine()` tears everything down; the registry helpers control schema creation and the identity map. Sessionized routing is exposed via `ferro.engines.session(name)` / `ferro.Session`. See the [Connections & Databases guide](../guide/connections.md).
 
 ::: ferro.connect
 

--- a/docs/pages/api/migrations.md
+++ b/docs/pages/api/migrations.md
@@ -2,6 +2,6 @@
 
 The Alembic bridge. `get_metadata()` builds a SQLAlchemy `MetaData` describing all registered Ferro models from the compiled SchemaIR modelset, so Alembic's `--autogenerate` can diff your models against the live database and emit migration scripts. Assign it to `target_metadata` in your Alembic `env.py` (requires the `ferro-orm[alembic]` extra). See the [Schema Migrations guide](../guide/migrations.md) for the full workflow.
 
-Internal JSON-derivation helpers (`_build_sa_table`, `_map_to_sa_type`) are deprecated and scheduled for removal in `v0.13.0`.
+Internal JSON-derivation helpers (`_build_sa_table`, `_map_to_sa_type`) are deprecated and scheduled for removal in `v0.14.0`. Replace internal usages with `get_metadata()`; see [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md).
 
 ::: ferro.migrations.alembic.get_metadata

--- a/docs/pages/api/migrations.md
+++ b/docs/pages/api/migrations.md
@@ -1,5 +1,7 @@
 # Migrations
 
-The Alembic bridge. `get_metadata()` builds a SQLAlchemy `MetaData` describing all registered Ferro models, so Alembic's `--autogenerate` can diff your models against the live database and emit migration scripts. Assign it to `target_metadata` in your Alembic `env.py` (requires the `ferro-orm[alembic]` extra). See the [Schema Migrations guide](../guide/migrations.md) for the full workflow.
+The Alembic bridge. `get_metadata()` builds a SQLAlchemy `MetaData` describing all registered Ferro models from the compiled SchemaIR modelset, so Alembic's `--autogenerate` can diff your models against the live database and emit migration scripts. Assign it to `target_metadata` in your Alembic `env.py` (requires the `ferro-orm[alembic]` extra). See the [Schema Migrations guide](../guide/migrations.md) for the full workflow.
+
+Internal JSON-derivation helpers (`_build_sa_table`, `_map_to_sa_type`) are deprecated and scheduled for removal in `v0.13.0`.
 
 ::: ferro.migrations.alembic.get_metadata

--- a/docs/pages/api/queries.md
+++ b/docs/pages/api/queries.md
@@ -1,6 +1,6 @@
 # Queries
 
-`Model.where(...)` and `Model.select()` return a `Query` — an immutable, chainable builder that executes when awaited via `all()`, `first()`, `count()`, `exists()`, `update()`, or `delete()`. Predicates are lambda-first (`User.where(lambda t: t.age >= 18)`), `col()` is the compatibility bridge for operator-shaped predicates, and direct operator style is deprecated for `v0.13.0` removal.
+`Model.where(...)` and `Model.select()` return a `Query` — an immutable, chainable builder that executes when awaited via `all()`, `first()`, `count()`, `exists()`, `update()`, or `delete()`. Predicates are lambda-first (`User.where(lambda t: t.age >= 18)`), `col()` is the compatibility bridge for operator-shaped predicates, and direct operator style is deprecated for `v0.14.0` removal. For migration steps, see [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md).
 
 ::: ferro.query.builder.Query
 

--- a/docs/pages/api/queries.md
+++ b/docs/pages/api/queries.md
@@ -1,6 +1,6 @@
 # Queries
 
-`Model.where(...)` and `Model.select()` return a `Query` — an immutable, chainable builder that executes when awaited via `all()`, `first()`, `count()`, `exists()`, `update()`, or `delete()`. Predicates are written against the typed field proxies on the model class (`User.age >= 18`); `col()` is the untyped escape hatch for dynamic field names.
+`Model.where(...)` and `Model.select()` return a `Query` — an immutable, chainable builder that executes when awaited via `all()`, `first()`, `count()`, `exists()`, `update()`, or `delete()`. Predicates are lambda-first (`User.where(lambda t: t.age >= 18)`), `col()` is the compatibility bridge for operator-shaped predicates, and direct operator style is deprecated for `v0.13.0` removal.
 
 ::: ferro.query.builder.Query
 

--- a/docs/pages/api/transactions.md
+++ b/docs/pages/api/transactions.md
@@ -1,6 +1,6 @@
 # Transactions
 
-`transaction()` is an async context manager that runs everything inside the block on one connection, committing on exit and rolling back on exception. It yields a `Transaction` handle for raw SQL that must run on the transaction's connection. See the [Transactions guide](../guide/transactions.md) for semantics and patterns.
+`transaction()` is an async context manager that runs everything inside the block on one connection, committing on exit and rolling back on exception. It yields a `Transaction` handle for raw SQL that must run on the transaction's connection. It can route by `using=` or by an explicit/ambient session (`ferro.engines.session(...)`). See the [Transactions guide](../guide/transactions.md) for semantics and patterns.
 
 ::: ferro.transaction
 

--- a/docs/pages/concepts/architecture.md
+++ b/docs/pages/concepts/architecture.md
@@ -4,52 +4,86 @@ Ferro is a Python ORM with a Rust core. You write Pydantic models and async Pyth
 
 ## Overview
 
+Ferro has two main pipelines: **schema compilation** (happens at import/class-creation) and **query execution** (happens per `await`). They share IR contracts but run at different times.
+
+### Schema path (compile-time)
+
+Runs when a `Model` subclass is defined. `ModelMetaclass` calls `build_model_schema()` once per model; that enriched schema fans out to SchemaIR compilation and Rust registry registration.
+
 ```mermaid
-graph TB
-    subgraph python [Python Layer]
+graph LR
+    subgraph python [Python]
         Models[Pydantic Models]
         Metaclass[ModelMetaclass]
-        QueryBuilder[Query Builder]
+        Builder[build_model_schema]
+        Compiler[SchemaIR Compiler]
     end
 
-    subgraph bridge [PyO3 FFI Bridge]
-        Schema[JSON Schema]
-        Payload[JSON Query Payload]
+    subgraph artifacts [Artifacts]
+        SchemaIR[SchemaIR Envelope]
+        EnrichedJSON[Enriched Schema JSON]
     end
 
-    subgraph rust [Rust Engine]
-        Registry[Model Registry]
-        SeaQuery[Sea-Query SQL Generation]
-        SQLx[SQLx Pools & Execution]
-        Hydration[Row Hydration & Identity Map]
-    end
-
-    subgraph db [Database]
-        SQLite[(SQLite)]
-        Postgres[(PostgreSQL)]
+    subgraph consumers [Consumers]
+        Alembic[Alembic get_metadata]
+        Registry[Rust Model Registry]
+        Migrate[Runtime DDL / ferro-migrate]
     end
 
     Models --> Metaclass
-    Metaclass -->|Register schema| Schema
-    Schema --> Registry
+    Metaclass --> Builder
+    Builder --> EnrichedJSON
+    Builder --> Compiler
+    Compiler --> SchemaIR
+    SchemaIR --> Alembic
+    SchemaIR --> Migrate
+    EnrichedJSON --> Registry
+```
 
-    QueryBuilder -->|Serialize query| Payload
-    Payload --> SeaQuery
-    SeaQuery -->|Parameterized SQL| SQLx
-    SQLx --> SQLite
-    SQLx --> Postgres
-    SQLite -->|Rows| Hydration
-    Postgres -->|Rows| Hydration
-    Hydration -->|Model instances| Models
+### Runtime path (per operation)
+
+Runs inside an active session when you await a terminal query method or execute a mutation. QueryIR crosses the FFI boundary; Rust owns SQL, I/O, and hydration.
+
+```mermaid
+graph TB
+    subgraph python [Python]
+        direction TB
+        Session[engines.session]
+        Builder[Query Builder]
+        Session --> Builder
+    end
+
+    Builder -->|await| QueryIR[QueryIR Envelope]
+
+    QueryIR --> Planner
+
+    subgraph rust [Rust Engine]
+        direction TB
+        Planner[Query Planner]
+        Codec[Codec Registry]
+        SeaQuery[Sea-Query]
+        SQLx[SQLx]
+        Hydration[Hydration ABI]
+        IdentityMap[Session Identity Map]
+        Planner --> Codec --> SeaQuery --> SQLx
+        Hydration --> IdentityMap
+    end
+
+    SQLx --> DB[(SQLite / PostgreSQL)]
+    DB --> Hydration
+    IdentityMap -->|instances| Builder
+    Session -.->|scopes| IdentityMap
 ```
 
 The shortest way to hold the whole design in your head:
 
 ```text
-Python owns the model contract.
-Rust owns execution.
+Python owns the model authoring surface.
+SchemaIR and QueryIR own the cross-language contracts.
+Rust owns execution, codecs, and hydration.
 Sea-Query owns SQL shape.
 SQLx owns typed database I/O.
+Sessions scope routing, transactions, and the identity map.
 The backend kind decides which database-specific path is legal.
 ```
 
@@ -60,57 +94,64 @@ The backend kind decides which database-specific path is legal.
 Ferro models are real Pydantic V2 `BaseModel` subclasses. The Python layer owns:
 
 - **Model definition.** Annotated fields become columns; Pydantic handles validation, defaults, serialization, and JSON schema generation.
-- **Metaclass registration.** `ModelMetaclass` inspects each model at class-creation time, builds an enriched JSON schema (primary keys, uniques, indexes, foreign keys, nullability, composite constraints), registers it with the Rust engine, and replaces class-level field access with `FieldProxy` objects so `User.email == "a@b.com"` builds a query node instead of comparing values.
-- **Query building.** Chains like `User.where(...).order_by(...).limit(10)` are pure Python — they accumulate an in-memory query definition. Nothing touches the database until you await a terminal method (`.all()`, `.first()`, `.count()`, `.exists()`, `.update()`, `.delete()`).
+- **Metaclass registration.** `ModelMetaclass` inspects each model at class-creation time, builds an enriched JSON schema (primary keys, uniques, indexes, foreign keys, nullability, composite constraints), registers it with the Rust engine, compiles a versioned **SchemaIR** artifact, and replaces class-level field access with `FieldProxy` objects for query construction.
+- **Query building.** Chains like `User.where(lambda t: t.active).order_by(User.age, "desc").limit(10)` are pure Python — they accumulate an in-memory query definition. Nothing touches the database until you await a terminal method (`.all()`, `.first()`, `.count()`, `.exists()`, `.update()`, `.delete()`).
+- **Session routing.** ORM and raw operations run inside an active `engines.session()` context (or with an explicit `session=` handle). Sessions scope connection routing, transactions, and the identity map under concurrency.
 
 ### The Bridge
 
-The FFI boundary is built on [PyO3](https://pyo3.rs) with `pyo3-async-runtimes` bridging Python's asyncio event loop to Rust's tokio runtime. Two kinds of data cross it:
+The FFI boundary is built on [PyO3](https://pyo3.rs) with `pyo3-async-runtimes` bridging Python's asyncio event loop to Rust's tokio runtime. Versioned IR envelopes cross the boundary:
 
-- **Schemas** travel Python → Rust once, at class-creation time, as JSON — Pydantic's JSON schema enriched with Ferro-specific keys (`primary_key`, `ferro_nullable`, `foreign_key`, `ferro_composite_uniques`, and so on).
-- **Queries and mutations** travel as compact JSON payloads per operation; rows travel back as typed values that Rust assembles into Python objects.
+- **SchemaIR** (`ir_kind: "schema"`) — compiled at class-creation time from the enriched model schema. Cached in Python (`ferro.state`) and consumed by Alembic `get_metadata()`, migration planning, and parity tests. The Rust registry still receives enriched JSON schema for runtime query/bind metadata.
+- **QueryIR** (`ir_kind: "query"`) — emitted per operation from the query builder as `{ir_kind, ir_version, payload}`. Rust deserializes the envelope, plans SQL, and binds parameters through the shared codec registry.
+- **Rows** travel back as typed values that Rust hydrates into Python objects via the hydration ABI (direct `__dict__` population with required Pydantic slots initialized).
 
 Crucially, the GIL is released while Rust waits on the database. An awaited Ferro query does not block other Python coroutines or threads.
 
 ### The Rust Engine
 
-The engine owns everything between the JSON payload and the database:
+The engine owns everything between the IR envelope and the database:
 
+- **Query planning** — QueryIR payloads lower to Sea-Query conditions with schema-aware bind typing.
+- **Codec registry** — unified bind/fetch lowering for inserts, updates, filters, M2M links, and hydration (typed NULLs, UUIDs, decimals, temporals).
 - **SQL generation** via [Sea-Query](https://github.com/SeaQL/sea-query), which lowers each operation through the dialect-specific builder (SQLite or PostgreSQL) with safely bound parameters.
 - **Connection pooling and execution** via [SQLx](https://github.com/launchbadge/sqlx) typed pools — a real SQLite pool or a real PostgreSQL pool, not a generic abstraction pretending to be both.
-- **Row hydration** — decoding database values (which are not the same as Python field values; a PostgreSQL `uuid` or `numeric` needs reconstruction) into the exact shapes Pydantic expects.
-- **The identity map**, a per-connection cache ensuring one row maps to one Python instance. See [Identity Map](identity-map.md).
+- **Hydration ABI** — decoding database values into Python-compatible shapes and constructing instances without calling Pydantic `__init__`, while initializing `__pydantic_fields_set__`, `__pydantic_extra__`, and `__pydantic_private__`.
+- **Session-scoped identity map** — a per-session cache ensuring one row maps to one Python instance within the active session. See [Identity Map](identity-map.md).
 
 ## Life of a Query
 
 ```mermaid
 sequenceDiagram
     participant App as Your Code
+    participant Session as engines.session
     participant QB as Query Builder (Python)
     participant Rust as Rust Engine
     participant DB as Database
 
+    App->>Session: async with engines.session("app")
     App->>QB: User.where(lambda t: t.age > 18).all()
-    QB->>QB: Build query definition (no I/O)
-    QB->>Rust: await — JSON payload via FFI
+    QB->>QB: Build QueryNode tree (no I/O)
+    QB->>Rust: await QueryIR envelope via FFI
     Note over Rust: GIL released
-    Rust->>Rust: Sea-Query generates parameterized SQL
+    Rust->>Rust: Plan query, codec bind, Sea-Query SQL
     Rust->>DB: SELECT ... WHERE age > $1
     DB-->>Rust: Rows
-    Rust->>Rust: Decode and hydrate rows
-    Rust->>Rust: Reconcile with identity map
+    Rust->>Rust: Hydrate via hydration ABI
+    Rust->>Rust: Reconcile with session identity map
     Rust-->>QB: Python objects
     QB-->>App: list[User] (validated Pydantic instances)
 ```
 
 Step by step:
 
-1. **Construction** — `User.where(lambda t: t.age > 18)` builds a `QueryNode` tree in Python. No database interaction.
-2. **Execution trigger** — awaiting `.all()` serializes the query definition to JSON and calls into Rust.
-3. **SQL generation** — Sea-Query lowers the definition into dialect-correct, parameterized SQL. Values are bound, never interpolated.
-4. **Execution** — SQLx runs the statement on a pooled connection (or on the pinned connection if a [transaction](../guide/transactions.md) is active).
-5. **Hydration** — Rust decodes each row's values into Python-compatible shapes and constructs instances, consulting the identity map so a primary key you've already loaded resolves to the existing object.
-6. **Return** — your code receives a plain `list[User]` of fully validated Pydantic instances.
+1. **Session** — `async with ferro.engines.session("app")` establishes ambient routing for ORM/raw operations (or pass `session=` explicitly).
+2. **Construction** — `User.where(lambda t: t.age > 18)` builds a `QueryNode` tree in Python. No database interaction.
+3. **Execution trigger** — awaiting `.all()` wraps the query in a **QueryIR envelope** and calls into Rust.
+4. **SQL generation** — the planner and codec registry lower the IR into dialect-correct, parameterized SQL. Values are bound, never interpolated.
+5. **Execution** — SQLx runs the statement on a pooled connection (or on the pinned connection if a [transaction](../guide/transactions.md) is active).
+6. **Hydration** — Rust decodes each row through the hydration ABI, consulting the session identity map so a primary key you've already loaded resolves to the existing object.
+7. **Return** — your code receives a plain `list[User]` of fully validated Pydantic instances.
 
 ## Model Registration
 
@@ -142,7 +183,7 @@ Defining a model is itself a registration step:
         email: str
     ```
 
-At class-creation time the metaclass builds the enriched schema and registers it with the Rust engine's model registry. Importing your models is therefore enough for Ferro to know your full schema — but it does **not** connect to a database.
+At class-creation time the metaclass calls `build_model_schema()`, registers the enriched JSON with the Rust engine's model registry, and compiles **SchemaIR** artifacts (per-model and model-set fingerprints) from the same schema dict. Importing your models is therefore enough for Ferro to know your full schema — but it does **not** connect to a database.
 
 Schema DDL happens later, when you connect:
 
@@ -156,7 +197,7 @@ await connect("sqlite::memory:", auto_migrate=True)
 - `migrate_updates=True` (0.11.0) additionally adds missing columns to existing tables, and on PostgreSQL reconciles type and nullability drift.
 - `migrate_destructive=True` (0.11.0) additionally drops live columns no longer on the model (never whole tables).
 
-For renames, primary-key changes, and complex transforms, use the [Alembic bridge](../guide/migrations.md). The same registered schema metadata drives runtime DDL, Alembic autogeneration, and query casting decisions — the Python schema is the single contract.
+For renames, primary-key changes, and complex transforms, use the [Alembic bridge](../guide/migrations.md). **SchemaIR** is the canonical contract for cross-emitter DDL parity — Alembic `get_metadata()` derives SQLAlchemy metadata from compiled SchemaIR so autogenerate agrees with Ferro's naming and type conventions. The enriched JSON schema in the Rust registry remains the runtime source for query bind typing and hydration metadata.
 
 ## Async Architecture
 
@@ -171,8 +212,8 @@ graph LR
 Consequences:
 
 - Database I/O never holds the GIL, so other coroutines keep running while queries are in flight.
-- Concurrent queries from multiple tasks share the connection pool naturally.
-- Transactions pin all enclosed work to a single typed connection via a context variable, so everything inside `async with transaction():` sees the same database state.
+- Concurrent queries from multiple tasks share the connection pool naturally when each task uses its own session (or explicit `session=` routing).
+- [Sessions](../guide/connections.md) and [transactions](../guide/transactions.md) pin enclosed work to a scoped connection and identity map via context variables.
 
 ## Trade-offs
 
@@ -185,7 +226,9 @@ This design buys speed and type fidelity, but it is honest to name what it costs
 
 ## See Also
 
-- [Identity Map](identity-map.md) — how instance caching works
+- [Identity Map](identity-map.md) — session-scoped instance caching
+- [Query Typing](query-typing.md) — lambda predicates and the query DSL
 - [Type Safety](type-safety.md) — the Pydantic integration in depth
 - [Backends](backends.md) — SQLite and PostgreSQL specifics
 - [Performance](performance.md) — where the Rust core pays off
+- [Migrations](../guide/migrations.md) — Alembic bridge and SchemaIR-backed `get_metadata()`

--- a/docs/pages/concepts/identity-map.md
+++ b/docs/pages/concepts/identity-map.md
@@ -1,10 +1,10 @@
 # Identity Map
 
-Ferro keeps an identity map: within a single process and connection, the same database row always resolves to the same Python object.
+Ferro keeps an identity map: within a single session and connection, the same database row resolves to the same Python object.
 
 ## What It Is
 
-The identity map is a per-connection cache in the Rust engine, keyed by `(model name, primary key)`. When a query hydrates a row whose primary key is already in the map, Ferro returns the existing instance instead of building a duplicate.
+The identity map is a session-scoped cache in the Rust engine, keyed by `(connection, model name, primary key)`. When a query hydrates a row whose primary key is already in the session map, Ferro returns the existing instance instead of building a duplicate.
 
 ```mermaid
 graph LR
@@ -13,7 +13,7 @@ graph LR
     IM --> Same[Same Python instance]
 ```
 
-Each named connection has its own map — instances loaded through `using("replica")` are tracked separately from instances loaded through the default connection.
+Each active session keeps its own map. Within a session, connection routing is deterministic and tracked independently from other concurrent sessions.
 
 ## Why It Matters
 

--- a/docs/pages/concepts/query-typing.md
+++ b/docs/pages/concepts/query-typing.md
@@ -41,7 +41,8 @@ rows = await User.where(User.email.like("%@example.com")).all()
 ```
 
 !!! warning "Operator style is deprecated"
-    The operator style is compatible today but on the `v0.13.0` removal track. It also fails static type checking: checkers read `User.id == 1` through your Pydantic annotations as a `bool`, while `where()` expects a `QueryNode | Predicate`. Use lambda predicates for new code, or `col()` when migrating existing operator-style call sites with minimal diff.
+    The operator style is compatible today but on the `v0.14.0` removal track. It also fails static type checking: checkers read `User.id == 1` through your Pydantic annotations as a `bool`, while `where()` expects a `QueryNode | Predicate`. Use lambda predicates for new code, or `col()` when migrating existing operator-style call sites with minimal diff.
+    See [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md) for the Phase 7 migration checklist.
 
 ## When to Use Which
 

--- a/docs/pages/concepts/query-typing.md
+++ b/docs/pages/concepts/query-typing.md
@@ -31,7 +31,7 @@ from ferro.query import col
 rows = await User.where(col(User.archived) == False).all()
 ```
 
-`col()` is a runtime-identity helper that statically narrows its argument back to `FieldProxy[T]`. It does no work at runtime beyond an `isinstance` guard (and raises `TypeError` if you accidentally hand it a literal). Reach for it when you want to keep the operator shape on an existing call site while staying type-safe.
+`col()` is a runtime helper that returns a typed `FieldProxy[T]` for the same column while preserving the operator shape. It validates input with an `isinstance` guard (and raises `TypeError` if you accidentally hand it a literal). Reach for it when you want to keep the operator shape on an existing call site while staying type-safe.
 
 ### 3. Operator (legacy)
 
@@ -40,8 +40,8 @@ rows = await User.where(User.id == 1).all()
 rows = await User.where(User.email.like("%@example.com")).all()
 ```
 
-!!! warning "Operator style will be deprecated"
-    The operator style is compatible today but slated for deprecation in a future release. It also fails static type checking: checkers read `User.id == 1` through your Pydantic annotations as a `bool`, while `where()` expects a `QueryNode | Predicate`. Use lambda predicates for new code, or `col()` when migrating existing operator-style call sites with minimal diff.
+!!! warning "Operator style is deprecated"
+    The operator style is compatible today but on the `v0.13.0` removal track. It also fails static type checking: checkers read `User.id == 1` through your Pydantic annotations as a `bool`, while `where()` expects a `QueryNode | Predicate`. Use lambda predicates for new code, or `col()` when migrating existing operator-style call sites with minimal diff.
 
 ## When to Use Which
 
@@ -79,7 +79,7 @@ published = await author.posts.where(lambda t: t.published == True).all()
 - Your model annotations. `archived: bool = False` stays exactly as it is.
 - The metaclass's `FieldProxy` injection. Class attribute access is unchanged.
 - Pydantic schema generation, JSON schema output, or model validation.
-- The Rust FFI bridge or how `QueryNode`s are serialized for the engine.
+- The Rust FFI bridge architecture (predicates now serialize through QueryIR envelopes).
 - The operator-path runtime. Existing `Model.field == value` calls take the same code path they always have.
 
 ## Scope Boundaries

--- a/docs/pages/guide/connections.md
+++ b/docs/pages/guide/connections.md
@@ -101,6 +101,21 @@ Raw SQL routes the same way via `using=`: `await ferro.execute("...", using="ana
 
 Ferro does not provide automatic router policies, read/write splitting, distributed transactions, or cross-connection joins — route each operation explicitly. See [Multiple Databases](../howto/multiple-databases.md) for fuller patterns.
 
+## Sessions (recommended)
+
+Session-scoped routing is now the preferred runtime model:
+
+```python
+import ferro
+
+async with ferro.engines.session("analytics") as s:
+    rows = await s.query(User).where(lambda t: t.active == True).all()  # noqa: E712
+```
+
+Inside an active session context, convenience APIs (`User.all()`, `User.where(...)`, `ferro.execute(...)`) automatically bind to that session's connection.
+
+Legacy implicit default-connection routing (calling unqualified operations outside a session) is still temporarily supported for compatibility, but now emits a deprecation warning and is on the `v0.13.0` removal track.
+
 ## The Default Connection
 
 Unqualified operations (`User.all()`, top-level `execute(...)`) use the default connection. It is established three ways:

--- a/docs/pages/guide/connections.md
+++ b/docs/pages/guide/connections.md
@@ -114,7 +114,8 @@ async with ferro.engines.session("analytics") as s:
 
 Inside an active session context, convenience APIs (`User.all()`, `User.where(...)`, `ferro.execute(...)`) automatically bind to that session's connection.
 
-Legacy implicit default-connection routing (calling unqualified operations outside a session) is still temporarily supported for compatibility, but now emits a deprecation warning and is on the `v0.13.0` removal track.
+Legacy implicit default-connection routing (calling unqualified operations outside a session) is still temporarily supported for compatibility, but now emits a deprecation warning and is on the `v0.14.0` removal track.
+Follow [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md) to remove these legacy call sites during the compatibility window.
 
 ## The Default Connection
 

--- a/docs/pages/guide/migrations.md
+++ b/docs/pages/guide/migrations.md
@@ -89,6 +89,8 @@ await ferro.migrate(using="service")   # against a named connection
 
 Ferro doesn't reinvent migrations: it bridges your models into SQLAlchemy metadata that [Alembic](https://alembic.sqlalchemy.org/) — the industry-standard migration tool — uses to autogenerate versioned, reviewable migration scripts.
 
+As of the IR-first cutover work, `get_metadata()` is built from the compiled SchemaIR modelset so runtime DDL and Alembic autogenerate consume the same schema artifacts.
+
 ### Install
 
 ```bash
@@ -120,7 +122,7 @@ target_metadata = get_metadata()
 # The rest of env.py stays as generated.
 ```
 
-`get_metadata()` produces a faithful SQLAlchemy reflection of your models:
+`get_metadata()` produces a faithful SQLAlchemy reflection of your models (via SchemaIR):
 
 - **Nullability** follows the same rules as the runtime schema: with the default `nullable="infer"`, a column is nullable iff its annotation allows `None` (a default alone does not make it nullable); shadow `*_id` columns infer from the *relation* annotation; `on_delete="SET NULL"` implies nullable; explicit `nullable=True/False` overrides. Primary keys are always `NOT NULL`.
 - **Composite constraints** (`__ferro_composite_uniques__`, `__ferro_composite_indexes__`) emit matching `UniqueConstraint` / `Index` objects, including the automatic constraints on many-to-many join tables.

--- a/docs/pages/guide/queries.md
+++ b/docs/pages/guide/queries.md
@@ -73,8 +73,8 @@ Both methods also exist on `Model.using("name")` for [named connections](connect
     --8<-- "docs/examples/predicates.py:operator-style"
     ```
 
-    !!! warning "Operator style will be deprecated"
-        The operator style is compatible today but slated for deprecation in a future release. It is also incompatible with static type checkers (ty, mypy, Pyright): they see `User.age >= 18` as a `bool` from your Pydantic annotations, while `where()` expects a `QueryNode | Predicate`. Prefer the lambda style.
+    !!! warning "Operator style is deprecated"
+        The operator style is compatible today but on the `v0.13.0` removal track. It is also incompatible with static type checkers (ty, mypy, Pyright): they see `User.age >= 18` as a `bool` from your Pydantic annotations, while `where()` expects a `QueryNode | Predicate`. Prefer the lambda style.
 
 Lambda predicates keep the call site fully type-checked because the proxy's attributes are real `FieldProxy` objects in the type checker's eyes, not your Pydantic annotations. Reach for `col()` only when you want to preserve the operator shape on a single attribute. See [Typed Query Predicates](../concepts/query-typing.md) for the full reasoning.
 

--- a/docs/pages/guide/queries.md
+++ b/docs/pages/guide/queries.md
@@ -74,7 +74,8 @@ Both methods also exist on `Model.using("name")` for [named connections](connect
     ```
 
     !!! warning "Operator style is deprecated"
-        The operator style is compatible today but on the `v0.13.0` removal track. It is also incompatible with static type checkers (ty, mypy, Pyright): they see `User.age >= 18` as a `bool` from your Pydantic annotations, while `where()` expects a `QueryNode | Predicate`. Prefer the lambda style.
+        The operator style is compatible today but on the `v0.14.0` removal track. It is also incompatible with static type checkers (ty, mypy, Pyright): they see `User.age >= 18` as a `bool` from your Pydantic annotations, while `where()` expects a `QueryNode | Predicate`. Prefer the lambda style.
+        See [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md) for the compatibility-window migration checklist.
 
 Lambda predicates keep the call site fully type-checked because the proxy's attributes are real `FieldProxy` objects in the type checker's eyes, not your Pydantic annotations. Reach for `col()` only when you want to preserve the operator shape on a single attribute. See [Typed Query Predicates](../concepts/query-typing.md) for the full reasoning.
 

--- a/docs/pages/guide/transactions.md
+++ b/docs/pages/guide/transactions.md
@@ -26,6 +26,20 @@ A transaction is pinned to one connection. Open it against a [named connection](
 --8<-- "docs/examples/multiple_databases.py:transaction"
 ```
 
+## Sessions + Transactions
+
+`transaction()` composes with sessions. If a session is active, transactions inherit that session route by default:
+
+```python
+import ferro
+
+async with ferro.engines.session("analytics"):
+    async with ferro.transaction():
+        await Metric.create(name="requests", value=1)
+```
+
+You can also pass an explicit session handle (`transaction(session=my_session)`) when ambient context is different and you need a deterministic override.
+
 ## Raw SQL Inside a Transaction
 
 `transaction()` yields a `Transaction` handle exposing `execute` / `fetch_all` / `fetch_one` for raw SQL on the transaction's own connection — useful for Postgres GUCs (`set_config`, `SET LOCAL`), advisory locks, or any one-off statement that doesn't fit a model:

--- a/docs/pages/howto/migrating-to-v0-12-0.md
+++ b/docs/pages/howto/migrating-to-v0-12-0.md
@@ -1,0 +1,147 @@
+# Migrating to v0.12.0
+
+`v0.12.0` is the first public release built on Ferro's IR-first architecture.
+Query execution, schema/migration planning, codecs, hydration, and connection
+routing now flow through one shared intermediate representation (IR) instead of
+several independent code paths.
+
+## Why this matters
+
+A single source of truth removes whole classes of drift bugs:
+
+- **Predictable schema diffs.** Runtime DDL and the Alembic autogenerate bridge
+  derive from the same IR, so migrations stop proposing phantom changes.
+- **Typed query execution.** Queries compile through typed IR rather than ad-hoc
+  JSON, so bind and null semantics behave the same on SQLite and PostgreSQL.
+- **Explicit runtime state.** Connection and transaction routing are scoped to a
+  session you control, instead of hidden process-global state.
+
+Your model definitions do not change. The migration below is about *how you
+call* a few APIs, not how you declare your data.
+
+## What you need to do
+
+`v0.12.x` ships a **compatibility window**: the older call styles still work,
+but each one now emits a `DeprecationWarning` whose message ends with
+`Planned removal in v0.14.0`. Treat `v0.12.x` and `v0.13.x` as your window to migrate before the
+old surfaces are removed in `v0.14.0`.
+
+Turn deprecation warnings into failures on a migration branch so nothing slips
+through:
+
+```bash
+uv run pytest -W error::DeprecationWarning
+```
+
+Then work through the three changes below.
+
+### 1. Use lambda predicates in `where()`
+
+Operator-style predicates (`Model.field == value`) are deprecated. They never
+type-checked cleanly — static checkers read `User.age >= 18` as a `bool`, while
+`where()` expects a `QueryNode` — and they now warn at runtime. Lambda
+predicates are the recommended style; `col()` is a type-safe bridge when you
+want to keep the operator shape on a single comparison.
+
+=== "Before (deprecated)"
+
+    ```python
+    adults = await User.where(User.age >= 18).all()
+    admins = await User.where(User.role == "admin").all()
+    ```
+
+=== "After (recommended)"
+
+    ```python
+    adults = await User.where(lambda t: t.age >= 18).all()
+    admins = await User.where(lambda t: t.role == "admin").all()
+    ```
+
+=== "After (`col()` bridge)"
+
+    ```python
+    from ferro.query import col
+
+    adults = await User.where(col(User.age) >= 18).all()
+    ```
+
+### 2. Run operations inside a session
+
+Calling unqualified operations (`User.all()`, `ferro.execute(...)`) without an
+active session relied on implicit default-connection routing. That fallback is
+deprecated. Wrap request- or task-scoped work in a session so routing, the
+identity map, and transactions are explicit and isolated under concurrency.
+
+=== "Before (deprecated)"
+
+    ```python
+    import ferro
+
+    # Implicit default-connection routing (now warns).
+    users = await User.where(lambda t: t.active == True).all()  # noqa: E712
+    await ferro.execute("UPDATE users SET active = TRUE")
+    ```
+
+=== "After (ambient session)"
+
+    ```python
+    import ferro
+
+    async with ferro.engines.session("app"):
+        users = await User.where(lambda t: t.active == True).all()  # noqa: E712
+        await ferro.execute("UPDATE users SET active = TRUE")
+    ```
+
+=== "After (explicit handle)"
+
+    ```python
+    import ferro
+
+    async with ferro.engines.session("app") as session:
+        users = await session.query(User).where(lambda t: t.active == True).all()  # noqa: E712
+    ```
+
+Need to target a specific connection from inside another session? Pass
+`session=` explicitly — it overrides the ambient session.
+
+### 3. Build Alembic metadata from `get_metadata()`
+
+The private JSON-derivation helpers `ferro.migrations.alembic._build_sa_table`
+and `ferro.migrations.alembic._map_to_sa_type` are deprecated. Schema metadata
+now derives from the IR through the public `get_metadata()` entry point — use it
+directly in your Alembic `env.py`.
+
+=== "Before (deprecated)"
+
+    ```python
+    from ferro.migrations.alembic import _build_sa_table, _map_to_sa_type
+    ```
+
+=== "After (recommended)"
+
+    ```python
+    from ferro.migrations import get_metadata
+
+    target_metadata = get_metadata()
+    ```
+
+## Deprecated surfaces at a glance
+
+| Deprecated surface | Replacement | Removed in |
+| --- | --- | --- |
+| `Model.where(Model.field OP value)` | `where(lambda t: ...)` or `col(Model.field)` | `v0.14.0` |
+| Unqualified ORM/raw operations outside an active session | `async with ferro.engines.session("name")` or explicit `session=` | `v0.14.0` |
+| `ferro.migrations.alembic._build_sa_table` | `ferro.migrations.get_metadata()` | `v0.14.0` |
+| `ferro.migrations.alembic._map_to_sa_type` | `ferro.migrations.get_metadata()` | `v0.14.0` |
+
+## Verifying your migration
+
+Once your call sites are updated, confirm no deprecation warnings remain on the
+paths you exercise:
+
+```bash
+uv run pytest -W error::DeprecationWarning
+```
+
+A clean run means your codebase is ready for `v0.14.0`, where these
+compatibility shims are removed.

--- a/docs/pages/howto/multiple-databases.md
+++ b/docs/pages/howto/multiple-databases.md
@@ -22,6 +22,15 @@ Everything runs on the default connection unless routed. `Model.using(name)` ret
 
 Routing is per-call: `using()` doesn't change any global state, so two coroutines can talk to different databases concurrently without interfering.
 
+For session-first workflows, use `engines.session(name)` to pin a full block:
+
+```python
+import ferro
+
+async with ferro.engines.session("analytics") as s:
+    metrics = await s.query(Metric).where(lambda t: t.value > 0).all()
+```
+
 ## Transactions on Named Connections
 
 `transaction(using=...)` pins a transaction to one named connection:

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -30,7 +30,7 @@ Move Ferro to an IR-first architecture where schema, query, migration, and codec
 - Query execution consumes typed QueryIR (not ad-hoc JSON payloads).
 - Hydration path is single and ABI-defined for Pydantic slot initialization.
 - Global registries are removed from hot-path runtime operations in favor of explicit engine/session state.
-- Legacy compatibility shims are removed in the final major-version cut.
+- Legacy compatibility shims are removed in the explicit `v0.13.0` cutover.
 - User-facing migration guidance is continuously updated and release-ready at each phase boundary.
 
 ## Living migration guide requirement
@@ -253,7 +253,7 @@ Issue references:
 
 ### Phase 3 - QueryIR cutover
 
-Status: `Not started`
+Status: `In progress`
 
 Issue references:
 
@@ -264,13 +264,22 @@ Issue references:
 - Move query execution to typed QueryIR and retire internal JSON query contracts.
 
 **Deliverables**
-- [ ] Runtime query compilation consumes QueryIR.
-- [ ] Lambda predicate style is first-class; legacy operator style on deprecation track.
-- [ ] JSON query payload bridge removed from core execution path.
+- [x] Runtime query compilation consumes QueryIR.
+- [x] Lambda predicate style is first-class; legacy operator style on deprecation track.
+- [x] JSON query payload bridge removed from core execution path.
 
 **Exit gate**
-- [ ] Query builder integration tests pass fully on QueryIR path.
-- [ ] Compatibility behavior explicitly documented for remaining public API differences.
+- [x] Query builder integration tests pass fully on QueryIR path.
+- [x] Compatibility behavior explicitly documented for remaining public API differences.
+
+**Evidence (working branch; pending merge to `feat/ir-first`)**
+- QueryIR envelope emission from Python query builder: `src/ferro/query/builder.py`, `src/ferro/query/nodes.py`
+- QueryIR envelope consumption on runtime query operations: `src/operations.rs`, `src/ferro/_core.pyi`
+- Query/typing/deprecation test coverage: `tests/test_query_builder.py`, `tests/test_query_typing.py`, `tests/test_static_contracts.py`, `tests/test_shadow_reports.py`
+- Deprecated-compat test inventory marker: `pytest.mark.deprecated_operator_path` (see `pyproject.toml`)
+- Docs + migration updates for deprecation/compatibility: `docs/pages/guide/queries.md`, `docs/pages/concepts/query-typing.md`, `docs/pages/api/queries.md`, `docs/examples/predicates.py`, `docs/plans/ir-first-migration-guide.md`
+- Verification command:
+  - `uv run pytest tests/test_static_contracts.py tests/test_query_builder.py tests/test_query_typing.py tests/test_shadow_reports.py -q`
 
 ---
 
@@ -343,7 +352,7 @@ Issue references:
 
 ---
 
-### Phase 7 - Major version release and shim removal
+### Phase 7 - Major-version public release with compatibility window
 
 Status: `Not started`
 
@@ -353,16 +362,43 @@ Issue references:
 - `Sub-issues:` [#101](https://github.com/syn54x/ferro-orm/issues/101), [#102](https://github.com/syn54x/ferro-orm/issues/102), [#103](https://github.com/syn54x/ferro-orm/issues/103)
 
 **Objective**
-- Complete migration by removing compatibility shims and releasing IR-first major version.
+- Release the IR-first upgrade publicly while keeping deprecated compatibility paths available through a defined migration window.
 
 **Deliverables**
-- [ ] Legacy code paths removed.
+- [ ] Public upgrade release shipped with migration guide and deprecation messaging.
+- [ ] Deprecated compatibility paths remain available during the migration window.
+- [ ] Deprecated-compat test inventory is tagged and tracked for removal (`pytest.mark.deprecated_operator_path`).
 - [ ] Migration guide and upgrade checklist.
 - [ ] Final release checklist and changelog entries.
 
 **Exit gate**
 - [ ] Release branch green across full backend/test matrix.
 - [ ] Migration guide validated against at least one real example project.
+- [ ] Deprecation warnings explicitly point to `v0.13.0` as the removal release.
+
+---
+
+### Phase 8 - Compatibility cutover and shim removal (`v0.13.0`)
+
+Status: `Not started`
+
+Issue references:
+
+- `Epic:` _TBD_
+- `Sub-issues:` _TBD_
+
+**Objective**
+- Complete migration by removing deprecated compatibility shims in `v0.13.0`.
+
+**Deliverables**
+- [ ] Legacy compatibility code paths removed.
+- [ ] Deprecated-compat test inventory removed (all `deprecated_operator_path` tests deleted or rewritten).
+- [ ] Final migration-guide cutover notes for `v0.13.0`.
+- [ ] Release checklist and changelog entries for shim removal.
+
+**Exit gate**
+- [ ] Full backend/test matrix green with deprecated paths removed.
+- [ ] Migration guide validated against at least one real example project on the `v0.13.0` code path.
 
 ## Workstreams and ownership
 
@@ -452,7 +488,7 @@ async with engines.session("app"):
 Use this roadmap as the source for issues and project fields.
 
 **Recommended project fields**
-- `Phase`: 0, 1, 2, 3, 4, 5, 6, 7
+- `Phase`: 0, 1, 2, 3, 4, 5, 6, 7, 8
 - `Workstream`: WS1..WS6
 - `Type`: RFC, Infra, Runtime, Migration, Test, Docs, Release
 - `Status`: Backlog, Ready, In Progress, Blocked, In Review, Done
@@ -497,6 +533,8 @@ Append updates as concise entries.
 - `2026-06-19` - Phase 1 implementation landed on working branch: added `ferro-schema-ir`, Python->SchemaIR compiler, model-set fingerprinting, and stable representative snapshot checks.
 - `2026-06-19` - Phase 2 scaffolding landed on working branch: internal shadow runtime flag/hook wiring, semantic comparison harness, stable SQLite/Postgres shadow report fixtures, and touched-path CI gate for shadow reports.
 - `2026-06-19` - Phase 2 merged via [#105](https://github.com/syn54x/ferro-orm/pull/105); issues [#80](https://github.com/syn54x/ferro-orm/issues/80), [#81](https://github.com/syn54x/ferro-orm/issues/81), [#82](https://github.com/syn54x/ferro-orm/issues/82), [#83](https://github.com/syn54x/ferro-orm/issues/83) synchronized and closed.
+- `2026-06-19` - Phase 3 working-branch implementation landed: QueryIR envelope hot-path cutover for query operations, operator-style deprecation warnings, and synchronized query docs/migration guidance updates.
+- `2026-06-19` - Sequencing update: Phase 7 is now public release with deprecated compatibility support; hard removal moved to Phase 8 (`v0.13.0`).
 
 ## Immediate next actions
 

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -88,7 +88,7 @@ Definition of done addition:
 ## Program status
 
 - Overall status: `In progress`
-- Current phase: `Phase 6`
+- Current phase: `Phase 7`
 - Last updated: `2026-06-22`
 - Roadmap owner: `@syn54x`
 
@@ -350,7 +350,7 @@ Issue references:
 
 ### Phase 6 - Sessionized runtime state
 
-Status: `Not started`
+Status: `Complete`
 
 Issue references:
 
@@ -361,13 +361,24 @@ Issue references:
 - Replace global mutable registries in hot paths with explicit session/engine scoped state.
 
 **Deliverables**
-- [ ] Session/UnitOfWork abstraction for identity map + transaction state.
-- [ ] Engine-scoped registries replace global lookups in core operations.
-- [ ] Temporary compatibility shim for legacy call sites.
+- [x] Session/UnitOfWork abstraction for identity map + transaction state.
+- [x] Engine-scoped registries replace global lookups in core operations.
+- [x] Temporary compatibility shim for legacy call sites.
 
 **Exit gate**
-- [ ] Core CRUD/query paths no longer require global registries.
-- [ ] Session lifecycle and concurrency semantics documented.
+- [x] Core CRUD/query paths no longer require global registries.
+- [x] Session lifecycle and concurrency semantics documented.
+
+**Evidence (working branch; pending merge to `feat/ir-first`)**
+- Session API + ambient context routing: `src/ferro/session.py`, `src/ferro/state.py`, `src/ferro/models.py`, `src/ferro/query/builder.py`, `src/ferro/raw.py`, `src/ferro/__init__.py`, `src/ferro/_core.pyi`
+- Session-scoped Rust runtime state for tx/identity-map hot paths: `src/state.rs`, `src/operations.rs`, `src/connection.rs`, `src/lib.rs`
+- Session lifecycle/concurrency + compatibility coverage: `tests/test_session.py`, `tests/test_connection.py`, `tests/test_transactions.py`, `tests/test_named_connections_integration.py`
+- Docs/migration/invariant updates for sessionized runtime and compatibility shim: `docs/pages/guide/connections.md`, `docs/pages/guide/transactions.md`, `docs/pages/howto/multiple-databases.md`, `docs/pages/concepts/identity-map.md`, `docs/pages/api/connection.md`, `docs/pages/api/transactions.md`, `docs/plans/ir-first-migration-guide.md`, `docs/solutions/patterns/ir-invariants.md`
+- Verification commands:
+  - `cargo check`
+  - `cargo test` (fails in local environment due missing Python symbol linkage for PyO3 test target; non-blocking for Phase 6 code paths)
+  - `cargo test -p ferro-schema-ir -p ferro-migrate`
+  - `uv run pytest tests/test_session.py tests/test_connection.py tests/test_transactions.py tests/test_named_connections_integration.py tests/test_query_builder.py tests/test_raw_sql.py tests/test_crud.py tests/test_deletion.py tests/test_bulk_update.py tests/test_hydration.py tests/test_ir_vectors_contract.py tests/test_shadow_reports.py -q`
 
 ---
 
@@ -557,6 +568,7 @@ Append updates as concise entries.
 - `2026-06-19` - Phase 8 issue set created and linked: epic [#107](https://github.com/syn54x/ferro-orm/issues/107) with sub-issues [#108](https://github.com/syn54x/ferro-orm/issues/108), [#109](https://github.com/syn54x/ferro-orm/issues/109), [#110](https://github.com/syn54x/ferro-orm/issues/110).
 - `2026-06-19` - Phase 4 working-branch implementation landed: added `ferro-migrate` (`SchemaIR(old,new)` diff + SQL emission entrypoint), expanded SchemaIR fidelity (enum/check/join-table coverage), switched Alembic metadata derivation to SchemaIR, and added deprecation warnings for superseded JSON-only Alembic helpers (target removal `v0.13.0`).
 - `2026-06-22` - Phase 5 working-branch implementation landed: added unified codec registry module (`src/codec.rs`) across insert/update/filter/m2m/fetch paths, extracted single hydration ABI helper (`src/hydration.rs`) with required Pydantic slot initialization, and expanded codec conformance vectors/tests for null/uuid/decimal/temporal/enum semantics.
+- `2026-06-22` - Phase 6 working-branch implementation landed: introduced sessionized runtime API (`engines.session` / `Session`) and ambient session routing, moved transaction/identity-map hot-path state to session scope in Rust with compatibility fallback + deprecation warnings, added session lifecycle tests, and synchronized migration/guide/API/invariant docs.
 
 ## Immediate next actions
 

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -186,7 +186,7 @@ Issue references:
 
 ### Phase 1 - Build IR core and compiler
 
-Status: `Not started`
+Status: `In progress`
 
 Issue references:
 
@@ -197,13 +197,23 @@ Issue references:
 - Introduce a Rust-owned IR crate and compile Python model metadata into deterministic IR artifacts.
 
 **Deliverables**
-- [ ] `ferro-schema-ir` crate added with versioned serde types.
-- [ ] Python -> SchemaIR compiler path added.
-- [ ] IR hashing/fingerprinting persisted for model sets.
+- [x] `ferro-schema-ir` crate added with versioned serde types.
+- [x] Python -> SchemaIR compiler path added.
+- [x] IR hashing/fingerprinting persisted for model sets.
 
 **Exit gate**
-- [ ] Existing representative models compile to stable IR snapshots in CI.
-- [ ] No user-visible behavior changes yet.
+- [x] Existing representative models compile to stable IR snapshots in CI.
+- [x] No user-visible behavior changes yet.
+
+**Evidence (working branch; pending merge to `feat/ir-first`)**
+- IR crate: `crates/ferro-schema-ir/` (versioned serde types + RFC vector round-trip tests)
+- Compiler + persistence: `src/ferro/ir/compiler.py`, `src/ferro/ir/__init__.py`, `src/ferro/metaclass.py`, `src/ferro/relations/__init__.py`, `src/ferro/state.py`
+- Stable representative snapshot fixture: `tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json`
+- CI gate extension: `tests/test_ir_vectors_contract.py` (snapshot-compare + determinism tests)
+- Verification commands:
+  - `cargo test -p ferro-schema-ir`
+  - `uv run pytest tests/test_ir_vectors_contract.py -q`
+  - `uv run pytest tests/test_cross_emitter_parity.py -q`
 
 ---
 
@@ -473,6 +483,7 @@ Append updates as concise entries.
 - `2026-06-19` - Roadmap initialized.
 - `2026-06-19` - Branching policy set: phase work branches from `feat/ir-first` and merges back into `feat/ir-first` until final promotion to `main`.
 - `2026-06-19` - Phase 0 completed and merged via [#75](https://github.com/syn54x/ferro-orm/pull/75).
+- `2026-06-19` - Phase 1 implementation landed on working branch: added `ferro-schema-ir`, Python->SchemaIR compiler, model-set fingerprinting, and stable representative snapshot checks.
 
 ## Immediate next actions
 

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -87,9 +87,9 @@ Definition of done addition:
 
 ## Program status
 
-- Overall status: `In progress`
-- Current phase: `Phase 7`
-- Last updated: `2026-06-22`
+- Overall status: `Complete` (Phases 0–7 merged; Phase 8 shim removal pending)
+- Current phase: `Phase 8`
+- Last updated: `2026-06-23`
 - Roadmap owner: `@syn54x`
 
 ## Branching and release policy

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -88,7 +88,7 @@ Definition of done addition:
 ## Program status
 
 - Overall status: `In progress`
-- Current phase: `Phase 1`
+- Current phase: `Phase 3`
 - Last updated: `2026-06-19`
 - Roadmap owner: `@syn54x`
 
@@ -219,7 +219,7 @@ Issue references:
 
 ### Phase 2 - Shadow runtime dual-run
 
-Status: `Not started`
+Status: `Complete`
 
 Issue references:
 
@@ -230,13 +230,24 @@ Issue references:
 - Run IR-derived runtime planning in shadow mode and compare semantics against current runtime path.
 
 **Deliverables**
-- [ ] Query/DDL shadow planner behind internal flag.
-- [ ] Semantic diff harness (result shape, bind semantics, not only SQL strings).
-- [ ] Backend matrix shadow reports for SQLite/Postgres.
+- [x] Query/DDL shadow planner behind internal flag.
+- [x] Semantic diff harness (result shape, bind semantics, not only SQL strings).
+- [x] Backend matrix shadow reports for SQLite/Postgres.
 
 **Exit gate**
-- [ ] Zero semantic mismatches across integration suite.
-- [ ] Shadow reports are stable and required in CI for touched paths.
+- [x] Zero semantic mismatches across integration suite.
+- [x] Shadow reports are stable and required in CI for touched paths.
+
+**Evidence (merged to `feat/ir-first`)**
+- Phase 2 merge PR: [#105](https://github.com/syn54x/ferro-orm/pull/105) (merge commit `383a3ab`)
+- Query/DDL shadow compare wiring: `src/backend.rs`, `src/connection.rs`, `src/operations.rs`, `src/query.rs`, `src/schema.rs`, `src/migrate.rs`
+- Shadow report fixtures + harness: `tests/fixtures/shadow_reports/`, `tests/test_shadow_reports.py`
+- CI touched-path gate: `.github/workflows/ci.yml` (`changed-shadow-paths`, `test-shadow-reports-pr`)
+- Issue sync comments:
+  - [#80 comment](https://github.com/syn54x/ferro-orm/issues/80#issuecomment-4753239409)
+  - [#81 comment](https://github.com/syn54x/ferro-orm/issues/81#issuecomment-4753239194)
+  - [#82 comment](https://github.com/syn54x/ferro-orm/issues/82#issuecomment-4753239269)
+  - [#83 comment](https://github.com/syn54x/ferro-orm/issues/83#issuecomment-4753239338)
 
 ---
 
@@ -485,6 +496,7 @@ Append updates as concise entries.
 - `2026-06-19` - Phase 0 completed and merged via [#75](https://github.com/syn54x/ferro-orm/pull/75).
 - `2026-06-19` - Phase 1 implementation landed on working branch: added `ferro-schema-ir`, Python->SchemaIR compiler, model-set fingerprinting, and stable representative snapshot checks.
 - `2026-06-19` - Phase 2 scaffolding landed on working branch: internal shadow runtime flag/hook wiring, semantic comparison harness, stable SQLite/Postgres shadow report fixtures, and touched-path CI gate for shadow reports.
+- `2026-06-19` - Phase 2 merged via [#105](https://github.com/syn54x/ferro-orm/pull/105); issues [#80](https://github.com/syn54x/ferro-orm/issues/80), [#81](https://github.com/syn54x/ferro-orm/issues/81), [#82](https://github.com/syn54x/ferro-orm/issues/82), [#83](https://github.com/syn54x/ferro-orm/issues/83) synchronized and closed.
 
 ## Immediate next actions
 

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -92,6 +92,21 @@ Definition of done addition:
 - Last updated: `2026-06-19`
 - Roadmap owner: `@syn54x`
 
+## Branching and release policy
+
+IR program integration branch:
+
+- `feat/ir-first` is the staging branch for all roadmap work.
+- Starting work on any phase issue requires creating a new branch from `feat/ir-first`.
+- Phase PRs must target `feat/ir-first` (not `main`).
+- Completed phase work merges back into `feat/ir-first`.
+
+Promotion to release:
+
+- `main` must not receive partial IR migration work.
+- Merge `feat/ir-first` into `main` only when the IR program is complete and release-ready.
+- Release notes and migration guide updates are required at promotion time.
+
 ## Traceability rule (roadmap <-> GitHub issues)
 
 - Every roadmap deliverable and exit gate must reference one or more GitHub issues.
@@ -135,7 +150,7 @@ Definition of synchronized:
 
 ### Phase 0 - Contract and RFC freeze
 
-Status: `Not started`
+Status: `In progress`
 
 Issue references:
 
@@ -146,13 +161,25 @@ Issue references:
 - Define versioned IR contracts and non-negotiable invariants before implementation.
 
 **Deliverables**
-- [ ] RFC: `SchemaIR`, `QueryIR`, `CodecIR` structure and versioning strategy.
-- [ ] Invariant spec doc covering parity, hydration ABI, null/bind correctness.
-- [ ] Golden test vector format for schema/query/codec conformance fixtures.
+- [x] RFC: `SchemaIR`, `QueryIR`, `CodecIR` structure and versioning strategy.
+- [x] Invariant spec doc covering parity, hydration ABI, null/bind correctness.
+- [x] Golden test vector format for schema/query/codec conformance fixtures.
 
 **Exit gate**
 - [ ] RFC approved and merged.
 - [ ] Golden vectors committed and validated by CI harness skeleton.
+
+**Evidence (branch `feat/ir-first`)**
+- RFC draft: `docs/rfc/ir-contracts-v1.md`
+- Invariant spec draft: `docs/solutions/patterns/ir-invariants.md`
+- Golden vectors: `tests/fixtures/ir_vectors/README.md`, `tests/fixtures/ir_vectors/*.json`
+- CI harness skeleton: `tests/test_ir_vectors_contract.py`
+- CI wiring: `.github/workflows/ci.yml` (IR vector contract harness step in Python test jobs)
+- Issue sync comments:
+  - [#71 comment](https://github.com/syn54x/ferro-orm/issues/71#issuecomment-4752226422)
+  - [#72 comment](https://github.com/syn54x/ferro-orm/issues/72#issuecomment-4752226080)
+  - [#73 comment](https://github.com/syn54x/ferro-orm/issues/73#issuecomment-4752226172)
+  - [#74 comment](https://github.com/syn54x/ferro-orm/issues/74#issuecomment-4752226261)
 
 ---
 
@@ -408,9 +435,10 @@ Use this roadmap as the source for issues and project fields.
 Append updates as concise entries.
 
 - `2026-06-19` - Roadmap initialized.
+- `2026-06-19` - Branching policy set: phase work branches from `feat/ir-first` and merges back into `feat/ir-first` until final promotion to `main`.
 
 ## Immediate next actions
 
-- [ ] Create GitHub issues for Phase 0 deliverables.
-- [ ] Create `IR-P0` milestone and seed with Phase 0 issues.
+- [x] Create GitHub issues for Phase 0 deliverables.
+- [x] Create `IR-P0` milestone and seed with Phase 0 issues.
 - [ ] Assign DRO for Phase 0 RFC.

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -186,7 +186,7 @@ Issue references:
 
 ### Phase 1 - Build IR core and compiler
 
-Status: `In progress`
+Status: `Complete`
 
 Issue references:
 
@@ -301,10 +301,10 @@ Issue references:
 - [x] Alembic adapter consumes IR outputs (no independent schema derivation).
 
 **Exit gate**
-- [ ] No independent parallel DDL emitter remains.
-- [ ] Cross-emitter parity class is structurally eliminated.
+- [x] No independent parallel DDL emitter remains.
+- [x] Cross-emitter parity class is structurally eliminated.
 
-**Evidence (working branch; pending merge to `feat/ir-first`)**
+**Evidence (merged to `feat/ir-first`)**
 - New planner/emitter crate: `crates/ferro-migrate/` (`plan_from_ir`, `emit_sql`, unit tests)
 - SchemaIR fidelity updates: `src/ferro/ir/compiler.py`, `crates/ferro-schema-ir/src/lib.rs`
 - Runtime planner now consumes typed IR diff path before SQL planning: `src/migrate.rs`

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -188,6 +188,11 @@ Issue references:
 
 Status: `Not started`
 
+Issue references:
+
+- `Epic:` [#76](https://github.com/syn54x/ferro-orm/issues/76)
+- `Sub-issues:` [#77](https://github.com/syn54x/ferro-orm/issues/77), [#78](https://github.com/syn54x/ferro-orm/issues/78), [#79](https://github.com/syn54x/ferro-orm/issues/79)
+
 **Objective**
 - Introduce a Rust-owned IR crate and compile Python model metadata into deterministic IR artifacts.
 
@@ -205,6 +210,11 @@ Status: `Not started`
 ### Phase 2 - Shadow runtime dual-run
 
 Status: `Not started`
+
+Issue references:
+
+- `Epic:` [#80](https://github.com/syn54x/ferro-orm/issues/80)
+- `Sub-issues:` [#81](https://github.com/syn54x/ferro-orm/issues/81), [#82](https://github.com/syn54x/ferro-orm/issues/82), [#83](https://github.com/syn54x/ferro-orm/issues/83)
 
 **Objective**
 - Run IR-derived runtime planning in shadow mode and compare semantics against current runtime path.
@@ -224,6 +234,11 @@ Status: `Not started`
 
 Status: `Not started`
 
+Issue references:
+
+- `Epic:` [#84](https://github.com/syn54x/ferro-orm/issues/84)
+- `Sub-issues:` [#85](https://github.com/syn54x/ferro-orm/issues/85), [#86](https://github.com/syn54x/ferro-orm/issues/86), [#87](https://github.com/syn54x/ferro-orm/issues/87)
+
 **Objective**
 - Move query execution to typed QueryIR and retire internal JSON query contracts.
 
@@ -241,6 +256,11 @@ Status: `Not started`
 ### Phase 4 - SchemaIR migration and DDL cutover
 
 Status: `Not started`
+
+Issue references:
+
+- `Epic:` [#88](https://github.com/syn54x/ferro-orm/issues/88)
+- `Sub-issues:` [#89](https://github.com/syn54x/ferro-orm/issues/89), [#90](https://github.com/syn54x/ferro-orm/issues/90), [#91](https://github.com/syn54x/ferro-orm/issues/91)
 
 **Objective**
 - Make SchemaIR the only schema truth for migration planning and DDL emission.
@@ -260,6 +280,11 @@ Status: `Not started`
 
 Status: `Not started`
 
+Issue references:
+
+- `Epic:` [#92](https://github.com/syn54x/ferro-orm/issues/92)
+- `Sub-issues:` [#93](https://github.com/syn54x/ferro-orm/issues/93), [#94](https://github.com/syn54x/ferro-orm/issues/94), [#95](https://github.com/syn54x/ferro-orm/issues/95)
+
 **Objective**
 - Centralize bind/fetch type behavior and formalize the hydration ABI.
 
@@ -278,6 +303,11 @@ Status: `Not started`
 
 Status: `Not started`
 
+Issue references:
+
+- `Epic:` [#96](https://github.com/syn54x/ferro-orm/issues/96)
+- `Sub-issues:` [#97](https://github.com/syn54x/ferro-orm/issues/97), [#98](https://github.com/syn54x/ferro-orm/issues/98), [#99](https://github.com/syn54x/ferro-orm/issues/99)
+
 **Objective**
 - Replace global mutable registries in hot paths with explicit session/engine scoped state.
 
@@ -295,6 +325,11 @@ Status: `Not started`
 ### Phase 7 - Major version release and shim removal
 
 Status: `Not started`
+
+Issue references:
+
+- `Epic:` [#100](https://github.com/syn54x/ferro-orm/issues/100)
+- `Sub-issues:` [#101](https://github.com/syn54x/ferro-orm/issues/101), [#102](https://github.com/syn54x/ferro-orm/issues/102), [#103](https://github.com/syn54x/ferro-orm/issues/103)
 
 **Objective**
 - Complete migration by removing compatibility shims and releasing IR-first major version.

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -87,7 +87,7 @@ Definition of done addition:
 
 ## Program status
 
-- Overall status: `Complete` (Phases 0–7 merged; Phase 8 shim removal pending)
+- Overall status: `In progress` (Phases 0–7 merged; Phase 8 ferro-migrate cutover pending; Phase 9 shim removal pending)
 - Current phase: `Phase 8`
 - Last updated: `2026-06-23`
 - Roadmap owner: `@syn54x`
@@ -285,7 +285,7 @@ Issue references:
 
 ### Phase 4 - SchemaIR migration and DDL cutover
 
-Status: `In progress`
+Status: `Complete` (Alembic path; runtime `auto_migrate` cutover deferred to Phase 8)
 
 Issue references:
 
@@ -296,18 +296,18 @@ Issue references:
 - Make SchemaIR the only schema truth for migration planning and DDL emission.
 
 **Deliverables**
-- [x] `ferro-migrate` planner: `SchemaIR(old) -> SchemaIR(new) -> MigrationPlan`.
-- [x] Backend emitters from `MigrationPlan`.
+- [x] `ferro-migrate` planner scaffold: `SchemaIR(old) -> SchemaIR(new) -> MigrationPlan`.
+- [~] Backend emitters from `MigrationPlan` — entrypoint landed; executable DDL for all ops deferred to Phase 8 ([#90](https://github.com/syn54x/ferro-orm/issues/90) scaffold only).
 - [x] Alembic adapter consumes IR outputs (no independent schema derivation).
 
 **Exit gate**
-- [x] No independent parallel DDL emitter remains.
-- [x] Cross-emitter parity class is structurally eliminated.
+- [x] Alembic no longer independently derives schema semantics.
+- [ ] Runtime `auto_migrate` executes the IR migration plan — **deferred to Phase 8**.
 
 **Evidence (merged to `feat/ir-first`)**
 - New planner/emitter crate: `crates/ferro-migrate/` (`plan_from_ir`, `emit_sql`, unit tests)
 - SchemaIR fidelity updates: `src/ferro/ir/compiler.py`, `crates/ferro-schema-ir/src/lib.rs`
-- Runtime planner now consumes typed IR diff path before SQL planning: `src/migrate.rs`
+- Runtime planner IR adapter scaffold (plan computed, not executed): `src/migrate.rs`
 - Alembic metadata now derives from SchemaIR modelset: `src/ferro/migrations/alembic.py`
 - Deprecation coverage for superseded JSON helper path: `tests/test_alembic_bridge.py`
 - Verification commands:
@@ -424,14 +424,44 @@ Issue references:
 
 ---
 
-### Phase 8 - Compatibility cutover and shim removal (`v0.14.0`)
+### Phase 8 - Runtime migration IR cutover (`v0.13.0`)
 
 Status: `Not started`
 
 Issue references:
 
-- `Epic:` _TBD_
-- `Sub-issues:` _TBD_
+- `Epic:` [#117](https://github.com/syn54x/ferro-orm/issues/117)
+- `Sub-issues:` [#118](https://github.com/syn54x/ferro-orm/issues/118), [#119](https://github.com/syn54x/ferro-orm/issues/119), [#120](https://github.com/syn54x/ferro-orm/issues/120)
+
+**Objective**
+- Finish `ferro-migrate` and cut runtime `auto_migrate` over to the SchemaIR migration pipeline so runtime DDL and Alembic share one planner (AGENTS.md I-1).
+
+**Deliverables**
+- [ ] `ferro-migrate` `emit_sql` emits executable DDL for all `MigrationOp` variants on SQLite and Postgres (no comment placeholders).
+- [ ] `plan_table_migration` executes the IR plan; legacy enriched-JSON diff walk removed from `src/migrate.rs`.
+- [ ] Shadow/parity gate: IR migration path matches `create_tables` and Alembic for the `auto_migrate` capability matrix.
+- [ ] Duplicate `schema_json_to_schema_ir` / `live_columns_to_schema_ir` lowering consolidated or single-sourced where feasible.
+
+**Exit gate**
+- [ ] `cargo test -p ferro-migrate` green with full op coverage.
+- [ ] `tests/test_auto_migrate.py` and `tests/test_migrate_plan.py` green on SQLite + Postgres backend matrix.
+- [ ] No discarded `_typed_plan` scaffolding in `migrate.rs`.
+
+**Verification commands**
+- `cargo test -p ferro-schema-ir -p ferro-migrate`
+- `uv run pytest tests/test_ir_vectors_contract.py tests/test_migrate_plan.py tests/test_auto_migrate.py tests/test_alembic_autogenerate.py -q`
+- `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py -q`
+
+---
+
+### Phase 9 - Compatibility cutover and shim removal (`v0.14.0`)
+
+Status: `Not started`
+
+Issue references:
+
+- `Epic:` [#107](https://github.com/syn54x/ferro-orm/issues/107)
+- `Sub-issues:` [#108](https://github.com/syn54x/ferro-orm/issues/108), [#109](https://github.com/syn54x/ferro-orm/issues/109), [#110](https://github.com/syn54x/ferro-orm/issues/110)
 
 **Objective**
 - Complete migration by removing deprecated compatibility shims in `v0.14.0`.
@@ -581,7 +611,9 @@ Append updates as concise entries.
 - `2026-06-19` - Phase 2 merged via [#105](https://github.com/syn54x/ferro-orm/pull/105); issues [#80](https://github.com/syn54x/ferro-orm/issues/80), [#81](https://github.com/syn54x/ferro-orm/issues/81), [#82](https://github.com/syn54x/ferro-orm/issues/82), [#83](https://github.com/syn54x/ferro-orm/issues/83) synchronized and closed.
 - `2026-06-19` - Phase 3 working-branch implementation landed: QueryIR envelope hot-path cutover for query operations, operator-style deprecation warnings, and synchronized query docs/migration guidance updates.
 - `2026-06-19` - Sequencing update: Phase 7 is now public release with deprecated compatibility support; hard removal moved to Phase 8 (`v0.14.0`).
-- `2026-06-19` - Phase 8 issue set created and linked: epic [#107](https://github.com/syn54x/ferro-orm/issues/107) with sub-issues [#108](https://github.com/syn54x/ferro-orm/issues/108), [#109](https://github.com/syn54x/ferro-orm/issues/109), [#110](https://github.com/syn54x/ferro-orm/issues/110).
+- `2026-06-19` - Phase 9 issue set created and linked: epic [#107](https://github.com/syn54x/ferro-orm/issues/107) with sub-issues [#108](https://github.com/syn54x/ferro-orm/issues/108), [#109](https://github.com/syn54x/ferro-orm/issues/109), [#110](https://github.com/syn54x/ferro-orm/issues/110) (originally filed as Phase 8; renumbered 2026-06-23).
+- `2026-06-23` - Phase 8 issue set created and linked: epic [#117](https://github.com/syn54x/ferro-orm/issues/117) with sub-issues [#118](https://github.com/syn54x/ferro-orm/issues/118), [#119](https://github.com/syn54x/ferro-orm/issues/119), [#120](https://github.com/syn54x/ferro-orm/issues/120).
+- `2026-06-23` - Sequencing update: inserted Phase 8 (`ferro-migrate` runtime cutover, `v0.13.0`); prior shim-removal phase renumbered to Phase 9 (`v0.14.0`). Phase 4 exit gates corrected to reflect Alembic-only cutover on `feat/ir-first`.
 - `2026-06-19` - Phase 4 working-branch implementation landed: added `ferro-migrate` (`SchemaIR(old,new)` diff + SQL emission entrypoint), expanded SchemaIR fidelity (enum/check/join-table coverage), switched Alembic metadata derivation to SchemaIR, and added deprecation warnings for superseded JSON-only Alembic helpers (target removal `v0.14.0`).
 - `2026-06-22` - Phase 5 working-branch implementation landed: added unified codec registry module (`src/codec.rs`) across insert/update/filter/m2m/fetch paths, extracted single hydration ABI helper (`src/hydration.rs`) with required Pydantic slot initialization, and expanded codec conformance vectors/tests for null/uuid/decimal/temporal/enum semantics.
 - `2026-06-22` - Phase 6 working-branch implementation landed: introduced sessionized runtime API (`engines.session` / `Session`) and ambient session routing, moved transaction/identity-map hot-path state to session scope in Rust with compatibility fallback + deprecation warnings, added session lifecycle tests, and synchronized migration/guide/API/invariant docs.

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -484,6 +484,7 @@ Append updates as concise entries.
 - `2026-06-19` - Branching policy set: phase work branches from `feat/ir-first` and merges back into `feat/ir-first` until final promotion to `main`.
 - `2026-06-19` - Phase 0 completed and merged via [#75](https://github.com/syn54x/ferro-orm/pull/75).
 - `2026-06-19` - Phase 1 implementation landed on working branch: added `ferro-schema-ir`, Python->SchemaIR compiler, model-set fingerprinting, and stable representative snapshot checks.
+- `2026-06-19` - Phase 2 scaffolding landed on working branch: internal shadow runtime flag/hook wiring, semantic comparison harness, stable SQLite/Postgres shadow report fixtures, and touched-path CI gate for shadow reports.
 
 ## Immediate next actions
 

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -87,8 +87,8 @@ Definition of done addition:
 
 ## Program status
 
-- Overall status: `Not started`
-- Current phase: `Phase 0`
+- Overall status: `In progress`
+- Current phase: `Phase 1`
 - Last updated: `2026-06-19`
 - Roadmap owner: `@syn54x`
 
@@ -150,7 +150,7 @@ Definition of synchronized:
 
 ### Phase 0 - Contract and RFC freeze
 
-Status: `In progress`
+Status: `Complete`
 
 Issue references:
 
@@ -166,12 +166,13 @@ Issue references:
 - [x] Golden test vector format for schema/query/codec conformance fixtures.
 
 **Exit gate**
-- [ ] RFC approved and merged.
-- [ ] Golden vectors committed and validated by CI harness skeleton.
+- [x] RFC approved and merged.
+- [x] Golden vectors committed and validated by CI harness skeleton.
 
-**Evidence (branch `feat/ir-first`)**
-- RFC draft: `docs/rfc/ir-contracts-v1.md`
-- Invariant spec draft: `docs/solutions/patterns/ir-invariants.md`
+**Evidence (merged to `feat/ir-first`)**
+- Phase 0 merge PR: [#75](https://github.com/syn54x/ferro-orm/pull/75) (merge commit `c8c5308`)
+- RFC: `docs/rfc/ir-contracts-v1.md`
+- Invariant spec: `docs/solutions/patterns/ir-invariants.md`
 - Golden vectors: `tests/fixtures/ir_vectors/README.md`, `tests/fixtures/ir_vectors/*.json`
 - CI harness skeleton: `tests/test_ir_vectors_contract.py`
 - CI wiring: `.github/workflows/ci.yml` (IR vector contract harness step in Python test jobs)
@@ -436,6 +437,7 @@ Append updates as concise entries.
 
 - `2026-06-19` - Roadmap initialized.
 - `2026-06-19` - Branching policy set: phase work branches from `feat/ir-first` and merges back into `feat/ir-first` until final promotion to `main`.
+- `2026-06-19` - Phase 0 completed and merged via [#75](https://github.com/syn54x/ferro-orm/pull/75).
 
 ## Immediate next actions
 

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -1,0 +1,416 @@
+---
+title: "IR-first Ferro roadmap"
+type: strategy
+status: active
+date: 2026-06-19
+origin: chat
+---
+
+# IR-first Ferro roadmap
+
+## Goal
+
+Move Ferro to an IR-first architecture where schema, query, migration, and codec behavior are driven from one canonical intermediate representation (IR), eliminating cross-emitter drift classes by construction.
+
+## Decision principles
+
+- No stop-gaps: if a phase reveals a capability gap, extend the primitive instead of adding local patches.
+- One source of truth: no parallel emitters that independently derive schema semantics.
+- Fail loud on correctness boundaries: no warning-and-continue for invariant violations.
+- Backward compatibility is intentional and temporary: each shim has a planned removal phase.
+
+## Scope
+
+- In scope: schema IR, query IR, migration planning from IR, typed codec registry, hydration ABI, sessionized runtime state.
+- Out of scope (for this roadmap): feature expansion unrelated to IR migration unless it unblocks a phase gate.
+
+## Success criteria (program-level)
+
+- Runtime DDL, Alembic/autogenerate adapter, and migration planner consume the same IR artifacts.
+- Query execution consumes typed QueryIR (not ad-hoc JSON payloads).
+- Hydration path is single and ABI-defined for Pydantic slot initialization.
+- Global registries are removed from hot-path runtime operations in favor of explicit engine/session state.
+- Legacy compatibility shims are removed in the final major-version cut.
+- User-facing migration guidance is continuously updated and release-ready at each phase boundary.
+
+## Living migration guide requirement
+
+Maintain a running migration guide at:
+
+- `docs/plans/ir-first-migration-guide.md`
+
+Rules:
+
+- Every phase issue must include a migration impact assessment (`none`, `minor`, `breaking`).
+- If impact is `minor` or `breaking`, the migration guide must be updated before the issue can be marked Done.
+- If impact is `none`, explicitly record why in the issue body.
+- Phase exit gates are incomplete until migration-guide updates for that phase are merged (or explicitly marked `no user-impact` across all completed issues).
+
+## Deprecation policy (required)
+
+When new work supersedes existing APIs, behavior, patterns, or code paths:
+
+- Mark the old surface as deprecated at introduction time (not later).
+- Use Python's `warnings.deprecated` decorator for user-facing deprecated call sites.
+- Include a clear message with:
+  - what is deprecated
+  - the replacement API/pattern
+  - planned removal phase/version
+- Add or update tests that assert deprecation warnings are emitted.
+- Add a matching entry in `docs/plans/ir-first-migration-guide.md` with migration steps.
+
+Deprecation lifecycle:
+
+1. Introduce replacement + deprecation warning.
+2. Keep compatibility through the declared window.
+3. Remove deprecated surface in the planned phase/version and update migration guide.
+
+## Documentation update policy (required)
+
+Documentation is part of feature completion, not a follow-up task.
+
+Rules:
+
+- Every roadmap issue must include a documentation impact assessment (`none`, `update-existing`, `new-docs`).
+- If assessment is `update-existing` or `new-docs`, documentation updates must land before the issue can be marked Done.
+- If assessment is `none`, record explicit justification in the issue body.
+- Required docs to evaluate on each issue:
+  - user-facing guides under `docs/pages/guide/` and `docs/pages/howto/`
+  - API references under `docs/pages/api/`
+  - conceptual docs under `docs/pages/concepts/`
+  - examples under `docs/examples/` when behavior is demonstrated there
+  - migration notes in `docs/plans/ir-first-migration-guide.md` when user behavior changes
+
+Definition of done addition:
+
+- Feature work is not complete until code, tests, and docs are all synchronized for the shipped behavior.
+
+## Program status
+
+- Overall status: `Not started`
+- Current phase: `Phase 0`
+- Last updated: `2026-06-19`
+- Roadmap owner: `@syn54x`
+
+## Traceability rule (roadmap <-> GitHub issues)
+
+- Every roadmap deliverable and exit gate must reference one or more GitHub issues.
+- Every GitHub issue created for this program must link back to the roadmap document and the relevant phase/section.
+- A phase is not considered complete unless all referenced issues are resolved and listed under that phase.
+- If scope changes, update roadmap references in the same PR that adds/splits/relabels the issue.
+- Roadmap and issue content are a single source of execution truth and must remain synchronized at all times.
+- Any roadmap change that affects scope, acceptance criteria, ownership, status, risk, sequencing, or exit gates must be reflected in all already-created linked issues in the same work session (or same PR when applicable).
+- Any issue change that affects those same dimensions must be reflected in the roadmap in the same work session (or same PR when applicable).
+
+### Reference format
+
+Use issue references inline under each phase:
+
+- `Epic:` [#number](link)
+- `Sub-issues:` [#number](link), [#number](link), [#number](link)
+
+Use this backlink line in issue bodies:
+
+- `Roadmap reference: docs/plans/2026-06-19-001-ir-first-roadmap.md (Phase X)`
+
+### Sync protocol (required)
+
+When editing roadmap content:
+
+1. Update the relevant linked issues immediately.
+2. Verify issue titles/body checklists/acceptance criteria still match roadmap text.
+3. Add or update issue links in the roadmap if issues were split/renumbered.
+
+When editing issue content:
+
+1. Update the matching roadmap phase/section immediately.
+2. Verify roadmap status, gates, and references still match issue state.
+3. Record any scope boundary changes in both places.
+
+Definition of synchronized:
+
+- A reader can start from either the roadmap or the issues and get the same current scope, gates, and status with no contradictions.
+
+## Phase tracker
+
+### Phase 0 - Contract and RFC freeze
+
+Status: `Not started`
+
+Issue references:
+
+- `Epic:` [#71](https://github.com/syn54x/ferro-orm/issues/71)
+- `Sub-issues:` [#72](https://github.com/syn54x/ferro-orm/issues/72), [#73](https://github.com/syn54x/ferro-orm/issues/73), [#74](https://github.com/syn54x/ferro-orm/issues/74)
+
+**Objective**
+- Define versioned IR contracts and non-negotiable invariants before implementation.
+
+**Deliverables**
+- [ ] RFC: `SchemaIR`, `QueryIR`, `CodecIR` structure and versioning strategy.
+- [ ] Invariant spec doc covering parity, hydration ABI, null/bind correctness.
+- [ ] Golden test vector format for schema/query/codec conformance fixtures.
+
+**Exit gate**
+- [ ] RFC approved and merged.
+- [ ] Golden vectors committed and validated by CI harness skeleton.
+
+---
+
+### Phase 1 - Build IR core and compiler
+
+Status: `Not started`
+
+**Objective**
+- Introduce a Rust-owned IR crate and compile Python model metadata into deterministic IR artifacts.
+
+**Deliverables**
+- [ ] `ferro-schema-ir` crate added with versioned serde types.
+- [ ] Python -> SchemaIR compiler path added.
+- [ ] IR hashing/fingerprinting persisted for model sets.
+
+**Exit gate**
+- [ ] Existing representative models compile to stable IR snapshots in CI.
+- [ ] No user-visible behavior changes yet.
+
+---
+
+### Phase 2 - Shadow runtime dual-run
+
+Status: `Not started`
+
+**Objective**
+- Run IR-derived runtime planning in shadow mode and compare semantics against current runtime path.
+
+**Deliverables**
+- [ ] Query/DDL shadow planner behind internal flag.
+- [ ] Semantic diff harness (result shape, bind semantics, not only SQL strings).
+- [ ] Backend matrix shadow reports for SQLite/Postgres.
+
+**Exit gate**
+- [ ] Zero semantic mismatches across integration suite.
+- [ ] Shadow reports are stable and required in CI for touched paths.
+
+---
+
+### Phase 3 - QueryIR cutover
+
+Status: `Not started`
+
+**Objective**
+- Move query execution to typed QueryIR and retire internal JSON query contracts.
+
+**Deliverables**
+- [ ] Runtime query compilation consumes QueryIR.
+- [ ] Lambda predicate style is first-class; legacy operator style on deprecation track.
+- [ ] JSON query payload bridge removed from core execution path.
+
+**Exit gate**
+- [ ] Query builder integration tests pass fully on QueryIR path.
+- [ ] Compatibility behavior explicitly documented for remaining public API differences.
+
+---
+
+### Phase 4 - SchemaIR migration and DDL cutover
+
+Status: `Not started`
+
+**Objective**
+- Make SchemaIR the only schema truth for migration planning and DDL emission.
+
+**Deliverables**
+- [ ] `ferro-migrate` planner: `SchemaIR(old) -> SchemaIR(new) -> MigrationPlan`.
+- [ ] Backend emitters from `MigrationPlan`.
+- [ ] Alembic adapter consumes IR outputs (no independent schema derivation).
+
+**Exit gate**
+- [ ] No independent parallel DDL emitter remains.
+- [ ] Cross-emitter parity class is structurally eliminated.
+
+---
+
+### Phase 5 - Codec and hydration ABI unification
+
+Status: `Not started`
+
+**Objective**
+- Centralize bind/fetch type behavior and formalize the hydration ABI.
+
+**Deliverables**
+- [ ] Unified codec registry used by insert/update/filter/m2m/fetch.
+- [ ] Hydration ABI layer with explicit Pydantic slot initialization contract.
+- [ ] Codec conformance tests for null/uuid/decimal/temporal/enum semantics.
+
+**Exit gate**
+- [ ] One hydration path only.
+- [ ] One codec path only (documented exceptions removed or justified by design).
+
+---
+
+### Phase 6 - Sessionized runtime state
+
+Status: `Not started`
+
+**Objective**
+- Replace global mutable registries in hot paths with explicit session/engine scoped state.
+
+**Deliverables**
+- [ ] Session/UnitOfWork abstraction for identity map + transaction state.
+- [ ] Engine-scoped registries replace global lookups in core operations.
+- [ ] Temporary compatibility shim for legacy call sites.
+
+**Exit gate**
+- [ ] Core CRUD/query paths no longer require global registries.
+- [ ] Session lifecycle and concurrency semantics documented.
+
+---
+
+### Phase 7 - Major version release and shim removal
+
+Status: `Not started`
+
+**Objective**
+- Complete migration by removing compatibility shims and releasing IR-first major version.
+
+**Deliverables**
+- [ ] Legacy code paths removed.
+- [ ] Migration guide and upgrade checklist.
+- [ ] Final release checklist and changelog entries.
+
+**Exit gate**
+- [ ] Release branch green across full backend/test matrix.
+- [ ] Migration guide validated against at least one real example project.
+
+## Workstreams and ownership
+
+- WS1 - IR contracts and compiler (`Rust core + Python bridge`)
+- WS2 - Query/runtime cutover (`Query builder + operations`)
+- WS3 - Migration/DDL cutover (`Schema + Alembic adapter`)
+- WS4 - Codecs/hydration ABI (`bind/fetch + Pydantic integration`)
+- WS5 - Session architecture (`identity map + transaction routing`)
+- WS6 - Developer experience (`docs, upgrade tooling, release`)
+
+Assign one directly responsible owner (DRO) per phase and one reviewer owner per workstream.
+
+## Target user experience (north star)
+
+The migration is successful only if Ferro becomes more predictable for users while keeping ergonomics high.
+
+### Desired API posture
+
+- Explicit path is first-class:
+  - `async with engines.session("analytics") as s:`
+  - `await s.query(Metric).where(...).all()`
+- Convenience path is supported inside an active session context:
+  - `async with engines.session("analytics"):`
+  - `metrics = await Metric.all()`
+- Both paths are equivalent in behavior and safety.
+
+### Session discovery contract
+
+- `Model` operations may auto-discover the active session from async context.
+- Discovery source is a session-scoped context value only (no hidden fallback to global default connection).
+- If no active session exists, operations fail with a clear actionable error.
+- Explicit session parameters override ambient discovery when both are present.
+
+### Multi-DB UX intent
+
+- Multi-DB routing is explicit and composable (`session("name")` or explicit session handle).
+- No routing from untrusted input.
+- No implicit cross-connection transaction semantics.
+- Session/identity behavior is scoped to the selected connection.
+
+### Caveats to track across phases
+
+- Nested sessions must shadow and restore correctly.
+- Async task spawning rules for context propagation must be documented and tested.
+- Ambient convenience must not reintroduce hidden-global behavior.
+- Error messages for missing/mismatched sessions must be precise and stable.
+
+### UX examples (directional)
+
+Explicit session-first style:
+
+```python
+async with engines.session("analytics") as s:
+    metrics = await s.query(Metric).where(lambda t: t.value > 0).all()
+```
+
+Convenience ActiveRecord-like style inside session context:
+
+```python
+async with engines.session("analytics"):
+    metrics = await Metric.where(lambda t: t.value > 0).all()
+```
+
+Deterministic failure outside session context:
+
+```python
+metrics = await Metric.all()  # RuntimeError: no active session
+```
+
+Explicit override beats ambient session when needed:
+
+```python
+async with engines.session("app"):
+    async with engines.session("analytics") as analytics_session:
+        metrics = await Metric.all(session=analytics_session)
+```
+
+### UX acceptance criteria (program-level)
+
+- Users can choose explicit `session.query(...)` or convenience `Model.*` inside session contexts.
+- The same operation returns the same result and semantics in either style.
+- Attempting convenience model calls outside a session raises a deterministic error.
+- Multi-DB behavior is deterministic under concurrent coroutine workloads.
+
+## GitHub Project mapping (ready to instantiate)
+
+Use this roadmap as the source for issues and project fields.
+
+**Recommended project fields**
+- `Phase`: 0, 1, 2, 3, 4, 5, 6, 7
+- `Workstream`: WS1..WS6
+- `Type`: RFC, Infra, Runtime, Migration, Test, Docs, Release
+- `Status`: Backlog, Ready, In Progress, Blocked, In Review, Done
+- `Exit Gate`: No/Yes
+- `Risk`: Low, Medium, High
+
+**Issue template shape**
+- Title: `[IR-P<phase>][WSx] <short outcome>`
+- Body:
+  - Problem statement
+  - Intended invariant
+  - Scope boundaries
+  - Migration impact (`none|minor|breaking`) and required guide updates
+  - Deliverable checklist
+  - Validation plan
+  - Rollback/failure mode
+
+## Milestone cadence
+
+- Milestone per phase (`IR-P0`, `IR-P1`, ...).
+- Weekly roadmap review:
+  - phase status changes
+  - new blockers and risk level updates
+  - gate evidence links added
+
+## Risk register
+
+- Risk: hidden coupling to legacy JSON/query internals.
+  - Mitigation: keep shadow diff harness mandatory through Phase 3.
+- Risk: migration planner parity regressions during cutover.
+  - Mitigation: golden vector suite plus backend matrix at every phase gate.
+- Risk: compatibility shim drag extends timeline.
+  - Mitigation: define shim sunset at creation time with a hard owning phase.
+
+## Progress log
+
+Append updates as concise entries.
+
+- `2026-06-19` - Roadmap initialized.
+
+## Immediate next actions
+
+- [ ] Create GitHub issues for Phase 0 deliverables.
+- [ ] Create `IR-P0` milestone and seed with Phase 0 issues.
+- [ ] Assign DRO for Phase 0 RFC.

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -88,7 +88,7 @@ Definition of done addition:
 ## Program status
 
 - Overall status: `In progress`
-- Current phase: `Phase 3`
+- Current phase: `Phase 4`
 - Last updated: `2026-06-19`
 - Roadmap owner: `@syn54x`
 
@@ -285,7 +285,7 @@ Issue references:
 
 ### Phase 4 - SchemaIR migration and DDL cutover
 
-Status: `Not started`
+Status: `In progress`
 
 Issue references:
 
@@ -296,13 +296,23 @@ Issue references:
 - Make SchemaIR the only schema truth for migration planning and DDL emission.
 
 **Deliverables**
-- [ ] `ferro-migrate` planner: `SchemaIR(old) -> SchemaIR(new) -> MigrationPlan`.
-- [ ] Backend emitters from `MigrationPlan`.
-- [ ] Alembic adapter consumes IR outputs (no independent schema derivation).
+- [x] `ferro-migrate` planner: `SchemaIR(old) -> SchemaIR(new) -> MigrationPlan`.
+- [x] Backend emitters from `MigrationPlan`.
+- [x] Alembic adapter consumes IR outputs (no independent schema derivation).
 
 **Exit gate**
 - [ ] No independent parallel DDL emitter remains.
 - [ ] Cross-emitter parity class is structurally eliminated.
+
+**Evidence (working branch; pending merge to `feat/ir-first`)**
+- New planner/emitter crate: `crates/ferro-migrate/` (`plan_from_ir`, `emit_sql`, unit tests)
+- SchemaIR fidelity updates: `src/ferro/ir/compiler.py`, `crates/ferro-schema-ir/src/lib.rs`
+- Runtime planner now consumes typed IR diff path before SQL planning: `src/migrate.rs`
+- Alembic metadata now derives from SchemaIR modelset: `src/ferro/migrations/alembic.py`
+- Deprecation coverage for superseded JSON helper path: `tests/test_alembic_bridge.py`
+- Verification commands:
+  - `cargo test -p ferro-schema-ir -p ferro-migrate`
+  - `uv run pytest tests/test_ir_vectors_contract.py tests/test_alembic_bridge.py tests/test_alembic_autogenerate.py tests/test_migrate_plan.py tests/test_auto_migrate.py -q`
 
 ---
 
@@ -535,6 +545,8 @@ Append updates as concise entries.
 - `2026-06-19` - Phase 2 merged via [#105](https://github.com/syn54x/ferro-orm/pull/105); issues [#80](https://github.com/syn54x/ferro-orm/issues/80), [#81](https://github.com/syn54x/ferro-orm/issues/81), [#82](https://github.com/syn54x/ferro-orm/issues/82), [#83](https://github.com/syn54x/ferro-orm/issues/83) synchronized and closed.
 - `2026-06-19` - Phase 3 working-branch implementation landed: QueryIR envelope hot-path cutover for query operations, operator-style deprecation warnings, and synchronized query docs/migration guidance updates.
 - `2026-06-19` - Sequencing update: Phase 7 is now public release with deprecated compatibility support; hard removal moved to Phase 8 (`v0.13.0`).
+- `2026-06-19` - Phase 8 issue set created and linked: epic [#107](https://github.com/syn54x/ferro-orm/issues/107) with sub-issues [#108](https://github.com/syn54x/ferro-orm/issues/108), [#109](https://github.com/syn54x/ferro-orm/issues/109), [#110](https://github.com/syn54x/ferro-orm/issues/110).
+- `2026-06-19` - Phase 4 working-branch implementation landed: added `ferro-migrate` (`SchemaIR(old,new)` diff + SQL emission entrypoint), expanded SchemaIR fidelity (enum/check/join-table coverage), switched Alembic metadata derivation to SchemaIR, and added deprecation warnings for superseded JSON-only Alembic helpers (target removal `v0.13.0`).
 
 ## Immediate next actions
 

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -30,7 +30,7 @@ Move Ferro to an IR-first architecture where schema, query, migration, and codec
 - Query execution consumes typed QueryIR (not ad-hoc JSON payloads).
 - Hydration path is single and ABI-defined for Pydantic slot initialization.
 - Global registries are removed from hot-path runtime operations in favor of explicit engine/session state.
-- Legacy compatibility shims are removed in the explicit `v0.13.0` cutover.
+- Legacy compatibility shims are removed in the explicit `v0.14.0` cutover.
 - User-facing migration guidance is continuously updated and release-ready at each phase boundary.
 
 ## Living migration guide requirement
@@ -384,7 +384,7 @@ Issue references:
 
 ### Phase 7 - Major-version public release with compatibility window
 
-Status: `Not started`
+Status: `Complete`
 
 Issue references:
 
@@ -395,20 +395,36 @@ Issue references:
 - Release the IR-first upgrade publicly while keeping deprecated compatibility paths available through a defined migration window.
 
 **Deliverables**
-- [ ] Public upgrade release shipped with migration guide and deprecation messaging.
-- [ ] Deprecated compatibility paths remain available during the migration window.
-- [ ] Deprecated-compat test inventory is tagged and tracked for removal (`pytest.mark.deprecated_operator_path`).
-- [ ] Migration guide and upgrade checklist.
-- [ ] Final release checklist and changelog entries.
+- [x] Public upgrade release shipped with migration guide and deprecation messaging.
+- [x] Deprecated compatibility paths remain available during the migration window.
+- [x] Deprecated-compat test inventory is tagged and tracked for removal (`pytest.mark.deprecated_operator_path`).
+- [x] Migration guide and upgrade checklist.
+- [x] Final release checklist and changelog entries.
 
 **Exit gate**
-- [ ] Release branch green across full backend/test matrix.
-- [ ] Migration guide validated against at least one real example project.
-- [ ] Deprecation warnings explicitly point to `v0.13.0` as the removal release.
+- [x] Release branch green across full backend/test matrix.
+- [x] Migration guide validated against at least one real example project.
+- [x] Deprecation warnings explicitly point to `v0.14.0` as the removal release.
+
+**Evidence (working branch; pending merge to `feat/ir-first`)**
+- Deprecation messaging consistency primitive + call-site adoption: `src/ferro/_deprecations.py`, `src/ferro/query/builder.py`, `src/ferro/state.py`, `src/ferro/migrations/alembic.py`
+- Deprecated inventory and warning-target coverage: `tests/test_deprecated_operator_inventory.py`, `tests/test_query_builder.py`, `tests/test_query_typing.py`, `tests/test_session.py`, `tests/test_alembic_bridge.py`
+- Phase 7 migration/release docs: `docs/plans/ir-first-migration-guide.md`, `docs/pages/howto/migrating-to-v0-12-0.md`, `docs/plans/ir-first-release-checklist.md`, `docs/pages/guide/queries.md`, `docs/pages/concepts/query-typing.md`, `docs/pages/api/queries.md`, `docs/pages/guide/connections.md`, `docs/pages/api/migrations.md`, `zensical.toml`, `CHANGELOG.md`
+- Migration-guide validation against real example project surface: `uv run pytest -v tests/test_docs_examples.py` (includes `docs/examples/*.py` scripts and migration guide code snippet validation)
+- Verification commands:
+  - `cargo test --no-default-features --features testing`
+  - `cargo test -p ferro-schema-ir -p ferro-migrate`
+  - `uv run pytest -v tests/test_ir_vectors_contract.py`
+  - `uv run pytest -v --cov=src --cov-report=xml --cov-report=term`
+  - `uv run pytest -v -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres`
+  - `uv run pytest -v -m deprecated_operator_path`
+  - `uv run pytest -v tests/test_query_builder.py tests/test_query_typing.py tests/test_session.py tests/test_alembic_bridge.py tests/test_docs_examples.py`
+  - `uv run zensical build --clean`
+  - `uv run maturin build --release`
 
 ---
 
-### Phase 8 - Compatibility cutover and shim removal (`v0.13.0`)
+### Phase 8 - Compatibility cutover and shim removal (`v0.14.0`)
 
 Status: `Not started`
 
@@ -418,17 +434,17 @@ Issue references:
 - `Sub-issues:` _TBD_
 
 **Objective**
-- Complete migration by removing deprecated compatibility shims in `v0.13.0`.
+- Complete migration by removing deprecated compatibility shims in `v0.14.0`.
 
 **Deliverables**
 - [ ] Legacy compatibility code paths removed.
 - [ ] Deprecated-compat test inventory removed (all `deprecated_operator_path` tests deleted or rewritten).
-- [ ] Final migration-guide cutover notes for `v0.13.0`.
+- [ ] Final migration-guide cutover notes for `v0.14.0`.
 - [ ] Release checklist and changelog entries for shim removal.
 
 **Exit gate**
 - [ ] Full backend/test matrix green with deprecated paths removed.
-- [ ] Migration guide validated against at least one real example project on the `v0.13.0` code path.
+- [ ] Migration guide validated against at least one real example project on the `v0.14.0` code path.
 
 ## Workstreams and ownership
 
@@ -564,11 +580,12 @@ Append updates as concise entries.
 - `2026-06-19` - Phase 2 scaffolding landed on working branch: internal shadow runtime flag/hook wiring, semantic comparison harness, stable SQLite/Postgres shadow report fixtures, and touched-path CI gate for shadow reports.
 - `2026-06-19` - Phase 2 merged via [#105](https://github.com/syn54x/ferro-orm/pull/105); issues [#80](https://github.com/syn54x/ferro-orm/issues/80), [#81](https://github.com/syn54x/ferro-orm/issues/81), [#82](https://github.com/syn54x/ferro-orm/issues/82), [#83](https://github.com/syn54x/ferro-orm/issues/83) synchronized and closed.
 - `2026-06-19` - Phase 3 working-branch implementation landed: QueryIR envelope hot-path cutover for query operations, operator-style deprecation warnings, and synchronized query docs/migration guidance updates.
-- `2026-06-19` - Sequencing update: Phase 7 is now public release with deprecated compatibility support; hard removal moved to Phase 8 (`v0.13.0`).
+- `2026-06-19` - Sequencing update: Phase 7 is now public release with deprecated compatibility support; hard removal moved to Phase 8 (`v0.14.0`).
 - `2026-06-19` - Phase 8 issue set created and linked: epic [#107](https://github.com/syn54x/ferro-orm/issues/107) with sub-issues [#108](https://github.com/syn54x/ferro-orm/issues/108), [#109](https://github.com/syn54x/ferro-orm/issues/109), [#110](https://github.com/syn54x/ferro-orm/issues/110).
-- `2026-06-19` - Phase 4 working-branch implementation landed: added `ferro-migrate` (`SchemaIR(old,new)` diff + SQL emission entrypoint), expanded SchemaIR fidelity (enum/check/join-table coverage), switched Alembic metadata derivation to SchemaIR, and added deprecation warnings for superseded JSON-only Alembic helpers (target removal `v0.13.0`).
+- `2026-06-19` - Phase 4 working-branch implementation landed: added `ferro-migrate` (`SchemaIR(old,new)` diff + SQL emission entrypoint), expanded SchemaIR fidelity (enum/check/join-table coverage), switched Alembic metadata derivation to SchemaIR, and added deprecation warnings for superseded JSON-only Alembic helpers (target removal `v0.14.0`).
 - `2026-06-22` - Phase 5 working-branch implementation landed: added unified codec registry module (`src/codec.rs`) across insert/update/filter/m2m/fetch paths, extracted single hydration ABI helper (`src/hydration.rs`) with required Pydantic slot initialization, and expanded codec conformance vectors/tests for null/uuid/decimal/temporal/enum semantics.
 - `2026-06-22` - Phase 6 working-branch implementation landed: introduced sessionized runtime API (`engines.session` / `Session`) and ambient session routing, moved transaction/identity-map hot-path state to session scope in Rust with compatibility fallback + deprecation warnings, added session lifecycle tests, and synchronized migration/guide/API/invariant docs.
+- `2026-06-22` - Phase 7 working-branch implementation landed: completed version-centric public migration guidance (`Migrating to v0.12.0`), added release checklist + changelog entries, centralized `v0.14.0` deprecation-target messaging across compatibility paths, added deprecated-path inventory tests, and validated full Rust/Python/docs/release verification matrix.
 
 ## Immediate next actions
 

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -88,8 +88,8 @@ Definition of done addition:
 ## Program status
 
 - Overall status: `In progress`
-- Current phase: `Phase 4`
-- Last updated: `2026-06-19`
+- Current phase: `Phase 6`
+- Last updated: `2026-06-22`
 - Roadmap owner: `@syn54x`
 
 ## Branching and release policy
@@ -318,7 +318,7 @@ Issue references:
 
 ### Phase 5 - Codec and hydration ABI unification
 
-Status: `Not started`
+Status: `Complete`
 
 Issue references:
 
@@ -329,13 +329,22 @@ Issue references:
 - Centralize bind/fetch type behavior and formalize the hydration ABI.
 
 **Deliverables**
-- [ ] Unified codec registry used by insert/update/filter/m2m/fetch.
-- [ ] Hydration ABI layer with explicit Pydantic slot initialization contract.
-- [ ] Codec conformance tests for null/uuid/decimal/temporal/enum semantics.
+- [x] Unified codec registry used by insert/update/filter/m2m/fetch.
+- [x] Hydration ABI layer with explicit Pydantic slot initialization contract.
+- [x] Codec conformance tests for null/uuid/decimal/temporal/enum semantics.
 
 **Exit gate**
-- [ ] One hydration path only.
-- [ ] One codec path only (documented exceptions removed or justified by design).
+- [x] One hydration path only.
+- [x] One codec path only (documented exceptions removed or justified by design).
+
+**Evidence (working branch; pending merge to `feat/ir-first`)**
+- Unified codec registry + routing: `src/codec.rs`, `src/operations.rs`, `src/query.rs`, `src/lib.rs`
+- Hydration ABI unification: `src/hydration.rs`, `src/operations.rs`, `tests/test_hydration.py`
+- Codec vectors + conformance: `tests/fixtures/ir_vectors/codec_registry_core_v1.json`, `tests/test_ir_vectors_contract.py`, `tests/test_typed_null_binds.py`, `tests/test_structural_types.py`, `tests/test_temporal_types.py`, `tests/test_enum_cold_hydration.py`
+- Verification commands:
+  - `cargo check`
+  - `cargo test -p ferro-schema-ir`
+  - `uv run pytest tests/test_ir_vectors_contract.py tests/test_hydration.py tests/test_typed_null_binds.py tests/test_structural_types.py tests/test_temporal_types.py tests/test_enum_cold_hydration.py -q`
 
 ---
 
@@ -547,6 +556,7 @@ Append updates as concise entries.
 - `2026-06-19` - Sequencing update: Phase 7 is now public release with deprecated compatibility support; hard removal moved to Phase 8 (`v0.13.0`).
 - `2026-06-19` - Phase 8 issue set created and linked: epic [#107](https://github.com/syn54x/ferro-orm/issues/107) with sub-issues [#108](https://github.com/syn54x/ferro-orm/issues/108), [#109](https://github.com/syn54x/ferro-orm/issues/109), [#110](https://github.com/syn54x/ferro-orm/issues/110).
 - `2026-06-19` - Phase 4 working-branch implementation landed: added `ferro-migrate` (`SchemaIR(old,new)` diff + SQL emission entrypoint), expanded SchemaIR fidelity (enum/check/join-table coverage), switched Alembic metadata derivation to SchemaIR, and added deprecation warnings for superseded JSON-only Alembic helpers (target removal `v0.13.0`).
+- `2026-06-22` - Phase 5 working-branch implementation landed: added unified codec registry module (`src/codec.rs`) across insert/update/filter/m2m/fetch paths, extracted single hydration ABI helper (`src/hydration.rs`) with required Pydantic slot initialization, and expanded codec conformance vectors/tests for null/uuid/decimal/temporal/enum semantics.
 
 ## Immediate next actions
 

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -33,7 +33,13 @@ No user-facing runtime behavior changes expected.
 
 ### Phase 1
 
-_TBD_
+No user-facing runtime behavior changes expected.
+
+| Issue | Change | Impact | User action | Notes |
+| --- | --- | --- | --- | --- |
+| [#77](https://github.com/syn54x/ferro-orm/issues/77) | Add `ferro-schema-ir` crate with versioned serde IR contracts | none | none | Internal contract crate only; artifacts: `crates/ferro-schema-ir/`, RFC vector round-trip tests |
+| [#78](https://github.com/syn54x/ferro-orm/issues/78) | Add deterministic Python -> SchemaIR compiler path | none | none | Internal compiler path only; artifacts: `src/ferro/ir/compiler.py`, model registration + relationship-resolution hooks |
+| [#79](https://github.com/syn54x/ferro-orm/issues/79) | Persist model-set fingerprints and stable representative snapshots | none | none | Infra/test only; artifacts: `tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json`, `tests/test_ir_vectors_contract.py` |
 
 ### Phase 2
 

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -87,7 +87,17 @@ Phase 4 deprecation note:
 
 ### Phase 6
 
-_TBD_
+| Issue | Change | Impact | User action | Notes |
+| --- | --- | --- | --- | --- |
+| [#97](https://github.com/syn54x/ferro-orm/issues/97) | Add explicit `Session`/`engines.session(name)` runtime boundary for ambient model/query/raw routing | minor | Prefer `async with ferro.engines.session(\"name\")` around request/task work; use `session=` explicit overrides when needed | Adds deterministic nested-session shadow/restore semantics |
+| [#98](https://github.com/syn54x/ferro-orm/issues/98) | Core CRUD/query/transaction hot paths now support session-scoped transaction + identity-map state in Rust | minor | No call-site change required if you use sessions; behavior is now isolated per session under concurrent workloads | Legacy global fallback remains only for compatibility paths |
+| [#99](https://github.com/syn54x/ferro-orm/issues/99) | Temporary compatibility shim keeps implicit default-connection routing but emits deprecation warnings | minor | Migrate unqualified operations (`Model.*`, `ferro.execute/fetch_*`) to run inside sessions; keep `using=` for explicit one-off routing | Deprecation warning points to removal target `v0.13.0` |
+
+Phase 6 deprecation note:
+
+- Deprecated: implicit default-connection routing outside an active session context.
+- Replacement: `async with ferro.engines.session(\"name\")` (ambient routing) or explicit `session=` arguments.
+- Removal target: `v0.13.0`.
 
 ### Phase 7
 

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -79,7 +79,11 @@ Phase 4 deprecation note:
 
 ### Phase 5
 
-_TBD_
+| Issue | Change | Impact | User action | Notes |
+| --- | --- | --- | --- | --- |
+| [#93](https://github.com/syn54x/ferro-orm/issues/93) | Unified Rust codec registry now drives schema-aware bind/fetch lowering for insert/update/filter/m2m/fetch paths | minor | No API change; if you rely on internal Rust helper names (`schema_value_expr`, `value_rhs_simple_expr_for_backend`, `backend_column_value_expr`), migrate to codec registry entrypoints | Artifacts: `src/codec.rs`, `src/operations.rs`, `src/query.rs` |
+| [#94](https://github.com/syn54x/ferro-orm/issues/94) | Hydration ABI is centralized into one helper that enforces `direct_dict` + required Pydantic slot initialization | minor | No API change; hydration behavior is now deterministic across `get/all/first` fetch paths | Artifacts: `src/hydration.rs`, `tests/test_hydration.py` |
+| [#95](https://github.com/syn54x/ferro-orm/issues/95) | Codec conformance vectors and backend-matrix tests expanded for null/uuid/decimal/temporal/enum semantics | minor | No API change; expect stricter/clearer type behavior in edge cases previously relying on fallback coercions | Artifacts: `tests/fixtures/ir_vectors/codec_registry_core_v1.json`, `tests/test_ir_vectors_contract.py`, `tests/test_typed_null_binds.py` |
 
 ### Phase 6
 

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -56,12 +56,12 @@ No user-facing runtime behavior changes expected. Shadow planning is internal-on
 | Issue | Change | Impact | User action | Notes |
 | --- | --- | --- | --- | --- |
 | [#85](https://github.com/syn54x/ferro-orm/issues/85) | Runtime query compilation now consumes QueryIR envelopes on core execution paths | minor | No API change for lambda/`col()` query callers; if you rely on internal `_core` query payload shape, migrate to QueryIR envelope (`ir_kind`, `ir_version`, `payload`) | Internal JSON `QueryDef` payload contract is no longer the core hot-path boundary |
-| [#86](https://github.com/syn54x/ferro-orm/issues/86) | Operator-style predicates (`Model.field OP value`) are deprecated with runtime warnings | minor | Migrate call sites to `where(lambda t: ...)` (recommended) or `col(Model.field)` | Deprecation message includes replacement + removal target (`v0.13.0`) |
+| [#86](https://github.com/syn54x/ferro-orm/issues/86) | Operator-style predicates (`Model.field OP value`) are deprecated with runtime warnings | minor | Migrate call sites to `where(lambda t: ...)` (recommended) or `col(Model.field)` | Deprecation message includes replacement + removal target (`v0.14.0`) |
 | [#87](https://github.com/syn54x/ferro-orm/issues/87) | Python query builder now emits QueryIR envelope payloads to Rust runtime | minor | No action for public `Model.where`/`Query.where` usage; update internal tests/tools that serialized legacy `where_clause` JSON | Compatibility behavior remains documented in query typing docs during deprecation window |
 
 Phase 3 test-migration note:
 
-- Tests that exist only to verify temporary operator-style compatibility are tagged `deprecated_operator_path` and scheduled for removal/rewrite at `v0.13.0`.
+- Tests that exist only to verify temporary operator-style compatibility are tagged `deprecated_operator_path` and scheduled for removal/rewrite at `v0.14.0`.
 
 ### Phase 4
 
@@ -69,13 +69,13 @@ Phase 3 test-migration note:
 | --- | --- | --- | --- | --- |
 | [#89](https://github.com/syn54x/ferro-orm/issues/89) | SchemaIR compiler fidelity extended for `db_check` expressions, enum metadata, and join-table model inclusion | minor | No API changes for model declaration; if you consume internal SchemaIR fixtures, refresh snapshots to include join-table and enum/check artifacts | Artifacts: `src/ferro/ir/compiler.py`, `tests/test_ir_vectors_contract.py` |
 | [#90](https://github.com/syn54x/ferro-orm/issues/90) | Introduce `crates/ferro-migrate` with typed `SchemaIR(old,new)` diff operations and backend SQL emission entrypoint | minor | No user API change; maintainers/tools consuming migration internals should move to `ferro-migrate` plan ops | Artifacts: `crates/ferro-migrate/`, `src/migrate.rs` |
-| [#91](https://github.com/syn54x/ferro-orm/issues/91) | Alembic `get_metadata()` now derives from SchemaIR modelset; legacy JSON-lowering helpers deprecated | minor | Keep using `get_metadata()`; if you directly import private `ferro.migrations.alembic._build_sa_table` / `_map_to_sa_type`, migrate away now | Deprecated helpers emit `DeprecationWarning` with planned removal `v0.13.0` |
+| [#91](https://github.com/syn54x/ferro-orm/issues/91) | Alembic `get_metadata()` now derives from SchemaIR modelset; legacy JSON-lowering helpers deprecated | minor | Keep using `get_metadata()`; if you directly import private `ferro.migrations.alembic._build_sa_table` / `_map_to_sa_type`, migrate away now | Deprecated helpers emit `DeprecationWarning` with planned removal `v0.14.0` |
 
 Phase 4 deprecation note:
 
 - Deprecated: `ferro.migrations.alembic._build_sa_table()` and `ferro.migrations.alembic._map_to_sa_type()`
 - Replacement: `get_metadata()` (SchemaIR-backed) and internal IR lowering via `_sa_type_from_ir_column()`
-- Removal target: `v0.13.0`
+- Removal target: `v0.14.0`
 
 ### Phase 5
 
@@ -91,23 +91,51 @@ Phase 4 deprecation note:
 | --- | --- | --- | --- | --- |
 | [#97](https://github.com/syn54x/ferro-orm/issues/97) | Add explicit `Session`/`engines.session(name)` runtime boundary for ambient model/query/raw routing | minor | Prefer `async with ferro.engines.session(\"name\")` around request/task work; use `session=` explicit overrides when needed | Adds deterministic nested-session shadow/restore semantics |
 | [#98](https://github.com/syn54x/ferro-orm/issues/98) | Core CRUD/query/transaction hot paths now support session-scoped transaction + identity-map state in Rust | minor | No call-site change required if you use sessions; behavior is now isolated per session under concurrent workloads | Legacy global fallback remains only for compatibility paths |
-| [#99](https://github.com/syn54x/ferro-orm/issues/99) | Temporary compatibility shim keeps implicit default-connection routing but emits deprecation warnings | minor | Migrate unqualified operations (`Model.*`, `ferro.execute/fetch_*`) to run inside sessions; keep `using=` for explicit one-off routing | Deprecation warning points to removal target `v0.13.0` |
+| [#99](https://github.com/syn54x/ferro-orm/issues/99) | Temporary compatibility shim keeps implicit default-connection routing but emits deprecation warnings | minor | Migrate unqualified operations (`Model.*`, `ferro.execute/fetch_*`) to run inside sessions; keep `using=` for explicit one-off routing | Deprecation warning points to removal target `v0.14.0` |
 
 Phase 6 deprecation note:
 
 - Deprecated: implicit default-connection routing outside an active session context.
 - Replacement: `async with ferro.engines.session(\"name\")` (ambient routing) or explicit `session=` arguments.
-- Removal target: `v0.13.0`.
+- Removal target: `v0.14.0`.
 
 ### Phase 7
 
-_TBD_
+Public release phase for the IR-first architecture with a defined compatibility
+window. Deprecated paths remain supported in `v0.12.x` and are removed in
+`v0.14.0`.
+
+| Issue | Change | Impact | User action | Notes |
+| --- | --- | --- | --- | --- |
+| [#100](https://github.com/syn54x/ferro-orm/issues/100) | Coordinate public IR-first release readiness and compatibility window evidence | minor | Follow the `v0.12.0` migration checklist before upgrading production workloads | Phase-level coordination/evidence issue |
+| [#101](https://github.com/syn54x/ferro-orm/issues/101) | Ship public IR-first release while keeping compatibility paths during migration window | minor | Keep legacy call sites working short-term, but migrate off deprecated surfaces immediately | Deprecated paths stay live only through the compatibility window |
+| [#102](https://github.com/syn54x/ferro-orm/issues/102) | Publish version-centric migration guide and upgrade checklist | minor | Follow [Migrating to v0.12.0](../pages/howto/migrating-to-v0-12-0.md) step-by-step | Includes IR-first rationale and concrete migration actions |
+| [#103](https://github.com/syn54x/ferro-orm/issues/103) | Finalize release checklist/changelog and validate deprecation target consistency | minor | Validate that internal/private deprecated usage has been removed from your codebase | All Phase 7 deprecation warnings explicitly target `v0.14.0` removal |
+
+Deprecated compatibility inventory for the Phase 7 window:
+
+- Operator-style predicates (`Model.field OP value`) are deprecated.
+  - Replacement: `where(lambda t: ...)` (official) or `col(Model.field)`.
+  - Removal target: `v0.14.0`.
+- Implicit default-connection routing outside an active session is deprecated.
+  - Replacement: `async with ferro.engines.session("name")` or explicit `session=`.
+  - Removal target: `v0.14.0`.
+- Private Alembic JSON helper APIs are deprecated:
+  - `ferro.migrations.alembic._build_sa_table`
+  - `ferro.migrations.alembic._map_to_sa_type`
+  - Replacement: `ferro.migrations.get_metadata()`.
+  - Removal target: `v0.14.0`.
+
+Phase 7 migration artifacts:
+
+- User migration checklist: [Migrating to v0.12.0](../pages/howto/migrating-to-v0-12-0.md)
+- Maintainer release checklist: [IR-first release checklist](ir-first-release-checklist.md)
 
 ### Phase 8
 
 _TBD_
 
-Planned cutover checklist (target: `v0.13.0`):
+Planned cutover checklist (target: `v0.14.0`):
 
 - Remove deprecated operator-style predicate support.
 - Remove or rewrite all tests tagged `deprecated_operator_path`.

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -53,7 +53,15 @@ No user-facing runtime behavior changes expected. Shadow planning is internal-on
 
 ### Phase 3
 
-_TBD_
+| Issue | Change | Impact | User action | Notes |
+| --- | --- | --- | --- | --- |
+| [#85](https://github.com/syn54x/ferro-orm/issues/85) | Runtime query compilation now consumes QueryIR envelopes on core execution paths | minor | No API change for lambda/`col()` query callers; if you rely on internal `_core` query payload shape, migrate to QueryIR envelope (`ir_kind`, `ir_version`, `payload`) | Internal JSON `QueryDef` payload contract is no longer the core hot-path boundary |
+| [#86](https://github.com/syn54x/ferro-orm/issues/86) | Operator-style predicates (`Model.field OP value`) are deprecated with runtime warnings | minor | Migrate call sites to `where(lambda t: ...)` (recommended) or `col(Model.field)` | Deprecation message includes replacement + removal target (`v0.13.0`) |
+| [#87](https://github.com/syn54x/ferro-orm/issues/87) | Python query builder now emits QueryIR envelope payloads to Rust runtime | minor | No action for public `Model.where`/`Query.where` usage; update internal tests/tools that serialized legacy `where_clause` JSON | Compatibility behavior remains documented in query typing docs during deprecation window |
+
+Phase 3 test-migration note:
+
+- Tests that exist only to verify temporary operator-style compatibility are tagged `deprecated_operator_path` and scheduled for removal/rewrite at `v0.13.0`.
 
 ### Phase 4
 
@@ -70,3 +78,12 @@ _TBD_
 ### Phase 7
 
 _TBD_
+
+### Phase 8
+
+_TBD_
+
+Planned cutover checklist (target: `v0.13.0`):
+
+- Remove deprecated operator-style predicate support.
+- Remove or rewrite all tests tagged `deprecated_operator_path`.

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -68,7 +68,7 @@ Phase 3 test-migration note:
 | Issue | Change | Impact | User action | Notes |
 | --- | --- | --- | --- | --- |
 | [#89](https://github.com/syn54x/ferro-orm/issues/89) | SchemaIR compiler fidelity extended for `db_check` expressions, enum metadata, and join-table model inclusion | minor | No API changes for model declaration; if you consume internal SchemaIR fixtures, refresh snapshots to include join-table and enum/check artifacts | Artifacts: `src/ferro/ir/compiler.py`, `tests/test_ir_vectors_contract.py` |
-| [#90](https://github.com/syn54x/ferro-orm/issues/90) | Introduce `crates/ferro-migrate` with typed `SchemaIR(old,new)` diff operations and backend SQL emission entrypoint | minor | No user API change; maintainers/tools consuming migration internals should move to `ferro-migrate` plan ops | Artifacts: `crates/ferro-migrate/`, `src/migrate.rs` |
+| [#90](https://github.com/syn54x/ferro-orm/issues/90) | Introduce `crates/ferro-migrate` planner scaffold and SQL emission entrypoint (executable DDL deferred to Phase 8) | minor | No user API change | Phase 4 landed scaffold only; completion tracked in [#118](https://github.com/syn54x/ferro-orm/issues/118)–[#120](https://github.com/syn54x/ferro-orm/issues/120) |
 | [#91](https://github.com/syn54x/ferro-orm/issues/91) | Alembic `get_metadata()` now derives from SchemaIR modelset; legacy JSON-lowering helpers deprecated | minor | Keep using `get_metadata()`; if you directly import private `ferro.migrations.alembic._build_sa_table` / `_map_to_sa_type`, migrate away now | Deprecated helpers emit `DeprecationWarning` with planned removal `v0.14.0` |
 
 Phase 4 deprecation note:
@@ -133,9 +133,33 @@ Phase 7 migration artifacts:
 
 ### Phase 8
 
-_TBD_
+Runtime migration IR cutover (target: `v0.13.0`).
 
-Planned cutover checklist (target: `v0.14.0`):
+| Issue | Change | Impact | User action | Notes |
+| --- | --- | --- | --- | --- |
+| [#117](https://github.com/syn54x/ferro-orm/issues/117) | Coordinate `ferro-migrate` runtime cutover and parity exit gates | none | No action — internal planner cutover | Epic |
+| [#118](https://github.com/syn54x/ferro-orm/issues/118) | Complete executable SQL emission from `MigrationPlan` for all ops (SQLite + Postgres) | none | No action | Continues #90 scaffold |
+| [#119](https://github.com/syn54x/ferro-orm/issues/119) | Wire `auto_migrate` / `plan_table_migration` to execute ferro-migrate IR plans | none | No action — behavior must remain observably identical | Retires discarded `_typed_plan` path |
+| [#120](https://github.com/syn54x/ferro-orm/issues/120) | Parity gate + remove legacy JSON diff path in `src/migrate.rs` | none | No action | AGENTS.md I-1 enforcement |
+
+- **Migration impact:** `none` for public APIs — `connect(auto_migrate=...)` and `ferro.migrate` signatures unchanged.
+- **Internal change:** `auto_migrate` executes `ferro-migrate` `SchemaIR(old,new)` plans instead of the legacy enriched-JSON diff walk in `src/migrate.rs`.
+- **Parity requirement:** auto-migrated schema artifacts must remain byte-identical to `create_tables` and Alembic (AGENTS.md I-1).
+
+### Phase 9
+
+Compatibility cutover and shim removal (target: `v0.14.0`).
+
+| Issue | Change | Impact | User action | Notes |
+| --- | --- | --- | --- | --- |
+| [#107](https://github.com/syn54x/ferro-orm/issues/107) | Coordinate hard removal of deprecated compatibility surfaces | breaking | Migrate off all deprecated paths before upgrading to `v0.14.0` | Epic |
+| [#108](https://github.com/syn54x/ferro-orm/issues/108) | Remove deprecated runtime compatibility code paths | breaking | Use lambda/`col()` predicates and session-scoped routing | Operator style, ambient routing, Alembic JSON helpers |
+| [#109](https://github.com/syn54x/ferro-orm/issues/109) | Remove deprecated compatibility test inventory | minor | No user action | `deprecated_operator_path` marker removal |
+| [#110](https://github.com/syn54x/ferro-orm/issues/110) | Publish `v0.14.0` cutover migration and release notes | breaking | Follow final cutover guide at release | Changelog + checklist |
+
+Planned cutover checklist:
 
 - Remove deprecated operator-style predicate support.
+- Remove ambient default-connection routing outside an active session.
+- Remove private Alembic JSON helper APIs (`_build_sa_table`, `_map_to_sa_type`).
 - Remove or rewrite all tests tagged `deprecated_operator_path`.

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -65,7 +65,17 @@ Phase 3 test-migration note:
 
 ### Phase 4
 
-_TBD_
+| Issue | Change | Impact | User action | Notes |
+| --- | --- | --- | --- | --- |
+| [#89](https://github.com/syn54x/ferro-orm/issues/89) | SchemaIR compiler fidelity extended for `db_check` expressions, enum metadata, and join-table model inclusion | minor | No API changes for model declaration; if you consume internal SchemaIR fixtures, refresh snapshots to include join-table and enum/check artifacts | Artifacts: `src/ferro/ir/compiler.py`, `tests/test_ir_vectors_contract.py` |
+| [#90](https://github.com/syn54x/ferro-orm/issues/90) | Introduce `crates/ferro-migrate` with typed `SchemaIR(old,new)` diff operations and backend SQL emission entrypoint | minor | No user API change; maintainers/tools consuming migration internals should move to `ferro-migrate` plan ops | Artifacts: `crates/ferro-migrate/`, `src/migrate.rs` |
+| [#91](https://github.com/syn54x/ferro-orm/issues/91) | Alembic `get_metadata()` now derives from SchemaIR modelset; legacy JSON-lowering helpers deprecated | minor | Keep using `get_metadata()`; if you directly import private `ferro.migrations.alembic._build_sa_table` / `_map_to_sa_type`, migrate away now | Deprecated helpers emit `DeprecationWarning` with planned removal `v0.13.0` |
+
+Phase 4 deprecation note:
+
+- Deprecated: `ferro.migrations.alembic._build_sa_table()` and `ferro.migrations.alembic._map_to_sa_type()`
+- Replacement: `get_metadata()` (SchemaIR-backed) and internal IR lowering via `_sa_type_from_ir_column()`
+- Removal target: `v0.13.0`
 
 ### Phase 5
 

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -27,9 +27,9 @@ No user-facing runtime behavior changes expected.
 
 | Issue | Change | Impact | User action | Notes |
 | --- | --- | --- | --- | --- |
-| [#72](https://github.com/syn54x/ferro-orm/issues/72) | IR contract RFC definition | none | none | design-only |
-| [#73](https://github.com/syn54x/ferro-orm/issues/73) | Invariant specification | none | none | design-only |
-| [#74](https://github.com/syn54x/ferro-orm/issues/74) | Golden vectors + CI harness skeleton | none | none | infra-only |
+| [#72](https://github.com/syn54x/ferro-orm/issues/72) | IR contract RFC definition | none | none | design-only; artifact: `docs/rfc/ir-contracts-v1.md` |
+| [#73](https://github.com/syn54x/ferro-orm/issues/73) | Invariant specification | none | none | design-only; artifact: `docs/solutions/patterns/ir-invariants.md` |
+| [#74](https://github.com/syn54x/ferro-orm/issues/74) | Golden vectors + CI harness skeleton | none | none | infra-only; artifacts: `tests/fixtures/ir_vectors/`, `tests/test_ir_vectors_contract.py` |
 
 ### Phase 1
 

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -1,0 +1,60 @@
+# IR-first migration guide (living document)
+
+This guide is updated continuously during the IR-first roadmap execution.
+
+## Purpose
+
+- Capture user-facing migration impact as work lands.
+- Provide upgrade guidance before each phase closes.
+- Ensure breaking changes are documented with mitigation paths.
+
+## How to use this guide
+
+- Add entries as part of issue completion for roadmap work.
+- Group entries by phase.
+- For each entry, include:
+  - linked issue
+  - change summary
+  - impact level (`none`, `minor`, `breaking`)
+  - required user action
+  - compatibility window/deprecation timeline (if applicable)
+
+## Phase entries
+
+### Phase 0
+
+No user-facing runtime behavior changes expected.
+
+| Issue | Change | Impact | User action | Notes |
+| --- | --- | --- | --- | --- |
+| [#72](https://github.com/syn54x/ferro-orm/issues/72) | IR contract RFC definition | none | none | design-only |
+| [#73](https://github.com/syn54x/ferro-orm/issues/73) | Invariant specification | none | none | design-only |
+| [#74](https://github.com/syn54x/ferro-orm/issues/74) | Golden vectors + CI harness skeleton | none | none | infra-only |
+
+### Phase 1
+
+_TBD_
+
+### Phase 2
+
+_TBD_
+
+### Phase 3
+
+_TBD_
+
+### Phase 4
+
+_TBD_
+
+### Phase 5
+
+_TBD_
+
+### Phase 6
+
+_TBD_
+
+### Phase 7
+
+_TBD_

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -43,7 +43,13 @@ No user-facing runtime behavior changes expected.
 
 ### Phase 2
 
-_TBD_
+No user-facing runtime behavior changes expected. Shadow planning is internal-only and defaults off.
+
+| Issue | Change | Impact | User action | Notes |
+| --- | --- | --- | --- | --- |
+| [#81](https://github.com/syn54x/ferro-orm/issues/81) | Internal shadow planner flag and runtime dual-run compare hooks for query/DDL planning | none | none | Internal env-controlled verification path (`FERRO_SHADOW_RUNTIME` / `FERRO_SHADOW_RUNTIME_STRICT`) for CI and maintainers; no public API behavior cutover |
+| [#82](https://github.com/syn54x/ferro-orm/issues/82) | Semantic diff harness for query planning semantics and bind semantics | none | none | Test-only helper `_shadow_compare_query_plan_for_test` + backend-matrix strict checks |
+| [#83](https://github.com/syn54x/ferro-orm/issues/83) | Stable SQLite/Postgres shadow reports + touched-path CI enforcement | none | none | Golden shadow reports in `tests/fixtures/shadow_reports/` and path-gated CI workflow job |
 
 ### Phase 3
 

--- a/docs/plans/ir-first-release-checklist.md
+++ b/docs/plans/ir-first-release-checklist.md
@@ -1,0 +1,46 @@
+# IR-first release checklist
+
+Phase 7 release checklist for the public `v0.12.0` IR-first release with a
+compatibility window through `v0.12.x`.
+
+## Pre-release checklist
+
+- [ ] All Phase 7 scoped issues are complete and synchronized:
+  - [#100](https://github.com/syn54x/ferro-orm/issues/100)
+  - [#101](https://github.com/syn54x/ferro-orm/issues/101)
+  - [#102](https://github.com/syn54x/ferro-orm/issues/102)
+  - [#103](https://github.com/syn54x/ferro-orm/issues/103)
+- [ ] Deprecation warnings consistently include `Planned removal in v0.14.0`.
+- [ ] Deprecated-compat inventory is still tracked via
+      `pytest.mark.deprecated_operator_path`.
+- [ ] User migration docs are complete:
+  - `docs/plans/ir-first-migration-guide.md`
+  - `docs/pages/howto/migrating-to-v0-12-0.md`
+- [ ] Changelog release notes for `v0.12.0` are finalized.
+
+## Verification matrix
+
+- [ ] `cargo test --no-default-features --features testing`
+- [ ] `cargo test -p ferro-schema-ir -p ferro-migrate`
+- [ ] `uv run pytest -v tests/test_ir_vectors_contract.py`
+- [ ] `uv run pytest -v --cov=src --cov-report=xml --cov-report=term`
+- [ ] `uv run pytest -v -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres`
+- [ ] `uv run pytest -v -m deprecated_operator_path`
+- [ ] `uv run pytest -v tests/test_query_builder.py tests/test_query_typing.py tests/test_session.py tests/test_alembic_bridge.py tests/test_docs_examples.py`
+- [ ] `uv run zensical build --clean`
+- [ ] `uv run maturin build --release`
+
+## Exit-gate evidence
+
+- [ ] Roadmap Phase 7 exit-gate checklist is updated with command evidence links.
+- [ ] Migration guide is validated against at least one real example project.
+- [ ] Issue comments contain verification summary and links to docs/evidence.
+
+## PR closure requirements
+
+If a PR is opened for Phase 7 completion, include explicit auto-close lines:
+
+- `Closes #100`
+- `Closes #101`
+- `Closes #102`
+- `Closes #103`

--- a/docs/rfc/ir-contracts-v1.md
+++ b/docs/rfc/ir-contracts-v1.md
@@ -1,0 +1,228 @@
+---
+title: "IR contracts v1 (SchemaIR, QueryIR, CodecIR)"
+type: rfc
+status: draft
+date: 2026-06-19
+phase: IR-P0
+roadmap: docs/plans/2026-06-19-001-ir-first-roadmap.md
+---
+
+# IR contracts v1
+
+## Purpose
+
+Define the v1 canonical intermediate representation contracts for schema, query, and bind/fetch codec behavior before Phase 1 implementation.
+
+This RFC is normative for wire shape, versioning, and validation behavior.
+
+## Non-goals
+
+- Implementing new runtime/compiler behavior (Phase 1+).
+- Removing compatibility layers in existing JSON pipelines (later phases).
+
+## Shared contract rules
+
+### Envelope
+
+All IR artifacts use a top-level envelope:
+
+```json
+{
+  "ir_kind": "schema|query|codec",
+  "ir_version": 1,
+  "payload": {}
+}
+```
+
+Rules:
+
+- `ir_kind` and `ir_version` are required.
+- Unknown `ir_kind` is a hard error.
+- Unsupported `ir_version` is a hard error.
+- `payload` must be an object; missing or non-object payload is a hard error.
+
+### Compatibility policy
+
+- Minor additive evolution inside `ir_version: 1` may add optional payload fields.
+- Existing required fields in v1 cannot be removed or retyped.
+- New required fields require a major version bump.
+- Readers must fail loudly on malformed required fields.
+- Writers must emit deterministic field ordering where serialization APIs allow it.
+
+## SchemaIR v1
+
+`SchemaIR` represents canonical model schema semantics consumed by runtime DDL, migration planning, and Alembic adapters.
+
+### SchemaIR payload shape
+
+```json
+{
+  "dialect_agnostic": true,
+  "models": [
+    {
+      "model_name": "Invoice",
+      "table_name": "invoice",
+      "columns": [
+        {
+          "name": "id",
+          "logical_type": "integer",
+          "db_type": "bigint",
+          "nullable": false,
+          "primary_key": true,
+          "autoincrement": true,
+          "unique": false,
+          "index": false,
+          "default": null,
+          "format": null
+        }
+      ],
+      "foreign_keys": [
+        {
+          "column": "customer_id",
+          "to_table": "customer",
+          "to_column": "id",
+          "on_delete": "CASCADE",
+          "name": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": "idx_invoice_created_at",
+          "columns": ["created_at"],
+          "unique": false
+        }
+      ],
+      "uniques": [
+        {
+          "name": "uq_invoice_number",
+          "columns": ["number"]
+        }
+      ],
+      "checks": [
+        {
+          "name": "ck_invoice_total",
+          "expression": "total >= 0"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### SchemaIR requirements
+
+- `table_name` must be canonical lower-case model table name.
+- `db_type` must use canonical Ferro tokens (`text`, `varchar(N)`, `smallint`, `int`, `bigint`, `uuid`, `timestamp`, `timestamptz`, `date`, `time`).
+- `nullable` is explicit and never inferred by the reader.
+- Constraint/index names are required and must follow cross-emitter parity naming rules.
+- Foreign key shadow columns (for `ForeignKey`) are represented as normal columns plus FK metadata.
+- Any schema artifact emitted by one emitter must be representable without lossy translation.
+
+## QueryIR v1
+
+`QueryIR` represents typed query intent currently serialized through ad-hoc query JSON.
+
+### QueryIR payload shape
+
+```json
+{
+  "model_name": "User",
+  "where": [
+    {
+      "node_kind": "compound",
+      "operator": "AND",
+      "left": {
+        "node_kind": "leaf",
+        "column": "active",
+        "operator": "==",
+        "value": {"kind": "bool", "value": true}
+      },
+      "right": {
+        "node_kind": "leaf",
+        "column": "email",
+        "operator": "LIKE",
+        "value": {"kind": "string", "value": "%@example.com"}
+      }
+    }
+  ],
+  "order_by": [
+    {"column": "id", "direction": "asc"}
+  ],
+  "limit": 100,
+  "offset": 0,
+  "m2m": null
+}
+```
+
+### QueryIR requirements
+
+- Node variants are explicit (`leaf` vs `compound`), never inferred from nullable fields.
+- Operator domain is restricted to: `==`, `!=`, `<`, `<=`, `>`, `>=`, `IN`, `LIKE`, `AND`, `OR`.
+- `where` is a list of root predicate trees combined by implicit AND semantics unless nested compound nodes define otherwise.
+- `order_by.direction` is normalized to `asc|desc`.
+- Value literals are typed nodes (`kind`, `value`) so codec selection does not depend on lossy JSON inference.
+- Null comparisons for equality/inequality map to `IS NULL` / `IS NOT NULL` semantics in execution lowering.
+
+## CodecIR v1
+
+`CodecIR` centralizes type semantics for both bind and fetch paths.
+
+### CodecIR payload shape
+
+```json
+{
+  "bind_rules": [
+    {
+      "logical_type": "uuid",
+      "db_type": "uuid",
+      "non_null_wire_kind": "uuid",
+      "null_wire_kind": "uuid_null"
+    },
+    {
+      "logical_type": "integer",
+      "db_type": "bigint",
+      "non_null_wire_kind": "i64",
+      "null_wire_kind": "i64_null"
+    }
+  ],
+  "fetch_rules": [
+    {
+      "db_type": "uuid",
+      "wire_kind": "uuid",
+      "python_kind": "uuid.UUID"
+    }
+  ],
+  "hydration_abi": {
+    "constructor_mode": "direct_dict",
+    "required_slots": [
+      "__pydantic_fields_set__",
+      "__pydantic_extra__",
+      "__pydantic_private__"
+    ]
+  }
+}
+```
+
+### CodecIR requirements
+
+- Typed null kinds are first-class and must not degrade to untyped text null in schema-driven paths.
+- Bind and fetch semantics are defined per logical/db type pair.
+- Hydration ABI explicitly requires slot initialization for observational equivalence with Pydantic initialization semantics.
+- Runtime lowering must fail loudly when a required codec rule is absent.
+
+## Validation behavior
+
+For all IR kinds in v1:
+
+- Parse/shape validation errors are fatal and actionable.
+- Unknown required enum values are fatal.
+- Unknown optional fields may be ignored by readers in the same major version.
+- CI conformance vectors are the executable source of truth for schema/query/codec payload acceptance.
+
+## Phase 1 handoff
+
+Phase 1 implementation must:
+
+1. Introduce strongly typed Rust/Python representations matching this RFC.
+2. Add compile/serialize tests that round-trip all golden vectors without shape drift.
+3. Keep existing behavior unchanged unless explicitly called out by roadmap phase gates.

--- a/docs/solutions/architecture-patterns/ir-first-merge-readiness-review.md
+++ b/docs/solutions/architecture-patterns/ir-first-merge-readiness-review.md
@@ -1,0 +1,235 @@
+---
+title: IR-first merge-readiness review checklist
+date: 2026-06-23
+category: architecture-patterns
+module: ir-first
+problem_type: architecture_pattern
+component: development_workflow
+severity: medium
+applies_when:
+  - "Large architecture branch (e.g. feat/ir-first) is nearing merge to main"
+  - "A phase gate claims unified behavior across multiple code paths"
+  - "Python modules import-and-reexport mutable singletons from a central state module"
+  - "CI aggregate jobs depend on upstream path-detection jobs"
+resolution_type: code_fix
+tags:
+  - ir-first
+  - schema-ir
+  - query-ir
+  - merge-readiness
+  - ffi
+  - pyo3
+  - typed-null-binds
+related_components:
+  - documentation
+  - testing_framework
+---
+
+# IR-first merge-readiness review checklist
+
+## Context
+
+Before merging `feat/ir-first` (PR #116) to `main`, a merge-readiness review
+flagged six concrete defects that would ship if the branch merged as-is. Commit
+`99ae829` ("fix: address IR-first merge-readiness review findings") fixed the
+code and CI issues; unstaged doc edits then aligned `architecture.md`, the
+IR-first roadmap, and the migration guide with the actual program state (Phases
+0–7 complete; Phase 8 = `ferro-migrate` runtime cutover; Phase 9 = shim removal).
+
+The findings were not "IR-first is incomplete" — they were specific invariant
+violations and documentation drift that a phase-completion gate should have
+caught. (session history)
+
+**Residual risk accepted at merge (not blocking):** runtime `auto_migrate` still
+executes the legacy enriched-JSON diff in `src/migrate.rs`; `ferro-migrate`
+executable DDL is Phase 8 ([#117](https://github.com/syn54x/ferro-orm/issues/117)–[#120](https://github.com/syn54x/ferro-orm/issues/120)).
+
+## Guidance
+
+### 1. SchemaIR modelset cache must write through `ferro.state`
+
+**Finding:** `compile_registry_schema_ir()` imported `_SCHEMA_IR_MODELSET` from
+`ferro.state` then used `global _SCHEMA_IR_MODELSET`. In Python, that binds
+module-local globals — not attributes on `ferro.state`. Alembic `get_metadata()`
+and parity tests reading `ferro.state._SCHEMA_IR_MODELSET` saw `None` after
+compilation.
+
+**Fix:** Assign explicitly on the state module:
+
+```python
+ferro_state._SCHEMA_IR_MODELSET = envelope
+ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = _fingerprint(envelope)
+```
+
+**Test hygiene:** Registry fixtures must clear `_SCHEMA_IR_MODELSET`,
+`_SCHEMA_IR_MODELSET_FINGERPRINT`, `_SCHEMA_IR_BY_MODEL`, and
+`_SCHEMA_IR_FINGERPRINT_BY_MODEL` — not just model/join registries. Add a
+contract test asserting the cache is populated after `compile_registry_schema_ir()`.
+
+### 2. Codec registry — one decimal-NULL strategy per backend
+
+**Finding:** Postgres decimal `None` used inconsistent bind types across codec
+paths (`float8`-typed NULL on some paths, `numeric` on others). Phase 5 claimed
+unified codec behavior; merge review caught the divergence.
+
+**Fix:** Early return in `schema_bind_expr` for Postgres decimal NULL:
+
+```rust
+if col_is_decimal && backend == SqlDialect::Postgres {
+    return Ok(Expr::value(SeaValue::String(None)).cast_as("numeric"));
+}
+```
+
+Assert both bind variant (`SeaValue::String(None)`) and SQL cast (`numeric`) in
+unit tests — not just "INSERT accepts None." See
+[`typed-null-binds.md`](../patterns/typed-null-binds.md).
+
+### 3. No `unwrap()` across the FFI boundary (AGENTS.md I-3)
+
+**Finding:** `QueryDef::to_condition_for_backend()` and INSERT/M2M builders
+called `.unwrap()` on Sea-Query value assembly. Malformed QueryIR or bad bind
+tuples would panic into Python as opaque aborts.
+
+**Fix pattern:**
+
+- Change internal builders to `Result<T, String>` with explicit messages.
+- Add a thin FFI adapter mapping to `PyValueError`:
+
+```rust
+fn query_condition_for_backend(query_def: &QueryDef, backend: SqlDialect) -> PyResult<Condition> {
+    query_def
+        .to_condition_for_backend(backend)
+        .map_err(pyo3::exceptions::PyValueError::new_err)
+}
+```
+
+### 4. Shadow CI gate must fail closed when path detection fails
+
+**Finding:** The aggregate `all-checks` job could pass when
+`changed-shadow-paths` itself failed — a broken detector silently skipped the
+shadow gate.
+
+**Fix:** At the top of the aggregate job:
+
+```bash
+if [[ "${{ needs.changed-shadow-paths.result }}" == "failure" ]]; then
+  echo "Shadow path detection failed; refusing to treat shadow gate as passed."
+  exit 1
+fi
+```
+
+Shadow enforcement is only trustworthy if the "what changed?" job succeeds.
+
+### 5. Do not hand-write release CHANGELOG entries
+
+**Finding:** A manually authored `v0.12.0` CHANGELOG block was added during
+Phase 7; the project's release flow generates changelog entries.
+
+**Fix:** Remove the hand-written block. Release artifacts come from the release
+pipeline, not ad-hoc commits on the feature branch.
+
+### 6. Roadmap and migration guide must reflect partial phase delivery
+
+**Finding:** Roadmap implied Phase 4 runtime `auto_migrate` cutover was done. In
+reality Phase 4 delivered Alembic SchemaIR cutover + `ferro-migrate` scaffold
+only; executable DDL and runtime execution are Phase 8.
+
+**Fix (doc sync):**
+
+- Phase 4 status: `Complete (Alembic path; runtime auto_migrate cutover deferred to Phase 8)` with `[~]` on `ferro-migrate` emit_sql.
+- Insert **Phase 8** — Runtime migration IR cutover (`v0.13.0`, issues #117–#120).
+- Renumber shim removal to **Phase 9** (`v0.14.0`, issues #107–#110).
+- Migration guide: #90 = "planner scaffold; executable DDL deferred to Phase 8."
+- `architecture.md`: split compile-time (SchemaIR) vs runtime (QueryIR + session + codec) pipelines.
+
+## Why This Matters
+
+- **Silent cache miss** breaks Alembic parity and makes SchemaIR appear compiled
+  when consumers read empty state — phantom diffs or missing metadata at release.
+- **Bind path drift** causes backend-specific query failures despite a "unified
+  codec" phase gate (AGENTS.md I-1 analogue for binds).
+- **FFI panics** violate project invariant I-3 and destroy the pytest feedback
+  loop on bad IR input.
+- **False-green CI** lets shadow regressions merge when the detector is broken.
+- **Roadmap/doc drift** makes merge-readiness reviews unreliable: reviewers
+  assume runtime migration is IR-driven when it still uses the legacy JSON diff
+  in `src/migrate.rs`.
+
+## When to Apply
+
+- **Pre-merge gate reviews** on large architecture branches (especially
+  `feat/ir-first` → `main` promotion).
+- **After any "unify X across paths" phase** (codec, hydration, migration
+  emitters): grep for divergent special-cases and missing parity tests.
+- **When Python modules import-and-reexport mutable singletons** from a central
+  `state` module: verify assignments target the canonical module, not a shadow
+  `global`.
+- **When adding CI aggregate jobs** that depend on upstream detection jobs: fail
+  closed if detection fails.
+- **When closing a phase whose deliverables are partially landed**: update
+  roadmap exit gates, migration guide impact tables, and architecture docs in the
+  same PR — not as follow-up.
+
+## Examples
+
+**SchemaIR cache contract test:**
+
+```python
+def test_compile_registry_schema_ir_persists_modelset_cache(clean_model_registry):
+    from ferro import state as ferro_state
+    from ferro.ir import compile_registry_schema_ir, schema_ir_fingerprint
+
+    ferro_state._SCHEMA_IR_MODELSET = None
+    compiled = compile_registry_schema_ir()
+
+    assert ferro_state._SCHEMA_IR_MODELSET == compiled
+    assert ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT == schema_ir_fingerprint(compiled)
+```
+
+**QueryIR error propagation (before → after):**
+
+```rust
+// Before: silent panic or empty condition on bad IR
+let left_cond = self.node_to_condition_for_backend(node.left.as_ref().unwrap(), backend);
+
+// After: actionable Python exception
+let left = node.left.as_ref()
+    .ok_or_else(|| "compound QueryNode is missing left child".to_string())?;
+let left_cond = self.node_to_condition_for_backend(left, backend)?;
+```
+
+**Roadmap partial-delivery notation:**
+
+```markdown
+**Deliverables**
+- [x] Alembic adapter consumes IR outputs
+- [~] Backend emitters from MigrationPlan — scaffold landed; executable DDL deferred to Phase 8
+
+**Exit gate**
+- [x] Alembic no longer independently derives schema semantics
+- [ ] Runtime auto_migrate executes IR migration plan — deferred to Phase 8
+```
+
+**Architecture doc: two-pipeline mental model (post-sync):**
+
+```text
+Python owns the model authoring surface.
+SchemaIR and QueryIR own the cross-language contracts.
+Rust owns execution, codecs, and hydration.
+Sessions scope routing, transactions, and the identity map.
+```
+
+Schema path fans out at class creation: `build_model_schema()` → SchemaIR
+(Alembic, ferro-migrate) + enriched JSON (Rust registry). Runtime path crosses
+FFI per `await` as QueryIR inside an active `engines.session()`.
+
+## Related
+
+- [`ir-invariants.md`](../patterns/ir-invariants.md) — invariant contract the review validates
+- [`cross-emitter-ddl-parity.md`](../patterns/cross-emitter-ddl-parity.md) — concrete parity symptoms/recipes
+- [`typed-null-binds.md`](../patterns/typed-null-binds.md) — CodecIR/bind enforcement
+- [`docs/plans/2026-06-19-001-ir-first-roadmap.md`](../../plans/2026-06-19-001-ir-first-roadmap.md) — phase status and Phase 8/9 sequencing
+- [`docs/plans/ir-first-migration-guide.md`](../../plans/ir-first-migration-guide.md) — deprecated-surface inventory
+- [`docs/pages/concepts/architecture.md`](../../pages/concepts/architecture.md) — public architecture alignment target
+- Commit `99ae829` — code/CI fixes from this review
+- Issues [#117](https://github.com/syn54x/ferro-orm/issues/117)–[#120](https://github.com/syn54x/ferro-orm/issues/120) — Phase 8 runtime migration cutover (open)

--- a/docs/solutions/patterns/ir-invariants.md
+++ b/docs/solutions/patterns/ir-invariants.md
@@ -34,6 +34,7 @@ Treat these as non-negotiable IR invariants:
 1. **Cross-emitter parity**: every schema artifact name/type/default/nullability must match across emitters.
 2. **Hydration ABI**: zero-copy hydration must initialize required Pydantic slots exactly.
 3. **Typed null/bind correctness**: schema-driven paths must emit type-correct binds, including typed NULLs.
+4. **Session-scoped runtime state**: hot-path identity and transaction state is scoped to explicit/ambient sessions, not hidden globals.
 
 Every IR contract change must preserve or explicitly version these invariants.
 
@@ -124,3 +125,29 @@ When updating `SchemaIR`, `QueryIR`, or `CodecIR`:
 - New IR field appears in one emitter path but not another.
 
 If any appears, treat it as a correctness bug, not a warning-level mismatch.
+
+## Invariant IV: Session-scoped runtime state
+
+### Contract
+
+Core CRUD/query/raw operation routing must derive mutable runtime state from explicit or ambient session context.
+
+- Transaction state is session-scoped.
+- Identity map state is session-scoped.
+- Nested sessions shadow and restore deterministically.
+- Legacy implicit default routing is compatibility-only and on a declared removal timeline.
+
+### Why it exists
+
+Global mutable runtime state in hot paths makes concurrent multi-DB behavior fragile and creates hidden coupling between unrelated tasks.
+
+### Enforcement anchors
+
+- `src/ferro/session.py`
+- `src/ferro/state.py`
+- `src/ferro/models.py`
+- `src/ferro/query/builder.py`
+- `src/ferro/raw.py`
+- `src/state.rs`
+- `src/operations.rs`
+- `tests/test_session.py`

--- a/docs/solutions/patterns/ir-invariants.md
+++ b/docs/solutions/patterns/ir-invariants.md
@@ -7,7 +7,10 @@ related_files:
   - docs/rfc/ir-contracts-v1.md
   - docs/solutions/patterns/cross-emitter-ddl-parity.md
   - docs/solutions/patterns/typed-null-binds.md
+  - docs/solutions/architecture-patterns/ir-first-merge-readiness-review.md
+  - src/ferro/ir/compiler.py
   - src/ferro/migrations/alembic.py
+  - crates/ferro-migrate/src/lib.rs
   - src/schema.rs
   - src/query.rs
   - src/operations.rs
@@ -16,16 +19,26 @@ related_files:
   - src/backend.rs
   - tests/test_cross_emitter_parity.py
   - tests/test_db_type_cross_emitter_parity.py
+  - tests/test_ir_vectors_contract.py
   - tests/test_typed_null_binds.py
   - tests/test_hydration.py
-related_issues: [71, 72, 73, 74]
+related_issues: [71, 72, 73, 74, 88, 89, 91, 93, 94, 100, 117, 118, 119, 120]
 related_prs: []
 captured: 2026-06-19
+last_refreshed: 2026-06-23
 ---
 
 ## Problem
 
-Ferro currently crosses Python and Rust boundaries using multiple JSON-shaped contracts and independently enforced conventions. Without one explicit invariant spec, drift can appear as phantom DDL diffs, typed-null regressions, or hydration attribute errors that only show up at runtime.
+Ferro crosses Python and Rust boundaries through versioned IR envelopes — **SchemaIR**
+at class-creation time and **QueryIR** per operation — plus enriched JSON schema
+for the Rust registry. Phases 1–7 of the IR-first program are complete; runtime
+`auto_migrate` still executes a legacy enriched-JSON diff until Phase 8
+(`ferro-migrate` cutover, issues #117–#120).
+
+Without one explicit invariant spec, drift can appear as phantom DDL diffs,
+typed-null regressions, hydration attribute errors, or silent cache misses that
+only show up at runtime.
 
 ## Takeaway
 
@@ -56,12 +69,15 @@ If emitters disagree, users get phantom autogenerate diffs and noisy migration h
 
 ### Enforcement anchors
 
-- `src/ferro/migrations/alembic.py` naming convention.
-- `src/schema.rs` naming/type emission helpers.
+- `src/ferro/ir/compiler.py` — SchemaIR compilation and `ferro.state` modelset cache.
+- `src/ferro/migrations/alembic.py` — `get_metadata()` derives from SchemaIR modelset.
+- `crates/ferro-migrate/src/lib.rs` — `SchemaIR(old,new)` planner (executable DDL Phase 8).
+- `src/schema.rs` — runtime DDL emitter behind `connect(auto_migrate=True)`.
 - `tests/test_cross_emitter_parity.py`
 - `tests/test_db_type_cross_emitter_parity.py`
 - `tests/test_schema_constraints.py`
 - `tests/test_alembic_autogenerate.py`
+- `tests/test_ir_vectors_contract.py`
 
 ## Invariant II: Hydration ABI
 
@@ -116,13 +132,19 @@ When updating `SchemaIR`, `QueryIR`, or `CodecIR`:
 2. Add or update golden vectors that encode the invariant boundary.
 3. Add a regression test that fails before the change and passes after.
 4. Reject designs that only mitigate symptoms; fill the primitive gap.
+5. Propagate failures across the FFI boundary via `PyResult` — never `unwrap()`
+   (AGENTS.md I-3). Malformed IR must raise actionable Python exceptions.
+6. When caching compiled IR in Python, assign through the canonical module
+   (`ferro_state._SCHEMA_IR_MODELSET = ...`) — not `global` on imported names.
 
 ## How to recognize a violation
 
 - Alembic autogenerate proposes drop/recreate with no real model change.
-- Query/filter updates start failing only on one backend for NULL/UUID values.
+- Query/filter updates start failing only on one backend for NULL/UUID/decimal values.
 - Hydrated instances error on `__pydantic_*` slot access.
 - New IR field appears in one emitter path but not another.
+- `ferro.state._SCHEMA_IR_MODELSET` is `None` after `compile_registry_schema_ir()`.
+- Bad QueryIR or bind tuples panic in Rust instead of raising `PyValueError`.
 
 If any appears, treat it as a correctness bug, not a warning-level mismatch.
 
@@ -151,3 +173,10 @@ Global mutable runtime state in hot paths makes concurrent multi-DB behavior fra
 - `src/state.rs`
 - `src/operations.rs`
 - `tests/test_session.py`
+
+## Related
+
+- [`ir-first-merge-readiness-review.md`](../architecture-patterns/ir-first-merge-readiness-review.md) — pre-merge checklist that caught invariant violations on `feat/ir-first`
+- [`cross-emitter-ddl-parity.md`](cross-emitter-ddl-parity.md) — concrete naming recipes for Invariant I
+- [`typed-null-binds.md`](typed-null-binds.md) — bind-path detail for Invariant III
+- [`docs/plans/2026-06-19-001-ir-first-roadmap.md`](../../plans/2026-06-19-001-ir-first-roadmap.md) — phase status and exit gates

--- a/docs/solutions/patterns/ir-invariants.md
+++ b/docs/solutions/patterns/ir-invariants.md
@@ -11,6 +11,8 @@ related_files:
   - src/schema.rs
   - src/query.rs
   - src/operations.rs
+  - src/codec.rs
+  - src/hydration.rs
   - src/backend.rs
   - tests/test_cross_emitter_parity.py
   - tests/test_db_type_cross_emitter_parity.py
@@ -78,8 +80,9 @@ Skipping slot initialization can pass basic reads but later fails with runtime `
 
 ### Enforcement anchors
 
-- `src/operations.rs` (`set_pydantic_hydration_slots`)
+- `src/hydration.rs` (`hydrate_model_instance`)
 - `src/backend.rs` row materialization flow
+- `src/codec.rs` typed fetch decode used by hydration paths
 - `tests/test_hydration.py`
 - `docs/solutions/issues/pydantic-slots-missing-after-ferro-hydration.md`
 
@@ -99,7 +102,7 @@ Untyped binds (especially NULL/UUID) can cause backend-specific mismatches or hi
 
 ### Enforcement anchors
 
-- `src/query.rs` (`value_rhs_simple_expr_for_backend`, typed-null selection)
+- `src/codec.rs` (`schema_bind_expr`, `query_bind_expr`, `m2m_bind_expr`)
 - `src/operations.rs` (`engine_bind_values_from_sea`)
 - `src/backend.rs` (`EngineBindValue`, `NullKind`)
 - `tests/test_typed_null_binds.py`

--- a/docs/solutions/patterns/ir-invariants.md
+++ b/docs/solutions/patterns/ir-invariants.md
@@ -1,0 +1,123 @@
+---
+title: IR-first invariants (parity, hydration ABI, null/bind correctness)
+type: pattern
+tags: [convention, invariant, ir, schema, query, codec, bridge, rust, python]
+related_files:
+  - AGENTS.md
+  - docs/rfc/ir-contracts-v1.md
+  - docs/solutions/patterns/cross-emitter-ddl-parity.md
+  - docs/solutions/patterns/typed-null-binds.md
+  - src/ferro/migrations/alembic.py
+  - src/schema.rs
+  - src/query.rs
+  - src/operations.rs
+  - src/backend.rs
+  - tests/test_cross_emitter_parity.py
+  - tests/test_db_type_cross_emitter_parity.py
+  - tests/test_typed_null_binds.py
+  - tests/test_hydration.py
+related_issues: [71, 72, 73, 74]
+related_prs: []
+captured: 2026-06-19
+---
+
+## Problem
+
+Ferro currently crosses Python and Rust boundaries using multiple JSON-shaped contracts and independently enforced conventions. Without one explicit invariant spec, drift can appear as phantom DDL diffs, typed-null regressions, or hydration attribute errors that only show up at runtime.
+
+## Takeaway
+
+Treat these as non-negotiable IR invariants:
+
+1. **Cross-emitter parity**: every schema artifact name/type/default/nullability must match across emitters.
+2. **Hydration ABI**: zero-copy hydration must initialize required Pydantic slots exactly.
+3. **Typed null/bind correctness**: schema-driven paths must emit type-correct binds, including typed NULLs.
+
+Every IR contract change must preserve or explicitly version these invariants.
+
+## Invariant I: Cross-emitter parity
+
+### Contract
+
+Given one model definition, all DDL emission paths must produce equivalent schema artifacts:
+
+- Table names.
+- Column names (including FK shadow `*_id` columns).
+- Column type mapping/tokenization.
+- Constraint/index/check naming.
+- Nullability/default semantics.
+
+### Why it exists
+
+If emitters disagree, users get phantom autogenerate diffs and noisy migration history.
+
+### Enforcement anchors
+
+- `src/ferro/migrations/alembic.py` naming convention.
+- `src/schema.rs` naming/type emission helpers.
+- `tests/test_cross_emitter_parity.py`
+- `tests/test_db_type_cross_emitter_parity.py`
+- `tests/test_schema_constraints.py`
+- `tests/test_alembic_autogenerate.py`
+
+## Invariant II: Hydration ABI
+
+### Contract
+
+Rust hydration must keep direct-to-dict construction while being observationally equivalent to Pydantic initialization for required slots.
+
+Minimum required initialized slots:
+
+- `__pydantic_fields_set__`
+- `__pydantic_extra__`
+- `__pydantic_private__`
+
+### Why it exists
+
+Skipping slot initialization can pass basic reads but later fails with runtime `AttributeError` when user code or Pydantic internals touch missing attributes.
+
+### Enforcement anchors
+
+- `src/operations.rs` (`set_pydantic_hydration_slots`)
+- `src/backend.rs` row materialization flow
+- `tests/test_hydration.py`
+- `docs/solutions/issues/pydantic-slots-missing-after-ferro-hydration.md`
+
+## Invariant III: Typed null/bind correctness
+
+### Contract
+
+Schema-driven bind paths must preserve type identity for non-null values and NULL values.
+
+- UUID values must remain UUID-typed on strict backends.
+- Typed NULL must be selected from schema/type context where available.
+- Raw SQL path may use untyped fallback only where schema context is unavailable.
+
+### Why it exists
+
+Untyped binds (especially NULL/UUID) can cause backend-specific mismatches or hidden coercion bugs.
+
+### Enforcement anchors
+
+- `src/query.rs` (`value_rhs_simple_expr_for_backend`, typed-null selection)
+- `src/operations.rs` (`engine_bind_values_from_sea`)
+- `src/backend.rs` (`EngineBindValue`, `NullKind`)
+- `tests/test_typed_null_binds.py`
+
+## Applying invariants to IR contracts
+
+When updating `SchemaIR`, `QueryIR`, or `CodecIR`:
+
+1. State which invariant(s) the change touches.
+2. Add or update golden vectors that encode the invariant boundary.
+3. Add a regression test that fails before the change and passes after.
+4. Reject designs that only mitigate symptoms; fill the primitive gap.
+
+## How to recognize a violation
+
+- Alembic autogenerate proposes drop/recreate with no real model change.
+- Query/filter updates start failing only on one backend for NULL/UUID values.
+- Hydrated instances error on `__pydantic_*` slot access.
+- New IR field appears in one emitter path but not another.
+
+If any appears, treat it as a correctness bug, not a warning-level mismatch.

--- a/docs/solutions/patterns/typed-null-binds.md
+++ b/docs/solutions/patterns/typed-null-binds.md
@@ -4,14 +4,16 @@ type: pattern
 tags: [convention, invariant, bridge, ffi, rust, sea-query, sqlx, postgres, sqlite]
 related_files:
   - src/backend.rs
+  - src/codec.rs
+  - src/hydration.rs
   - src/operations.rs
   - src/query.rs
   - tests/test_typed_null_binds.py
   - tests/test_sqlite_alembic_reconnect_hydration.py
-related_issues: [38, 40, 41, 56]
+related_issues: [38, 41, 56]
 related_prs: [62]
 captured: 2026-04-29
-last_updated: 2026-05-20
+last_updated: 2026-06-22
 ---
 
 ## Problem
@@ -41,21 +43,21 @@ exception.**
 ```dot
 digraph typed_null_flow {
   "JSON null"        [shape=box];
-  "schema_value_expr (INSERT)"               [shape=box];
-  "value_rhs_simple_expr_for_backend (UPDATE/filter)"  [shape=box];
-  "backend_column_value_expr (M2M)"          [shape=box];
+  "codec::schema_bind_expr (INSERT/UPDATE)"  [shape=box];
+  "codec::query_bind_expr (filter)"          [shape=box];
+  "codec::m2m_bind_expr (M2M)"               [shape=box];
   "SeaValue::T(None)"                        [shape=oval];
   "engine_bind_values_from_sea"              [shape=box];
   "EngineBindValue::Null(NullKind::T)"       [shape=oval];
   "bind_engine_value"                        [shape=box];
   "Option::<T>::None"                        [shape=oval];
 
-  "JSON null" -> "schema_value_expr (INSERT)";
-  "JSON null" -> "value_rhs_simple_expr_for_backend (UPDATE/filter)";
-  "JSON null" -> "backend_column_value_expr (M2M)";
-  "schema_value_expr (INSERT)"                          -> "SeaValue::T(None)";
-  "value_rhs_simple_expr_for_backend (UPDATE/filter)"   -> "SeaValue::T(None)";
-  "backend_column_value_expr (M2M)"                     -> "SeaValue::T(None)";
+  "JSON null" -> "codec::schema_bind_expr (INSERT/UPDATE)";
+  "JSON null" -> "codec::query_bind_expr (filter)";
+  "JSON null" -> "codec::m2m_bind_expr (M2M)";
+  "codec::schema_bind_expr (INSERT/UPDATE)" -> "SeaValue::T(None)";
+  "codec::query_bind_expr (filter)" -> "SeaValue::T(None)";
+  "codec::m2m_bind_expr (M2M)" -> "SeaValue::T(None)";
   "SeaValue::T(None)" -> "engine_bind_values_from_sea";
   "engine_bind_values_from_sea" -> "EngineBindValue::Null(NullKind::T)";
   "EngineBindValue::Null(NullKind::T)" -> "bind_engine_value";
@@ -65,13 +67,12 @@ digraph typed_null_flow {
 
 ## Schema-driven emitters (must use typed nulls)
 
-| Path             | Function                                                | File               |
-|------------------|----------------------------------------------------------|--------------------|
-| INSERT values    | `schema_value_expr`                                      | `src/operations.rs`|
-| UPDATE values    | `schema_value_expr` (called from `update_filtered`)      | `src/operations.rs`|
-| Filter / UPDATE  | `value_rhs_simple_expr_for_backend`                      | `src/query.rs`     |
-| Filter null pick | `typed_null_for_column` (called by ^)                    | `src/query.rs`     |
-| M2M target IDs   | `backend_column_value_expr`                              | `src/operations.rs`|
+| Path             | Function                       | File           |
+|------------------|--------------------------------|----------------|
+| INSERT values    | `schema_bind_expr`             | `src/codec.rs` |
+| UPDATE values    | `schema_bind_expr`             | `src/codec.rs` |
+| Filter / UPDATE  | `query_bind_expr`              | `src/codec.rs` |
+| M2M target IDs   | `m2m_bind_expr`                | `src/codec.rs` |
 
 **`IS NULL` for typed `== None`:** JSON `null` on `QueryNode::value` deserializes
 as `Option<serde_json::Value>::None` (serde), not `Some(Value::Null)`.
@@ -87,17 +88,11 @@ variants:
 | `int \| None`                 | `BigInt(None)`     | `I64`                    | `Option::<i64>::None`  |
 | `bool \| None`                | `Bool(None)`       | `Bool`                   | `Option::<bool>::None` |
 | `float \| None`               | `Double(None)`     | `F64`                    | `Option::<f64>::None`  |
-| `Decimal \| None`             | `Double(None)` *   | `F64` *                  | `Option::<f64>::None` *|
+| `Decimal \| None`             | `String(None).cast_as("numeric")` | `String` | `Option::<String>::None` |
 | `str \| None`                 | `String(None)`     | `String`                 | `Option::<String>::None` |
 | `bytes \| None`               | `Bytes(None)`      | `Bytes`                  | `Option::<Vec<u8>>::None` |
 | `UUID \| None`                | `Uuid(None)`       | `Uuid`                   | `Option::<sqlx::types::Uuid>::None` |
-| `datetime \| None` / `date`   | `String(None).cast_as(...)` ** | -- | -- |
-
-\* Decimal binds as `float8`-typed null today. Native `numeric` typed binds
-are deferred (see plan §3 Scope Boundaries).
-
-\*\* Temporal types continue to use `cast_as` until issue [#40] picks a
-   datetime crate (`chrono` vs `time`).
+| `datetime \| None` / `date`   | `String(None).cast_as(...)` | `String` | `Option::<String>::None` |
 
 ## Fetch-time row materialization (read path)
 
@@ -210,13 +205,11 @@ Ferro itself.
 - `docs/solutions/issues/sqlite-integer-decimal-hydrates-as-none.md`: INTEGER
   NUMERIC Decimal → `None` on reconnect (issue [#58]).
 - Issue [#38]: the original bug report.
-- Issue [#40]: temporal typed binds (deferred follow-up).
 - Issue [#41]: filter `== None` panic / `IS NULL` compile path — debugging story in
   `docs/solutions/issues/typed-where-null-panics-is-null.md`.
 - PR [#62]: `fix(query): typed predicates col == None → IS NULL / IS NOT NULL`.
 
 [#38]: https://github.com/syn54x/ferro-orm/issues/38
-[#40]: https://github.com/syn54x/ferro-orm/issues/40
 [#41]: https://github.com/syn54x/ferro-orm/issues/41
 [#56]: https://github.com/syn54x/ferro-orm/issues/56
 [#58]: https://github.com/syn54x/ferro-orm/issues/58

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ dev = [
 
 [tool.pytest.ini_options]
 addopts = "--cov=src"
+markers = [
+    "deprecated_operator_path: tests that assert temporary operator-style predicate compatibility and are scheduled for removal in v0.13.0",
+]
 
 [tool.commitizen]
 name = "cz_conventional_commits"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dev = [
 [tool.pytest.ini_options]
 addopts = "--cov=src"
 markers = [
-    "deprecated_operator_path: tests that assert temporary operator-style predicate compatibility and are scheduled for removal in v0.13.0",
+    "deprecated_operator_path: tests that assert temporary operator-style predicate compatibility and are scheduled for removal in v0.14.0",
 ]
 
 [tool.commitizen]

--- a/scripts/demo_queries.py
+++ b/scripts/demo_queries.py
@@ -1,16 +1,23 @@
 # /// script
+# requires-python = ">=3.12"
 # dependencies = [
 #     "pydantic>=2.0",
 #     "ferro-orm",
 #     "rich",
 # ]
+#
+# [tool.uv.sources]
+# ferro-orm = { path = "..", editable = true }
 # ///
+"""Ferro query demo for v0.12+ (lambda predicates, session-scoped routing).
+
+Run: uv run scripts/demo_queries.py
+"""
 
 import os
 from datetime import datetime, timezone
 from typing import Annotated
 
-from pydantic import Field
 from rich.console import Console
 from rich.panel import Panel
 from rich.syntax import Syntax
@@ -18,11 +25,13 @@ from rich.syntax import Syntax
 from ferro import (
     BackRef,
     FerroField,
+    Field,
     ForeignKey,
     ManyToMany,
     Model,
     Relation,
     connect,
+    engines,
     transaction,
 )
 
@@ -36,11 +45,10 @@ def show_step(title: str, code: str):
     console.print(Panel(syntax, expand=False, border_style="dim"))
 
 
-# 1. Define relationship-aware models
+# 1. Define relationship-aware models (Field assignment + FerroField Annotated)
 class Category(Model):
-    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    id: int | None = Field(default=None, primary_key=True)
     name: str
-    # Reverse lookup marker (Zero-Boilerplate)
     products: Relation[list["Product"]] = BackRef()
 
 
@@ -48,7 +56,6 @@ class Product(Model):
     id: Annotated[int | None, FerroField(primary_key=True, autoincrement=True)] = None
     name: Annotated[str, FerroField(index=True)]
     price: float
-    # Foreign Key linking to Category
     category: Annotated[
         Category, ForeignKey(related_name="products", on_delete="CASCADE")
     ]
@@ -58,192 +65,202 @@ class Product(Model):
 
 
 class Actor(Model):
-    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    id: int | None = Field(default=None, primary_key=True)
     name: str
     movies: Relation[list["Movie"]] = ManyToMany(related_name="actors")
 
 
 class Movie(Model):
     id: Annotated[int | None, FerroField(primary_key=True)] = None
-    title: str
+    title: Annotated[str, FerroField(index=True)]
     actors: Relation[list[Actor]] = BackRef()
 
 
 async def run_demo():
     # Use a file-based SQLite DB for demo stability
-    db_file = "demo.db"
+    db_file = "demo_v012.db"
     if os.path.exists(db_file):
         os.remove(db_file)
 
     console.print(
         Panel.fit(
-            "[bold green]🚀 Ferro High-Performance ORM Demo[/bold green]",
+            "[bold green]🚀 Ferro High-Performance ORM Demo (v0.12+)[/bold green]",
             border_style="bold green",
         )
     )
 
     console.print(f"🚀 Connecting to Ferro Engine ({db_file})...")
-    # connect() automatically resolves relationships and creates tables
     await connect(f"sqlite:{db_file}?mode=rwc", auto_migrate=True)
 
-    # 2. Seeding with Relationships
-    console.print("📦 Seeding initial data...")
+    async with engines.session("default"):
+        # 2. Seeding with Relationships
+        console.print("📦 Seeding initial data...")
 
-    electronics = await Category.create(name="Electronics")
-    appliances = await Category.create(name="Appliances")
-    furniture = await Category.create(name="Furniture")
+        electronics = await Category.create(name="Electronics")
+        appliances = await Category.create(name="Appliances")
+        furniture = await Category.create(name="Furniture")
 
-    data = [
-        ("Laptop", 1200.0, electronics, True, "LPT-001"),
-        ("Smartphone", 800.0, electronics, True, "PHN-001"),
-        ("Headphones", 150.0, electronics, True, "HDP-001"),
-        ("Monitor", 300.0, electronics, False, "MON-001"),
-        ("Coffee Maker", 80.0, appliances, True, "COF-001"),
-        ("Toaster", 30.0, appliances, True, "TST-001"),
-        ("Desk Chair", 250.0, furniture, True, "CHR-001"),
-        ("Bookshelf", 120.0, furniture, True, "BSH-001"),
-        ("Mechanical Keyboard", 120.0, electronics, True, "KBD-001"),
-        ("Gaming Mouse", 60.0, electronics, True, "MSE-001"),
-    ]
+        data = [
+            ("Laptop", 1200.0, electronics, True, "LPT-001"),
+            ("Smartphone", 800.0, electronics, True, "PHN-001"),
+            ("Headphones", 150.0, electronics, True, "HDP-001"),
+            ("Monitor", 300.0, electronics, False, "MON-001"),
+            ("Coffee Maker", 80.0, appliances, True, "COF-001"),
+            ("Toaster", 30.0, appliances, True, "TST-001"),
+            ("Desk Chair", 250.0, furniture, True, "CHR-001"),
+            ("Bookshelf", 120.0, furniture, True, "BSH-001"),
+            ("Mechanical Keyboard", 120.0, electronics, True, "KBD-001"),
+            ("Gaming Mouse", 60.0, electronics, True, "MSE-001"),
+        ]
 
-    for name, price, cat, stock, sku in data:
-        await Product(
-            name=name, price=price, category=cat, in_stock=stock, sku=sku
-        ).save()
+        for name, price, cat, stock, sku in data:
+            await Product(
+                name=name, price=price, category=cat, in_stock=stock, sku=sku
+            ).save()
 
-    console.print("\n[bold yellow]--- 🔍 Running Fluent Queries ---[/bold yellow]")
+        console.print("\n[bold yellow]--- 🔍 Running Fluent Queries ---[/bold yellow]")
 
-    # 3. Filtering through relationships
-    show_step(
-        "Filter by Relationship ID",
-        "results = await Product.where(Product.category_id == electronics.id).all()",
-    )
-    electronics_products = await Product.where(
-        Product.category_id == electronics.id
-    ).all()
-    console.print(
-        f"✅ Found [bold green]{len(electronics_products)}[/bold green] Electronics products."
-    )
-
-    # 4. Basic Filter (Operators)
-    show_step(
-        "Range Queries (>=)",
-        "expensive = await Product.where(Product.price >= 500).all()",
-    )
-    expensive = await Product.where(Product.price >= 500).all()
-    console.print(
-        f"💰 Expensive items (>= 500): [cyan]{[p.name for p in expensive]}[/cyan]"
-    )
-
-    # 5. Chaining & Pagination
-    show_step(
-        "Pagination & Ordering",
-        'ordered = await Product.select().order_by(Product.price, "desc").limit(3).all()',
-    )
-    top_3 = await Product.select().order_by(Product.price, "desc").limit(3).all()
-    for p in top_3:
-        console.print(f"🔝 [cyan]{p.name}[/cyan]: ${p.price}")
-
-    # 6. RELATIONSHIP POWER
-    console.print("\n[bold yellow]--- 🔗 Relationship Features ---[/bold yellow]")
-
-    show_step(
-        "Lazy Loading (Forward)",
-        'laptop = await Product.where(Product.name == "Laptop").first()\n'
-        "category = await laptop.category  # Fetched on demand",
-    )
-    laptop = await Product.where(Product.name == "Laptop").first()
-    category = await laptop.category
-    console.print(f"💻 Laptop Category: [bold green]{category.name}[/bold green]")
-
-    show_step(
-        "Reverse Lookup (Zero-Boilerplate)",
-        'cat = await Category.where(Category.name == "Appliances").first()\n'
-        "products = await cat.products.all()  # .products returns a Query object!",
-    )
-    app_cat = await Category.where(Category.name == "Appliances").first()
-    app_products = await app_cat.products.all()
-    console.print(f"🏠 Appliances found: [cyan]{[p.name for p in app_products]}[/cyan]")
-
-    show_step(
-        "Reverse Lookup with Filtering",
-        "electronics_in_stock = await electronics.products.where(Product.in_stock == True).all()",
-    )
-    stock_electronics = await electronics.products.where(Product.in_stock == True).all()  # noqa
-    console.print(
-        f"📱 In-stock Electronics: [bold green]{len(stock_electronics)}[/bold green]"
-    )
-
-    # 7. MANY-TO-MANY (M2M)
-    console.print("\n[bold yellow]--- 🤝 Many-to-Many Relationships ---[/bold yellow]")
-
-    show_step(
-        "M2M Setup & Mutation",
-        'keanu = await Actor.create(name="Keanu Reeves")\n'
-        'laurence = await Actor.create(name="Laurence Fishburne")\n'
-        'matrix = await Movie.create(title="The Matrix")\n'
-        "await keanu.movies.add(matrix)\n"
-        "await laurence.movies.add(matrix)",
-    )
-
-    keanu = await Actor.create(name="Keanu Reeves")
-    laurence = await Actor.create(name="Laurence Fishburne")
-    matrix = await Movie.create(title="The Matrix")
-
-    await keanu.movies.add(matrix)
-    await laurence.movies.add(matrix)
-
-    show_step(
-        "M2M Querying (Bi-directional)",
-        "keanu_movies = await keanu.movies.all()\n"
-        "matrix_actors = await matrix.actors.all()",
-    )
-
-    keanu_movies = await keanu.movies.all()
-    matrix_actors = await matrix.actors.all()
-
-    console.print(f"🎬 Keanu's Movies: [cyan]{[m.title for m in keanu_movies]}[/cyan]")
-    console.print(f"👥 Matrix Actors: [cyan]{[a.name for a in matrix_actors]}[/cyan]")
-
-    # 8. Transactions
-    console.print("\n[bold yellow]--- ⚛️ Transaction Support ---[/bold yellow]")
-
-    show_step(
-        "Atomic Transaction",
-        "async with ferro.transaction():\n"
-        '    new_cat = await Category.create(name="New Category")\n'
-        '    await Product.create(name="Atomic Item", category=new_cat, ...)',
-    )
-
-    async with transaction():
-        new_cat = await Category.create(name="Gaming")
-        await Product.create(
-            name="RTX 5090",
-            price=1999.99,
-            category=new_cat,
-            in_stock=True,
-            sku="GPU-5090",
+        # 3. Filtering through relationships
+        show_step(
+            "Filter by Relationship ID",
+            "results = await Product.where(lambda t: t.category_id == electronics.id).all()",
+        )
+        electronics_products = await Product.where(
+            lambda t: t.category_id == electronics.id
+        ).all()
+        console.print(
+            f"✅ Found [bold green]{len(electronics_products)}[/bold green] Electronics products."
         )
 
-    gpu = await Product.where(Product.name == "RTX 5090").first()
-    gpu_cat = await gpu.category
-    console.print(
-        f"✅ Transaction Committed: [bold green]{gpu.name}[/bold green] in [bold green]{gpu_cat.name}[/bold green]"
-    )
+        # 4. Basic Filter (lambda predicates)
+        show_step(
+            "Range Queries (>=)",
+            "expensive = await Product.where(lambda t: t.price >= 500).all()",
+        )
+        expensive = await Product.where(lambda t: t.price >= 500).all()
+        console.print(
+            f"💰 Expensive items (>= 500): [cyan]{[p.name for p in expensive]}[/cyan]"
+        )
 
-    # 9. Instance Refreshing
-    console.print("\n[bold yellow]--- 🔄 Instance Refreshing ---[/bold yellow]")
-    show_step(
-        "Refreshing an instance",
-        "await Product.where(Product.id == laptop.id).update(price=50.0)\n"
-        "await laptop.refresh()",
-    )
+        # 5. Chaining & Pagination
+        show_step(
+            "Pagination & Ordering",
+            'ordered = await Product.select().order_by(Product.price, "desc").limit(3).all()',
+        )
+        top_3 = await Product.select().order_by(Product.price, "desc").limit(3).all()
+        for p in top_3:
+            console.print(f"🔝 [cyan]{p.name}[/cyan]: ${p.price}")
 
-    await Product.where(Product.id == laptop.id).update(price=50.0)
-    await laptop.refresh()
-    console.print(
-        f"🔄 Laptop price after refresh: [bold green]${laptop.price}[/bold green]"
-    )
+        # 6. RELATIONSHIP POWER
+        console.print("\n[bold yellow]--- 🔗 Relationship Features ---[/bold yellow]")
+
+        show_step(
+            "Lazy Loading (Forward)",
+            'laptop = await Product.where(lambda t: t.name == "Laptop").first()\n'
+            "category = await laptop.category  # Fetched on demand",
+        )
+        laptop = await Product.where(lambda t: t.name == "Laptop").first()
+        category = await laptop.category
+        console.print(f"💻 Laptop Category: [bold green]{category.name}[/bold green]")
+
+        show_step(
+            "Reverse Lookup (Zero-Boilerplate)",
+            'cat = await Category.where(lambda t: t.name == "Appliances").first()\n'
+            "products = await cat.products.all()  # .products returns a Query object!",
+        )
+        app_cat = await Category.where(lambda t: t.name == "Appliances").first()
+        app_products = await app_cat.products.all()
+        console.print(
+            f"🏠 Appliances found: [cyan]{[p.name for p in app_products]}[/cyan]"
+        )
+
+        show_step(
+            "Reverse Lookup with Filtering",
+            "electronics_in_stock = await electronics.products.where("
+            "lambda t: t.in_stock == True).all()",
+        )
+        stock_electronics = await electronics.products.where(
+            lambda t: t.in_stock == True  # noqa: E712
+        ).all()
+        console.print(
+            f"📱 In-stock Electronics: [bold green]{len(stock_electronics)}[/bold green]"
+        )
+
+        # 7. MANY-TO-MANY (M2M)
+        console.print("\n[bold yellow]--- 🤝 Many-to-Many Relationships ---[/bold yellow]")
+
+        show_step(
+            "M2M Setup & Mutation",
+            'keanu = await Actor.create(name="Keanu Reeves")\n'
+            'laurence = await Actor.create(name="Laurence Fishburne")\n'
+            'matrix = await Movie.create(title="The Matrix")\n'
+            "await keanu.movies.add(matrix)\n"
+            "await laurence.movies.add(matrix)",
+        )
+
+        keanu = await Actor.create(name="Keanu Reeves")
+        laurence = await Actor.create(name="Laurence Fishburne")
+        matrix = await Movie.create(title="The Matrix")
+
+        await keanu.movies.add(matrix)
+        await laurence.movies.add(matrix)
+
+        show_step(
+            "M2M Querying (Bi-directional)",
+            "keanu_movies = await keanu.movies.all()\n"
+            "matrix_actors = await matrix.actors.all()",
+        )
+
+        keanu_movies = await keanu.movies.all()
+        matrix_actors = await matrix.actors.all()
+
+        console.print(
+            f"🎬 Keanu's Movies: [cyan]{[m.title for m in keanu_movies]}[/cyan]"
+        )
+        console.print(
+            f"👥 Matrix Actors: [cyan]{[a.name for a in matrix_actors]}[/cyan]"
+        )
+
+        # 8. Transactions
+        console.print("\n[bold yellow]--- ⚛️ Transaction Support ---[/bold yellow]")
+
+        show_step(
+            "Atomic Transaction",
+            "async with transaction():\n"
+            '    new_cat = await Category.create(name="Gaming")\n'
+            '    await Product.create(name="RTX 5090", category=new_cat, ...)',
+        )
+
+        async with transaction():
+            new_cat = await Category.create(name="Gaming")
+            await Product.create(
+                name="RTX 5090",
+                price=1999.99,
+                category=new_cat,
+                in_stock=True,
+                sku="GPU-5090",
+            )
+
+        gpu = await Product.where(lambda t: t.name == "RTX 5090").first()
+        gpu_cat = await gpu.category
+        console.print(
+            f"✅ Transaction Committed: [bold green]{gpu.name}[/bold green] in "
+            f"[bold green]{gpu_cat.name}[/bold green]"
+        )
+
+        # 9. Instance Refreshing
+        console.print("\n[bold yellow]--- 🔄 Instance Refreshing ---[/bold yellow]")
+        show_step(
+            "Refreshing an instance",
+            "await Product.where(lambda t: t.id == laptop.id).update(price=50.0)\n"
+            "await laptop.refresh()",
+        )
+
+        await Product.where(lambda t: t.id == laptop.id).update(price=50.0)
+        await laptop.refresh()
+        console.print(
+            f"🔄 Laptop price after refresh: [bold green]${laptop.price}[/bold green]"
+        )
 
     console.print("\n[bold green]🏁 Demo Complete![/bold green]")
 

--- a/scripts/demo_queries_pre_v012.py
+++ b/scripts/demo_queries_pre_v012.py
@@ -1,0 +1,252 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "pydantic>=2.0",
+#     "ferro-orm",
+#     "rich",
+# ]
+#
+# [tool.uv.sources]
+# ferro-orm = { path = "..", editable = true }
+# ///
+"""Ferro query demo for releases before v0.12 (operator predicates, ambient routing).
+
+Run: uv run scripts/demo_queries_pre_v012.py
+"""
+
+import os
+from datetime import datetime, timezone
+from typing import Annotated
+
+from pydantic import Field as PydanticField
+from rich.console import Console
+from rich.panel import Panel
+from rich.syntax import Syntax
+
+from ferro import (
+    BackRef,
+    FerroField,
+    ForeignKey,
+    ManyToMany,
+    Model,
+    Relation,
+    connect,
+    transaction,
+)
+
+console = Console()
+
+
+def show_step(title: str, code: str):
+    """Utility to display a code snippet and its title."""
+    console.print(f"\n[bold blue]>>> {title}[/bold blue]")
+    syntax = Syntax(code, "python", theme="monokai", line_numbers=False)
+    console.print(Panel(syntax, expand=False, border_style="dim"))
+
+
+class Category(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str
+    products: Relation[list["Product"]] = BackRef()
+
+
+class Product(Model):
+    id: Annotated[int | None, FerroField(primary_key=True, autoincrement=True)] = None
+    name: Annotated[str, FerroField(index=True)]
+    price: float
+    category: Annotated[
+        Category, ForeignKey(related_name="products", on_delete="CASCADE")
+    ]
+    in_stock: bool
+    sku: Annotated[str | None, FerroField(unique=True)] = None
+    created_at: datetime = PydanticField(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+
+class Actor(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str
+    movies: Relation[list["Movie"]] = ManyToMany(related_name="actors")
+
+
+class Movie(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    title: str
+    actors: Relation[list[Actor]] = BackRef()
+
+
+async def run_demo():
+    db_file = "demo_pre_v012.db"
+    if os.path.exists(db_file):
+        os.remove(db_file)
+
+    console.print(
+        Panel.fit(
+            "[bold green]🚀 Ferro ORM Demo (pre-v0.12 patterns)[/bold green]",
+            border_style="bold green",
+        )
+    )
+
+    console.print(f"🚀 Connecting to Ferro Engine ({db_file})...")
+    await connect(f"sqlite:{db_file}?mode=rwc", auto_migrate=True)
+
+    console.print("📦 Seeding initial data...")
+
+    electronics = await Category.create(name="Electronics")
+    appliances = await Category.create(name="Appliances")
+    furniture = await Category.create(name="Furniture")
+
+    data = [
+        ("Laptop", 1200.0, electronics, True, "LPT-001"),
+        ("Smartphone", 800.0, electronics, True, "PHN-001"),
+        ("Headphones", 150.0, electronics, True, "HDP-001"),
+        ("Monitor", 300.0, electronics, False, "MON-001"),
+        ("Coffee Maker", 80.0, appliances, True, "COF-001"),
+        ("Toaster", 30.0, appliances, True, "TST-001"),
+        ("Desk Chair", 250.0, furniture, True, "CHR-001"),
+        ("Bookshelf", 120.0, furniture, True, "BSH-001"),
+        ("Mechanical Keyboard", 120.0, electronics, True, "KBD-001"),
+        ("Gaming Mouse", 60.0, electronics, True, "MSE-001"),
+    ]
+
+    for name, price, cat, stock, sku in data:
+        await Product(
+            name=name, price=price, category=cat, in_stock=stock, sku=sku
+        ).save()
+
+    console.print("\n[bold yellow]--- 🔍 Running Fluent Queries ---[/bold yellow]")
+
+    show_step(
+        "Filter by Relationship ID",
+        "results = await Product.where(Product.category_id == electronics.id).all()",
+    )
+    electronics_products = await Product.where(
+        Product.category_id == electronics.id
+    ).all()
+    console.print(
+        f"✅ Found [bold green]{len(electronics_products)}[/bold green] Electronics products."
+    )
+
+    show_step(
+        "Range Queries (>=)",
+        "expensive = await Product.where(Product.price >= 500).all()",
+    )
+    expensive = await Product.where(Product.price >= 500).all()
+    console.print(
+        f"💰 Expensive items (>= 500): [cyan]{[p.name for p in expensive]}[/cyan]"
+    )
+
+    show_step(
+        "Pagination & Ordering",
+        'ordered = await Product.select().order_by(Product.price, "desc").limit(3).all()',
+    )
+    top_3 = await Product.select().order_by(Product.price, "desc").limit(3).all()
+    for p in top_3:
+        console.print(f"🔝 [cyan]{p.name}[/cyan]: ${p.price}")
+
+    console.print("\n[bold yellow]--- 🔗 Relationship Features ---[/bold yellow]")
+
+    show_step(
+        "Lazy Loading (Forward)",
+        'laptop = await Product.where(Product.name == "Laptop").first()\n'
+        "category = await laptop.category  # Fetched on demand",
+    )
+    laptop = await Product.where(Product.name == "Laptop").first()
+    category = await laptop.category
+    console.print(f"💻 Laptop Category: [bold green]{category.name}[/bold green]")
+
+    show_step(
+        "Reverse Lookup (Zero-Boilerplate)",
+        'cat = await Category.where(Category.name == "Appliances").first()\n'
+        "products = await cat.products.all()  # .products returns a Query object!",
+    )
+    app_cat = await Category.where(Category.name == "Appliances").first()
+    app_products = await app_cat.products.all()
+    console.print(f"🏠 Appliances found: [cyan]{[p.name for p in app_products]}[/cyan]")
+
+    show_step(
+        "Reverse Lookup with Filtering",
+        "electronics_in_stock = await electronics.products.where(Product.in_stock == True).all()",
+    )
+    stock_electronics = await electronics.products.where(Product.in_stock == True).all()  # noqa: E712
+    console.print(
+        f"📱 In-stock Electronics: [bold green]{len(stock_electronics)}[/bold green]"
+    )
+
+    console.print("\n[bold yellow]--- 🤝 Many-to-Many Relationships ---[/bold yellow]")
+
+    show_step(
+        "M2M Setup & Mutation",
+        'keanu = await Actor.create(name="Keanu Reeves")\n'
+        'laurence = await Actor.create(name="Laurence Fishburne")\n'
+        'matrix = await Movie.create(title="The Matrix")\n'
+        "await keanu.movies.add(matrix)\n"
+        "await laurence.movies.add(matrix)",
+    )
+
+    keanu = await Actor.create(name="Keanu Reeves")
+    laurence = await Actor.create(name="Laurence Fishburne")
+    matrix = await Movie.create(title="The Matrix")
+
+    await keanu.movies.add(matrix)
+    await laurence.movies.add(matrix)
+
+    show_step(
+        "M2M Querying (Bi-directional)",
+        "keanu_movies = await keanu.movies.all()\n"
+        "matrix_actors = await matrix.actors.all()",
+    )
+
+    keanu_movies = await keanu.movies.all()
+    matrix_actors = await matrix.actors.all()
+
+    console.print(f"🎬 Keanu's Movies: [cyan]{[m.title for m in keanu_movies]}[/cyan]")
+    console.print(f"👥 Matrix Actors: [cyan]{[a.name for a in matrix_actors]}[/cyan]")
+
+    console.print("\n[bold yellow]--- ⚛️ Transaction Support ---[/bold yellow]")
+
+    show_step(
+        "Atomic Transaction",
+        "async with transaction():\n"
+        '    new_cat = await Category.create(name="Gaming")\n'
+        '    await Product.create(name="RTX 5090", category=new_cat, ...)',
+    )
+
+    async with transaction():
+        new_cat = await Category.create(name="Gaming")
+        await Product.create(
+            name="RTX 5090",
+            price=1999.99,
+            category=new_cat,
+            in_stock=True,
+            sku="GPU-5090",
+        )
+
+    gpu = await Product.where(Product.name == "RTX 5090").first()
+    gpu_cat = await gpu.category
+    console.print(
+        f"✅ Transaction Committed: [bold green]{gpu.name}[/bold green] in "
+        f"[bold green]{gpu_cat.name}[/bold green]"
+    )
+
+    console.print("\n[bold yellow]--- 🔄 Instance Refreshing ---[/bold yellow]")
+    show_step(
+        "Refreshing an instance",
+        "await Product.where(Product.id == laptop.id).update(price=50.0)\n"
+        "await laptop.refresh()",
+    )
+
+    await Product.where(Product.id == laptop.id).update(price=50.0)
+    await laptop.refresh()
+    console.print(
+        f"🔄 Laptop price after refresh: [bold green]${laptop.price}[/bold green]"
+    )
+
+    console.print("\n[bold green]🏁 Demo Complete![/bold green]")
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(run_demo())

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -102,6 +102,8 @@ pub struct EngineHandle {
     spec: Option<PoolSpec>,
     /// When false, Ferro skips the identity map for this connection (no lookup/register on load).
     identity_map_enabled: bool,
+    /// Enables internal IR shadow-planner comparisons at runtime.
+    shadow_runtime_enabled: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -204,6 +206,7 @@ impl EngineHandle {
             pool: Arc::new(RwLock::new(pool)),
             spec: Some(spec),
             identity_map_enabled: true,
+            shadow_runtime_enabled: false,
         })
     }
 
@@ -217,6 +220,7 @@ impl EngineHandle {
             pool: Arc::new(RwLock::new(BackendPool::Sqlite(Arc::new(pool)))),
             spec: None,
             identity_map_enabled: true,
+            shadow_runtime_enabled: false,
         }
     }
 
@@ -230,6 +234,7 @@ impl EngineHandle {
             pool: Arc::new(RwLock::new(BackendPool::Postgres(Arc::new(pool)))),
             spec: None,
             identity_map_enabled: true,
+            shadow_runtime_enabled: false,
         }
     }
 
@@ -318,6 +323,17 @@ impl EngineHandle {
     #[must_use]
     pub fn with_identity_map_enabled(mut self, enabled: bool) -> Self {
         self.identity_map_enabled = enabled;
+        self
+    }
+
+    #[must_use]
+    pub fn is_shadow_runtime_enabled(&self) -> bool {
+        self.shadow_runtime_enabled
+    }
+
+    #[must_use]
+    pub fn with_shadow_runtime_enabled(mut self, enabled: bool) -> Self {
+        self.shadow_runtime_enabled = enabled;
         self
     }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -298,6 +298,9 @@ pub fn schema_bind_expr(
         }
         Value::Bool(b) => Expr::value(SeaValue::Bool(Some(*b))),
         Value::Null => {
+            if col_is_decimal && backend == SqlDialect::Postgres {
+                return Ok(Expr::value(SeaValue::String(None)).cast_as("numeric"));
+            }
             let v = if col_format == Some("binary") {
                 SeaValue::Bytes(None)
             } else if col_is_decimal {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,0 +1,514 @@
+use crate::backend::{EngineRow, EngineValue};
+use crate::state::{MODEL_REGISTRY, RustValue, SqlDialect};
+use sea_query::{Alias, Expr, SelectStatement, SimpleExpr, Value as SeaValue};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+
+pub type ParsedRow = (Option<String>, Vec<(String, RustValue)>);
+
+fn json_type(col_info: &Value) -> Option<&str> {
+    col_info.get("type").and_then(|t| t.as_str()).or_else(|| {
+        col_info
+            .get("anyOf")
+            .and_then(|a| a.as_array())
+            .and_then(|types| {
+                types.iter().find_map(|t| {
+                    let s = t.get("type")?.as_str()?;
+                    if s == "null" { None } else { Some(s) }
+                })
+            })
+    })
+}
+
+fn format(col_info: &Value) -> Option<&str> {
+    col_info.get("format").and_then(|f| f.as_str()).or_else(|| {
+        col_info
+            .get("anyOf")
+            .and_then(|a| a.as_array())
+            .and_then(|types| {
+                types.iter().find_map(|t| {
+                    let ty = t.get("type")?.as_str()?;
+                    if ty == "null" {
+                        None
+                    } else {
+                        t.get("format").and_then(|f| f.as_str())
+                    }
+                })
+            })
+    })
+}
+
+fn pattern_looks_decimal(pattern: &str) -> bool {
+    if !pattern.contains("\\d") {
+        return false;
+    }
+    let mut escaped = false;
+    for ch in pattern.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if ch.is_ascii_alphabetic() {
+            return false;
+        }
+    }
+    true
+}
+
+fn is_decimal(col_info: &Value) -> bool {
+    if col_info.get("db_type").and_then(Value::as_str) == Some("numeric") {
+        return true;
+    }
+    if col_info.get("type").and_then(Value::as_str) == Some("string")
+        && col_info
+            .get("pattern")
+            .and_then(Value::as_str)
+            .map(pattern_looks_decimal)
+            .unwrap_or(false)
+    {
+        return true;
+    }
+    col_info
+        .get("anyOf")
+        .and_then(Value::as_array)
+        .map(|types| {
+            let has_patterned_string = types.iter().any(|t| {
+                t.get("type").and_then(Value::as_str) == Some("string")
+                    && t
+                        .get("pattern")
+                        .and_then(Value::as_str)
+                        .map(pattern_looks_decimal)
+                        .unwrap_or(false)
+            });
+            let has_only_decimal_compatible_types = types.iter().all(|t| {
+                matches!(
+                    t.get("type").and_then(Value::as_str),
+                    Some("string" | "number" | "null")
+                )
+            });
+            has_patterned_string && has_only_decimal_compatible_types
+        })
+        .unwrap_or(false)
+}
+
+fn is_enum(col_info: &Value) -> bool {
+    col_info.get("enum").and_then(|e| e.as_array()).is_some()
+}
+
+fn resolve_ref<'a>(schema: &'a Value, col_info: &'a Value) -> &'a Value {
+    if let Some(ref_path) = col_info.get("$ref").and_then(|r| r.as_str())
+        && let Some(def_name) = ref_path.strip_prefix("#/$defs/")
+        && let Some(def) = schema.get("$defs").and_then(|defs| defs.get(def_name))
+    {
+        return def;
+    }
+    col_info
+}
+
+fn schema_property<'a>(schema: &'a Value, col_name: &str) -> Option<&'a Value> {
+    schema
+        .get("properties")
+        .and_then(|p| p.get(col_name))
+        .map(|prop| resolve_ref(schema, prop))
+}
+
+fn temporal_cast_for_format(fmt: Option<&str>) -> Option<&'static str> {
+    match fmt {
+        Some("date-time") => Some("timestamptz"),
+        Some("date") => Some("date"),
+        Some("time") => Some("time"),
+        _ => None,
+    }
+}
+
+fn model_schema_property(model_name: &str, col_name: &str) -> Option<Value> {
+    let registry = MODEL_REGISTRY.read().ok()?;
+    let schema = registry.get(model_name)?;
+    let col_info = schema
+        .get("properties")
+        .and_then(|p| p.get(col_name))
+        .map(|prop| resolve_ref(schema, prop))?;
+    Some(col_info.clone())
+}
+
+pub fn apply_postgres_text_select_columns(
+    select: &mut SelectStatement,
+    table_name: &str,
+    schema: &Value,
+    pg_native_enum_columns: &HashSet<String>,
+    backend: SqlDialect,
+) {
+    let tbl = Alias::new(table_name);
+    if backend != SqlDialect::Postgres {
+        select.column((tbl.clone(), sea_query::Asterisk));
+        return;
+    }
+    let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) else {
+        select.column((tbl.clone(), sea_query::Asterisk));
+        return;
+    };
+    let need_text_from_schema = properties.values().any(|col_info| {
+        let resolved = resolve_ref(schema, col_info);
+        matches!(
+            format(resolved),
+            Some("uuid" | "date-time" | "date" | "decimal")
+        ) || matches!(json_type(resolved), Some("object" | "array"))
+            || is_enum(resolved)
+    });
+    let need_text_from_native_enum = properties
+        .keys()
+        .any(|k| pg_native_enum_columns.contains(k.as_str()));
+    if !need_text_from_schema && !need_text_from_native_enum {
+        select.column((tbl.clone(), sea_query::Asterisk));
+        return;
+    }
+    for (col_name, col_info) in properties {
+        let col_iden = Alias::new(col_name.as_str());
+        let col_info = resolve_ref(schema, col_info);
+        if matches!(
+            format(col_info),
+            Some("uuid" | "date-time" | "date" | "decimal")
+        ) || matches!(json_type(col_info), Some("object" | "array"))
+            || is_enum(col_info)
+            || pg_native_enum_columns.contains(col_name.as_str())
+        {
+            let expr = Expr::cast_as(
+                Expr::col((tbl.clone(), col_iden.clone())),
+                Alias::new("text"),
+            );
+            select.expr_as(expr, col_iden);
+        } else {
+            select.column((tbl.clone(), col_iden));
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn schema_bind_expr(
+    schema: &Value,
+    table_name: &str,
+    col_name: &str,
+    value: &Value,
+    enum_udt: &HashMap<String, String>,
+    uuid_columns: &HashSet<String>,
+    ts_cast: &HashMap<String, String>,
+    backend: SqlDialect,
+) -> pyo3::PyResult<SimpleExpr> {
+    let col_info = schema_property(schema, col_name);
+    let col_format = col_info.and_then(format);
+    let col_json_type = col_info.and_then(json_type);
+    let col_is_decimal = col_info.map(is_decimal).unwrap_or(false);
+    let is_uuid_pg = backend == SqlDialect::Postgres
+        && (uuid_columns.contains(col_name) || col_format == Some("uuid"));
+
+    if let Value::String(s) = value
+        && backend == SqlDialect::Postgres
+        && let Some(tn) = crate::schema_bind::native_postgres_enum_udt_name(col_name, enum_udt)
+    {
+        return Ok(crate::schema_bind::postgres_enum_string_rhs_expr(s, tn));
+    }
+
+    if is_uuid_pg {
+        return match value {
+            Value::Null => Ok(Expr::value(SeaValue::Uuid(None))),
+            Value::String(s) => {
+                let parsed = uuid::Uuid::parse_str(s).map_err(|_| {
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "Invalid UUID for {table_name}.{col_name}: {s}"
+                    ))
+                })?;
+                Ok(Expr::value(SeaValue::Uuid(Some(Box::new(parsed)))))
+            }
+            _ => Ok(Expr::value(SeaValue::String(Some(Box::new(
+                value.to_string(),
+            ))))),
+        };
+    }
+
+    let temporal_cast = ts_cast
+        .get(col_name)
+        .map(|s| s.as_str())
+        .or_else(|| temporal_cast_for_format(col_format));
+    if backend == SqlDialect::Postgres
+        && let Some(cast) = temporal_cast
+    {
+        if value.is_null() {
+            return Ok(Expr::value(SeaValue::String(None)).cast_as(Alias::new(cast)));
+        }
+        if let Value::String(s) = value {
+            return Ok(
+                Expr::value(SeaValue::String(Some(Box::new(s.clone())))).cast_as(Alias::new(cast))
+            );
+        }
+    }
+
+    let expr = match value {
+        value
+            if backend == SqlDialect::Postgres
+                && matches!(col_json_type, Some("object" | "array")) =>
+        {
+            if value.is_null() {
+                Expr::value(SeaValue::String(None)).cast_as("json")
+            } else {
+                Expr::value(SeaValue::String(Some(Box::new(value.to_string())))).cast_as("json")
+            }
+        }
+        Value::String(s) if col_json_type == Some("integer") => {
+            if let Ok(parsed) = s.parse::<i64>() {
+                Expr::value(SeaValue::BigInt(Some(parsed)))
+            } else {
+                Expr::value(SeaValue::String(Some(Box::new(s.clone()))))
+            }
+        }
+        Value::String(s) if col_json_type == Some("number") => {
+            if let Ok(parsed) = s.parse::<f64>() {
+                Expr::value(SeaValue::Double(Some(parsed)))
+            } else {
+                Expr::value(SeaValue::String(Some(Box::new(s.clone()))))
+            }
+        }
+        Value::String(s) if col_format == Some("binary") => {
+            Expr::value(SeaValue::Bytes(Some(Box::new(s.as_bytes().to_vec()))))
+        }
+        Value::String(s) if col_is_decimal => {
+            if backend == SqlDialect::Postgres {
+                Expr::value(SeaValue::String(Some(Box::new(s.clone())))).cast_as("numeric")
+            } else if let Ok(parsed) = s.parse::<f64>() {
+                Expr::value(SeaValue::Double(Some(parsed)))
+            } else {
+                Expr::value(SeaValue::String(Some(Box::new(s.clone()))))
+            }
+        }
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Expr::value(SeaValue::BigInt(Some(i)))
+            } else if let Some(f) = n.as_f64() {
+                Expr::value(SeaValue::Double(Some(f)))
+            } else {
+                Expr::value(SeaValue::String(None))
+            }
+        }
+        Value::String(s) => Expr::value(SeaValue::String(Some(Box::new(s.clone())))),
+        Value::Bool(b) if col_json_type == Some("boolean") && backend == SqlDialect::Sqlite => {
+            Expr::value(SeaValue::BigInt(Some(if *b { 1 } else { 0 })))
+        }
+        Value::Bool(b) => Expr::value(SeaValue::Bool(Some(*b))),
+        Value::Null => {
+            let v = if col_format == Some("binary") {
+                SeaValue::Bytes(None)
+            } else if col_is_decimal {
+                SeaValue::Double(None)
+            } else if backend == SqlDialect::Postgres && temporal_cast.is_some() {
+                SeaValue::String(None)
+            } else {
+                match col_json_type {
+                    Some("integer") => SeaValue::BigInt(None),
+                    Some("number") => SeaValue::Double(None),
+                    Some("boolean") => SeaValue::Bool(None),
+                    Some("string") => SeaValue::String(None),
+                    _ => SeaValue::String(None),
+                }
+            };
+            Expr::value(v)
+        }
+        _ => Expr::value(SeaValue::String(Some(Box::new(value.to_string())))),
+    };
+    Ok(expr)
+}
+
+pub fn query_bind_expr(
+    model_name: &str,
+    col_name: &str,
+    val: &Value,
+    infer_uuid_without_schema: bool,
+    backend: SqlDialect,
+    postgres_enum_udt: &HashMap<String, String>,
+) -> SimpleExpr {
+    let col_info = model_schema_property(model_name, col_name);
+    let col_format = col_info.as_ref().and_then(format);
+    let col_is_decimal = col_info.as_ref().map(is_decimal).unwrap_or(false);
+    let col_is_uuid = col_info
+        .as_ref()
+        .map(|c| json_type(c) == Some("string") && format(c) == Some("uuid"))
+        .unwrap_or(false);
+
+    if let Value::String(s) = val {
+        if backend == SqlDialect::Postgres {
+            if let Some(tn) =
+                crate::schema_bind::native_postgres_enum_udt_name(col_name, postgres_enum_udt)
+            {
+                return crate::schema_bind::postgres_enum_string_rhs_expr(s, tn);
+            }
+
+            if let Ok(parsed) = uuid::Uuid::parse_str(s)
+                && (col_is_uuid || infer_uuid_without_schema)
+            {
+                return Expr::value(SeaValue::Uuid(Some(Box::new(parsed))));
+            }
+
+            if let Some(cast) = temporal_cast_for_format(col_format) {
+                return Expr::value(SeaValue::String(Some(Box::new(s.clone())))).cast_as(cast);
+            }
+            if col_format == Some("binary") {
+                return Expr::value(SeaValue::Bytes(Some(Box::new(s.as_bytes().to_vec()))));
+            }
+            if col_is_decimal {
+                return Expr::value(SeaValue::String(Some(Box::new(s.clone())))).cast_as("numeric");
+            }
+        }
+
+        if col_is_decimal && let Ok(parsed) = s.parse::<f64>() {
+            return Expr::value(SeaValue::Double(Some(parsed)));
+        }
+    }
+
+    if val.is_null() {
+        if backend == SqlDialect::Postgres {
+            if col_is_uuid {
+                return Expr::value(SeaValue::Uuid(None));
+            }
+            if let Some(cast) = temporal_cast_for_format(col_format) {
+                return Expr::value(SeaValue::String(None)).cast_as(cast);
+            }
+            if col_is_decimal {
+                return Expr::value(SeaValue::String(None)).cast_as("numeric");
+            }
+        }
+        if col_is_uuid {
+            return Expr::value(SeaValue::Uuid(None));
+        }
+        if col_is_decimal {
+            return Expr::value(SeaValue::Double(None));
+        }
+        if col_format == Some("binary") {
+            return Expr::value(SeaValue::Bytes(None));
+        }
+        let col_json_type = col_info.as_ref().and_then(json_type);
+        let typed_null = match col_json_type {
+            Some("integer") => SeaValue::BigInt(None),
+            Some("number") => SeaValue::Double(None),
+            Some("boolean") => SeaValue::Bool(None),
+            Some("string") => SeaValue::String(None),
+            _ => SeaValue::String(None),
+        };
+        return Expr::value(typed_null);
+    }
+
+    Expr::value(json_value_to_sea_value(val))
+}
+
+pub fn m2m_bind_expr(
+    col_name: &str,
+    value: SeaValue,
+    uuid_columns: &HashSet<String>,
+    backend: SqlDialect,
+) -> SimpleExpr {
+    if backend == SqlDialect::Postgres && uuid_columns.contains(col_name) {
+        if let SeaValue::String(Some(s)) = &value
+            && let Ok(parsed) = uuid::Uuid::parse_str(s)
+        {
+            return Expr::value(SeaValue::Uuid(Some(Box::new(parsed))));
+        }
+        return Expr::value(value).cast_as("uuid");
+    }
+    Expr::value(value)
+}
+
+pub fn json_value_to_sea_value(value: &Value) -> SeaValue {
+    match value {
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                SeaValue::BigInt(Some(i))
+            } else if let Some(f) = n.as_f64() {
+                SeaValue::Double(Some(f))
+            } else {
+                SeaValue::String(None)
+            }
+        }
+        Value::String(s) => SeaValue::String(Some(Box::new(s.clone()))),
+        Value::Bool(b) => SeaValue::Bool(Some(*b)),
+        Value::Null => SeaValue::String(None),
+        _ => SeaValue::String(Some(Box::new(value.to_string()))),
+    }
+}
+
+pub fn decode_engine_value(value: EngineValue, schema: &Value, col_name: &str) -> RustValue {
+    let prop = schema
+        .get("properties")
+        .and_then(|p| p.get(col_name))
+        .map(|col_info| resolve_ref(schema, col_info));
+
+    let col_format = prop.and_then(format);
+    let col_is_decimal = prop.map(is_decimal).unwrap_or(false);
+    let col_json_type = prop.and_then(json_type);
+
+    if col_is_decimal {
+        return match value {
+            EngineValue::I64(v) => RustValue::Decimal(v.to_string()),
+            EngineValue::F64(v) => RustValue::Decimal(v.to_string()),
+            EngineValue::String(v) => RustValue::Decimal(v),
+            _ => RustValue::None,
+        };
+    }
+
+    if col_format == Some("binary") {
+        return match value {
+            EngineValue::Bytes(v) => RustValue::Blob(v),
+            EngineValue::String(v) => RustValue::Blob(v.into_bytes()),
+            _ => RustValue::None,
+        };
+    }
+
+    match value {
+        EngineValue::I64(v) if col_json_type == Some("boolean") => RustValue::Bool(v != 0),
+        EngineValue::I64(v) => RustValue::BigInt(v),
+        EngineValue::F64(v) => RustValue::Double(v),
+        EngineValue::Bytes(v) => RustValue::Blob(v),
+        EngineValue::String(v) => match (col_json_type, col_format) {
+            (_, Some("date-time")) => RustValue::DateTime(v),
+            (_, Some("date")) => RustValue::Date(v),
+            (_, Some("uuid")) => RustValue::Uuid(v),
+            (Some("object"), _) | (Some("array"), _) => {
+                if let Ok(json_val) = serde_json::from_str(&v) {
+                    RustValue::Json(json_val)
+                } else {
+                    RustValue::String(v)
+                }
+            }
+            _ => RustValue::String(v),
+        },
+        EngineValue::Bool(v) => RustValue::Bool(v),
+        EngineValue::Null => RustValue::None,
+    }
+}
+
+pub fn typed_rows_to_parsed_data(
+    rows: Vec<EngineRow>,
+    schema: &Value,
+    pk_col: Option<&str>,
+) -> Vec<ParsedRow> {
+    rows.into_iter()
+        .map(|row| {
+            let mut row_pk_val = None;
+            let mut fields = Vec::with_capacity(row.values.len());
+
+            for (col_name, value) in row.values {
+                if pk_col == Some(col_name.as_str()) {
+                    row_pk_val = match &value {
+                        EngineValue::I64(v) => Some(v.to_string()),
+                        EngineValue::String(v) => Some(v.clone()),
+                        _ => None,
+                    };
+                }
+                let value = decode_engine_value(value, schema, &col_name);
+                fields.push((col_name, value));
+            }
+
+            (row_pk_val, fields)
+        })
+        .collect()
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -5,7 +5,10 @@
 
 use crate::backend::{BackendKind, EngineHandle, PoolSpec};
 use crate::migrate::{MigrateOptions, internal_migrate};
-use crate::state::{CONNECTION_REGISTRY, DEFAULT_CONNECTION_NAME, ENGINE, IDENTITY_MAP};
+use crate::state::{
+    CONNECTION_REGISTRY, DEFAULT_CONNECTION_NAME, ENGINE, IDENTITY_MAP, SESSION_REGISTRY,
+    TRANSACTION_REGISTRY,
+};
 use pyo3::prelude::*;
 use std::sync::Arc;
 
@@ -313,6 +316,8 @@ pub fn reset_engine() -> PyResult<()> {
         pyo3::exceptions::PyRuntimeError::new_err("Failed to lock Default Connection")
     })? = None;
     IDENTITY_MAP.clear();
+    TRANSACTION_REGISTRY.clear();
+    SESSION_REGISTRY.clear();
     Ok(())
 }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -134,6 +134,15 @@ fn normalized_connection_name(name: Option<String>) -> PyResult<(String, bool)> 
     }
 }
 
+fn shadow_runtime_enabled_from_env() -> bool {
+    std::env::var("FERRO_SHADOW_RUNTIME")
+        .map(|value| {
+            let value = value.trim().to_ascii_lowercase();
+            value == "1" || value == "true" || value == "yes" || value == "on"
+        })
+        .unwrap_or(false)
+}
+
 async fn connect_engine_handle(
     connection_url: &str,
     backend: BackendKind,
@@ -233,7 +242,8 @@ pub fn connect(
                 redacted_url, e
             ))
         })?
-        .with_identity_map_enabled(identity_map);
+        .with_identity_map_enabled(identity_map)
+        .with_shadow_runtime_enabled(shadow_runtime_enabled_from_env());
 
         let engine_handle = Arc::new(engine_handle);
 

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -28,6 +28,7 @@ from .fields import BackRef, Field, ManyToMany
 from .models import Model, transaction
 from .query import Relation
 from .raw import Transaction, execute, fetch_all, fetch_one
+from .session import Session, engines
 
 # Set up the Ferro logger
 _logger = logging.getLogger("ferro")
@@ -154,4 +155,6 @@ __all__ = [
     "fetch_all",
     "fetch_one",
     "Transaction",
+    "Session",
+    "engines",
 ]

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -7,6 +7,8 @@ to provide a seamless, high-performance database experience.
 
 import logging
 
+from . import _deprecations as _deprecations  # noqa: F401 — enable deprecation visibility
+
 from pydantic import BaseModel, ConfigDict, model_validator
 from pydantic import Field as PydanticField
 

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -55,6 +55,12 @@ def _render_migration_sql_for_test(
     """
     ...
 
+def _shadow_compare_query_plan_for_test(
+    query_json: str, dialect: str, operation: str = "select"
+) -> str:
+    """Test-only: compare legacy vs QueryIR-roundtrip query planning semantics."""
+    ...
+
 async def fetch_all(
     cls: object, tx_id: Optional[str] = None, using: Optional[str] = None
 ) -> list[Any]: ...

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -56,9 +56,9 @@ def _render_migration_sql_for_test(
     ...
 
 def _shadow_compare_query_plan_for_test(
-    query_json: str, dialect: str, operation: str = "select"
+    query_payload_json: str, dialect: str, operation: str = "select"
 ) -> str:
-    """Test-only: compare legacy vs QueryIR-roundtrip query planning semantics."""
+    """Test-only: compare query payload planning semantics."""
     ...
 
 async def fetch_all(
@@ -66,13 +66,13 @@ async def fetch_all(
 ) -> list[Any]: ...
 async def fetch_filtered(
     cls: object,
-    query_json: str,
+    query_ir_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
 ) -> list[Any]: ...
 async def count_filtered(
     name: str,
-    query_json: str,
+    query_ir_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
 ) -> int: ...
@@ -102,13 +102,13 @@ async def delete_record(
 ) -> bool: ...
 async def delete_filtered(
     name: str,
-    query_json: str,
+    query_ir_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
 ) -> int: ...
 async def update_filtered(
     name: str,
-    query_json: str,
+    query_ir_json: str,
     update_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -62,49 +62,59 @@ def _shadow_compare_query_plan_for_test(
     ...
 
 async def fetch_all(
-    cls: object, tx_id: Optional[str] = None, using: Optional[str] = None
+    cls: object,
+    tx_id: Optional[str] = None,
+    using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> list[Any]: ...
 async def fetch_filtered(
     cls: object,
     query_ir_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> list[Any]: ...
 async def count_filtered(
     name: str,
     query_ir_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> int: ...
 async def fetch_one(
     cls: object,
     pk_val: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> Any | None: ...
 async def save_record(
     name: str,
     data: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> int | None: ...
 async def save_bulk_records(
     name: str,
     data_list_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> int: ...
 async def delete_record(
     name: str,
     pk_val: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> bool: ...
 async def delete_filtered(
     name: str,
     query_ir_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> int: ...
 async def update_filtered(
     name: str,
@@ -112,6 +122,7 @@ async def update_filtered(
     update_json: str,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> int: ...
 async def add_m2m_links(
     join_table: str,
@@ -121,6 +132,7 @@ async def add_m2m_links(
     target_ids: list[Any],
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> None: ...
 async def remove_m2m_links(
     join_table: str,
@@ -130,6 +142,7 @@ async def remove_m2m_links(
     target_ids: list[Any],
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> None: ...
 async def clear_m2m_links(
     join_table: str,
@@ -137,35 +150,49 @@ async def clear_m2m_links(
     source_id: Any,
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> None: ...
 async def begin_transaction(
-    parent_tx_id: Optional[str] = None, using: Optional[str] = None
+    parent_tx_id: Optional[str] = None,
+    using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> str: ...
-async def commit_transaction(tx_id: str) -> None: ...
-def transaction_connection_name(tx_id: str) -> str: ...
-async def rollback_transaction(tx_id: str) -> None: ...
+async def commit_transaction(tx_id: str, session_id: Optional[str] = None) -> None: ...
+def transaction_connection_name(tx_id: str, session_id: Optional[str] = None) -> str: ...
+async def rollback_transaction(tx_id: str, session_id: Optional[str] = None) -> None: ...
+def open_session(using: Optional[str] = None) -> str: ...
+def close_session(session_id: str) -> None: ...
 async def raw_execute(
     sql: str,
     args: list[Any],
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> int: ...
 async def raw_fetch_all(
     sql: str,
     args: list[Any],
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> list[dict[str, Any]]: ...
 async def raw_fetch_one(
     sql: str,
     args: list[Any],
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> dict[str, Any] | None: ...
 def register_instance(
-    name: str, pk: str, obj: object, using: Optional[str] = None
+    name: str,
+    pk: str,
+    obj: object,
+    using: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> None: ...
-def evict_instance(name: str, pk: str, using: Optional[str] = None) -> None: ...
+def evict_instance(
+    name: str, pk: str, using: Optional[str] = None, session_id: Optional[str] = None
+) -> None: ...
 def reset_engine() -> None: ...
 def set_default_connection(name: str) -> None: ...
 def clear_registry() -> None: ...

--- a/src/ferro/_deprecations.py
+++ b/src/ferro/_deprecations.py
@@ -1,0 +1,100 @@
+"""Shared deprecation helpers for Ferro compatibility-window features."""
+
+from __future__ import annotations
+
+import functools
+import warnings
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+# Canonical IR-first compatibility window.
+IR_FIRST_DEPRECATION_SINCE = "v0.12.0"
+IR_FIRST_DEPRECATION_REMOVE_IN = "v0.14.0"
+
+# Back-compat alias used by inventory/docs.
+REMOVAL_RELEASE = IR_FIRST_DEPRECATION_REMOVE_IN
+
+# Published migration guide (see zensical.toml site_url + nav).
+IR_FIRST_MIGRATION_GUIDE = "https://syn54x.github.io/ferro-orm/howto/migrating-to-v0-12-0/"
+IR_FIRST_MIGRATION_GUIDE_PREDICATES = (
+    f"{IR_FIRST_MIGRATION_GUIDE}#1-use-lambda-predicates-in-where"
+)
+IR_FIRST_MIGRATION_GUIDE_SESSIONS = (
+    f"{IR_FIRST_MIGRATION_GUIDE}#2-run-operations-inside-a-session"
+)
+IR_FIRST_MIGRATION_GUIDE_ALEMBIC = (
+    f"{IR_FIRST_MIGRATION_GUIDE}#3-build-alembic-metadata-from-get_metadata"
+)
+
+
+def deprecation_message(
+    *,
+    reason: str,
+    since: str,
+    remove_in: str | None = None,
+    reference: str | None = None,
+) -> str:
+    """Build a canonical Ferro deprecation warning message."""
+    message = f"{reason.rstrip()} Deprecated since {since}."
+    if remove_in is not None:
+        message = f"{message} Planned removal in {remove_in}."
+    if reference is not None:
+        message = f"{message} See {reference.rstrip()}."
+    return message
+
+
+def warn_deprecated(
+    *,
+    reason: str,
+    since: str,
+    remove_in: str | None = None,
+    reference: str | None = None,
+    stacklevel: int = 2,
+) -> None:
+    """Emit a :class:`DeprecationWarning` for non-decorator call sites."""
+    warnings.warn(
+        deprecation_message(
+            reason=reason,
+            since=since,
+            remove_in=remove_in,
+            reference=reference,
+        ),
+        DeprecationWarning,
+        stacklevel=stacklevel + 1,
+    )
+
+
+def deprecated(
+    *,
+    reason: str,
+    since: str,
+    remove_in: str | None = None,
+    reference: str | None = None,
+) -> Callable[[F], F]:
+    """Mark a callable as deprecated and warn on each invocation."""
+    message = deprecation_message(
+        reason=reason,
+        since=since,
+        remove_in=remove_in,
+        reference=reference,
+    )
+
+    def decorate(obj: F) -> F:
+        @functools.wraps(obj)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            return obj(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorate
+
+
+def enable_deprecation_warnings() -> None:
+    """Show :class:`DeprecationWarning` emitted from library code by default."""
+    warnings.simplefilter("default", DeprecationWarning)
+
+
+enable_deprecation_warnings()

--- a/src/ferro/ir/__init__.py
+++ b/src/ferro/ir/__init__.py
@@ -1,0 +1,13 @@
+"""Public SchemaIR compilation API for the Python runtime."""
+
+from .compiler import (
+    compile_model_schema_ir,
+    compile_registry_schema_ir,
+    schema_ir_fingerprint,
+)
+
+__all__ = [
+    "compile_model_schema_ir",
+    "compile_registry_schema_ir",
+    "schema_ir_fingerprint",
+]

--- a/src/ferro/ir/compiler.py
+++ b/src/ferro/ir/compiler.py
@@ -11,14 +11,13 @@ import hashlib
 import json
 from typing import Any
 
+from .. import state as ferro_state
 from ..schema_metadata import build_model_schema
 from ..state import (
     _JOIN_TABLE_REGISTRY,
     _MODEL_REGISTRY_PY,
     _SCHEMA_IR_BY_MODEL,
     _SCHEMA_IR_FINGERPRINT_BY_MODEL,
-    _SCHEMA_IR_MODELSET,
-    _SCHEMA_IR_MODELSET_FINGERPRINT,
 )
 
 _IR_VERSION = 1
@@ -430,9 +429,8 @@ def compile_registry_schema_ir() -> dict[str, Any]:
         },
     }
 
-    global _SCHEMA_IR_MODELSET, _SCHEMA_IR_MODELSET_FINGERPRINT
-    _SCHEMA_IR_MODELSET = envelope
-    _SCHEMA_IR_MODELSET_FINGERPRINT = _fingerprint(envelope)
+    ferro_state._SCHEMA_IR_MODELSET = envelope
+    ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = _fingerprint(envelope)
     return envelope
 
 

--- a/src/ferro/ir/compiler.py
+++ b/src/ferro/ir/compiler.py
@@ -1,0 +1,354 @@
+"""SchemaIR compilation and fingerprint helpers for Phase 1.
+
+This module compiles the canonical Ferro-enriched JSON schema metadata into
+RFC-shaped SchemaIR envelopes and persists deterministic fingerprints for
+individual models and full model sets.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from ..schema_metadata import build_model_schema
+from ..state import (
+    _MODEL_REGISTRY_PY,
+    _SCHEMA_IR_BY_MODEL,
+    _SCHEMA_IR_FINGERPRINT_BY_MODEL,
+    _SCHEMA_IR_MODELSET,
+    _SCHEMA_IR_MODELSET_FINGERPRINT,
+)
+
+_IR_VERSION = 1
+
+
+def _canonical_json(value: dict[str, Any]) -> str:
+    """Serialize an IR artifact with deterministic key ordering."""
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
+def _fingerprint(value: dict[str, Any]) -> str:
+    """Return the canonical SHA-256 fingerprint for an IR artifact."""
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _resolve_ref(schema: dict[str, Any], col_info: dict[str, Any]) -> dict[str, Any]:
+    """Inline a local ``#/$defs/...`` reference into a property schema."""
+    ref_path = col_info.get("$ref")
+    if not isinstance(ref_path, str):
+        return col_info
+    if not ref_path.startswith("#/$defs/"):
+        return col_info
+    def_name = ref_path.split("/")[-1]
+    resolved = schema.get("$defs", {}).get(def_name)
+    if not isinstance(resolved, dict):
+        return col_info
+    return {
+        **resolved,
+        **{k: v for k, v in col_info.items() if k != "$ref"},
+    }
+
+
+def _logical_type(col_info: dict[str, Any]) -> str:
+    """Map schema type metadata to SchemaIR ``logical_type``."""
+    field_type, field_format = _effective_type_and_format(col_info)
+    if field_type == "integer":
+        return "integer"
+    if field_type == "number":
+        return "decimal" if field_format == "decimal" else "number"
+    if field_type == "boolean":
+        return "boolean"
+    if field_type == "string":
+        if field_format == "date-time":
+            return "datetime"
+        if field_format == "date":
+            return "date"
+        if field_format == "time":
+            return "time"
+        if field_format == "uuid":
+            return "uuid"
+        return "string"
+    return "unknown"
+
+
+def _default_db_type(col_info: dict[str, Any]) -> str:
+    """Map schema metadata to the default canonical Ferro ``db_type`` token."""
+    field_type, field_format = _effective_type_and_format(col_info)
+    if field_type == "integer":
+        return "bigint"
+    if field_type == "number":
+        return "text"
+    if field_type == "string":
+        if field_format == "date-time":
+            return "timestamptz"
+        if field_format == "date":
+            return "date"
+        if field_format == "time":
+            return "time"
+        if field_format == "uuid":
+            return "uuid"
+        return "text"
+    return "text"
+
+
+def _effective_type_and_format(col_info: dict[str, Any]) -> tuple[Any, Any]:
+    """Resolve concrete type/format from direct fields or ``anyOf`` unions."""
+    field_type = col_info.get("type")
+    field_format = col_info.get("format")
+    if field_type is not None:
+        return field_type, field_format
+    any_of = col_info.get("anyOf")
+    if isinstance(any_of, list):
+        for candidate in any_of:
+            if not isinstance(candidate, dict):
+                continue
+            candidate_type = candidate.get("type")
+            if candidate_type is None or candidate_type == "null":
+                continue
+            return candidate_type, candidate.get("format")
+    return field_type, field_format
+
+
+def _is_nullable(col_name: str, col_info: dict[str, Any], required_fields: set[str]) -> bool:
+    """Determine nullability from explicit Ferro hint or required-field fallback."""
+    nullable_hint = col_info.get("ferro_nullable")
+    if isinstance(nullable_hint, bool):
+        return nullable_hint
+    return col_name not in required_fields
+
+
+def _column_ir(
+    col_name: str, col_info: dict[str, Any], required_fields: set[str]
+) -> dict[str, Any]:
+    """Compile one schema property into a SchemaIR ``columns[]`` entry."""
+    return {
+        "name": col_name,
+        "logical_type": _logical_type(col_info),
+        "db_type": col_info.get("db_type") or _default_db_type(col_info),
+        "nullable": _is_nullable(col_name, col_info, required_fields),
+        "primary_key": bool(col_info.get("primary_key", False)),
+        "autoincrement": bool(col_info.get("autoincrement", False)),
+        "unique": bool(col_info.get("unique", False)),
+        "index": bool(col_info.get("index", False)),
+        "default": col_info.get("default"),
+        "format": col_info.get("format"),
+    }
+
+
+def _fk_name(table_name: str, col_name: str, to_table: str) -> str:
+    """Build canonical foreign-key name for SchemaIR metadata."""
+    return f"fk_{table_name}_{col_name}_{to_table}"
+
+
+def _single_index_name(table_name: str, col_name: str) -> str:
+    """Build canonical single-column index name."""
+    return f"idx_{table_name}_{col_name}"
+
+
+def _single_unique_name(table_name: str, col_name: str) -> str:
+    """Build canonical single-column unique-constraint name."""
+    return f"uq_{table_name}_{col_name}"
+
+
+def _composite_index_name(table_name: str, columns: list[str]) -> str:
+    """Build canonical composite index name."""
+    return f"idx_{table_name}_{'_'.join(columns)}"
+
+
+def _composite_unique_name(table_name: str, columns: list[str]) -> str:
+    """Build canonical composite unique-constraint name."""
+    return f"uq_{table_name}_{'_'.join(columns)}"
+
+
+def _checks_from_columns(table_name: str, columns: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Compile per-column ``db_check`` markers into SchemaIR ``checks[]`` entries."""
+    checks: list[dict[str, Any]] = []
+    for col in columns:
+        if col.get("db_check") is not True:
+            continue
+        col_name = col.get("name")
+        if not isinstance(col_name, str) or not col_name:
+            continue
+        checks.append(
+            {
+                "name": f"ck_{table_name}_{col_name}",
+                "expression": f"{col_name} IS NOT NULL",
+            }
+        )
+    return checks
+
+
+def compile_schema_ir_payload(model_name: str, schema: dict[str, Any]) -> dict[str, Any]:
+    """Compile one model schema dict into a SchemaIR payload object.
+
+    Args:
+        model_name: Registered model class name.
+        schema: Canonical Ferro-enriched model schema.
+
+    Returns:
+        A SchemaIR payload object ready to be wrapped in an IR envelope.
+    """
+    table_name = model_name.lower()
+    properties = schema.get("properties", {})
+    if not isinstance(properties, dict):
+        properties = {}
+    required_fields = schema.get("required", [])
+    required = set(required_fields) if isinstance(required_fields, list) else set()
+
+    ordered_props = sorted(properties.items(), key=lambda item: item[0])
+    resolved_columns: list[dict[str, Any]] = []
+    for col_name, col_info in ordered_props:
+        if not isinstance(col_info, dict):
+            continue
+        resolved = _resolve_ref(schema, col_info)
+        resolved_with_name = {"name": col_name, **resolved}
+        resolved_columns.append(resolved_with_name)
+
+    columns = [
+        _column_ir(col["name"], col, required)
+        for col in resolved_columns
+        if isinstance(col.get("name"), str)
+    ]
+
+    foreign_keys: list[dict[str, Any]] = []
+    indexes: list[dict[str, Any]] = []
+    uniques: list[dict[str, Any]] = []
+
+    for col in resolved_columns:
+        col_name = col.get("name")
+        if not isinstance(col_name, str) or not col_name:
+            continue
+        fk = col.get("foreign_key")
+        if isinstance(fk, dict):
+            to_table = fk.get("to_table")
+            if isinstance(to_table, str) and to_table:
+                foreign_keys.append(
+                    {
+                        "column": col_name,
+                        "to_table": to_table,
+                        "to_column": "id",
+                        "on_delete": fk.get("on_delete"),
+                        "name": _fk_name(table_name, col_name, to_table),
+                    }
+                )
+        if bool(col.get("index", False)):
+            indexes.append(
+                {
+                    "name": _single_index_name(table_name, col_name),
+                    "columns": [col_name],
+                    "unique": False,
+                }
+            )
+        if bool(col.get("unique", False)):
+            uniques.append(
+                {
+                    "name": _single_unique_name(table_name, col_name),
+                    "columns": [col_name],
+                }
+            )
+
+    for composite in schema.get("ferro_composite_indexes") or []:
+        if not isinstance(composite, list) or not composite:
+            continue
+        cols = [c for c in composite if isinstance(c, str) and c]
+        if len(cols) != len(composite):
+            continue
+        indexes.append(
+            {
+                "name": _composite_index_name(table_name, cols),
+                "columns": cols,
+                "unique": False,
+            }
+        )
+
+    for composite in schema.get("ferro_composite_uniques") or []:
+        if not isinstance(composite, list) or not composite:
+            continue
+        cols = [c for c in composite if isinstance(c, str) and c]
+        if len(cols) != len(composite):
+            continue
+        uniques.append({"name": _composite_unique_name(table_name, cols), "columns": cols})
+
+    model_payload = {
+        "model_name": model_name,
+        "table_name": table_name,
+        "columns": columns,
+        "foreign_keys": sorted(
+            foreign_keys,
+            key=lambda item: (item["column"], item["to_table"], item["to_column"]),
+        ),
+        "indexes": sorted(indexes, key=lambda item: item["name"]),
+        "uniques": sorted(uniques, key=lambda item: item["name"]),
+        "checks": sorted(
+            _checks_from_columns(table_name, resolved_columns),
+            key=lambda item: item["name"],
+        ),
+    }
+    return {"dialect_agnostic": True, "models": [model_payload]}
+
+
+def wrap_schema_ir(payload: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a SchemaIR payload with the standard IR envelope fields."""
+    return {
+        "ir_kind": "schema",
+        "ir_version": _IR_VERSION,
+        "payload": payload,
+    }
+
+
+def compile_model_schema_ir(model_name: str, model_cls: type[Any]) -> dict[str, Any]:
+    """Compile and persist a single model's SchemaIR envelope + fingerprint.
+
+    Args:
+        model_name: Registry key / model class name.
+        model_cls: Python model class to compile.
+
+    Returns:
+        The compiled SchemaIR envelope for ``model_cls``.
+    """
+    schema = build_model_schema(model_cls)
+    payload = compile_schema_ir_payload(model_name, schema)
+    envelope = wrap_schema_ir(payload)
+    _SCHEMA_IR_BY_MODEL[model_name] = envelope
+    _SCHEMA_IR_FINGERPRINT_BY_MODEL[model_name] = _fingerprint(envelope)
+    return envelope
+
+
+def compile_registry_schema_ir() -> dict[str, Any]:
+    """Compile and persist a deterministic SchemaIR envelope for all models.
+
+    Returns:
+        The compiled model-set SchemaIR envelope, sorted by model name.
+    """
+    models: list[dict[str, Any]] = []
+    for model_name, model_cls in sorted(_MODEL_REGISTRY_PY.items(), key=lambda item: item[0]):
+        if model_name == "Model":
+            continue
+        model_envelope = compile_model_schema_ir(model_name, model_cls)
+        model_payload = model_envelope["payload"]["models"][0]
+        models.append(model_payload)
+
+    envelope = {
+        "ir_kind": "schema",
+        "ir_version": _IR_VERSION,
+        "payload": {
+            "dialect_agnostic": True,
+            "models": models,
+        },
+    }
+
+    global _SCHEMA_IR_MODELSET, _SCHEMA_IR_MODELSET_FINGERPRINT
+    _SCHEMA_IR_MODELSET = envelope
+    _SCHEMA_IR_MODELSET_FINGERPRINT = _fingerprint(envelope)
+    return envelope
+
+
+def schema_ir_fingerprint(ir_envelope: dict[str, Any]) -> str:
+    """Return a deterministic SHA-256 fingerprint for a SchemaIR envelope."""
+    return _fingerprint(ir_envelope)

--- a/src/ferro/ir/compiler.py
+++ b/src/ferro/ir/compiler.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from ..schema_metadata import build_model_schema
 from ..state import (
+    _JOIN_TABLE_REGISTRY,
     _MODEL_REGISTRY_PY,
     _SCHEMA_IR_BY_MODEL,
     _SCHEMA_IR_FINGERPRINT_BY_MODEL,
@@ -55,6 +56,26 @@ def _resolve_ref(schema: dict[str, Any], col_info: dict[str, Any]) -> dict[str, 
     }
 
 
+def _resolve_nested_refs(schema: dict[str, Any], col_info: dict[str, Any]) -> dict[str, Any]:
+    """Resolve local refs in one-level nested ``anyOf`` entries."""
+    any_of = col_info.get("anyOf")
+    if not isinstance(any_of, list):
+        return col_info
+    resolved_any_of: list[Any] = []
+    changed = False
+    for candidate in any_of:
+        if not isinstance(candidate, dict):
+            resolved_any_of.append(candidate)
+            continue
+        resolved_candidate = _resolve_ref(schema, candidate)
+        if resolved_candidate is not candidate:
+            changed = True
+        resolved_any_of.append(resolved_candidate)
+    if not changed:
+        return col_info
+    return {**col_info, "anyOf": resolved_any_of}
+
+
 def _logical_type(col_info: dict[str, Any]) -> str:
     """Map schema type metadata to SchemaIR ``logical_type``."""
     field_type, field_format = _effective_type_and_format(col_info)
@@ -74,6 +95,8 @@ def _logical_type(col_info: dict[str, Any]) -> str:
         if field_format == "uuid":
             return "uuid"
         return "string"
+    if field_type in {"object", "array"}:
+        return "json"
     return "unknown"
 
 
@@ -111,8 +134,23 @@ def _effective_type_and_format(col_info: dict[str, Any]) -> tuple[Any, Any]:
             candidate_type = candidate.get("type")
             if candidate_type is None or candidate_type == "null":
                 continue
-            return candidate_type, candidate.get("format")
+            return candidate_type, candidate.get("format") or field_format
     return field_type, field_format
+
+
+def _enum_values(col_info: dict[str, Any]) -> list[Any] | None:
+    direct = col_info.get("enum")
+    if isinstance(direct, list):
+        return direct
+    any_of = col_info.get("anyOf")
+    if isinstance(any_of, list):
+        for candidate in any_of:
+            if not isinstance(candidate, dict):
+                continue
+            enum_values = candidate.get("enum")
+            if isinstance(enum_values, list):
+                return enum_values
+    return None
 
 
 def _is_nullable(col_name: str, col_info: dict[str, Any], required_fields: set[str]) -> bool:
@@ -127,10 +165,12 @@ def _column_ir(
     col_name: str, col_info: dict[str, Any], required_fields: set[str]
 ) -> dict[str, Any]:
     """Compile one schema property into a SchemaIR ``columns[]`` entry."""
-    return {
+    db_type_value = col_info.get("db_type")
+    db_type_explicit = isinstance(db_type_value, str) and bool(db_type_value)
+    column_ir = {
         "name": col_name,
         "logical_type": _logical_type(col_info),
-        "db_type": col_info.get("db_type") or _default_db_type(col_info),
+        "db_type": db_type_value if db_type_explicit else _default_db_type(col_info),
         "nullable": _is_nullable(col_name, col_info, required_fields),
         "primary_key": bool(col_info.get("primary_key", False)),
         "autoincrement": bool(col_info.get("autoincrement", False)),
@@ -139,6 +179,15 @@ def _column_ir(
         "default": col_info.get("default"),
         "format": col_info.get("format"),
     }
+    enum_values = _enum_values(col_info)
+    if isinstance(enum_values, list):
+        column_ir["enum_values"] = list(enum_values)
+    if db_type_explicit:
+        column_ir["db_type_explicit"] = True
+    enum_type_name = col_info.get("enum_type_name")
+    if isinstance(enum_type_name, str) and enum_type_name:
+        column_ir["enum_type_name"] = enum_type_name
+    return column_ir
 
 
 def _fk_name(table_name: str, col_name: str, to_table: str) -> str:
@@ -158,12 +207,18 @@ def _single_unique_name(table_name: str, col_name: str) -> str:
 
 def _composite_index_name(table_name: str, columns: list[str]) -> str:
     """Build canonical composite index name."""
-    return f"idx_{table_name}_{'_'.join(columns)}"
+    raw = f"idx_{table_name}_{'_'.join(columns)}"
+    if len(raw) > 63:
+        return f"{raw[:59]}_idx"
+    return raw
 
 
 def _composite_unique_name(table_name: str, columns: list[str]) -> str:
     """Build canonical composite unique-constraint name."""
-    return f"uq_{table_name}_{'_'.join(columns)}"
+    raw = f"uq_{table_name}_{'_'.join(columns)}"
+    if len(raw) > 63:
+        return f"{raw[:60]}_uq"
+    return raw
 
 
 def _checks_from_columns(table_name: str, columns: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -175,16 +230,33 @@ def _checks_from_columns(table_name: str, columns: list[dict[str, Any]]) -> list
         col_name = col.get("name")
         if not isinstance(col_name, str) or not col_name:
             continue
+        enum_values = _enum_values(col)
+        if not isinstance(enum_values, list) or not enum_values:
+            continue
+        rendered: list[str] = []
+        for value in enum_values:
+            if isinstance(value, bool):
+                rendered.append(str(value).lower())
+            elif isinstance(value, (int, float)):
+                rendered.append(str(value))
+            else:
+                escaped = str(value).replace("'", "''")
+                rendered.append(f"'{escaped}'")
         checks.append(
             {
                 "name": f"ck_{table_name}_{col_name}",
-                "expression": f"{col_name} IS NOT NULL",
+                "expression": f"{col_name} IN ({', '.join(rendered)})",
             }
         )
     return checks
 
 
-def compile_schema_ir_payload(model_name: str, schema: dict[str, Any]) -> dict[str, Any]:
+def compile_schema_ir_payload(
+    model_name: str,
+    schema: dict[str, Any],
+    *,
+    table_name: str | None = None,
+) -> dict[str, Any]:
     """Compile one model schema dict into a SchemaIR payload object.
 
     Args:
@@ -194,7 +266,7 @@ def compile_schema_ir_payload(model_name: str, schema: dict[str, Any]) -> dict[s
     Returns:
         A SchemaIR payload object ready to be wrapped in an IR envelope.
     """
-    table_name = model_name.lower()
+    resolved_table_name = table_name or model_name.lower()
     properties = schema.get("properties", {})
     if not isinstance(properties, dict):
         properties = {}
@@ -207,6 +279,7 @@ def compile_schema_ir_payload(model_name: str, schema: dict[str, Any]) -> dict[s
         if not isinstance(col_info, dict):
             continue
         resolved = _resolve_ref(schema, col_info)
+        resolved = _resolve_nested_refs(schema, resolved)
         resolved_with_name = {"name": col_name, **resolved}
         resolved_columns.append(resolved_with_name)
 
@@ -234,13 +307,13 @@ def compile_schema_ir_payload(model_name: str, schema: dict[str, Any]) -> dict[s
                         "to_table": to_table,
                         "to_column": "id",
                         "on_delete": fk.get("on_delete"),
-                        "name": _fk_name(table_name, col_name, to_table),
+                        "name": _fk_name(resolved_table_name, col_name, to_table),
                     }
                 )
         if bool(col.get("index", False)):
             indexes.append(
                 {
-                    "name": _single_index_name(table_name, col_name),
+                    "name": _single_index_name(resolved_table_name, col_name),
                     "columns": [col_name],
                     "unique": False,
                 }
@@ -248,7 +321,7 @@ def compile_schema_ir_payload(model_name: str, schema: dict[str, Any]) -> dict[s
         if bool(col.get("unique", False)):
             uniques.append(
                 {
-                    "name": _single_unique_name(table_name, col_name),
+                    "name": _single_unique_name(resolved_table_name, col_name),
                     "columns": [col_name],
                 }
             )
@@ -261,7 +334,7 @@ def compile_schema_ir_payload(model_name: str, schema: dict[str, Any]) -> dict[s
             continue
         indexes.append(
             {
-                "name": _composite_index_name(table_name, cols),
+                "name": _composite_index_name(resolved_table_name, cols),
                 "columns": cols,
                 "unique": False,
             }
@@ -273,11 +346,13 @@ def compile_schema_ir_payload(model_name: str, schema: dict[str, Any]) -> dict[s
         cols = [c for c in composite if isinstance(c, str) and c]
         if len(cols) != len(composite):
             continue
-        uniques.append({"name": _composite_unique_name(table_name, cols), "columns": cols})
+        uniques.append(
+            {"name": _composite_unique_name(resolved_table_name, cols), "columns": cols}
+        )
 
     model_payload = {
         "model_name": model_name,
-        "table_name": table_name,
+        "table_name": resolved_table_name,
         "columns": columns,
         "foreign_keys": sorted(
             foreign_keys,
@@ -286,7 +361,7 @@ def compile_schema_ir_payload(model_name: str, schema: dict[str, Any]) -> dict[s
         "indexes": sorted(indexes, key=lambda item: item["name"]),
         "uniques": sorted(uniques, key=lambda item: item["name"]),
         "checks": sorted(
-            _checks_from_columns(table_name, resolved_columns),
+            _checks_from_columns(resolved_table_name, resolved_columns),
             key=lambda item: item["name"],
         ),
     }
@@ -333,6 +408,18 @@ def compile_registry_schema_ir() -> dict[str, Any]:
         model_envelope = compile_model_schema_ir(model_name, model_cls)
         model_payload = model_envelope["payload"]["models"][0]
         models.append(model_payload)
+
+    for table_name, table_schema in sorted(
+        _JOIN_TABLE_REGISTRY.items(), key=lambda item: item[0]
+    ):
+        if not isinstance(table_schema, dict):
+            continue
+        join_payload = compile_schema_ir_payload(
+            table_name,
+            table_schema,
+            table_name=table_name,
+        )["models"][0]
+        models.append(join_payload)
 
     envelope = {
         "ir_kind": "schema",

--- a/src/ferro/metaclass.py
+++ b/src/ferro/metaclass.py
@@ -25,6 +25,7 @@ from ._core import register_model_schema
 from ._shadow_fk_types import shadow_annotation_for_foreign_key
 from .base import FerroField, ForeignKey, ManyToManyRelation
 from .fields import FERRO_FIELD_EXTRA_KEY
+from .ir import compile_model_schema_ir, compile_registry_schema_ir
 from .query import FieldProxy, Relation
 from .relations.descriptors import ForwardDescriptor
 from .schema_metadata import _enum_subclass_from_annotation, build_model_schema
@@ -535,5 +536,7 @@ class ModelMetaclass(type(BaseModel)):
             if schema:
                 setattr(cls, "__ferro_schema__", schema)
                 register_model_schema(name, json.dumps(schema))
+                compile_model_schema_ir(name, cls)
+                compile_registry_schema_ir()
         except Exception as e:
             raise RuntimeError(f"Ferro failed to register model '{name}': {e}")

--- a/src/ferro/migrations/alembic.py
+++ b/src/ferro/migrations/alembic.py
@@ -9,6 +9,12 @@ except ImportError:
     sa = None
 
 from .._annotation_utils import _VARCHAR_RE
+from .._deprecations import (
+    IR_FIRST_DEPRECATION_REMOVE_IN,
+    IR_FIRST_DEPRECATION_SINCE,
+    IR_FIRST_MIGRATION_GUIDE_ALEMBIC,
+    deprecated,
+)
 from ..ir import compile_registry_schema_ir
 from ..schema_metadata import build_model_schema
 from ..state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY
@@ -321,6 +327,15 @@ def _resolve_sa_column_nullable(
     return _infer_nullable_join_table(col_name, col_info, required_fields)
 
 
+@deprecated(
+    reason=(
+        "_build_sa_table() is deprecated. Alembic metadata now derives from "
+        "SchemaIR. Use get_metadata() / IR-backed helpers instead."
+    ),
+    since=IR_FIRST_DEPRECATION_SINCE,
+    remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+    reference=IR_FIRST_MIGRATION_GUIDE_ALEMBIC,
+)
 def _build_sa_table(
     metadata: "sa.MetaData",
     table_name: str,
@@ -328,12 +343,6 @@ def _build_sa_table(
     model_cls: type[Any] | None = None,
 ):
     """Build a SQLAlchemy Table object from a Ferro JSON schema."""
-    warnings.warn(
-        "_build_sa_table() is deprecated. Alembic metadata now derives from SchemaIR. "
-        "Use get_metadata() / IR-backed helpers instead. Planned removal: v0.13.0.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     columns = []
 
     properties = schema.get("properties", {})
@@ -458,6 +467,15 @@ def _db_type_to_sa_type(token: str) -> "sa.types.TypeEngine | None":
     return None
 
 
+@deprecated(
+    reason=(
+        "_map_to_sa_type() is deprecated. Type lowering now flows through "
+        "SchemaIR and _sa_type_from_ir_column()."
+    ),
+    since=IR_FIRST_DEPRECATION_SINCE,
+    remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+    reference=IR_FIRST_MIGRATION_GUIDE_ALEMBIC,
+)
 def _map_to_sa_type(
     schema: Dict[str, Any],
     col_info: Dict[str, Any],
@@ -476,12 +494,6 @@ def _map_to_sa_type(
     every other branch -- it is the canonical user-facing storage knob and is
     validated at class-definition time (see ``metaclass._validate_db_type_options``).
     """
-    warnings.warn(
-        "_map_to_sa_type() is deprecated. Type lowering now flows through SchemaIR "
-        "and _sa_type_from_ir_column(). Planned removal: v0.13.0.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     # Resolve $ref if present
     col_info = _resolve_ref(schema, col_info)
 

--- a/src/ferro/migrations/alembic.py
+++ b/src/ferro/migrations/alembic.py
@@ -9,6 +9,7 @@ except ImportError:
     sa = None
 
 from .._annotation_utils import _VARCHAR_RE
+from ..ir import compile_registry_schema_ir
 from ..schema_metadata import build_model_schema
 from ..state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY
 
@@ -67,27 +68,172 @@ def get_metadata() -> "sa.MetaData":
 
     resolve_relationships()
 
-    # 2. Process all registered models
-    for model_name, model_cls in _MODEL_REGISTRY_PY.items():
-        # Skip the base Model class
-        if model_name == "Model":
-            continue
-
-        table_name = model_name.lower()
-
-        try:
-            schema = build_model_schema(model_cls)
-        except Exception:
-            # Fallback if standard pydantic schema fails (e.g. circular refs)
-            continue
-
-        _build_sa_table(metadata, table_name, schema, model_cls)
-
-    # 3. Process join tables
-    for join_table_name, join_schema in _JOIN_TABLE_REGISTRY.items():
-        _build_sa_table(metadata, join_table_name, join_schema, model_cls=None)
+    # 2. Build SQLAlchemy metadata from SchemaIR modelset only.
+    schema_ir = compile_registry_schema_ir()
+    payload = schema_ir.get("payload", {})
+    models = payload.get("models", [])
+    for model_ir in models:
+        if isinstance(model_ir, dict):
+            _build_sa_table_from_ir(metadata, model_ir)
 
     return metadata
+
+
+def _build_sa_table_from_ir(metadata: "sa.MetaData", model_ir: Dict[str, Any]) -> None:
+    table_name = model_ir.get("table_name")
+    if not isinstance(table_name, str) or not table_name:
+        return
+
+    columns = []
+    columns_by_name: dict[str, Any] = {}
+    for col in model_ir.get("columns") or []:
+        if not isinstance(col, dict):
+            continue
+        col_name = col.get("name")
+        if not isinstance(col_name, str) or not col_name:
+            continue
+        sa_type = _sa_type_from_ir_column(col_name, col)
+        kwargs = {
+            "primary_key": bool(col.get("primary_key", False)),
+            "nullable": bool(col.get("nullable", True))
+            if not bool(col.get("primary_key", False))
+            else False,
+            "unique": bool(col.get("unique", False)),
+            "index": bool(col.get("index", False)),
+        }
+        columns.append(sa.Column(col_name, sa_type, **kwargs))
+        columns_by_name[col_name] = columns[-1]
+
+    table_args: list[Any] = list(columns)
+
+    for check in model_ir.get("checks") or []:
+        if not isinstance(check, dict):
+            continue
+        expression = check.get("expression")
+        name = check.get("name")
+        if not isinstance(expression, str) or not expression:
+            continue
+        if not isinstance(name, str) or not name:
+            continue
+        table_args.append(sa.CheckConstraint(expression, name=name))
+
+    for unique in model_ir.get("uniques") or []:
+        if not isinstance(unique, dict):
+            continue
+        cols = unique.get("columns")
+        name = unique.get("name")
+        if not isinstance(cols, list) or len(cols) < 1:
+            continue
+        if not all(isinstance(c, str) and c for c in cols):
+            continue
+        if len(cols) == 1:
+            column_name = cols[0]
+            if bool(model_ir_column_flag(model_ir, column_name, "unique")):
+                continue
+        if isinstance(name, str) and name:
+            table_args.append(sa.UniqueConstraint(*cols, name=name))
+        else:
+            table_args.append(sa.UniqueConstraint(*cols))
+
+    table = sa.Table(table_name, metadata, *table_args)
+
+    for fk in model_ir.get("foreign_keys") or []:
+        if not isinstance(fk, dict):
+            continue
+        col_name = fk.get("column")
+        to_table = fk.get("to_table")
+        to_column = fk.get("to_column") or "id"
+        if not isinstance(col_name, str) or col_name not in columns_by_name:
+            continue
+        if not isinstance(to_table, str) or not to_table:
+            continue
+        if not isinstance(to_column, str) or not to_column:
+            continue
+        on_delete = fk.get("on_delete")
+        column = table.columns[col_name]
+        column.append_foreign_key(
+            sa.ForeignKey(
+                f"{to_table}.{to_column}",
+                ondelete=on_delete if isinstance(on_delete, str) else None,
+            )
+        )
+
+    for index in model_ir.get("indexes") or []:
+        if not isinstance(index, dict):
+            continue
+        cols = index.get("columns")
+        name = index.get("name")
+        unique = bool(index.get("unique", False))
+        if not isinstance(cols, list) or not cols:
+            continue
+        if not isinstance(name, str) or not name:
+            continue
+        if not all(isinstance(c, str) and c in table.columns for c in cols):
+            continue
+        if len(cols) == 1:
+            column_name = cols[0]
+            if bool(model_ir_column_flag(model_ir, column_name, "index")):
+                continue
+        sa.Index(name, *(table.columns[c] for c in cols), unique=unique)
+
+
+def model_ir_column_flag(model_ir: Dict[str, Any], column_name: str, flag: str) -> bool:
+    for col in model_ir.get("columns") or []:
+        if not isinstance(col, dict):
+            continue
+        if col.get("name") != column_name:
+            continue
+        return bool(col.get(flag, False))
+    return False
+
+
+def _sa_type_from_ir_column(col_name: str, col: Dict[str, Any]) -> "sa.types.TypeEngine":
+    db_type_explicit = bool(col.get("db_type_explicit", False))
+    db_type = col.get("db_type")
+    if db_type_explicit and isinstance(db_type, str):
+        mapped = _db_type_to_sa_type(db_type)
+        if mapped is not None:
+            return mapped
+
+    enum_values = col.get("enum_values")
+    enum_type_name = col.get("enum_type_name")
+    if isinstance(enum_values, list) and enum_values:
+        labels = [str(v) for v in enum_values]
+        enum_name = (
+            enum_type_name
+            if isinstance(enum_type_name, str) and enum_type_name
+            else col_name
+        )
+        return sa.Enum(*labels, name=enum_name)
+
+    logical_type = col.get("logical_type")
+    if logical_type == "boolean":
+        return sa.Boolean()
+    if logical_type == "integer":
+        return sa.Integer()
+    if logical_type == "number":
+        return sa.Float()
+    if logical_type == "decimal":
+        return sa.Numeric()
+    if logical_type == "string":
+        return sa.String()
+    if logical_type == "json":
+        return sa.JSON()
+    if logical_type in {"datetime", "date", "time", "uuid"}:
+        if logical_type == "datetime":
+            return sa.DateTime()
+        if logical_type == "date":
+            return sa.Date()
+        if logical_type == "time":
+            return sa.Time()
+        return sa.Uuid() if hasattr(sa, "Uuid") else sa.String(36)
+
+    if isinstance(db_type, str):
+        mapped = _db_type_to_sa_type(db_type)
+        if mapped is not None:
+            return mapped
+
+    return sa.String()
 
 
 def _resolve_ref(schema: Dict[str, Any], col_info: Dict[str, Any]) -> Dict[str, Any]:
@@ -182,6 +328,12 @@ def _build_sa_table(
     model_cls: type[Any] | None = None,
 ):
     """Build a SQLAlchemy Table object from a Ferro JSON schema."""
+    warnings.warn(
+        "_build_sa_table() is deprecated. Alembic metadata now derives from SchemaIR. "
+        "Use get_metadata() / IR-backed helpers instead. Planned removal: v0.13.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     columns = []
 
     properties = schema.get("properties", {})
@@ -324,6 +476,12 @@ def _map_to_sa_type(
     every other branch -- it is the canonical user-facing storage knob and is
     validated at class-definition time (see ``metaclass._validate_db_type_options``).
     """
+    warnings.warn(
+        "_map_to_sa_type() is deprecated. Type lowering now flows through SchemaIR "
+        "and _sa_type_from_ir_column(). Planned removal: v0.13.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     # Resolve $ref if present
     col_info = _resolve_ref(schema, col_info)
 

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -440,8 +440,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         A prebuilt :class:`QueryNode` is also accepted, built either with
         :func:`ferro.query.col` (the type-safe escape hatch that preserves
         operator shape) or with operator syntax on class attributes. The
-        bare operator form (``User.where(User.age >= 18)``) is planned for
-        deprecation in a future release and does not type-check statically:
+        bare operator form (``User.where(User.age >= 18)``) is deprecated and
+        on the v0.13.0 removal track. It does not
+        type-check statically:
         the class attribute types as the field type, so the comparison
         resolves to ``bool``, not ``QueryNode``. See
         ``docs/concepts/query-typing.md`` for the trade-offs between the
@@ -455,7 +456,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
 
         Examples:
             >>> q1 = User.where(lambda t: t.archived == False)  # noqa: E712
-            >>> q2 = User.where(User.id == 1)
+            >>> q2 = User.where(lambda t: t.id == 1)
             >>> isinstance(q1, Query) and isinstance(q2, Query)
             True
         """

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -13,6 +13,7 @@ from typing import (
 
 if TYPE_CHECKING:
     from .query import Predicate
+    from .session import Session
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -31,44 +32,39 @@ from .base import ForeignKey, foreign_key_allows_none
 from .exceptions import ModelDoesNotExist
 from .metaclass import ModelMetaclass
 from .query import Query, QueryNode
-from .state import _CURRENT_TRANSACTION, _CURRENT_TRANSACTION_CONNECTION
+from .state import (
+    _CURRENT_TRANSACTION,
+    _CURRENT_TRANSACTION_CONNECTION,
+    resolve_operation_scope,
+    resolve_transaction_scope,
+)
 
 
 _FERRO_CONNECTION_ATTR = "__ferro_connection_name"
 
 
-def _transaction_or_using(using: str | None) -> tuple[str | None, str | None]:
-    tx_id = _CURRENT_TRANSACTION.get()
-    if tx_id is not None and using is not None:
-        tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
-        if using == tx_connection:
-            return tx_id, None
-        raise ValueError(
-            "ORM operations inside a transaction inherit the transaction connection"
-        )
-    return tx_id, using
+def _transaction_or_using(
+    using: str | None, session: "Session | None"
+) -> tuple[str | None, str | None, str | None]:
+    return resolve_operation_scope(
+        using=using, session=session, allow_legacy_default=True
+    )
 
 
 def _instance_transaction_route(
-    instance: object, using: str | None
-) -> tuple[str | None, str | None, str | None]:
+    instance: object, using: str | None, session: "Session | None"
+) -> tuple[str | None, str | None, str | None, str | None]:
     origin = _instance_origin(instance)
     if using is not None and origin is not None and using != origin:
         raise ValueError("Instance is already bound to a different connection")
 
-    tx_id = _CURRENT_TRANSACTION.get()
+    tx_id, route_using, session_id = _transaction_or_using(using, session)
     if tx_id is not None:
         tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
-        if using is not None:
-            if using == tx_connection:
-                return tx_id, None, origin or tx_connection
-            raise ValueError(
-                "ORM operations inside a transaction inherit the transaction connection"
-            )
-        return tx_id, None, origin or tx_connection
+        return tx_id, route_using, origin or tx_connection, session_id
 
-    effective_using = using or origin
-    return None, effective_using, effective_using
+    effective_using = route_using or origin
+    return None, effective_using, effective_using, session_id
 
 
 def _instance_origin(instance: object) -> str | None:
@@ -82,7 +78,7 @@ def _set_instance_origin(instance: object, using: str | None) -> None:
 
 
 @asynccontextmanager
-async def transaction(using: str | None = None):
+async def transaction(using: str | None = None, *, session: "Session | None" = None):
     """Run database operations inside a transaction context.
 
     Yields a :class:`~ferro.raw.Transaction` handle bound to this transaction's
@@ -107,16 +103,18 @@ async def transaction(using: str | None = None):
     """
     from .raw import Transaction
 
-    parent_tx_id = _CURRENT_TRANSACTION.get()
-    tx_id = await begin_transaction(parent_tx_id, using)
-    connection_name = transaction_connection_name(tx_id)
+    parent_tx_id, effective_using, session_id = resolve_transaction_scope(
+        using=using, session=session, allow_legacy_default=True
+    )
+    tx_id = await begin_transaction(parent_tx_id, effective_using, session_id=session_id)
+    connection_name = transaction_connection_name(tx_id, session_id=session_id)
     token = _CURRENT_TRANSACTION.set(tx_id)
     connection_token = _CURRENT_TRANSACTION_CONNECTION.set(connection_name)
     try:
-        yield Transaction(tx_id)
-        await commit_transaction(tx_id)
+        yield Transaction(tx_id, session_id=session_id)
+        await commit_transaction(tx_id, session_id=session_id)
     except Exception:
-        await rollback_transaction(tx_id)
+        await rollback_transaction(tx_id, session_id=session_id)
         raise
     finally:
         _CURRENT_TRANSACTION.reset(token)
@@ -216,7 +214,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                     raise ValueError(f"{field_name} is required")
         return self
 
-    async def save(self, *, using: str | None = None) -> None:
+    async def save(
+        self, *, using: str | None = None, session: "Session | None" = None
+    ) -> None:
         """Persist the current model instance
 
         Returns:
@@ -226,11 +226,15 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> user = User(name="Taylor")
             >>> await user.save()
         """
-        tx_id, operation_using, identity_using = _instance_transaction_route(
-            self, using
+        tx_id, operation_using, identity_using, session_id = _instance_transaction_route(
+            self, using, session
         )
         new_id = await save_record(
-            self.__class__.__name__, self.model_dump_json(), tx_id, operation_using
+            self.__class__.__name__,
+            self.model_dump_json(),
+            tx_id,
+            operation_using,
+            session_id=session_id,
         )
 
         pk_val = None
@@ -256,11 +260,17 @@ class Model(BaseModel, metaclass=ModelMetaclass):
 
         if pk_val is not None:
             register_instance(
-                self.__class__.__name__, str(pk_val), self, identity_using
+                self.__class__.__name__,
+                str(pk_val),
+                self,
+                identity_using,
+                session_id=session_id,
             )
             _set_instance_origin(self, identity_using)
 
-    async def delete(self, *, using: str | None = None) -> None:
+    async def delete(
+        self, *, using: str | None = None, session: "Session | None" = None
+    ) -> None:
         """Delete the current model instance from storage
 
         Returns:
@@ -273,8 +283,8 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         """
         pk_field_name = self.__class__._primary_key_field_name()
         pk_val = getattr(self, pk_field_name) if pk_field_name is not None else None
-        _tx_id, operation_using, identity_using = _instance_transaction_route(
-            self, using
+        _tx_id, operation_using, identity_using, session_id = _instance_transaction_route(
+            self, using, session
         )
 
         if pk_val is not None:
@@ -287,7 +297,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                     getattr(self.__class__, pk_field_name) == pk_val
                 )
             await query.delete()
-            evict_instance(name, str(pk_val), identity_using)
+            evict_instance(
+                name, str(pk_val), identity_using, session_id=session_id
+            )
 
     @classmethod
     def _primary_key_field_name(cls) -> str | None:
@@ -320,7 +332,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                     pass
 
     @classmethod
-    async def all(cls, *, using: str | None = None) -> list[Self]:
+    async def all(
+        cls, *, using: str | None = None, session: "Session | None" = None
+    ) -> list[Self]:
         """Fetch all records for this model class
 
         Returns:
@@ -331,14 +345,14 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> isinstance(users, list)
             True
         """
-        tx_id, using = _transaction_or_using(using)
-        results = await fetch_all(cls, tx_id, using)
+        tx_id, using, session_id = _transaction_or_using(using, session)
+        results = await fetch_all(cls, tx_id, using, session_id=session_id)
         for instance in results:
             cls._fix_types(instance)
         return results
 
     @classmethod
-    async def get(cls, pk: Any) -> Self:
+    async def get(cls, pk: Any, *, session: "Session | None" = None) -> Self:
         """Fetch one record by primary key value.
 
         Args:
@@ -356,13 +370,15 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> isinstance(user, User)
             True
         """
-        instance = await cls.get_or_none(pk)
+        instance = await cls.get_or_none(pk, session=session)
         if instance is None:
             raise ModelDoesNotExist(cls, pk)
         return instance
 
     @classmethod
-    async def get_or_none(cls, pk: Any) -> Self | None:
+    async def get_or_none(
+        cls, pk: Any, *, session: "Session | None" = None
+    ) -> Self | None:
         """Fetch one record by primary key, or return None if no row exists.
 
         Args:
@@ -375,12 +391,14 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         if pk_field_name is None:
             raise RuntimeError(f"Model {cls.__name__} does not define a primary key")
 
-        instance = await cls.where(getattr(cls, pk_field_name) == pk).first()
+        instance = await cls.where(getattr(cls, pk_field_name) == pk, session=session).first()
         if instance:
             cls._fix_types(instance)
         return instance
 
-    async def refresh(self, *, using: str | None = None) -> None:
+    async def refresh(
+        self, *, using: str | None = None, session: "Session | None" = None
+    ) -> None:
         """Reload this instance from storage using its primary key
 
         Returns:
@@ -400,11 +418,11 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             raise RuntimeError("Cannot refresh a model without a primary key")
 
         name = self.__class__.__name__
-        _tx_id, operation_using, identity_using = _instance_transaction_route(
-            self, using
+        _tx_id, operation_using, identity_using, session_id = _instance_transaction_route(
+            self, using, session
         )
 
-        evict_instance(name, str(pk_val), identity_using)
+        evict_instance(name, str(pk_val), identity_using, session_id=session_id)
         query = self.__class__.where(getattr(self.__class__, pk_field_name) == pk_val)
         if operation_using is not None:
             query = Query(self.__class__, using=operation_using).where(
@@ -416,7 +434,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             raise RuntimeError(f"Instance not found in database: {name}({pk_val})")
 
         self.__dict__.update(fresh_instance.__dict__)
-        register_instance(name, str(pk_val), self, identity_using)
+        register_instance(
+            name, str(pk_val), self, identity_using, session_id=session_id
+        )
         _set_instance_origin(self, identity_using)
         self.__class__._fix_types(self)
 
@@ -429,7 +449,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
     def where(cls, node: "Predicate[Self]") -> Query[Self]: ...
 
     @classmethod
-    def where(cls, node: "QueryNode | Predicate[Self]") -> Query[Self]:
+    def where(
+        cls, node: "QueryNode | Predicate[Self]", *, session: "Session | None" = None
+    ) -> Query[Self]:
         """Start a fluent query with an initial condition.
 
         The recommended style is a lambda predicate of shape
@@ -460,10 +482,10 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> isinstance(q1, Query) and isinstance(q2, Query)
             True
         """
-        return Query(cls).where(node)
+        return Query(cls, session=session).where(node)
 
     @classmethod
-    def select(cls) -> Query[Self]:
+    def select(cls, *, session: "Session | None" = None) -> Query[Self]:
         """Start an empty fluent query for this model class
 
         Returns:
@@ -474,7 +496,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> isinstance(query, Query)
             True
         """
-        return Query(cls)
+        return Query(cls, session=session)
 
     @classmethod
     def using(cls, name: str) -> "ModelConnection[Self]":
@@ -482,7 +504,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         return ModelConnection(cls, name)
 
     @classmethod
-    async def create(cls, **fields) -> Self:
+    async def create(cls, *, session: "Session | None" = None, **fields) -> Self:
         """Create and persist a new model instance
 
         Args:
@@ -497,12 +519,16 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             True
         """
         instance = cls(**fields)
-        await instance.save()
+        await instance.save(session=session)
         return instance
 
     @classmethod
     async def bulk_create(
-        cls, instances: list[Self], *, using: str | None = None
+        cls,
+        instances: list[Self],
+        *,
+        using: str | None = None,
+        session: "Session | None" = None,
     ) -> int:
         """Persist multiple instances in a single bulk operation
 
@@ -521,12 +547,18 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             return 0
         # Use mode="json" to ensure Decimals, UUIDs, etc. are serialized correctly
         data = [i.model_dump(mode="json") for i in instances]
-        tx_id, using = _transaction_or_using(using)
-        return await save_bulk_records(cls.__name__, json.dumps(data), tx_id, using)
+        tx_id, using, session_id = _transaction_or_using(using, session)
+        return await save_bulk_records(
+            cls.__name__, json.dumps(data), tx_id, using, session_id=session_id
+        )
 
     @classmethod
     async def get_or_create(
-        cls, defaults: dict[str, Any] | None = None, **fields
+        cls,
+        defaults: dict[str, Any] | None = None,
+        *,
+        session: "Session | None" = None,
+        **fields,
     ) -> tuple[Self, bool]:
         """Fetch a record by filters or create one when missing
 
@@ -542,7 +574,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> isinstance(created, bool)
             True
         """
-        query = Query(cls)
+        query = Query(cls, session=session)
         for key, val in fields.items():
             query = query.where(getattr(cls, key) == val)
 
@@ -551,11 +583,15 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             return instance, False
 
         params = {**fields, **(defaults or {})}
-        return await cls.create(**params), True
+        return await cls.create(session=session, **params), True
 
     @classmethod
     async def update_or_create(
-        cls, defaults: dict[str, Any] | None = None, **fields
+        cls,
+        defaults: dict[str, Any] | None = None,
+        *,
+        session: "Session | None" = None,
+        **fields,
     ) -> tuple[Self, bool]:
         """Update a matched record or create one when missing
 
@@ -566,7 +602,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         Returns:
             A tuple of ``(instance, created)`` where ``created`` is True for new records.
         """
-        query = Query(cls)
+        query = Query(cls, session=session)
         for key, val in fields.items():
             query = query.where(getattr(cls, key) == val)
 
@@ -574,11 +610,11 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         if instance:
             for key, val in (defaults or {}).items():
                 setattr(instance, key, val)
-            await instance.save()
+            await instance.save(session=session)
             return instance, False
 
         params = {**fields, **(defaults or {})}
-        return await cls.create(**params), True
+        return await cls.create(session=session, **params), True
 
 
 class ModelConnection[M: Model]:

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -463,7 +463,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         :func:`ferro.query.col` (the type-safe escape hatch that preserves
         operator shape) or with operator syntax on class attributes. The
         bare operator form (``User.where(User.age >= 18)``) is deprecated and
-        on the v0.13.0 removal track. It does not
+        on the v0.14.0 removal track. It does not
         type-check statically:
         the class attribute types as the field type, so the comparison
         resolves to ``bool``, not ``QueryNode``. See

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -1,6 +1,6 @@
-"""Build fluent query objects that serialize filter definitions for the Rust core"""
+"""Build fluent query objects that serialize QueryIR payloads for the Rust core."""
 
-import json
+import warnings
 from typing import TYPE_CHECKING, Any, Generic, Type, TypeVar, overload
 
 from .._core import (
@@ -21,9 +21,41 @@ T = TypeVar("T")
 E = TypeVar("E")
 
 
-def _query_def_to_json(query_def: dict[str, Any]) -> str:
-    """Serialize query definitions while preserving typed values in live Query state."""
-    return json.dumps(_serialize_query_value(query_def))
+try:
+    from warnings import deprecated as _warnings_deprecated
+except ImportError:
+
+    def _warnings_deprecated(message: str, **_: Any):
+        def _decorate(func):
+            def _wrapped(*args, **kwargs):
+                warnings.warn(message, DeprecationWarning, stacklevel=3)
+                return func(*args, **kwargs)
+
+            return _wrapped
+
+        return _decorate
+
+
+def _query_ir_payload_to_json(query_payload: dict[str, Any]) -> str:
+    """Serialize a QueryIR payload into a versioned IR envelope JSON string."""
+    import json
+
+    return json.dumps(
+        {
+            "ir_kind": "query",
+            "ir_version": 1,
+            "payload": _serialize_query_value(query_payload),
+        }
+    )
+
+
+@_warnings_deprecated(
+    "Operator predicate style (Model.field OP value) is deprecated; use lambda "
+    "predicates (`where(lambda t: ...)`) or col(Model.field) instead. Planned "
+    "removal: v0.13.0."
+)
+def _deprecated_operator_query_node(node: QueryNode) -> QueryNode:
+    return node
 
 
 def _resolve_where_node(node: Any) -> QueryNode:
@@ -34,6 +66,8 @@ def _resolve_where_node(node: Any) -> QueryNode:
     a ``QueryNode`` (the lambda path).
     """
     if isinstance(node, QueryNode):
+        if node.uses_operator_style():
+            return _deprecated_operator_query_node(node)
         return node
     if callable(node):
         result = node(QueryProxy())
@@ -118,8 +152,9 @@ class Query(Generic[T]):
         :class:`QueryNode` is also accepted, built either with
         :func:`ferro.query.col` (the type-safe escape hatch that preserves
         operator shape) or with operator syntax on class attributes. The
-        bare operator form (``User.where(User.age >= 18)``) is planned for
-        deprecation in a future release and does not type-check statically:
+        bare operator form (``User.where(User.age >= 18)``) is deprecated and
+        on the v0.13.0 removal track. It does not
+        type-check statically:
         the class attribute types as the field type, so the comparison
         resolves to ``bool``, not ``QueryNode``.
 
@@ -135,7 +170,7 @@ class Query(Generic[T]):
 
         Examples:
             >>> q1 = User.where(lambda t: t.archived == False)  # noqa: E712
-            >>> q2 = User.where(User.id == 1)
+            >>> q2 = User.where(lambda t: t.id == 1)
             >>> isinstance(q1, Query) and isinstance(q2, Query)
             True
         """
@@ -216,7 +251,7 @@ class Query(Generic[T]):
         """
         query_def = {
             "model_name": self.model_cls.__name__,
-            "where_clause": [node.to_dict() for node in self.where_clause],
+            "where": [node.to_ir_dict() for node in self.where_clause],
             "order_by": self.order_by_clause,
             "limit": self._limit,
             "offset": self._offset,
@@ -224,7 +259,7 @@ class Query(Generic[T]):
         }
         tx_id, using = self._transaction_or_using()
         results = await fetch_filtered(
-            self.model_cls, _query_def_to_json(query_def), tx_id, using
+            self.model_cls, _query_ir_payload_to_json(query_def), tx_id, using
         )
         for instance in results:
             if hasattr(self.model_cls, "_fix_types"):
@@ -244,12 +279,15 @@ class Query(Generic[T]):
         """
         query_def = {
             "model_name": self.model_cls.__name__,
-            "where_clause": [node.to_dict() for node in self.where_clause],
+            "where": [node.to_ir_dict() for node in self.where_clause],
+            "order_by": [],
+            "limit": None,
+            "offset": None,
             "m2m": self._m2m_context,
         }
         tx_id, using = self._transaction_or_using()
         return await count_filtered(
-            self.model_cls.__name__, _query_def_to_json(query_def), tx_id, using
+            self.model_cls.__name__, _query_ir_payload_to_json(query_def), tx_id, using
         )
 
     async def update(self, **fields) -> int:
@@ -268,9 +306,11 @@ class Query(Generic[T]):
         """
         query_def = {
             "model_name": self.model_cls.__name__,
-            "where_clause": [node.to_dict() for node in self.where_clause],
+            "where": [node.to_ir_dict() for node in self.where_clause],
+            "order_by": [],
             "limit": self._limit,
             "offset": self._offset,
+            "m2m": None,
         }
         from pydantic_core import to_json
 
@@ -278,7 +318,7 @@ class Query(Generic[T]):
         # Use pydantic_core.to_json to handle Decimals, UUIDs, etc. in kwargs
         return await update_filtered(
             self.model_cls.__name__,
-            _query_def_to_json(query_def),
+            _query_ir_payload_to_json(query_def),
             to_json(fields).decode(),
             tx_id,
             using,
@@ -316,13 +356,15 @@ class Query(Generic[T]):
         """
         query_def = {
             "model_name": self.model_cls.__name__,
-            "where_clause": [node.to_dict() for node in self.where_clause],
+            "where": [node.to_ir_dict() for node in self.where_clause],
+            "order_by": [],
             "limit": self._limit,
             "offset": self._offset,
+            "m2m": None,
         }
         tx_id, using = self._transaction_or_using()
         return await delete_filtered(
-            self.model_cls.__name__, _query_def_to_json(query_def), tx_id, using
+            self.model_cls.__name__, _query_ir_payload_to_json(query_def), tx_id, using
         )
 
     async def exists(self) -> bool:

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -92,7 +92,9 @@ class Query(Generic[T]):
         order_by_clause: Sort definitions sent to the Rust core.
     """
 
-    def __init__(self, model_cls: Type[T], using: str | None = None):
+    def __init__(
+        self, model_cls: Type[T], using: str | None = None, session: Any | None = None
+    ):
         """Initialize a query for a model class.
 
         Args:
@@ -105,23 +107,19 @@ class Query(Generic[T]):
         """
         self.model_cls = model_cls
         self._using = using
+        self._session = session
         self.where_clause: list["QueryNode"] = []
         self.order_by_clause: list[dict[str, str]] = []
         self._limit: int | None = None
         self._offset: int | None = None
         self._m2m_context: dict[str, Any] | None = None
 
-    def _transaction_or_using(self) -> tuple[str | None, str | None]:
-        from ..state import _CURRENT_TRANSACTION, _CURRENT_TRANSACTION_CONNECTION
+    def _transaction_or_using(self) -> tuple[str | None, str | None, str | None]:
+        from ..state import resolve_operation_scope
 
-        tx_id = _CURRENT_TRANSACTION.get()
-        if tx_id is not None and self._using is not None:
-            if self._using == _CURRENT_TRANSACTION_CONNECTION.get():
-                return tx_id, None
-            raise ValueError(
-                "ORM queries inside a transaction inherit the transaction connection"
-            )
-        return tx_id, self._using
+        return resolve_operation_scope(
+            using=self._using, session=self._session, allow_legacy_default=True
+        )
 
     def _m2m(
         self, join_table: str, source_col: str, target_col: str, source_id: Any
@@ -257,9 +255,13 @@ class Query(Generic[T]):
             "offset": self._offset,
             "m2m": self._m2m_context,
         }
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         results = await fetch_filtered(
-            self.model_cls, _query_ir_payload_to_json(query_def), tx_id, using
+            self.model_cls,
+            _query_ir_payload_to_json(query_def),
+            tx_id,
+            using,
+            session_id=session_id,
         )
         for instance in results:
             if hasattr(self.model_cls, "_fix_types"):
@@ -285,9 +287,13 @@ class Query(Generic[T]):
             "offset": None,
             "m2m": self._m2m_context,
         }
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         return await count_filtered(
-            self.model_cls.__name__, _query_ir_payload_to_json(query_def), tx_id, using
+            self.model_cls.__name__,
+            _query_ir_payload_to_json(query_def),
+            tx_id,
+            using,
+            session_id=session_id,
         )
 
     async def update(self, **fields) -> int:
@@ -314,7 +320,7 @@ class Query(Generic[T]):
         }
         from pydantic_core import to_json
 
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         # Use pydantic_core.to_json to handle Decimals, UUIDs, etc. in kwargs
         return await update_filtered(
             self.model_cls.__name__,
@@ -322,6 +328,7 @@ class Query(Generic[T]):
             to_json(fields).decode(),
             tx_id,
             using,
+            session_id=session_id,
         )
 
     async def first(self) -> T | None:
@@ -362,9 +369,13 @@ class Query(Generic[T]):
             "offset": self._offset,
             "m2m": None,
         }
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         return await delete_filtered(
-            self.model_cls.__name__, _query_ir_payload_to_json(query_def), tx_id, using
+            self.model_cls.__name__,
+            _query_ir_payload_to_json(query_def),
+            tx_id,
+            using,
+            session_id=session_id,
         )
 
     async def exists(self) -> bool:
@@ -407,7 +418,7 @@ class Query(Generic[T]):
 
         from ..state import _CURRENT_TRANSACTION
 
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         await add_m2m_links(
             self._m2m_context["join_table"],
             self._m2m_context["source_col"],
@@ -416,6 +427,7 @@ class Query(Generic[T]):
             ids,
             tx_id,
             using,
+            session_id=session_id,
         )
 
     async def remove(self, *instances: Any) -> None:
@@ -443,7 +455,7 @@ class Query(Generic[T]):
 
         from ..state import _CURRENT_TRANSACTION
 
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         await remove_m2m_links(
             self._m2m_context["join_table"],
             self._m2m_context["source_col"],
@@ -452,6 +464,7 @@ class Query(Generic[T]):
             ids,
             tx_id,
             using,
+            session_id=session_id,
         )
 
     async def clear(self) -> None:
@@ -471,13 +484,14 @@ class Query(Generic[T]):
 
         from ..state import _CURRENT_TRANSACTION
 
-        tx_id, using = self._transaction_or_using()
+        tx_id, using, session_id = self._transaction_or_using()
         await clear_m2m_links(
             self._m2m_context["join_table"],
             self._m2m_context["source_col"],
             self._m2m_context["source_id"],
             tx_id,
             using,
+            session_id=session_id,
         )
 
     def __repr__(self):

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -1,8 +1,13 @@
 """Build fluent query objects that serialize QueryIR payloads for the Rust core."""
 
-import warnings
 from typing import TYPE_CHECKING, Any, Generic, Type, TypeVar, overload
 
+from .._deprecations import (
+    IR_FIRST_DEPRECATION_REMOVE_IN,
+    IR_FIRST_DEPRECATION_SINCE,
+    IR_FIRST_MIGRATION_GUIDE_PREDICATES,
+    deprecated,
+)
 from .._core import (
     add_m2m_links,
     clear_m2m_links,
@@ -21,21 +26,6 @@ T = TypeVar("T")
 E = TypeVar("E")
 
 
-try:
-    from warnings import deprecated as _warnings_deprecated
-except ImportError:
-
-    def _warnings_deprecated(message: str, **_: Any):
-        def _decorate(func):
-            def _wrapped(*args, **kwargs):
-                warnings.warn(message, DeprecationWarning, stacklevel=3)
-                return func(*args, **kwargs)
-
-            return _wrapped
-
-        return _decorate
-
-
 def _query_ir_payload_to_json(query_payload: dict[str, Any]) -> str:
     """Serialize a QueryIR payload into a versioned IR envelope JSON string."""
     import json
@@ -49,10 +39,14 @@ def _query_ir_payload_to_json(query_payload: dict[str, Any]) -> str:
     )
 
 
-@_warnings_deprecated(
-    "Operator predicate style (Model.field OP value) is deprecated; use lambda "
-    "predicates (`where(lambda t: ...)`) or col(Model.field) instead. Planned "
-    "removal: v0.13.0."
+@deprecated(
+    reason=(
+        "Operator predicate style (Model.field OP value) is deprecated; use lambda "
+        "predicates (`where(lambda t: ...)`) or col(Model.field) instead."
+    ),
+    since=IR_FIRST_DEPRECATION_SINCE,
+    remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+    reference=IR_FIRST_MIGRATION_GUIDE_PREDICATES,
 )
 def _deprecated_operator_query_node(node: QueryNode) -> QueryNode:
     return node
@@ -151,7 +145,7 @@ class Query(Generic[T]):
         :func:`ferro.query.col` (the type-safe escape hatch that preserves
         operator shape) or with operator syntax on class attributes. The
         bare operator form (``User.where(User.age >= 18)``) is deprecated and
-        on the v0.13.0 removal track. It does not
+        on the v0.14.0 removal track. It does not
         type-check statically:
         the class attribute types as the field type, so the comparison
         resolves to ``bool``, not ``QueryNode``.

--- a/src/ferro/query/nodes.py
+++ b/src/ferro/query/nodes.py
@@ -36,6 +36,7 @@ class QueryNode:
         left: "QueryNode | None" = None,
         right: "QueryNode | None" = None,
         is_compound: bool = False,
+        predicate_style: str | None = None,
     ):
         """Initialize a query expression node
 
@@ -53,6 +54,7 @@ class QueryNode:
         self.left = left
         self.right = right
         self.is_compound = is_compound
+        self.predicate_style = predicate_style
 
     def __or__(self, other: "QueryNode") -> "QueryNode":
         """Combine two nodes with logical OR
@@ -70,7 +72,15 @@ class QueryNode:
         """
         if not isinstance(other, QueryNode):
             return NotImplemented
-        return QueryNode(left=self, operator="OR", right=other, is_compound=True)
+        return QueryNode(
+            left=self,
+            operator="OR",
+            right=other,
+            is_compound=True,
+            predicate_style="operator"
+            if self.uses_operator_style() or other.uses_operator_style()
+            else self.predicate_style or other.predicate_style,
+        )
 
     def __and__(self, other: "QueryNode") -> "QueryNode":
         """Combine two nodes with logical AND
@@ -88,7 +98,15 @@ class QueryNode:
         """
         if not isinstance(other, QueryNode):
             return NotImplemented
-        return QueryNode(left=self, operator="AND", right=other, is_compound=True)
+        return QueryNode(
+            left=self,
+            operator="AND",
+            right=other,
+            is_compound=True,
+            predicate_style="operator"
+            if self.uses_operator_style() or other.uses_operator_style()
+            else self.predicate_style or other.predicate_style,
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the query node tree into a JSON-friendly dictionary
@@ -116,6 +134,30 @@ class QueryNode:
             "is_compound": True,
         }
 
+    def to_ir_dict(self) -> dict[str, Any]:
+        """Serialize the query node tree into a QueryIR payload shape."""
+        if not self.is_compound:
+            serialized = _serialize_query_value(self.value)
+            return {
+                "node_kind": "leaf",
+                "column": self.column,
+                "operator": self.operator,
+                "value": {"kind": _query_value_kind(serialized), "value": serialized},
+            }
+        return {
+            "node_kind": "compound",
+            "operator": self.operator,
+            "left": self.left.to_ir_dict() if self.left else None,
+            "right": self.right.to_ir_dict() if self.right else None,
+        }
+
+    def uses_operator_style(self) -> bool:
+        if self.is_compound:
+            return (self.left.uses_operator_style() if self.left else False) or (
+                self.right.uses_operator_style() if self.right else False
+            )
+        return self.predicate_style == "operator"
+
     def __repr__(self):
         """Return a developer-friendly representation of the node"""
         if not self.is_compound:
@@ -138,6 +180,24 @@ def _serialize_query_value(value: Any) -> Any:
     return value
 
 
+def _query_value_kind(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "list"
+    if isinstance(value, dict):
+        return "object"
+    return "unknown"
+
+
 class FieldProxy(Generic[TField]):
     """Capture field comparisons and build query nodes
 
@@ -154,41 +214,50 @@ class FieldProxy(Generic[TField]):
         True
     """
 
-    def __init__(self, column: str):
+    def __init__(self, column: str, predicate_style: str = "operator"):
         """Initialize a field proxy for a specific column
 
         Args:
             column: Database column name to target in expressions.
         """
         self.column = column
+        self.predicate_style = predicate_style
 
     def __eq__(  # type: ignore[override]  # ty: ignore[invalid-method-override]
         self, other: "TField | FieldProxy[TField]"
     ) -> QueryNode:
         """Build an equality comparison node"""
-        return QueryNode(self.column, "==", other)
+        return QueryNode(
+            self.column, "==", other, predicate_style=self.predicate_style
+        )
 
     def __ne__(  # type: ignore[override]  # ty: ignore[invalid-method-override]
         self, other: "TField | FieldProxy[TField]"
     ) -> QueryNode:
         """Build an inequality comparison node"""
-        return QueryNode(self.column, "!=", other)
+        return QueryNode(
+            self.column, "!=", other, predicate_style=self.predicate_style
+        )
 
     def __lt__(self, other: "TField | FieldProxy[TField]") -> QueryNode:
         """Build a less-than comparison node"""
-        return QueryNode(self.column, "<", other)
+        return QueryNode(self.column, "<", other, predicate_style=self.predicate_style)
 
     def __le__(self, other: "TField | FieldProxy[TField]") -> QueryNode:
         """Build a less-than-or-equal comparison node"""
-        return QueryNode(self.column, "<=", other)
+        return QueryNode(
+            self.column, "<=", other, predicate_style=self.predicate_style
+        )
 
     def __gt__(self, other: "TField | FieldProxy[TField]") -> QueryNode:
         """Build a greater-than comparison node"""
-        return QueryNode(self.column, ">", other)
+        return QueryNode(self.column, ">", other, predicate_style=self.predicate_style)
 
     def __ge__(self, other: "TField | FieldProxy[TField]") -> QueryNode:
         """Build a greater-than-or-equal comparison node"""
-        return QueryNode(self.column, ">=", other)
+        return QueryNode(
+            self.column, ">=", other, predicate_style=self.predicate_style
+        )
 
     def in_(
         self, other: "list[TField] | tuple[TField, ...] | set[TField]"
@@ -213,7 +282,9 @@ class FieldProxy(Generic[TField]):
             raise TypeError(
                 f"The 'in_' operator expects a list, tuple, or set, got {type(other).__name__}"
             )
-        return QueryNode(self.column, "IN", list(other))
+        return QueryNode(
+            self.column, "IN", list(other), predicate_style=self.predicate_style
+        )
 
     def like(self: "FieldProxy[str]", pattern: str) -> QueryNode:
         """Build a ``LIKE`` comparison node
@@ -233,7 +304,9 @@ class FieldProxy(Generic[TField]):
             >>> email_filter.operator
             'LIKE'
         """
-        return QueryNode(self.column, "LIKE", pattern)
+        return QueryNode(
+            self.column, "LIKE", pattern, predicate_style=self.predicate_style
+        )
 
     def __lshift__(
         self, other: "list[TField] | tuple[TField, ...] | set[TField]"
@@ -292,7 +365,7 @@ def col(value: TField) -> "FieldProxy[TField]":
         raise TypeError(
             f"col() expects a model column reference (FieldProxy), got {type(value).__name__}"
         )
-    return value  # type: ignore[return-value]
+    return FieldProxy(value.column, predicate_style="col")  # type: ignore[return-value]
 
 
 class QueryProxy(Generic[TModel]):
@@ -319,7 +392,7 @@ class QueryProxy(Generic[TModel]):
 
     def __getattr__(self, name: str) -> "FieldProxy[Any]":
         """Return a fresh ``FieldProxy`` for any attribute name."""
-        return FieldProxy(name)
+        return FieldProxy(name, predicate_style="lambda")
 
 
 Predicate: TypeAlias = Callable[[QueryProxy[TModel]], QueryNode]

--- a/src/ferro/raw.py
+++ b/src/ferro/raw.py
@@ -31,7 +31,7 @@ from typing import Any
 from ._core import raw_execute as _raw_execute
 from ._core import raw_fetch_all as _raw_fetch_all
 from ._core import raw_fetch_one as _raw_fetch_one
-from .state import _CURRENT_TRANSACTION, _CURRENT_TRANSACTION_CONNECTION
+from .state import resolve_operation_scope
 
 __all__ = ["execute", "fetch_all", "fetch_one", "Transaction"]
 
@@ -68,16 +68,17 @@ def _check_sql(sql: str) -> None:
         raise ValueError("sql must be a non-empty statement")
 
 
-def _transaction_or_using(using: str | None) -> tuple[str | None, str | None]:
-    tx_id = _CURRENT_TRANSACTION.get()
-    if tx_id is not None and using is not None:
-        if using == _CURRENT_TRANSACTION_CONNECTION.get():
-            return tx_id, None
-        raise ValueError("Raw SQL inside a transaction inherits the transaction connection")
-    return tx_id, using
+def _transaction_or_using(
+    using: str | None, session: Any | None
+) -> tuple[str | None, str | None, str | None]:
+    return resolve_operation_scope(
+        using=using, session=session, allow_legacy_default=True
+    )
 
 
-async def execute(sql: str, *args: Any, using: str | None = None) -> int:
+async def execute(
+    sql: str, *args: Any, using: str | None = None, session: Any | None = None
+) -> int:
     """Run a raw SQL statement, returning rows affected.
 
     Honors the active ``transaction()`` block via the ``_CURRENT_TRANSACTION``
@@ -88,12 +89,12 @@ async def execute(sql: str, *args: Any, using: str | None = None) -> int:
     """
     _check_sql(sql)
     marshalled = [_marshal(a) for a in args]
-    tx_id, using = _transaction_or_using(using)
-    return await _raw_execute(sql, marshalled, tx_id, using)
+    tx_id, using, session_id = _transaction_or_using(using, session)
+    return await _raw_execute(sql, marshalled, tx_id, using, session_id=session_id)
 
 
 async def fetch_all(
-    sql: str, *args: Any, using: str | None = None
+    sql: str, *args: Any, using: str | None = None, session: Any | None = None
 ) -> list[dict[str, Any]]:
     """Run a raw SQL query and return all rows as a list of dicts.
 
@@ -102,12 +103,12 @@ async def fetch_all(
     """
     _check_sql(sql)
     marshalled = [_marshal(a) for a in args]
-    tx_id, using = _transaction_or_using(using)
-    return await _raw_fetch_all(sql, marshalled, tx_id, using)
+    tx_id, using, session_id = _transaction_or_using(using, session)
+    return await _raw_fetch_all(sql, marshalled, tx_id, using, session_id=session_id)
 
 
 async def fetch_one(
-    sql: str, *args: Any, using: str | None = None
+    sql: str, *args: Any, using: str | None = None, session: Any | None = None
 ) -> dict[str, Any] | None:
     """Run a raw SQL query and return the first row as a dict, or ``None``.
 
@@ -115,8 +116,8 @@ async def fetch_one(
     """
     _check_sql(sql)
     marshalled = [_marshal(a) for a in args]
-    tx_id, using = _transaction_or_using(using)
-    return await _raw_fetch_one(sql, marshalled, tx_id, using)
+    tx_id, using, session_id = _transaction_or_using(using, session)
+    return await _raw_fetch_one(sql, marshalled, tx_id, using, session_id=session_id)
 
 
 class Transaction:
@@ -132,22 +133,27 @@ class Transaction:
     subsequent call raises :class:`RuntimeError`.
     """
 
-    __slots__ = ("_tx_id",)
+    __slots__ = ("_tx_id", "_session_id")
 
-    def __init__(self, tx_id: str) -> None:
+    def __init__(self, tx_id: str, session_id: str | None = None) -> None:
         self._tx_id = tx_id
+        self._session_id = session_id
 
     async def execute(self, sql: str, *args: Any) -> int:
         _check_sql(sql)
         marshalled = [_marshal(a) for a in args]
-        return await _raw_execute(sql, marshalled, self._tx_id)
+        return await _raw_execute(sql, marshalled, self._tx_id, session_id=self._session_id)
 
     async def fetch_all(self, sql: str, *args: Any) -> list[dict[str, Any]]:
         _check_sql(sql)
         marshalled = [_marshal(a) for a in args]
-        return await _raw_fetch_all(sql, marshalled, self._tx_id)
+        return await _raw_fetch_all(
+            sql, marshalled, self._tx_id, session_id=self._session_id
+        )
 
     async def fetch_one(self, sql: str, *args: Any) -> dict[str, Any] | None:
         _check_sql(sql)
         marshalled = [_marshal(a) for a in args]
-        return await _raw_fetch_one(sql, marshalled, self._tx_id)
+        return await _raw_fetch_one(
+            sql, marshalled, self._tx_id, session_id=self._session_id
+        )

--- a/src/ferro/relations/__init__.py
+++ b/src/ferro/relations/__init__.py
@@ -8,6 +8,7 @@ from .._shadow_fk_types import (
     schema_fragment_for_pk,
 )
 from ..base import ForeignKey, ManyToManyRelation
+from ..ir import compile_registry_schema_ir
 from ..schema_metadata import build_model_schema
 from ..state import (  # noqa: F401
     _JOIN_TABLE_REGISTRY,
@@ -148,4 +149,5 @@ def resolve_relationships():
         except Exception:
             pass
 
+    compile_registry_schema_ir()
     _PENDING_RELATIONS.clear()

--- a/src/ferro/session.py
+++ b/src/ferro/session.py
@@ -1,0 +1,43 @@
+"""Session-scoped runtime state for Ferro operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ._core import close_session as _core_close_session
+from ._core import open_session as _core_open_session
+from .state import _CURRENT_SESSION
+
+
+@dataclass(slots=True)
+class Session:
+    connection_name: str | None = None
+    session_id: str | None = None
+    _token: Any = None
+
+    async def __aenter__(self) -> "Session":
+        self.session_id = _core_open_session(self.connection_name)
+        self._token = _CURRENT_SESSION.set(self)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._token is not None:
+            _CURRENT_SESSION.reset(self._token)
+            self._token = None
+        if self.session_id is not None:
+            _core_close_session(self.session_id)
+            self.session_id = None
+
+    def query(self, model_cls):
+        from .query import Query
+
+        return Query(model_cls, session=self)
+
+
+class EngineManager:
+    def session(self, name: str | None = None) -> Session:
+        return Session(connection_name=name)
+
+
+engines = EngineManager()

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -1,5 +1,6 @@
 from contextvars import ContextVar
-from typing import Any
+import warnings
+from typing import Any, Protocol
 
 # Context variable to store the active transaction ID for the current task
 _CURRENT_TRANSACTION: ContextVar[str | None] = ContextVar(
@@ -8,6 +9,23 @@ _CURRENT_TRANSACTION: ContextVar[str | None] = ContextVar(
 
 _CURRENT_TRANSACTION_CONNECTION: ContextVar[str | None] = ContextVar(
     "current_transaction_connection", default=None
+)
+
+
+class SessionLike(Protocol):
+    session_id: str
+    connection_name: str
+
+
+_CURRENT_SESSION: ContextVar[SessionLike | None] = ContextVar(
+    "current_session", default=None
+)
+
+
+_LEGACY_DEFAULT_CONNECTION_DEPRECATION = (
+    "Implicit default-connection routing without an active session is deprecated; "
+    "use `async with ferro.engines.session(\"name\")` (or pass `session=...`) for "
+    "ORM/raw operations. Planned removal: v0.13.0."
 )
 
 # Global registry for models (Python side)
@@ -26,3 +44,85 @@ _SCHEMA_IR_MODELSET_FINGERPRINT: str | None = None
 # Per-model compiled SchemaIR artifacts and fingerprints.
 _SCHEMA_IR_BY_MODEL: dict[str, dict[str, Any]] = {}
 _SCHEMA_IR_FINGERPRINT_BY_MODEL: dict[str, str] = {}
+
+
+def resolve_operation_scope(
+    *,
+    using: str | None,
+    session: SessionLike | None,
+    allow_legacy_default: bool,
+) -> tuple[str | None, str | None, str | None]:
+    """Resolve `(tx_id, using, session_id)` for ORM/raw operations."""
+    tx_id = _CURRENT_TRANSACTION.get()
+    tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
+
+    ambient_session = _CURRENT_SESSION.get()
+    explicit_session = session
+    effective_session = explicit_session or ambient_session
+
+    # Explicit `using` can override ambient sessions for compatibility, but not
+    # explicitly supplied `session=...`.
+    if effective_session is not None and using is not None:
+        if explicit_session is not None and using != effective_session.connection_name:
+            raise ValueError(
+                "Explicit `using` conflicts with explicit `session` connection"
+            )
+        if explicit_session is None and using != effective_session.connection_name:
+            effective_session = None
+
+    session_id = effective_session.session_id if effective_session is not None else None
+
+    if tx_id is not None:
+        if using is not None and using != tx_connection:
+            raise ValueError(
+                "Operations inside a transaction inherit the transaction connection"
+            )
+        if effective_session is not None and tx_connection is not None:
+            if effective_session.connection_name != tx_connection:
+                raise ValueError(
+                    "Active transaction is bound to a different connection than session"
+                )
+        return tx_id, None, session_id
+
+    effective_using = using or (
+        effective_session.connection_name if effective_session is not None else None
+    )
+    if effective_using is None and allow_legacy_default:
+        warnings.warn(_LEGACY_DEFAULT_CONNECTION_DEPRECATION, DeprecationWarning, stacklevel=3)
+    return None, effective_using, session_id
+
+
+def resolve_transaction_scope(
+    *,
+    using: str | None,
+    session: SessionLike | None,
+    allow_legacy_default: bool,
+) -> tuple[str | None, str | None, str | None]:
+    parent_tx_id = _CURRENT_TRANSACTION.get()
+    tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
+    ambient_session = _CURRENT_SESSION.get()
+    explicit_session = session
+    effective_session = explicit_session or ambient_session
+
+    if effective_session is not None and using is not None:
+        if explicit_session is not None and using != effective_session.connection_name:
+            raise ValueError(
+                "Explicit `using` conflicts with explicit `session` connection"
+            )
+        if explicit_session is None and using != effective_session.connection_name:
+            effective_session = None
+
+    if parent_tx_id is not None:
+        # Nested tx route is always inherited from parent.
+        return parent_tx_id, None, (
+            effective_session.session_id if effective_session is not None else None
+        )
+
+    effective_using = using or (
+        effective_session.connection_name if effective_session is not None else None
+    )
+    if effective_using is None and allow_legacy_default:
+        warnings.warn(_LEGACY_DEFAULT_CONNECTION_DEPRECATION, DeprecationWarning, stacklevel=3)
+    return None, effective_using, (
+        effective_session.session_id if effective_session is not None else None
+    )

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -1,6 +1,13 @@
 from contextvars import ContextVar
-import warnings
+
 from typing import Any, Protocol
+
+from ._deprecations import (
+    IR_FIRST_DEPRECATION_REMOVE_IN,
+    IR_FIRST_DEPRECATION_SINCE,
+    IR_FIRST_MIGRATION_GUIDE_SESSIONS,
+    warn_deprecated,
+)
 
 # Context variable to store the active transaction ID for the current task
 _CURRENT_TRANSACTION: ContextVar[str | None] = ContextVar(
@@ -21,11 +28,10 @@ _CURRENT_SESSION: ContextVar[SessionLike | None] = ContextVar(
     "current_session", default=None
 )
 
-
-_LEGACY_DEFAULT_CONNECTION_DEPRECATION = (
+_LEGACY_DEFAULT_CONNECTION_REASON = (
     "Implicit default-connection routing without an active session is deprecated; "
     "use `async with ferro.engines.session(\"name\")` (or pass `session=...`) for "
-    "ORM/raw operations. Planned removal: v0.13.0."
+    "ORM/raw operations."
 )
 
 # Global registry for models (Python side)
@@ -88,7 +94,13 @@ def resolve_operation_scope(
         effective_session.connection_name if effective_session is not None else None
     )
     if effective_using is None and allow_legacy_default:
-        warnings.warn(_LEGACY_DEFAULT_CONNECTION_DEPRECATION, DeprecationWarning, stacklevel=3)
+        warn_deprecated(
+            reason=_LEGACY_DEFAULT_CONNECTION_REASON,
+            since=IR_FIRST_DEPRECATION_SINCE,
+            remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+            reference=IR_FIRST_MIGRATION_GUIDE_SESSIONS,
+            stacklevel=2,
+        )
     return None, effective_using, session_id
 
 
@@ -122,7 +134,13 @@ def resolve_transaction_scope(
         effective_session.connection_name if effective_session is not None else None
     )
     if effective_using is None and allow_legacy_default:
-        warnings.warn(_LEGACY_DEFAULT_CONNECTION_DEPRECATION, DeprecationWarning, stacklevel=3)
+        warn_deprecated(
+            reason=_LEGACY_DEFAULT_CONNECTION_REASON,
+            since=IR_FIRST_DEPRECATION_SINCE,
+            remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+            reference=IR_FIRST_MIGRATION_GUIDE_SESSIONS,
+            stacklevel=2,
+        )
     return None, effective_using, (
         effective_session.session_id if effective_session is not None else None
     )

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -1,4 +1,5 @@
 from contextvars import ContextVar
+from typing import Any
 
 # Context variable to store the active transaction ID for the current task
 _CURRENT_TRANSACTION: ContextVar[str | None] = ContextVar(
@@ -17,3 +18,11 @@ _PENDING_RELATIONS = []
 
 # Global registry for automatically generated join tables
 _JOIN_TABLE_REGISTRY = {}
+
+# Latest compiled SchemaIR model-set artifact and fingerprint.
+_SCHEMA_IR_MODELSET: dict[str, Any] | None = None
+_SCHEMA_IR_MODELSET_FINGERPRINT: str | None = None
+
+# Per-model compiled SchemaIR artifacts and fingerprints.
+_SCHEMA_IR_BY_MODEL: dict[str, dict[str, Any]] = {}
+_SCHEMA_IR_FINGERPRINT_BY_MODEL: dict[str, str] = {}

--- a/src/hydration.rs
+++ b/src/hydration.rs
@@ -1,0 +1,57 @@
+use crate::state::RustValue;
+use pyo3::prelude::*;
+use std::collections::HashMap;
+
+fn set_pydantic_hydration_slots<'py>(
+    py: Python<'py>,
+    cls: &Bound<'py, PyAny>,
+    instance: &Bound<'py, PyAny>,
+) -> PyResult<()> {
+    let model_config = cls.getattr(pyo3::intern!(py, "model_config"))?;
+    let extra_policy = model_config.call_method1(
+        pyo3::intern!(py, "get"),
+        (pyo3::intern!(py, "extra"), pyo3::intern!(py, "ignore")),
+    )?;
+    let extra_slot = if extra_policy.eq(pyo3::intern!(py, "allow"))? {
+        pyo3::types::PyDict::new(py).into_any().unbind()
+    } else {
+        py.None()
+    };
+    instance.setattr(pyo3::intern!(py, "__pydantic_extra__"), extra_slot)?;
+    instance.setattr(pyo3::intern!(py, "__pydantic_private__"), py.None())?;
+    Ok(())
+}
+
+pub fn hydrate_model_instance<'py>(
+    py: Python<'py>,
+    cls: &Bound<'py, PyAny>,
+    connection_name: &str,
+    fields: Vec<(String, RustValue)>,
+    py_col_names: &HashMap<String, pyo3::Py<pyo3::types::PyString>>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let instance = cls.call_method1(pyo3::intern!(py, "__new__"), (cls,))?;
+    let dict_attr = instance.getattr(pyo3::intern!(py, "__dict__"))?;
+    let dict = dict_attr.cast::<pyo3::types::PyDict>()?;
+    dict.set_item(
+        pyo3::intern!(py, "__ferro_connection_name"),
+        connection_name,
+    )?;
+    let fields_set = pyo3::types::PySet::empty(py)?;
+
+    for (col_name, val) in fields {
+        let py_val = val.into_py_any(py)?;
+        if let Some(py_name) = py_col_names.get(&col_name) {
+            let py_name = py_name.bind(py);
+            dict.set_item(py_name, py_val)?;
+            fields_set.add(py_name)?;
+        } else {
+            let py_name = pyo3::types::PyString::new(py, &col_name);
+            dict.set_item(&py_name, py_val)?;
+            fields_set.add(&py_name)?;
+        }
+    }
+
+    let _ = instance.setattr(pyo3::intern!(py, "__pydantic_fields_set__"), fields_set);
+    set_pydantic_hydration_slots(py, cls, &instance)?;
+    Ok(instance)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,8 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m
     )?)?;
     m.add_function(wrap_pyfunction!(operations::rollback_transaction, m)?)?;
+    m.add_function(wrap_pyfunction!(operations::open_session, m)?)?;
+    m.add_function(wrap_pyfunction!(operations::close_session, m)?)?;
     m.add_function(wrap_pyfunction!(operations::raw_execute, m)?)?;
     m.add_function(wrap_pyfunction!(operations::raw_fetch_all, m)?)?;
     m.add_function(wrap_pyfunction!(operations::raw_fetch_one, m)?)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,10 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(operations::raw_execute, m)?)?;
     m.add_function(wrap_pyfunction!(operations::raw_fetch_all, m)?)?;
     m.add_function(wrap_pyfunction!(operations::raw_fetch_one, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        operations::_shadow_compare_query_plan_for_test,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(connection::reset_engine, m)?)?;
     m.add_function(wrap_pyfunction!(connection::set_default_connection, m)?)?;
     m.add_function(wrap_pyfunction!(clear_registry, m)?)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@
 //! hydration using PyO3 and SQLx.
 
 mod backend;
+mod codec;
 mod connection;
+mod hydration;
 mod introspect;
 mod migrate;
 mod operations;

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -312,14 +312,20 @@ fn shadow_compare_migration_plan(
     backend: SqlDialect,
     opts: MigrateOptions,
 ) -> Result<(), String> {
-    let legacy =
-        plan_table_migration(table_lower, schema, live, backend, opts).map_err(|e| e.to_string())?;
+    let legacy = plan_table_migration(table_lower, schema, live, backend, opts)
+        .map_err(|e| e.to_string())?;
     let schema_roundtrip: serde_json::Value =
         serde_json::from_str(&serde_json::to_string(schema).map_err(|e| e.to_string())?)
             .map_err(|e| e.to_string())?;
     let live_roundtrip = live.to_vec();
-    let shadow = plan_table_migration(table_lower, &schema_roundtrip, &live_roundtrip, backend, opts)
-        .map_err(|e| e.to_string())?;
+    let shadow = plan_table_migration(
+        table_lower,
+        &schema_roundtrip,
+        &live_roundtrip,
+        backend,
+        opts,
+    )
+    .map_err(|e| e.to_string())?;
     if legacy.statements == shadow.statements
         && legacy.drop_columns == shadow.drop_columns
         && legacy.warnings == shadow.warnings
@@ -622,7 +628,8 @@ pub async fn internal_migrate(engine: Arc<EngineHandle>, opts: MigrateOptions) -
 
         let mut plan = plan_table_migration(&table_lower, &schema, &live, backend, opts)?;
         if engine.is_shadow_runtime_enabled()
-            && let Err(diff) = shadow_compare_migration_plan(&table_lower, &schema, &live, backend, opts)
+            && let Err(diff) =
+                shadow_compare_migration_plan(&table_lower, &schema, &live, backend, opts)
         {
             crate::log_debug(format!("⚠️ Ferro shadow runtime mismatch: {diff}"));
             if std::env::var("FERRO_SHADOW_RUNTIME_STRICT")

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -12,6 +12,11 @@
 //! created one (AGENTS.md § I-1).
 
 use crate::backend::EngineHandle;
+use ferro_migrate::{BackendDialect, emit_sql, plan_from_ir};
+use ferro_schema_ir::{
+    IrEnvelope, SchemaCheck, SchemaColumn, SchemaForeignKey, SchemaIndex, SchemaIrPayload,
+    SchemaModel, SchemaUnique,
+};
 use crate::introspect::{
     LiveColumn, live_table_columns, quote_ident, sqlite_indexes_covering_column,
 };
@@ -26,6 +31,157 @@ use sea_query::{
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+
+fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> IrEnvelope<SchemaIrPayload> {
+    let mut columns = Vec::new();
+    if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
+        for (name, raw_col) in properties {
+            let resolved = if let Some(ref_path) = raw_col.get("$ref").and_then(|r| r.as_str()) {
+                if let Some(def_name) = ref_path.strip_prefix("#/$defs/") {
+                    schema
+                        .get("$defs")
+                        .and_then(|defs| defs.get(def_name))
+                        .unwrap_or(raw_col)
+                } else {
+                    raw_col
+                }
+            } else {
+                raw_col
+            };
+            let nullable = raw_col
+                .get("ferro_nullable")
+                .or_else(|| resolved.get("ferro_nullable"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            let db_type = raw_col
+                .get("db_type")
+                .or_else(|| resolved.get("db_type"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("text")
+                .to_string();
+            columns.push(SchemaColumn {
+                name: name.clone(),
+                logical_type: resolved
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string(),
+                db_type,
+                db_type_explicit: raw_col
+                    .get("db_type")
+                    .or_else(|| resolved.get("db_type"))
+                    .and_then(|v| v.as_str())
+                    .map(|_| true),
+                nullable,
+                primary_key: resolved
+                    .get("primary_key")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+                autoincrement: resolved
+                    .get("autoincrement")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+                unique: resolved.get("unique").and_then(|v| v.as_bool()).unwrap_or(false),
+                index: resolved.get("index").and_then(|v| v.as_bool()).unwrap_or(false),
+                default: resolved.get("default").cloned(),
+                format: resolved
+                    .get("format")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+                enum_values: resolved.get("enum").and_then(|v| v.as_array()).cloned(),
+                enum_type_name: resolved
+                    .get("enum_type_name")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+            });
+        }
+    }
+    columns.sort_by(|a, b| a.name.cmp(&b.name));
+
+    IrEnvelope {
+        ir_kind: "schema".to_string(),
+        ir_version: 1,
+        payload: SchemaIrPayload {
+            dialect_agnostic: true,
+            models: vec![SchemaModel {
+                model_name: table_lower.to_string(),
+                table_name: table_lower.to_string(),
+                columns,
+                foreign_keys: Vec::<SchemaForeignKey>::new(),
+                indexes: Vec::<SchemaIndex>::new(),
+                uniques: Vec::<SchemaUnique>::new(),
+                checks: Vec::<SchemaCheck>::new(),
+            }],
+        },
+    }
+}
+
+fn declared_type_to_db_type(declared: &str) -> String {
+    let lower = declared.to_ascii_lowercase();
+    if lower.contains("smallint") {
+        return "smallint".to_string();
+    }
+    if lower.contains("bigint") {
+        return "bigint".to_string();
+    }
+    if lower.contains("int") {
+        return "int".to_string();
+    }
+    if lower.contains("uuid") || lower.contains("char(32)") {
+        return "uuid".to_string();
+    }
+    if lower.contains("timestamp with time zone") {
+        return "timestamptz".to_string();
+    }
+    if lower.contains("timestamp") || lower.contains("datetime") {
+        return "timestamp".to_string();
+    }
+    if lower == "date" || lower.contains("date_") {
+        return "date".to_string();
+    }
+    if lower == "time" || lower.contains("time_") {
+        return "time".to_string();
+    }
+    "text".to_string()
+}
+
+fn live_columns_to_schema_ir(table_lower: &str, live: &[LiveColumn]) -> IrEnvelope<SchemaIrPayload> {
+    let mut columns: Vec<SchemaColumn> = live
+        .iter()
+        .map(|col| SchemaColumn {
+            name: col.name.clone(),
+            logical_type: "unknown".to_string(),
+            db_type: declared_type_to_db_type(&col.declared_type),
+            db_type_explicit: None,
+            nullable: col.is_nullable,
+            primary_key: col.is_primary_key,
+            autoincrement: false,
+            unique: false,
+            index: false,
+            default: None,
+            format: None,
+            enum_values: None,
+            enum_type_name: None,
+        })
+        .collect();
+    columns.sort_by(|a, b| a.name.cmp(&b.name));
+    IrEnvelope {
+        ir_kind: "schema".to_string(),
+        ir_version: 1,
+        payload: SchemaIrPayload {
+            dialect_agnostic: true,
+            models: vec![SchemaModel {
+                model_name: table_lower.to_string(),
+                table_name: table_lower.to_string(),
+                columns,
+                foreign_keys: Vec::<SchemaForeignKey>::new(),
+                indexes: Vec::<SchemaIndex>::new(),
+                uniques: Vec::<SchemaUnique>::new(),
+                checks: Vec::<SchemaCheck>::new(),
+            }],
+        },
+    }
+}
 
 /// Which migration behaviors beyond table creation are enabled.
 #[derive(Clone, Copy, Debug, Default)]
@@ -255,6 +411,17 @@ pub fn plan_table_migration(
     backend: SqlDialect,
     opts: MigrateOptions,
 ) -> PyResult<MigrationPlan> {
+    let old_ir = live_columns_to_schema_ir(table_lower, live);
+    let new_ir = schema_json_to_schema_ir(table_lower, schema);
+    let _typed_plan = plan_from_ir(&old_ir, &new_ir);
+    let _typed_sql = emit_sql(
+        &_typed_plan,
+        match backend {
+            SqlDialect::Sqlite => BackendDialect::Sqlite,
+            SqlDialect::Postgres => BackendDialect::Postgres,
+        },
+    );
+
     let mut plan = MigrationPlan::new();
     if !opts.updates {
         return Ok(plan);

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -305,6 +305,35 @@ pub fn plan_table_migration(
     Ok(plan)
 }
 
+fn shadow_compare_migration_plan(
+    table_lower: &str,
+    schema: &serde_json::Value,
+    live: &[LiveColumn],
+    backend: SqlDialect,
+    opts: MigrateOptions,
+) -> Result<(), String> {
+    let legacy =
+        plan_table_migration(table_lower, schema, live, backend, opts).map_err(|e| e.to_string())?;
+    let schema_roundtrip: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(schema).map_err(|e| e.to_string())?)
+            .map_err(|e| e.to_string())?;
+    let live_roundtrip = live.to_vec();
+    let shadow = plan_table_migration(table_lower, &schema_roundtrip, &live_roundtrip, backend, opts)
+        .map_err(|e| e.to_string())?;
+    if legacy.statements == shadow.statements
+        && legacy.drop_columns == shadow.drop_columns
+        && legacy.warnings == shadow.warnings
+    {
+        return Ok(());
+    }
+    Err(format!(
+        "shadow migration-plan mismatch for '{}': legacy={} shadow={}",
+        table_lower,
+        serde_json::to_string(&legacy.statements).unwrap_or_else(|_| "<legacy>".to_string()),
+        serde_json::to_string(&shadow.statements).unwrap_or_else(|_| "<shadow>".to_string())
+    ))
+}
+
 /// Plan the `ADD COLUMN` (and any follow-up DDL) for a model column missing
 /// from the live table.
 fn plan_missing_column(
@@ -592,6 +621,17 @@ pub async fn internal_migrate(engine: Arc<EngineHandle>, opts: MigrateOptions) -
         };
 
         let mut plan = plan_table_migration(&table_lower, &schema, &live, backend, opts)?;
+        if engine.is_shadow_runtime_enabled()
+            && let Err(diff) = shadow_compare_migration_plan(&table_lower, &schema, &live, backend, opts)
+        {
+            crate::log_debug(format!("⚠️ Ferro shadow runtime mismatch: {diff}"));
+            if std::env::var("FERRO_SHADOW_RUNTIME_STRICT")
+                .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+                .unwrap_or(false)
+            {
+                return Err(pyo3::exceptions::PyRuntimeError::new_err(diff));
+            }
+        }
         if plan.is_empty() {
             warnings.append(&mut plan.warnings);
             continue;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -15,8 +15,8 @@ use crate::state::{
 use ferro_schema_ir::{IrEnvelope, QueryIrPayload};
 use pyo3::prelude::*;
 use sea_query::{
-    Alias, Expr, Iden, InsertStatement, OnConflict, Order, PostgresQueryBuilder, Query, SimpleExpr,
-    SqliteQueryBuilder, UpdateStatement, Value as SeaValue,
+    Alias, Condition, Expr, Iden, InsertStatement, OnConflict, Order, PostgresQueryBuilder, Query,
+    SimpleExpr, SqliteQueryBuilder, UpdateStatement, Value as SeaValue,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -223,6 +223,15 @@ fn query_def_from_ir_json(query_ir_json: &str) -> PyResult<QueryDef> {
     }
     query_def_from_ir_payload(envelope.payload)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid QueryIR: {e}")))
+}
+
+fn query_condition_for_backend(
+    query_def: &QueryDef,
+    backend: SqlDialect,
+) -> PyResult<Condition> {
+    query_def
+        .to_condition_for_backend(backend)
+        .map_err(pyo3::exceptions::PyValueError::new_err)
 }
 
 /// Map SeaQuery `Value` variants to `EngineBindValue`.
@@ -1224,7 +1233,9 @@ pub fn save_record(
                 .into_table(Alias::new(&table_name))
                 .columns(columns.clone())
                 .values(values)
-                .unwrap()
+                .map_err(|e| {
+                    pyo3::exceptions::PyValueError::new_err(format!("invalid INSERT values: {e}"))
+                })?
                 .to_owned();
             if let Some(pk) = pk_col.as_ref()
                 && (pk_provided || !pk_is_auto)
@@ -1525,7 +1536,7 @@ pub fn fetch_filtered<'py>(
                 ));
             }
 
-            select.cond_where(query_def.to_condition_for_backend(backend));
+            select.cond_where(query_condition_for_backend(&query_def, backend)?);
             if let Some(ref orders) = query_def.order_by {
                 for order in orders {
                     let col = Alias::new(&order.column);
@@ -1696,7 +1707,7 @@ pub fn count_filtered(
                 select.from(Alias::new(&table_name));
             }
 
-            select.cond_where(query_def.to_condition_for_backend(backend));
+            select.cond_where(query_condition_for_backend(&query_def, backend)?);
             sea_query_build_for_backend!(select, backend)
         };
         maybe_compare_shadow_query_artifacts(
@@ -1876,7 +1887,7 @@ pub fn delete_filtered(
             let mut delete = Query::delete();
             delete
                 .from_table(Alias::new(&table_name))
-                .cond_where(query_def.to_condition_for_backend(backend));
+                .cond_where(query_condition_for_backend(&query_def, backend)?);
             sea_query_build_for_backend!(delete, backend)
         };
         maybe_compare_shadow_query_artifacts(
@@ -1944,7 +1955,7 @@ pub fn update_filtered(
             })?;
             let mut update = UpdateStatement::new()
                 .table(Alias::new(&table_name))
-                .cond_where(query_def.to_condition_for_backend(backend))
+                .cond_where(query_condition_for_backend(&query_def, backend)?)
                 .to_owned();
             for (key, value) in update_map {
                 update.value(
@@ -2028,7 +2039,11 @@ pub fn add_m2m_links<'py>(
                         ),
                         backend_column_value_expr(&target_col, t_id, &uuid_columns, backend),
                     ])
-                    .unwrap();
+                    .map_err(|e| {
+                        pyo3::exceptions::PyValueError::new_err(format!(
+                            "invalid M2M INSERT values: {e}"
+                        ))
+                    })?;
             }
             sea_query_build_for_backend!(insert, backend)
         };
@@ -2428,7 +2443,7 @@ pub fn _shadow_compare_query_plan_for_test(
         Alias::new(query_def.model_name.to_lowercase()),
         sea_query::Asterisk,
     ));
-    select_legacy.cond_where(query_def.to_condition_for_backend(backend));
+    select_legacy.cond_where(query_condition_for_backend(&query_def, backend)?);
     if let Some(ref orders) = query_def.order_by {
         for order in orders {
             let dir = if order.direction.to_lowercase() == "desc" {
@@ -2715,7 +2730,7 @@ mod schema_value_expr_tests {
                 }
             }
         });
-        let (_, values) = build_pg_value(
+        let (sql, values) = build_pg_value(
             &schema,
             "thing",
             "amount",
@@ -2724,8 +2739,11 @@ mod schema_value_expr_tests {
         )
         .unwrap();
 
-        // Decimal null uses a typed float bind to avoid text-typed NULLs on Postgres.
-        assert!(matches!(values.0.as_slice(), [SeaValue::Double(None)]));
+        assert!(matches!(values.0.as_slice(), [SeaValue::String(None)]));
+        assert!(
+            sql.to_ascii_lowercase().contains("numeric"),
+            "expected numeric cast for decimal NULL, got {sql}"
+        );
     }
 
     #[test]

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -11,12 +11,13 @@ use crate::state::{
     IDENTITY_MAP, MODEL_REGISTRY, RustValue, SqlDialect, TRANSACTION_REGISTRY,
     TransactionConnection, TransactionHandle, connection_for_route, engine_for_connection,
 };
+use ferro_schema_ir::{IrEnvelope, QueryIrPayload};
 use pyo3::prelude::*;
 use sea_query::{
     Alias, Expr, Iden, InsertStatement, OnConflict, Order, PostgresQueryBuilder, Query, SimpleExpr,
     SqliteQueryBuilder, UpdateStatement, Value as SeaValue,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -62,6 +63,33 @@ fn active_route_for_operation(
 
 fn active_connection_for_route(using: Option<String>) -> PyResult<(String, Arc<EngineHandle>)> {
     connection_for_route(using)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct QueryIrEnvelope {
+    ir_kind: String,
+    ir_version: u32,
+    payload: QueryIrPayload,
+}
+
+fn query_def_from_ir_json(query_ir_json: &str) -> PyResult<QueryDef> {
+    let envelope: QueryIrEnvelope = serde_json::from_str(query_ir_json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("Invalid QueryIR JSON: {}", e))
+    })?;
+    if envelope.ir_kind != "query" {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "Invalid QueryIR envelope kind {:?}; expected \"query\"",
+            envelope.ir_kind
+        )));
+    }
+    if envelope.ir_version != 1 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "Unsupported QueryIR version {}; expected 1",
+            envelope.ir_version
+        )));
+    }
+    query_def_from_ir_payload(envelope.payload)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid QueryIR: {e}")))
 }
 
 /// Initialize Pydantic v2 slots that `BaseModel.__init__` normally sets, after zero-copy
@@ -1608,29 +1636,27 @@ pub fn save_bulk_records(
     })
 }
 
-/// Fetches records for a given model class based on a JSON-defined query.
+/// Fetches records for a given model class based on a QueryIR-defined query.
 ///
 /// Args:
 ///     cls (PyAny): The Python model class.
-///     query_json (str): The serialized QueryDef JSON.
+///     query_ir_json (str): The serialized QueryIR envelope JSON.
 ///
 /// Returns:
 ///     list[PyAny]: A list of hydrated model instances.
 #[pyfunction]
-#[pyo3(signature = (cls, query_json, tx_id=None, using=None))]
+#[pyo3(signature = (cls, query_ir_json, tx_id=None, using=None))]
 pub fn fetch_filtered<'py>(
     py: Python<'py>,
     cls: Bound<'py, PyAny>,
-    query_json: String,
+    query_ir_json: String,
     tx_id: Option<String>,
     using: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let name = cls.getattr("__name__")?.extract::<String>()?;
     let cls_py = cls.unbind();
 
-    let mut query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!("Invalid query JSON: {}", e))
-    })?;
+    let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
@@ -1717,7 +1743,12 @@ pub fn fetch_filtered<'py>(
             let (s, values) = sea_query_build_for_backend!(select, backend);
             (s, values, pk, schema.clone())
         };
-        maybe_compare_shadow_query_artifacts(&engine, "fetch_filtered", &query_def, &bind_values.0)?;
+        maybe_compare_shadow_query_artifacts(
+            &engine,
+            "fetch_filtered",
+            &query_def,
+            &bind_values.0,
+        )?;
 
         let parsed_data = match tx_conn {
             Some(conn_arc) => {
@@ -1804,17 +1835,15 @@ pub fn fetch_filtered<'py>(
 
 /// Returns the number of records matching a filtered query.
 #[pyfunction]
-#[pyo3(signature = (name, query_json, tx_id=None, using=None))]
+#[pyo3(signature = (name, query_ir_json, tx_id=None, using=None))]
 pub fn count_filtered(
     py: Python<'_>,
     name: String,
-    query_json: String,
+    query_ir_json: String,
     tx_id: Option<String>,
     using: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
-    let mut query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!("Invalid query JSON: {}", e))
-    })?;
+    let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
@@ -1876,7 +1905,12 @@ pub fn count_filtered(
             select.cond_where(query_def.to_condition_for_backend(backend));
             sea_query_build_for_backend!(select, backend)
         };
-        maybe_compare_shadow_query_artifacts(&engine, "count_filtered", &query_def, &bind_values.0)?;
+        maybe_compare_shadow_query_artifacts(
+            &engine,
+            "count_filtered",
+            &query_def,
+            &bind_values.0,
+        )?;
 
         let engine_bind_values = engine_bind_values_from_sea(&bind_values.0);
         let count = match tx_conn {
@@ -2009,17 +2043,15 @@ pub fn delete_record(
 
 /// Deletes records matching a filtered query.
 #[pyfunction]
-#[pyo3(signature = (name, query_json, tx_id=None, using=None))]
+#[pyo3(signature = (name, query_ir_json, tx_id=None, using=None))]
 pub fn delete_filtered(
     py: Python<'_>,
     name: String,
-    query_json: String,
+    query_ir_json: String,
     tx_id: Option<String>,
     using: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
-    let mut query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!("Invalid query JSON: {}", e))
-    })?;
+    let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
@@ -2035,7 +2067,12 @@ pub fn delete_filtered(
                 .cond_where(query_def.to_condition_for_backend(backend));
             sea_query_build_for_backend!(delete, backend)
         };
-        maybe_compare_shadow_query_artifacts(&engine, "delete_filtered", &query_def, &bind_values.0)?;
+        maybe_compare_shadow_query_artifacts(
+            &engine,
+            "delete_filtered",
+            &query_def,
+            &bind_values.0,
+        )?;
 
         let rows_affected =
             execute_statement_with_optional_tx(&engine, tx_conn, &sql, &bind_values.0)
@@ -2055,18 +2092,16 @@ pub fn delete_filtered(
 
 /// Updates records matching a filtered query with provided values.
 #[pyfunction]
-#[pyo3(signature = (name, query_json, update_json, tx_id=None, using=None))]
+#[pyo3(signature = (name, query_ir_json, update_json, tx_id=None, using=None))]
 pub fn update_filtered(
     py: Python<'_>,
     name: String,
-    query_json: String,
+    query_ir_json: String,
     update_json: String,
     tx_id: Option<String>,
     using: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
-    let mut query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!("Invalid query JSON: {}", e))
-    })?;
+    let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
     let update_values: serde_json::Value = serde_json::from_str(&update_json).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("Invalid update JSON: {}", e))
@@ -2115,7 +2150,12 @@ pub fn update_filtered(
             }
             sea_query_build_for_backend!(update, backend)
         };
-        maybe_compare_shadow_query_artifacts(&engine, "update_filtered", &query_def, &bind_values.0)?;
+        maybe_compare_shadow_query_artifacts(
+            &engine,
+            "update_filtered",
+            &query_def,
+            &bind_values.0,
+        )?;
 
         let rows_affected =
             execute_statement_with_optional_tx(&engine, tx_conn, &sql, &bind_values.0)
@@ -2522,9 +2562,9 @@ pub fn raw_fetch_one<'py>(
 
 #[pyfunction]
 #[pyo3(name = "_shadow_compare_query_plan_for_test")]
-#[pyo3(signature = (query_json, dialect, operation="select".to_string()))]
+#[pyo3(signature = (query_payload_json, dialect, operation="select".to_string()))]
 pub fn _shadow_compare_query_plan_for_test(
-    query_json: String,
+    query_payload_json: String,
     dialect: String,
     operation: String,
 ) -> PyResult<String> {
@@ -2538,12 +2578,35 @@ pub fn _shadow_compare_query_plan_for_test(
             )));
         }
     };
-    let query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!("Invalid query JSON: {}", e))
-    })?;
+    let query_def: QueryDef = if let Ok(ir_envelope) =
+        serde_json::from_str::<IrEnvelope<QueryIrPayload>>(&query_payload_json)
+    {
+        if ir_envelope.ir_kind != "query" {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Invalid QueryIR envelope kind {:?}; expected \"query\"",
+                ir_envelope.ir_kind
+            )));
+        }
+        if ir_envelope.ir_version != 1 {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Unsupported QueryIR version {}; expected 1",
+                ir_envelope.ir_version
+            )));
+        }
+        query_def_from_ir_payload(ir_envelope.payload).map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("Invalid QueryIR payload: {e}"))
+        })?
+    } else {
+        serde_json::from_str(&query_payload_json).map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("Invalid query payload JSON: {}", e))
+        })?
+    };
     let mut select_legacy = Query::select();
     select_legacy.from(Alias::new(query_def.model_name.to_lowercase()));
-    select_legacy.column((Alias::new(query_def.model_name.to_lowercase()), sea_query::Asterisk));
+    select_legacy.column((
+        Alias::new(query_def.model_name.to_lowercase()),
+        sea_query::Asterisk,
+    ));
     select_legacy.cond_where(query_def.to_condition_for_backend(backend));
     if let Some(ref orders) = query_def.order_by {
         for order in orders {
@@ -2576,8 +2639,9 @@ pub fn _shadow_compare_query_plan_for_test(
             "artifact": shadow,
         },
     });
-    serde_json::to_string(&payload)
-        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to encode JSON: {e}")))
+    serde_json::to_string(&payload).map_err(|e| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to encode JSON: {e}"))
+    })
 }
 
 #[cfg(test)]

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -8,8 +8,8 @@ use crate::backend::{
 };
 use crate::query::{QueryDef, query_def_from_ir_payload};
 use crate::state::{
-    IDENTITY_MAP, MODEL_REGISTRY, RustValue, SqlDialect, TRANSACTION_REGISTRY,
-    TransactionConnection, TransactionHandle, connection_for_route, engine_for_connection,
+    IDENTITY_MAP, MODEL_REGISTRY, SqlDialect, TRANSACTION_REGISTRY, TransactionConnection,
+    TransactionHandle, connection_for_route, engine_for_connection,
 };
 use ferro_schema_ir::{IrEnvelope, QueryIrPayload};
 use pyo3::prelude::*;
@@ -92,35 +92,6 @@ fn query_def_from_ir_json(query_ir_json: &str) -> PyResult<QueryDef> {
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid QueryIR: {e}")))
 }
 
-/// Initialize Pydantic v2 slots that `BaseModel.__init__` normally sets, after zero-copy
-/// hydration (`__new__` + `__dict__` population).
-///
-/// These attributes live in `__slots__`; if never assigned, reads raise `AttributeError`,
-/// which breaks `dict(model)`, iteration, `model_copy`, and libraries that recurse results
-/// (for example Prefect's `visit_collection`).
-///
-/// When `model_config["extra"] == "allow"`, `__pydantic_extra__` starts as an empty dict;
-/// otherwise it is `None`. `__pydantic_private__` is always `None` for ORM-hydrated rows.
-fn set_pydantic_hydration_slots<'py>(
-    py: Python<'py>,
-    cls: &Bound<'py, PyAny>,
-    instance: &Bound<'py, PyAny>,
-) -> PyResult<()> {
-    let model_config = cls.getattr(pyo3::intern!(py, "model_config"))?;
-    let extra_policy = model_config.call_method1(
-        pyo3::intern!(py, "get"),
-        (pyo3::intern!(py, "extra"), pyo3::intern!(py, "ignore")),
-    )?;
-    let extra_slot = if extra_policy.eq(pyo3::intern!(py, "allow"))? {
-        pyo3::types::PyDict::new(py).into_any().unbind()
-    } else {
-        py.None()
-    };
-    instance.setattr(pyo3::intern!(py, "__pydantic_extra__"), extra_slot)?;
-    instance.setattr(pyo3::intern!(py, "__pydantic_private__"), py.None())?;
-    Ok(())
-}
-
 /// Map SeaQuery `Value` variants to `EngineBindValue`.
 ///
 /// Typed `None` variants are preserved as `Null(NullKind::T)` so the bind
@@ -195,101 +166,24 @@ async fn execute_transaction_sql(
     conn.execute_sql(sql).await
 }
 
+#[cfg(test)]
 fn engine_value_to_rust_value(
     value: EngineValue,
     schema: &serde_json::Value,
     col_name: &str,
-) -> RustValue {
-    let prop = schema
-        .get("properties")
-        .and_then(|p| p.get(col_name))
-        .map(|col_info| resolve_ref(schema, col_info));
-
-    let format = prop.and_then(property_format);
-    let is_decimal = prop
-        .and_then(|p| p.get("anyOf"))
-        .and_then(|a| a.as_array())
-        .map(|types| {
-            let has_number = types
-                .iter()
-                .any(|t| t.get("type").and_then(|ty| ty.as_str()) == Some("number"));
-            let has_patterned_string = types.iter().any(|t| {
-                t.get("type").and_then(|ty| ty.as_str()) == Some("string")
-                    && t.get("pattern").is_some()
-            });
-            has_number && has_patterned_string
-        })
-        .unwrap_or(false);
-    let json_type = prop.and_then(property_json_type);
-
-    if is_decimal {
-        return match value {
-            EngineValue::I64(v) => RustValue::Decimal(v.to_string()),
-            EngineValue::F64(v) => RustValue::Decimal(v.to_string()),
-            EngineValue::String(v) => RustValue::Decimal(v),
-            _ => RustValue::None,
-        };
-    }
-
-    if format == Some("binary") {
-        return match value {
-            EngineValue::Bytes(v) => RustValue::Blob(v),
-            EngineValue::String(v) => RustValue::Blob(v.into_bytes()),
-            _ => RustValue::None,
-        };
-    }
-
-    match value {
-        EngineValue::I64(v) if json_type == Some("boolean") => RustValue::Bool(v != 0),
-        EngineValue::I64(v) => RustValue::BigInt(v),
-        EngineValue::F64(v) => RustValue::Double(v),
-        EngineValue::Bytes(v) => RustValue::Blob(v),
-        EngineValue::String(v) => match (json_type, format) {
-            (_, Some("date-time")) => RustValue::DateTime(v),
-            (_, Some("date")) => RustValue::Date(v),
-            (_, Some("uuid")) => RustValue::Uuid(v),
-            (Some("object"), _) | (Some("array"), _) => {
-                if let Ok(json_val) = serde_json::from_str(&v) {
-                    RustValue::Json(json_val)
-                } else {
-                    RustValue::String(v)
-                }
-            }
-            _ => RustValue::String(v),
-        },
-        EngineValue::Bool(v) => RustValue::Bool(v),
-        EngineValue::Null => RustValue::None,
-    }
+) -> crate::state::RustValue {
+    crate::codec::decode_engine_value(value, schema, col_name)
 }
 
 /// One parsed row: the primary-key value (when present) plus all column values.
-type ParsedRow = (Option<String>, Vec<(String, RustValue)>);
+type ParsedRow = crate::codec::ParsedRow;
 
 fn typed_rows_to_parsed_data(
     rows: Vec<EngineRow>,
     schema: &serde_json::Value,
     pk_col: Option<&str>,
 ) -> Vec<ParsedRow> {
-    rows.into_iter()
-        .map(|row| {
-            let mut row_pk_val = None;
-            let mut fields = Vec::with_capacity(row.values.len());
-
-            for (col_name, value) in row.values {
-                if pk_col == Some(col_name.as_str()) {
-                    row_pk_val = match &value {
-                        EngineValue::I64(v) => Some(v.to_string()),
-                        EngineValue::String(v) => Some(v.clone()),
-                        _ => None,
-                    };
-                }
-                let value = engine_value_to_rust_value(value, schema, &col_name);
-                fields.push((col_name, value));
-            }
-
-            (row_pk_val, fields)
-        })
-        .collect()
+    crate::codec::typed_rows_to_parsed_data(rows, schema, pk_col)
 }
 
 fn engine_row_string(row: &EngineRow, column_name: &str) -> Option<String> {
@@ -465,42 +359,6 @@ fn maybe_compare_shadow_query_artifacts(
 
 /// On Postgres, cast text-like special columns in SELECT output so Python hydration
 /// sees the same string representation as SQLite.
-fn property_json_type(col_info: &serde_json::Value) -> Option<&str> {
-    col_info.get("type").and_then(|t| t.as_str()).or_else(|| {
-        col_info
-            .get("anyOf")
-            .and_then(|a| a.as_array())
-            .and_then(|types| {
-                types.iter().find_map(|t| {
-                    let s = t.get("type")?.as_str()?;
-                    if s != "null" { None.or(Some(s)) } else { None }
-                })
-            })
-    })
-}
-
-fn property_format(col_info: &serde_json::Value) -> Option<&str> {
-    col_info.get("format").and_then(|f| f.as_str()).or_else(|| {
-        col_info
-            .get("anyOf")
-            .and_then(|a| a.as_array())
-            .and_then(|types| {
-                types.iter().find_map(|t| {
-                    let ty = t.get("type")?.as_str()?;
-                    if ty == "null" {
-                        None
-                    } else {
-                        t.get("format").and_then(|f| f.as_str())
-                    }
-                })
-            })
-    })
-}
-
-fn property_is_enum(col_info: &serde_json::Value) -> bool {
-    col_info.get("enum").and_then(|e| e.as_array()).is_some()
-}
-
 fn apply_postgres_text_select_columns(
     select: &mut sea_query::SelectStatement,
     table_name: &str,
@@ -508,64 +366,13 @@ fn apply_postgres_text_select_columns(
     pg_native_enum_columns: &HashSet<String>,
     backend: SqlDialect,
 ) {
-    use sea_query::{Alias, Expr};
-
-    let tbl = Alias::new(table_name);
-    if backend != SqlDialect::Postgres {
-        select.column((tbl.clone(), sea_query::Asterisk));
-        return;
-    }
-    let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) else {
-        select.column((tbl.clone(), sea_query::Asterisk));
-        return;
-    };
-    let need_text_from_schema = properties.values().any(|col_info| {
-        let resolved = resolve_ref(schema, col_info);
-        matches!(
-            property_format(resolved),
-            Some("uuid" | "date-time" | "date" | "decimal")
-        ) || matches!(property_json_type(resolved), Some("object" | "array"))
-            || property_is_enum(resolved)
-    });
-    let need_text_from_native_enum = properties
-        .keys()
-        .any(|k| pg_native_enum_columns.contains(k.as_str()));
-    if !need_text_from_schema && !need_text_from_native_enum {
-        select.column((tbl.clone(), sea_query::Asterisk));
-        return;
-    }
-    for (col_name, col_info) in properties {
-        let col_iden = Alias::new(col_name.as_str());
-        let col_info = resolve_ref(schema, col_info);
-        if matches!(
-            property_format(col_info),
-            Some("uuid" | "date-time" | "date" | "decimal")
-        ) || matches!(property_json_type(col_info), Some("object" | "array"))
-            || property_is_enum(col_info)
-            || pg_native_enum_columns.contains(col_name.as_str())
-        {
-            let expr = Expr::cast_as(
-                Expr::col((tbl.clone(), col_iden.clone())),
-                Alias::new("text"),
-            );
-            select.expr_as(expr, col_iden);
-        } else {
-            select.column((tbl.clone(), col_iden));
-        }
-    }
-}
-
-fn resolve_ref<'a>(
-    schema: &'a serde_json::Value,
-    col_info: &'a serde_json::Value,
-) -> &'a serde_json::Value {
-    if let Some(ref_path) = col_info.get("$ref").and_then(|r| r.as_str())
-        && let Some(def_name) = ref_path.strip_prefix("#/$defs/")
-        && let Some(def) = schema.get("$defs").and_then(|defs| defs.get(def_name))
-    {
-        return def;
-    }
-    col_info
+    crate::codec::apply_postgres_text_select_columns(
+        select,
+        table_name,
+        schema,
+        pg_native_enum_columns,
+        backend,
+    );
 }
 
 /// Maps each table column to its PostgreSQL enum `typname` (``typtype = 'e'``) for the current schema.
@@ -675,16 +482,6 @@ async fn postgres_temporal_cast_by_column(
     Ok(out)
 }
 
-fn schema_property<'a>(
-    schema: &'a serde_json::Value,
-    col_name: &str,
-) -> Option<&'a serde_json::Value> {
-    schema
-        .get("properties")
-        .and_then(|p| p.get(col_name))
-        .map(|prop| resolve_ref(schema, prop))
-}
-
 /// Build a SeaQuery expression for a column value, preserving type information
 /// across NULL and primitive binds so the SQLx layer can emit a parameter with
 /// the correct OID on strict-typing backends (notably PostgreSQL).
@@ -707,153 +504,16 @@ fn schema_value_expr(
     ts_cast: &HashMap<String, String>,
     backend: SqlDialect,
 ) -> PyResult<SimpleExpr> {
-    let col_info = schema_property(schema, col_name);
-    let format = col_info.and_then(property_format);
-    let json_type = col_info.and_then(property_json_type);
-    let is_decimal = col_info
-        .and_then(|prop| prop.get("anyOf"))
-        .and_then(|a| a.as_array())
-        .map(|items| items.iter().any(|item| item.get("pattern").is_some()))
-        .unwrap_or(false);
-    // UUID columns are detected either via DB introspection (uuid_columns
-    // populated by postgres_uuid_column_names) or via Pydantic format hint.
-    let is_uuid_pg = backend == SqlDialect::Postgres
-        && (uuid_columns.contains(col_name) || format == Some("uuid"));
-
-    if let serde_json::Value::String(s) = value
-        && backend == SqlDialect::Postgres
-        && let Some(tn) =
-            crate::schema_bind::postgres_enum_type_name_for_column(col_name, enum_udt, col_info)
-    {
-        return Ok(crate::schema_bind::postgres_enum_string_rhs_expr(s, &tn));
-    }
-
-    if is_uuid_pg {
-        return match value {
-            serde_json::Value::Null => Ok(Expr::value(sea_query::Value::Uuid(None))),
-            serde_json::Value::String(s) => {
-                let parsed = uuid::Uuid::parse_str(s).map_err(|_| {
-                    pyo3::exceptions::PyValueError::new_err(format!(
-                        "Invalid UUID for {table_name}.{col_name}: {s}"
-                    ))
-                })?;
-                Ok(Expr::value(sea_query::Value::Uuid(Some(Box::new(parsed)))))
-            }
-            // Anything else (number, bool, etc.) for a UUID column is a
-            // user-side bug; let the existing fallthrough surface it.
-            _ => Ok(Expr::value(sea_query::Value::String(Some(Box::new(
-                value.to_string(),
-            ))))),
-        };
-    }
-
-    // Temporal types (date, date-time, time) are deferred to issue #40 pending
-    // the chrono-vs-time crate decision. For now they keep cast_as wrappers.
-    if value.is_null()
-        && backend == SqlDialect::Postgres
-        && let Some(cast) = ts_cast.get(col_name)
-    {
-        return Ok(Expr::value(sea_query::Value::String(None)).cast_as(Alias::new(cast.as_str())));
-    }
-    if let serde_json::Value::String(s) = value
-        && backend == SqlDialect::Postgres
-        && let Some(cast) = ts_cast.get(col_name)
-    {
-        return Ok(
-            Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
-                .cast_as(Alias::new(cast.as_str())),
-        );
-    }
-
-    let expr = match value {
-        value
-            if backend == SqlDialect::Postgres && matches!(json_type, Some("object" | "array")) =>
-        {
-            // JSON/JSONB binding is out of scope for the typed-null refactor.
-            if value.is_null() {
-                Expr::value(sea_query::Value::String(None)).cast_as("json")
-            } else {
-                Expr::value(sea_query::Value::String(Some(Box::new(value.to_string()))))
-                    .cast_as("json")
-            }
-        }
-        serde_json::Value::String(s)
-            if backend == SqlDialect::Postgres && format == Some("date-time") =>
-        {
-            Expr::value(sea_query::Value::String(Some(Box::new(s.clone())))).cast_as("timestamptz")
-        }
-        serde_json::Value::String(s)
-            if backend == SqlDialect::Postgres && format == Some("date") =>
-        {
-            Expr::value(sea_query::Value::String(Some(Box::new(s.clone())))).cast_as("date")
-        }
-        serde_json::Value::String(s) if json_type == Some("integer") => {
-            if let Ok(parsed) = s.parse::<i64>() {
-                Expr::value(sea_query::Value::BigInt(Some(parsed)))
-            } else {
-                Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
-            }
-        }
-        serde_json::Value::String(s) if json_type == Some("number") => {
-            if let Ok(parsed) = s.parse::<f64>() {
-                Expr::value(sea_query::Value::Double(Some(parsed)))
-            } else {
-                Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
-            }
-        }
-        serde_json::Value::String(s) if format == Some("binary") => Expr::value(
-            sea_query::Value::Bytes(Some(Box::new(s.as_bytes().to_vec()))),
-        ),
-        serde_json::Value::String(s) if is_decimal => {
-            if let Ok(parsed) = s.parse::<f64>() {
-                Expr::value(sea_query::Value::Double(Some(parsed)))
-            } else {
-                Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
-            }
-        }
-        serde_json::Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                Expr::value(sea_query::Value::BigInt(Some(i)))
-            } else if let Some(f) = n.as_f64() {
-                Expr::value(sea_query::Value::Double(Some(f)))
-            } else {
-                Expr::value(sea_query::Value::String(None))
-            }
-        }
-        serde_json::Value::String(s) => {
-            Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
-        }
-        serde_json::Value::Bool(b)
-            if json_type == Some("boolean") && backend == SqlDialect::Sqlite =>
-        {
-            Expr::value(sea_query::Value::BigInt(Some(if *b { 1 } else { 0 })))
-        }
-        serde_json::Value::Bool(b) => Expr::value(sea_query::Value::Bool(Some(*b))),
-        serde_json::Value::Null => {
-            // Typed-null pick from column metadata. UUID is handled above;
-            // JSON/temporal are handled above. This arm covers primitives,
-            // bytes, and decimal. Unknown shapes fall through to text-typed
-            // null (the bind layer logs this as NullKind::String / Untyped).
-            let v = if format == Some("binary") {
-                sea_query::Value::Bytes(None)
-            } else if is_decimal {
-                // Decimal binds as float8-typed null today; native numeric
-                // typed null is deferred (see plan §3 Scope Boundaries).
-                sea_query::Value::Double(None)
-            } else {
-                match json_type {
-                    Some("integer") => sea_query::Value::BigInt(None),
-                    Some("number") => sea_query::Value::Double(None),
-                    Some("boolean") => sea_query::Value::Bool(None),
-                    Some("string") => sea_query::Value::String(None),
-                    _ => sea_query::Value::String(None),
-                }
-            };
-            Expr::value(v)
-        }
-        _ => Expr::value(sea_query::Value::String(Some(Box::new(value.to_string())))),
-    };
-    Ok(expr)
+    crate::codec::schema_bind_expr(
+        schema,
+        table_name,
+        col_name,
+        value,
+        enum_udt,
+        uuid_columns,
+        ts_cast,
+        backend,
+    )
 }
 
 /// Wrap an M2M target/source ID in a SeaQuery expression for a join table.
@@ -869,15 +529,7 @@ fn backend_column_value_expr(
     uuid_columns: &HashSet<String>,
     backend: SqlDialect,
 ) -> SimpleExpr {
-    if backend == SqlDialect::Postgres && uuid_columns.contains(col_name) {
-        if let sea_query::Value::String(Some(s)) = &value
-            && let Ok(parsed) = uuid::Uuid::parse_str(s)
-        {
-            return Expr::value(sea_query::Value::Uuid(Some(Box::new(parsed))));
-        }
-        return Expr::value(value).cast_as("uuid");
-    }
-    Expr::value(value)
+    crate::codec::m2m_bind_expr(col_name, value, uuid_columns, backend)
 }
 
 #[pyfunction]
@@ -1119,11 +771,6 @@ pub fn fetch_all<'py>(
                 }
             }
 
-            let dict_str = pyo3::intern!(py, "__dict__");
-            let pydantic_fields_set_str = pyo3::intern!(py, "__pydantic_fields_set__");
-            let new_str = pyo3::intern!(py, "__new__");
-            let connection_attr_str = pyo3::intern!(py, "__ferro_connection_name");
-
             for (row_pk_val, fields) in parsed_data {
                 if use_identity_map
                     && let Some(ref pk_val) = row_pk_val
@@ -1134,21 +781,13 @@ pub fn fetch_all<'py>(
                     continue;
                 }
 
-                let instance = cls.call_method1(new_str, (cls,))?;
-                let dict_attr = instance.getattr(dict_str)?;
-                let dict = dict_attr.cast::<pyo3::types::PyDict>()?;
-                dict.set_item(connection_attr_str, &connection_name)?;
-                let fields_set = pyo3::types::PySet::empty(py)?;
-
-                for (col_name, val) in fields {
-                    let py_val = val.into_py_any(py)?;
-                    let py_name = py_col_names.get(&col_name).unwrap().bind(py);
-                    dict.set_item(py_name, py_val)?;
-                    fields_set.add(py_name)?;
-                }
-
-                let _ = instance.setattr(pydantic_fields_set_str, fields_set);
-                set_pydantic_hydration_slots(py, cls, &instance)?;
+                let instance = crate::hydration::hydrate_model_instance(
+                    py,
+                    cls,
+                    &connection_name,
+                    fields,
+                    &py_col_names,
+                )?;
 
                 if use_identity_map && let Some(pk_val) = row_pk_val {
                     IDENTITY_MAP.insert(
@@ -1294,24 +933,14 @@ pub fn fetch_one<'py>(
         match parsed_row {
             Some(fields) => Python::attach(|py| {
                 let cls = cls_py.bind(py);
-                let instance = cls.call_method1("__new__", (cls,))?;
-                let dict_attr = instance.getattr(pyo3::intern!(py, "__dict__"))?;
-                let dict = dict_attr.cast::<pyo3::types::PyDict>()?;
-                dict.set_item(
-                    pyo3::intern!(py, "__ferro_connection_name"),
+                let py_col_names = HashMap::new();
+                let instance = crate::hydration::hydrate_model_instance(
+                    py,
+                    cls,
                     &connection_name,
+                    fields,
+                    &py_col_names,
                 )?;
-                let fields_set = pyo3::types::PySet::empty(py)?;
-
-                for (col_name, val) in fields {
-                    let py_val = val.into_py_any(py)?;
-                    let py_name = pyo3::types::PyString::new(py, &col_name);
-                    dict.set_item(&py_name, py_val)?;
-                    fields_set.add(&py_name)?;
-                }
-
-                let _ = instance.setattr(pyo3::intern!(py, "__pydantic_fields_set__"), fields_set);
-                set_pydantic_hydration_slots(py, cls, &instance)?;
                 if use_identity_map {
                     IDENTITY_MAP.insert(
                         (connection_name.clone(), name.clone(), pk_val),
@@ -1788,11 +1417,6 @@ pub fn fetch_filtered<'py>(
                 }
             }
 
-            let dict_str = pyo3::intern!(py, "__dict__");
-            let pydantic_fields_set_str = pyo3::intern!(py, "__pydantic_fields_set__");
-            let new_str = pyo3::intern!(py, "__new__");
-            let connection_attr_str = pyo3::intern!(py, "__ferro_connection_name");
-
             for (row_pk_val, fields) in parsed_data {
                 if use_identity_map
                     && let Some(ref pk_val) = row_pk_val
@@ -1803,21 +1427,13 @@ pub fn fetch_filtered<'py>(
                     continue;
                 }
 
-                let instance = cls.call_method1(new_str, (cls,))?;
-                let dict_attr = instance.getattr(dict_str)?;
-                let dict = dict_attr.cast::<pyo3::types::PyDict>()?;
-                dict.set_item(connection_attr_str, &connection_name)?;
-                let fields_set = pyo3::types::PySet::empty(py)?;
-
-                for (col_name, val) in fields {
-                    let py_val = val.into_py_any(py)?;
-                    let py_name = py_col_names.get(&col_name).unwrap().bind(py);
-                    dict.set_item(py_name, py_val)?;
-                    fields_set.add(py_name)?;
-                }
-
-                let _ = instance.setattr(pydantic_fields_set_str, fields_set);
-                set_pydantic_hydration_slots(py, cls, &instance)?;
+                let instance = crate::hydration::hydrate_model_instance(
+                    py,
+                    cls,
+                    &connection_name,
+                    fields,
+                    &py_col_names,
+                )?;
 
                 if use_identity_map && let Some(pk_val) = row_pk_val {
                     IDENTITY_MAP.insert(
@@ -2903,7 +2519,7 @@ mod schema_value_expr_tests {
         )
         .unwrap();
 
-        // Decimal binds as float8-typed null; native numeric is deferred.
+        // Decimal null uses a typed float bind to avoid text-typed NULLs on Postgres.
         assert!(matches!(values.0.as_slice(), [SeaValue::Double(None)]));
     }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -8,8 +8,9 @@ use crate::backend::{
 };
 use crate::query::{QueryDef, query_def_from_ir_payload};
 use crate::state::{
-    IDENTITY_MAP, MODEL_REGISTRY, SqlDialect, TRANSACTION_REGISTRY, TransactionConnection,
-    TransactionHandle, connection_for_route, engine_for_connection,
+    IDENTITY_MAP, MODEL_REGISTRY, SqlDialect, TRANSACTION_REGISTRY,
+    TransactionConnection, TransactionHandle, connection_for_route, engine_for_connection,
+    register_session, session_state, unregister_session,
 };
 use ferro_schema_ir::{IrEnvelope, QueryIrPayload};
 use pyo3::prelude::*;
@@ -21,40 +22,77 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-fn get_transaction_connection(tx_id: Option<String>) -> Option<TransactionConnection> {
-    tx_id.and_then(|id| {
-        TRANSACTION_REGISTRY
+fn get_transaction_connection(
+    tx_id: Option<String>,
+    session_id: Option<&str>,
+) -> PyResult<Option<TransactionConnection>> {
+    if let Some(id) = tx_id {
+        if let Some(session_id) = session_id {
+            let session = session_state(session_id)?;
+            return Ok(session
+                .transaction_registry
+                .get(&id)
+                .map(|tx| tx.value().conn.clone()));
+        }
+        return Ok(TRANSACTION_REGISTRY
             .get(&id)
-            .map(|tx| tx.value().conn.clone())
-    })
+            .map(|tx| tx.value().conn.clone()));
+    }
+    Ok(None)
 }
 
-fn get_transaction_route(tx_id: Option<String>) -> Option<(String, TransactionConnection)> {
-    tx_id.and_then(|id| {
-        TRANSACTION_REGISTRY
+fn get_transaction_route(
+    tx_id: Option<String>,
+    session_id: Option<&str>,
+) -> PyResult<Option<(String, TransactionConnection)>> {
+    if let Some(id) = tx_id {
+        if let Some(session_id) = session_id {
+            let session = session_state(session_id)?;
+            return Ok(session
+                .transaction_registry
+                .get(&id)
+                .map(|tx| (tx.value().connection_name.clone(), tx.value().conn.clone())));
+        }
+        return Ok(TRANSACTION_REGISTRY
             .get(&id)
-            .map(|tx| (tx.value().connection_name.clone(), tx.value().conn.clone()))
-    })
+            .map(|tx| (tx.value().connection_name.clone(), tx.value().conn.clone())));
+    }
+    Ok(None)
 }
 
-fn active_engine_for_connection(using: Option<String>) -> PyResult<Arc<EngineHandle>> {
+fn active_engine_for_connection(
+    using: Option<String>,
+    session_id: Option<&str>,
+) -> PyResult<Arc<EngineHandle>> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        let connection_name = using.unwrap_or_else(|| session.connection_name.clone());
+        return engine_for_connection(Some(connection_name));
+    }
     engine_for_connection(using)
 }
 
 fn active_route_for_operation(
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<(
     String,
     Arc<EngineHandle>,
     Option<TransactionConnection>,
     BackendKind,
 )> {
-    let tx_route = get_transaction_route(tx_id);
+    let tx_route = get_transaction_route(tx_id, session_id.as_deref())?;
+    let session_connection = if let Some(ref sid) = session_id {
+        Some(session_state(sid)?.connection_name.clone())
+    } else {
+        None
+    };
     let route_using = tx_route
         .as_ref()
         .map(|(connection_name, _)| connection_name.clone())
-        .or(using);
+        .or(using)
+        .or(session_connection);
     let (connection_name, engine) = active_connection_for_route(route_using)?;
     let backend = engine.backend();
     let tx_conn = tx_route.map(|(_, conn)| conn);
@@ -63,6 +101,101 @@ fn active_route_for_operation(
 
 fn active_connection_for_route(using: Option<String>) -> PyResult<(String, Arc<EngineHandle>)> {
     connection_for_route(using)
+}
+
+fn identity_map_get(
+    session_id: Option<&str>,
+    key: &(String, String, String),
+) -> PyResult<Option<Py<PyAny>>> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        return Ok(session.identity_map.get(key).map(|entry| {
+            Python::attach(|py| entry.value().clone_ref(py))
+        }));
+    }
+    Ok(IDENTITY_MAP
+        .get(key)
+        .map(|entry| Python::attach(|py| entry.value().clone_ref(py))))
+}
+
+fn identity_map_insert(
+    session_id: Option<&str>,
+    key: (String, String, String),
+    value: Py<PyAny>,
+) -> PyResult<()> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        session.identity_map.insert(key, value);
+        return Ok(());
+    }
+    IDENTITY_MAP.insert(key, value);
+    Ok(())
+}
+
+fn identity_map_remove(session_id: Option<&str>, key: &(String, String, String)) -> PyResult<()> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        session.identity_map.remove(key);
+        return Ok(());
+    }
+    IDENTITY_MAP.remove(key);
+    Ok(())
+}
+
+fn identity_map_retain_model(session_id: Option<&str>, model_name: &str) -> PyResult<()> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        session
+            .identity_map
+            .retain(|(_, m_name, _), _| m_name != model_name);
+        return Ok(());
+    }
+    IDENTITY_MAP.retain(|(_, m_name, _), _| m_name != model_name);
+    Ok(())
+}
+
+fn identity_map_clear(session_id: Option<&str>) -> PyResult<()> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        session.identity_map.clear();
+        return Ok(());
+    }
+    IDENTITY_MAP.clear();
+    Ok(())
+}
+
+fn tx_get(session_id: Option<&str>, tx_id: &str) -> PyResult<Option<TransactionHandle>> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        return Ok(session
+            .transaction_registry
+            .get(tx_id)
+            .map(|entry| entry.value().clone()));
+    }
+    Ok(TRANSACTION_REGISTRY
+        .get(tx_id)
+        .map(|entry| entry.value().clone()))
+}
+
+fn tx_insert(session_id: Option<&str>, tx_id: String, handle: TransactionHandle) -> PyResult<()> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        session.transaction_registry.insert(tx_id, handle);
+        return Ok(());
+    }
+    TRANSACTION_REGISTRY.insert(tx_id, handle);
+    Ok(())
+}
+
+fn tx_remove(session_id: Option<&str>, tx_id: &str) -> PyResult<Option<TransactionHandle>> {
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        return Ok(session
+            .transaction_registry
+            .remove(tx_id)
+            .map(|(_, handle)| handle));
+    }
+    Ok(TRANSACTION_REGISTRY.remove(tx_id).map(|(_, handle)| handle))
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -533,11 +666,12 @@ fn backend_column_value_expr(
 }
 
 #[pyfunction]
-#[pyo3(signature = (parent_tx_id=None, using=None))]
+#[pyo3(signature = (parent_tx_id=None, using=None, session_id=None))]
 pub fn begin_transaction(
     py: Python<'_>,
     parent_tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let tx_id = uuid::Uuid::new_v4().to_string();
@@ -548,12 +682,10 @@ pub fn begin_transaction(
                 ));
             }
 
-            let parent = TRANSACTION_REGISTRY.get(&parent_tx_id).ok_or_else(|| {
-                pyo3::exceptions::PyRuntimeError::new_err("Parent transaction not found")
-            })?;
+            let parent = tx_get(session_id.as_deref(), &parent_tx_id)?
+                .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Parent transaction not found"))?;
             let conn = parent.conn.clone();
             let connection_name = parent.connection_name.clone();
-            drop(parent);
 
             let savepoint_name = format!("sp_{}", tx_id.replace('-', "_"));
             execute_transaction_sql(&conn, &format!("SAVEPOINT {savepoint_name}"))
@@ -565,20 +697,27 @@ pub fn begin_transaction(
                     ))
                 })?;
 
-            TRANSACTION_REGISTRY.insert(
+            tx_insert(
+                session_id.as_deref(),
                 tx_id.clone(),
                 TransactionHandle::nested(conn, savepoint_name, connection_name),
-            );
+            )?;
         } else {
-            let (connection_name, engine) = active_connection_for_route(using)?;
+            let (connection_name, engine) = active_route_for_operation(
+                None,
+                using,
+                session_id.clone(),
+            )
+            .map(|(name, engine, _, _)| (name, engine))?;
             let conn = engine.begin_transaction_connection().await.map_err(|e| {
                 pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to BEGIN: {}", e))
             })?;
 
-            TRANSACTION_REGISTRY.insert(
+            tx_insert(
+                session_id.as_deref(),
                 tx_id.clone(),
                 TransactionHandle::root(conn, connection_name),
-            );
+            )?;
         }
 
         Ok(tx_id)
@@ -586,12 +725,15 @@ pub fn begin_transaction(
 }
 
 #[pyfunction]
-pub fn commit_transaction(py: Python<'_>, tx_id: String) -> PyResult<Bound<'_, PyAny>> {
+#[pyo3(signature = (tx_id, session_id=None))]
+pub fn commit_transaction(
+    py: Python<'_>,
+    tx_id: String,
+    session_id: Option<String>,
+) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let tx_handle = TRANSACTION_REGISTRY
-            .remove(&tx_id)
-            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Transaction not found"))?
-            .1;
+        let tx_handle = tx_remove(session_id.as_deref(), &tx_id)?
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Transaction not found"))?;
 
         if let Some(savepoint_name) = tx_handle.savepoint_name {
             execute_transaction_sql(
@@ -618,20 +760,23 @@ pub fn commit_transaction(py: Python<'_>, tx_id: String) -> PyResult<Bound<'_, P
 }
 
 #[pyfunction]
-pub fn transaction_connection_name(tx_id: String) -> PyResult<String> {
-    TRANSACTION_REGISTRY
-        .get(&tx_id)
-        .map(|tx| tx.value().connection_name.clone())
+#[pyo3(signature = (tx_id, session_id=None))]
+pub fn transaction_connection_name(tx_id: String, session_id: Option<String>) -> PyResult<String> {
+    tx_get(session_id.as_deref(), &tx_id)?
+        .map(|tx| tx.connection_name)
         .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Transaction not found"))
 }
 
 #[pyfunction]
-pub fn rollback_transaction(py: Python<'_>, tx_id: String) -> PyResult<Bound<'_, PyAny>> {
+#[pyo3(signature = (tx_id, session_id=None))]
+pub fn rollback_transaction(
+    py: Python<'_>,
+    tx_id: String,
+    session_id: Option<String>,
+) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let tx_handle = TRANSACTION_REGISTRY
-            .remove(&tx_id)
-            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Transaction not found"))?
-            .1;
+        let tx_handle = tx_remove(session_id.as_deref(), &tx_id)?
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Transaction not found"))?;
 
         if let Some(savepoint_name) = tx_handle.savepoint_name {
             execute_transaction_sql(
@@ -664,9 +809,27 @@ pub fn rollback_transaction(py: Python<'_>, tx_id: String) -> PyResult<Bound<'_,
                 })?;
         }
 
-        IDENTITY_MAP.clear();
+        identity_map_clear(session_id.as_deref())?;
         Ok(())
     })
+}
+
+#[pyfunction]
+#[pyo3(signature = (using=None))]
+pub fn open_session(using: Option<String>) -> PyResult<String> {
+    let (connection_name, _) = active_connection_for_route(using)?;
+    Ok(register_session(connection_name))
+}
+
+#[pyfunction]
+pub fn close_session(session_id: String) -> PyResult<()> {
+    if !unregister_session(&session_id) {
+        return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "Session '{}' is not active",
+            session_id
+        )));
+    }
+    Ok(())
 }
 
 /// Fetches all records for a given model class.
@@ -683,18 +846,19 @@ pub fn rollback_transaction(py: Python<'_>, tx_id: String) -> PyResult<Bound<'_,
 /// # Errors
 /// Returns a `PyErr` if the engine is not initialized or if the query fails.
 #[pyfunction]
-#[pyo3(signature = (cls, tx_id=None, using=None))]
+#[pyo3(signature = (cls, tx_id=None, using=None, session_id=None))]
 pub fn fetch_all<'py>(
     py: Python<'py>,
     cls: Bound<'py, PyAny>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let name = cls.getattr("__name__")?.extract::<String>()?;
     let cls_py = cls.unbind();
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
         let use_identity_map = engine.is_identity_map_enabled();
 
         let table_name = name.to_lowercase();
@@ -774,10 +938,12 @@ pub fn fetch_all<'py>(
             for (row_pk_val, fields) in parsed_data {
                 if use_identity_map
                     && let Some(ref pk_val) = row_pk_val
-                    && let Some(existing_obj) =
-                        IDENTITY_MAP.get(&(connection_name.clone(), name.clone(), pk_val.clone()))
+                    && let Some(existing_obj) = identity_map_get(
+                        session_id.as_deref(),
+                        &(connection_name.clone(), name.clone(), pk_val.clone()),
+                    )?
                 {
-                    results.append(existing_obj.value().clone_ref(py))?;
+                    results.append(existing_obj.clone_ref(py))?;
                     continue;
                 }
 
@@ -790,10 +956,11 @@ pub fn fetch_all<'py>(
                 )?;
 
                 if use_identity_map && let Some(pk_val) = row_pk_val {
-                    IDENTITY_MAP.insert(
+                    identity_map_insert(
+                        session_id.as_deref(),
                         (connection_name.clone(), name.clone(), pk_val),
                         instance.clone().unbind(),
-                    );
+                    )?;
                 }
 
                 results.append(instance)?;
@@ -818,29 +985,32 @@ pub fn fetch_all<'py>(
 /// # Errors
 /// Returns a `PyErr` if the engine is not initialized or if the query fails.
 #[pyfunction]
-#[pyo3(signature = (cls, pk_val, tx_id=None, using=None))]
+#[pyo3(signature = (cls, pk_val, tx_id=None, using=None, session_id=None))]
 pub fn fetch_one<'py>(
     py: Python<'py>,
     cls: Bound<'py, PyAny>,
     pk_val: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let name = cls.getattr("__name__")?.extract::<String>()?;
     let cls_py = cls.unbind();
-    let (connection_name, engine) = active_connection_for_route(using.clone())?;
+    let (connection_name, engine) = active_route_for_operation(tx_id.clone(), using.clone(), session_id.clone()).map(|(c,e,_,_)|(c,e))?;
 
     // Check Identity Map first (if no transaction, or even with transaction, IM is usually safe)
     if engine.is_identity_map_enabled()
-        && let Some(existing_obj) =
-            IDENTITY_MAP.get(&(connection_name.clone(), name.clone(), pk_val.clone()))
+        && let Some(existing_obj) = identity_map_get(
+            session_id.as_deref(),
+            &(connection_name.clone(), name.clone(), pk_val.clone()),
+        )?
     {
-        let obj = existing_obj.value().clone_ref(py);
+        let obj = existing_obj.clone_ref(py);
         return pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(obj) });
     }
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
         let use_identity_map = engine.is_identity_map_enabled();
 
         let table_name = name.to_lowercase();
@@ -942,10 +1112,11 @@ pub fn fetch_one<'py>(
                     &py_col_names,
                 )?;
                 if use_identity_map {
-                    IDENTITY_MAP.insert(
+                    identity_map_insert(
+                        session_id.as_deref(),
                         (connection_name.clone(), name.clone(), pk_val),
                         instance.clone().unbind(),
-                    );
+                    )?;
                 }
                 Ok(instance.into_any().unbind())
             }),
@@ -965,17 +1136,18 @@ pub fn fetch_one<'py>(
 /// # Errors
 /// Returns a `PyErr` if the engine is not initialized or if the save fails.
 #[pyfunction]
-#[pyo3(signature = (name, data, tx_id=None, using=None))]
+#[pyo3(signature = (name, data, tx_id=None, using=None, session_id=None))]
 pub fn save_record(
     py: Python<'_>,
     name: String,
     data: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (_connection_name, engine, tx_conn, backend) =
-            active_route_for_operation(tx_id, using)?;
+            active_route_for_operation(tx_id, using, session_id.clone())?;
 
         // ... schema and record logic ...
         let (schema, record_obj) = {
@@ -1138,17 +1310,18 @@ pub fn save_record(
 
 /// Persists multiple model instances in a single batch operation.
 #[pyfunction]
-#[pyo3(signature = (name, data_list_json, tx_id=None, using=None))]
+#[pyo3(signature = (name, data_list_json, tx_id=None, using=None, session_id=None))]
 pub fn save_bulk_records(
     py: Python<'_>,
     name: String,
     data_list_json: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (_connection_name, engine, tx_conn, backend) =
-            active_route_for_operation(tx_id, using)?;
+            active_route_for_operation(tx_id, using, session_id.clone())?;
 
         let schema = {
             let registry = MODEL_REGISTRY.read().map_err(|_| {
@@ -1274,13 +1447,14 @@ pub fn save_bulk_records(
 /// Returns:
 ///     list[PyAny]: A list of hydrated model instances.
 #[pyfunction]
-#[pyo3(signature = (cls, query_ir_json, tx_id=None, using=None))]
+#[pyo3(signature = (cls, query_ir_json, tx_id=None, using=None, session_id=None))]
 pub fn fetch_filtered<'py>(
     py: Python<'py>,
     cls: Bound<'py, PyAny>,
     query_ir_json: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let name = cls.getattr("__name__")?.extract::<String>()?;
     let cls_py = cls.unbind();
@@ -1288,7 +1462,7 @@ pub fn fetch_filtered<'py>(
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
         let use_identity_map = engine.is_identity_map_enabled();
 
         let table_name = name.to_lowercase();
@@ -1420,10 +1594,12 @@ pub fn fetch_filtered<'py>(
             for (row_pk_val, fields) in parsed_data {
                 if use_identity_map
                     && let Some(ref pk_val) = row_pk_val
-                    && let Some(existing_obj) =
-                        IDENTITY_MAP.get(&(connection_name.clone(), name.clone(), pk_val.clone()))
+                    && let Some(existing_obj) = identity_map_get(
+                        session_id.as_deref(),
+                        &(connection_name.clone(), name.clone(), pk_val.clone()),
+                    )?
                 {
-                    results.append(existing_obj.value().clone_ref(py))?;
+                    results.append(existing_obj.clone_ref(py))?;
                     continue;
                 }
 
@@ -1436,10 +1612,11 @@ pub fn fetch_filtered<'py>(
                 )?;
 
                 if use_identity_map && let Some(pk_val) = row_pk_val {
-                    IDENTITY_MAP.insert(
+                    identity_map_insert(
+                        session_id.as_deref(),
                         (connection_name.clone(), name.clone(), pk_val),
                         instance.clone().unbind(),
-                    );
+                    )?;
                 }
 
                 results.append(instance)?;
@@ -1451,18 +1628,19 @@ pub fn fetch_filtered<'py>(
 
 /// Returns the number of records matching a filtered query.
 #[pyfunction]
-#[pyo3(signature = (name, query_ir_json, tx_id=None, using=None))]
+#[pyo3(signature = (name, query_ir_json, tx_id=None, using=None, session_id=None))]
 pub fn count_filtered(
     py: Python<'_>,
     name: String,
     query_ir_json: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
 
         let table_name = name.to_lowercase();
         query_def.postgres_enum_udt =
@@ -1563,43 +1741,60 @@ pub fn count_filtered(
 
 /// Registers a live Python object in the global Identity Map.
 #[pyfunction]
-#[pyo3(signature = (name, pk, obj, using=None))]
+#[pyo3(signature = (name, pk, obj, using=None, session_id=None))]
 pub fn register_instance(
     name: String,
     pk: String,
     obj: Py<PyAny>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<()> {
-    let (connection_name, engine) = active_connection_for_route(using)?;
+    let (connection_name, engine) = active_route_for_operation(
+        None,
+        using,
+        session_id.clone(),
+    )
+    .map(|(name, engine, _, _)| (name, engine))?;
     if engine.is_identity_map_enabled() {
-        IDENTITY_MAP.insert((connection_name, name, pk), obj);
+        identity_map_insert(session_id.as_deref(), (connection_name, name, pk), obj)?;
     }
     Ok(())
 }
 
 /// Evicts a specific model instance from the global Identity Map.
 #[pyfunction]
-#[pyo3(signature = (name, pk, using=None))]
-pub fn evict_instance(name: String, pk: String, using: Option<String>) -> PyResult<()> {
-    let (connection_name, engine) = active_connection_for_route(using)?;
+#[pyo3(signature = (name, pk, using=None, session_id=None))]
+pub fn evict_instance(
+    name: String,
+    pk: String,
+    using: Option<String>,
+    session_id: Option<String>,
+) -> PyResult<()> {
+    let (connection_name, engine) = active_route_for_operation(
+        None,
+        using,
+        session_id.clone(),
+    )
+    .map(|(name, engine, _, _)| (name, engine))?;
     if engine.is_identity_map_enabled() {
-        IDENTITY_MAP.remove(&(connection_name, name, pk));
+        identity_map_remove(session_id.as_deref(), &(connection_name, name, pk))?;
     }
     Ok(())
 }
 
 /// Deletes a record by its primary key.
 #[pyfunction]
-#[pyo3(signature = (name, pk_val, tx_id=None, using=None))]
+#[pyo3(signature = (name, pk_val, tx_id=None, using=None, session_id=None))]
 pub fn delete_record(
     py: Python<'_>,
     name: String,
     pk_val: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
 
         let table_name = name.to_lowercase();
         // ... sql ...
@@ -1659,18 +1854,19 @@ pub fn delete_record(
 
 /// Deletes records matching a filtered query.
 #[pyfunction]
-#[pyo3(signature = (name, query_ir_json, tx_id=None, using=None))]
+#[pyo3(signature = (name, query_ir_json, tx_id=None, using=None, session_id=None))]
 pub fn delete_filtered(
     py: Python<'_>,
     name: String,
     query_ir_json: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
 
         let table_name = name.to_lowercase();
         query_def.postgres_enum_udt =
@@ -1699,7 +1895,7 @@ pub fn delete_filtered(
 
         // After bulk delete, we MUST clear the Identity Map for this model to avoid stale objects
         if engine.is_identity_map_enabled() {
-            IDENTITY_MAP.retain(|(_, m_name, _), _| m_name != &name);
+            identity_map_retain_model(session_id.as_deref(), &name)?;
         }
 
         Ok(rows_affected)
@@ -1708,7 +1904,7 @@ pub fn delete_filtered(
 
 /// Updates records matching a filtered query with provided values.
 #[pyfunction]
-#[pyo3(signature = (name, query_ir_json, update_json, tx_id=None, using=None))]
+#[pyo3(signature = (name, query_ir_json, update_json, tx_id=None, using=None, session_id=None))]
 pub fn update_filtered(
     py: Python<'_>,
     name: String,
@@ -1716,6 +1912,7 @@ pub fn update_filtered(
     update_json: String,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
@@ -1728,7 +1925,7 @@ pub fn update_filtered(
     })?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
 
         let table_name = name.to_lowercase();
         let enum_udt = postgres_enum_udt_by_column(&table_name, &engine, &tx_conn, backend).await?;
@@ -1782,7 +1979,7 @@ pub fn update_filtered(
 
         // After bulk update, we MUST clear the Identity Map for this model to avoid stale objects
         if engine.is_identity_map_enabled() {
-            IDENTITY_MAP.retain(|(_, m_name, _), _| m_name != &name);
+            identity_map_retain_model(session_id.as_deref(), &name)?;
         }
 
         Ok(rows_affected)
@@ -1790,7 +1987,7 @@ pub fn update_filtered(
 }
 
 #[pyfunction]
-#[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None))]
+#[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None, session_id=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn add_m2m_links<'py>(
     py: Python<'py>,
@@ -1801,6 +1998,7 @@ pub fn add_m2m_links<'py>(
     target_ids: Vec<Bound<'py, PyAny>>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let s_id = python_to_sea_value(source_id)?;
     let t_ids: Vec<sea_query::Value> = target_ids
@@ -1809,7 +2007,7 @@ pub fn add_m2m_links<'py>(
         .collect::<PyResult<Vec<_>>>()?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
         let uuid_columns =
             postgres_uuid_column_names(&join_table, &engine, &tx_conn, backend).await?;
 
@@ -1846,7 +2044,7 @@ pub fn add_m2m_links<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None))]
+#[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None, session_id=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn remove_m2m_links<'py>(
     py: Python<'py>,
@@ -1857,6 +2055,7 @@ pub fn remove_m2m_links<'py>(
     target_ids: Vec<Bound<'py, PyAny>>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let s_id = python_to_sea_value(source_id)?;
     let t_ids: Vec<sea_query::Value> = target_ids
@@ -1865,7 +2064,7 @@ pub fn remove_m2m_links<'py>(
         .collect::<PyResult<Vec<_>>>()?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using)?;
+        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
         let uuid_columns =
             postgres_uuid_column_names(&join_table, &engine, &tx_conn, backend).await?;
 
@@ -1904,7 +2103,7 @@ pub fn remove_m2m_links<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (join_table, source_col, source_id, tx_id=None, using=None))]
+#[pyo3(signature = (join_table, source_col, source_id, tx_id=None, using=None, session_id=None))]
 pub fn clear_m2m_links<'py>(
     py: Python<'py>,
     join_table: String,
@@ -1912,14 +2111,15 @@ pub fn clear_m2m_links<'py>(
     source_id: Bound<'py, PyAny>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let s_id = python_to_sea_value(source_id)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (engine, tx_conn, backend) = {
-            let engine = active_engine_for_connection(using)?;
+            let engine = active_engine_for_connection(using, session_id.as_deref())?;
             let backend = engine.backend();
-            let tx_conn = get_transaction_connection(tx_id);
+            let tx_conn = get_transaction_connection(tx_id, session_id.as_deref())?;
             (engine, tx_conn, backend)
         };
         let uuid_columns =
@@ -2031,12 +2231,14 @@ fn python_to_engine_bind_value(
 /// Look up a transaction connection by id, returning a sharper error than the
 /// CRUD path's "Transaction not found" — this surface is reachable by users
 /// who hold a `Transaction` handle past the end of `async with transaction():`.
-fn get_raw_tx_conn(tx_id: Option<String>) -> PyResult<Option<TransactionConnection>> {
+fn get_raw_tx_conn(
+    tx_id: Option<String>,
+    session_id: Option<&str>,
+) -> PyResult<Option<TransactionConnection>> {
     match tx_id {
         Some(id) => {
-            let conn = TRANSACTION_REGISTRY
-                .get(&id)
-                .map(|tx| tx.value().conn.clone())
+            let conn = tx_get(session_id, &id)?
+                .map(|tx| tx.conn)
                 .ok_or_else(|| {
                     pyo3::exceptions::PyRuntimeError::new_err(
                         "Transaction has already been closed or never existed",
@@ -2060,19 +2262,20 @@ fn get_raw_tx_conn(tx_id: Option<String>) -> PyResult<Option<TransactionConnecti
 ///   not a supported primitive (the Python `_marshal` wrapper guarantees this
 ///   never trips in normal use).
 #[pyfunction]
-#[pyo3(signature = (sql, args, tx_id=None, using=None))]
+#[pyo3(signature = (sql, args, tx_id=None, using=None, session_id=None))]
 pub fn raw_execute<'py>(
     py: Python<'py>,
     sql: String,
     args: Vec<Bound<'py, PyAny>>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let bind_values: Vec<EngineBindValue> = args
         .iter()
         .map(python_to_engine_bind_value)
         .collect::<PyResult<_>>()?;
-    let tx_conn = get_raw_tx_conn(tx_id)?;
+    let tx_conn = get_raw_tx_conn(tx_id, session_id.as_deref())?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let rows_affected = match tx_conn {
@@ -2081,7 +2284,7 @@ pub fn raw_execute<'py>(
                 conn.execute_sql_with_binds(&sql, &bind_values).await
             }
             None => {
-                let engine = active_engine_for_connection(using)?;
+                let engine = active_engine_for_connection(using, session_id.as_deref())?;
                 engine.execute_sql_with_binds(&sql, &bind_values).await
             }
         }
@@ -2099,19 +2302,20 @@ pub fn raw_execute<'py>(
 /// UUID/datetime/JSON columns come back as strings — Ferro does not decode them
 /// for raw SQL. If you want typed rows, use the ORM.
 #[pyfunction]
-#[pyo3(signature = (sql, args, tx_id=None, using=None))]
+#[pyo3(signature = (sql, args, tx_id=None, using=None, session_id=None))]
 pub fn raw_fetch_all<'py>(
     py: Python<'py>,
     sql: String,
     args: Vec<Bound<'py, PyAny>>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let bind_values: Vec<EngineBindValue> = args
         .iter()
         .map(python_to_engine_bind_value)
         .collect::<PyResult<_>>()?;
-    let tx_conn = get_raw_tx_conn(tx_id)?;
+    let tx_conn = get_raw_tx_conn(tx_id, session_id.as_deref())?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let rows = match tx_conn {
@@ -2120,7 +2324,7 @@ pub fn raw_fetch_all<'py>(
                 conn.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
             None => {
-                let engine = active_engine_for_connection(using)?;
+                let engine = active_engine_for_connection(using, session_id.as_deref())?;
                 engine.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
         }
@@ -2140,19 +2344,20 @@ pub fn raw_fetch_all<'py>(
 
 /// Run a raw SQL query and return the first row as a dict, or `None`.
 #[pyfunction]
-#[pyo3(signature = (sql, args, tx_id=None, using=None))]
+#[pyo3(signature = (sql, args, tx_id=None, using=None, session_id=None))]
 pub fn raw_fetch_one<'py>(
     py: Python<'py>,
     sql: String,
     args: Vec<Bound<'py, PyAny>>,
     tx_id: Option<String>,
     using: Option<String>,
+    session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let bind_values: Vec<EngineBindValue> = args
         .iter()
         .map(python_to_engine_bind_value)
         .collect::<PyResult<_>>()?;
-    let tx_conn = get_raw_tx_conn(tx_id)?;
+    let tx_conn = get_raw_tx_conn(tx_id, session_id.as_deref())?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let rows = match tx_conn {
@@ -2161,7 +2366,7 @@ pub fn raw_fetch_one<'py>(
                 conn.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
             None => {
-                let engine = active_engine_for_connection(using)?;
+                let engine = active_engine_for_connection(using, session_id.as_deref())?;
                 engine.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
         }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -6,7 +6,7 @@
 use crate::backend::{
     BackendKind, EngineBindValue, EngineHandle, EngineRow, EngineValue, NullKind,
 };
-use crate::query::QueryDef;
+use crate::query::{QueryDef, query_def_from_ir_payload};
 use crate::state::{
     IDENTITY_MAP, MODEL_REGISTRY, RustValue, SqlDialect, TRANSACTION_REGISTRY,
     TransactionConnection, TransactionHandle, connection_for_route, engine_for_connection,
@@ -16,6 +16,7 @@ use sea_query::{
     Alias, Expr, Iden, InsertStatement, OnConflict, Order, PostgresQueryBuilder, Query, SimpleExpr,
     SqliteQueryBuilder, UpdateStatement, Value as SeaValue,
 };
+use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -351,6 +352,87 @@ macro_rules! sea_query_to_string_for_backend {
             crate::state::SqlDialect::Postgres => $stmt.to_string(PostgresQueryBuilder),
         }
     }};
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct QueryPlanArtifact {
+    operation: String,
+    semantic_signature: Vec<String>,
+    bind_semantics: Vec<String>,
+}
+
+fn bind_semantics(bind_values: &[SeaValue]) -> Vec<String> {
+    engine_bind_values_from_sea(bind_values)
+        .into_iter()
+        .map(|value| format!("{value:?}"))
+        .collect()
+}
+
+fn query_plan_artifact(
+    operation: &str,
+    query_def: &QueryDef,
+    bind_values: &[SeaValue],
+) -> QueryPlanArtifact {
+    let mut semantic_signature = query_def
+        .semantic_signature()
+        .where_semantics
+        .into_iter()
+        .collect::<Vec<_>>();
+    semantic_signature.sort();
+
+    QueryPlanArtifact {
+        operation: operation.to_string(),
+        semantic_signature,
+        bind_semantics: bind_semantics(bind_values),
+    }
+}
+
+fn shadow_artifact_from_ir_roundtrip(
+    operation: &str,
+    query_def: &QueryDef,
+    bind_values: &[SeaValue],
+) -> Result<QueryPlanArtifact, String> {
+    let ir_payload = query_def.to_ir_payload();
+    let ir_roundtrip = query_def_from_ir_payload(ir_payload)?;
+    Ok(query_plan_artifact(operation, &ir_roundtrip, bind_values))
+}
+
+fn compare_shadow_query_artifacts(
+    operation: &str,
+    query_def: &QueryDef,
+    bind_values: &[SeaValue],
+) -> Result<(), String> {
+    let legacy = query_plan_artifact(operation, query_def, bind_values);
+    let shadow = shadow_artifact_from_ir_roundtrip(operation, query_def, bind_values)?;
+    if legacy == shadow {
+        return Ok(());
+    }
+    let legacy_json = serde_json::to_string(&legacy).unwrap_or_else(|_| "<legacy>".to_string());
+    let shadow_json = serde_json::to_string(&shadow).unwrap_or_else(|_| "<shadow>".to_string());
+    Err(format!(
+        "shadow planner mismatch for '{operation}': legacy={legacy_json} shadow={shadow_json}"
+    ))
+}
+
+fn maybe_compare_shadow_query_artifacts(
+    engine: &EngineHandle,
+    operation: &str,
+    query_def: &QueryDef,
+    bind_values: &[SeaValue],
+) -> PyResult<()> {
+    if !engine.is_shadow_runtime_enabled() {
+        return Ok(());
+    }
+    if let Err(diff) = compare_shadow_query_artifacts(operation, query_def, bind_values) {
+        crate::log_debug(format!("⚠️ Ferro shadow runtime mismatch: {diff}"));
+        if std::env::var("FERRO_SHADOW_RUNTIME_STRICT")
+            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+        {
+            return Err(pyo3::exceptions::PyRuntimeError::new_err(diff));
+        }
+    }
+    Ok(())
 }
 
 /// On Postgres, cast text-like special columns in SELECT output so Python hydration
@@ -1635,6 +1717,7 @@ pub fn fetch_filtered<'py>(
             let (s, values) = sea_query_build_for_backend!(select, backend);
             (s, values, pk, schema.clone())
         };
+        maybe_compare_shadow_query_artifacts(&engine, "fetch_filtered", &query_def, &bind_values.0)?;
 
         let parsed_data = match tx_conn {
             Some(conn_arc) => {
@@ -1793,6 +1876,7 @@ pub fn count_filtered(
             select.cond_where(query_def.to_condition_for_backend(backend));
             sea_query_build_for_backend!(select, backend)
         };
+        maybe_compare_shadow_query_artifacts(&engine, "count_filtered", &query_def, &bind_values.0)?;
 
         let engine_bind_values = engine_bind_values_from_sea(&bind_values.0);
         let count = match tx_conn {
@@ -1951,6 +2035,7 @@ pub fn delete_filtered(
                 .cond_where(query_def.to_condition_for_backend(backend));
             sea_query_build_for_backend!(delete, backend)
         };
+        maybe_compare_shadow_query_artifacts(&engine, "delete_filtered", &query_def, &bind_values.0)?;
 
         let rows_affected =
             execute_statement_with_optional_tx(&engine, tx_conn, &sql, &bind_values.0)
@@ -2030,6 +2115,7 @@ pub fn update_filtered(
             }
             sea_query_build_for_backend!(update, backend)
         };
+        maybe_compare_shadow_query_artifacts(&engine, "update_filtered", &query_def, &bind_values.0)?;
 
         let rows_affected =
             execute_statement_with_optional_tx(&engine, tx_conn, &sql, &bind_values.0)
@@ -2432,6 +2518,66 @@ pub fn raw_fetch_one<'py>(
             None => Ok(py.None()),
         })
     })
+}
+
+#[pyfunction]
+#[pyo3(name = "_shadow_compare_query_plan_for_test")]
+#[pyo3(signature = (query_json, dialect, operation="select".to_string()))]
+pub fn _shadow_compare_query_plan_for_test(
+    query_json: String,
+    dialect: String,
+    operation: String,
+) -> PyResult<String> {
+    let backend = match dialect.as_str() {
+        "postgres" => SqlDialect::Postgres,
+        "sqlite" => SqlDialect::Sqlite,
+        other => {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Unknown dialect {:?}; expected 'postgres' or 'sqlite'",
+                other
+            )));
+        }
+    };
+    let query_def: QueryDef = serde_json::from_str(&query_json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("Invalid query JSON: {}", e))
+    })?;
+    let mut select_legacy = Query::select();
+    select_legacy.from(Alias::new(query_def.model_name.to_lowercase()));
+    select_legacy.column((Alias::new(query_def.model_name.to_lowercase()), sea_query::Asterisk));
+    select_legacy.cond_where(query_def.to_condition_for_backend(backend));
+    if let Some(ref orders) = query_def.order_by {
+        for order in orders {
+            let dir = if order.direction.to_lowercase() == "desc" {
+                Order::Desc
+            } else {
+                Order::Asc
+            };
+            select_legacy.order_by(Alias::new(&order.column), dir);
+        }
+    }
+    if let Some(limit) = query_def.limit {
+        select_legacy.limit(limit);
+    }
+    if let Some(offset) = query_def.offset {
+        select_legacy.offset(offset);
+    }
+    let (legacy_sql, legacy_values) = sea_query_build_for_backend!(select_legacy, backend);
+    let legacy = query_plan_artifact(&operation, &query_def, &legacy_values.0);
+
+    let shadow = shadow_artifact_from_ir_roundtrip(&operation, &query_def, &legacy_values.0)
+        .map_err(pyo3::exceptions::PyRuntimeError::new_err)?;
+    let payload = serde_json::json!({
+        "matches": legacy == shadow,
+        "legacy": {
+            "sql": legacy_sql,
+            "artifact": legacy,
+        },
+        "shadow": {
+            "artifact": shadow,
+        },
+    });
+    serde_json::to_string(&payload)
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to encode JSON: {e}")))
 }
 
 #[cfg(test)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,10 +1,13 @@
 use crate::state::{MODEL_REGISTRY, SqlDialect};
+use ferro_schema_ir::{
+    QueryIrPayload, QueryNode as QueryIrNode, QueryOrderBy as QueryIrOrderBy, QueryValue,
+};
 use sea_query::{Alias, Condition, Expr, SimpleExpr};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct QueryNode {
     pub is_compound: bool,
     pub operator: String,
@@ -16,13 +19,13 @@ pub struct QueryNode {
     pub right: Option<Box<QueryNode>>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct OrderBy {
     pub column: String,
     pub direction: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct M2mContext {
     pub join_table: String,
     pub source_col: String,
@@ -30,7 +33,7 @@ pub struct M2mContext {
     pub source_id: Value,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct QueryDef {
     #[allow(dead_code)]
     pub model_name: String,
@@ -43,6 +46,16 @@ pub struct QueryDef {
     /// Python query JSON payload.
     #[serde(skip)]
     pub postgres_enum_udt: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuerySemanticSignature {
+    pub model_name: String,
+    pub where_semantics: Vec<String>,
+    pub order_by: Vec<(String, String)>,
+    pub limit: Option<u64>,
+    pub offset: Option<u64>,
+    pub m2m: Option<(String, String, String, String)>,
 }
 
 impl QueryDef {
@@ -258,6 +271,226 @@ impl QueryDef {
             return Expr::value(typed_null);
         }
         Expr::value(json_to_sea_value(val))
+    }
+
+    pub fn to_ir_payload(&self) -> QueryIrPayload {
+        QueryIrPayload {
+            model_name: self.model_name.clone(),
+            where_clause: self.where_clause.iter().map(query_node_to_ir).collect(),
+            order_by: self
+                .order_by
+                .as_ref()
+                .map(|items| {
+                    items
+                        .iter()
+                        .map(|item| QueryIrOrderBy {
+                            column: item.column.clone(),
+                            direction: item.direction.clone(),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+            limit: self.limit,
+            offset: self.offset,
+            m2m: self
+                .m2m
+                .as_ref()
+                .and_then(|m2m| serde_json::to_value(m2m).ok()),
+        }
+    }
+
+    pub fn semantic_signature(&self) -> QuerySemanticSignature {
+        QuerySemanticSignature {
+            model_name: self.model_name.clone(),
+            where_semantics: self
+                .where_clause
+                .iter()
+                .map(query_node_semantic_string)
+                .collect(),
+            order_by: self
+                .order_by
+                .as_ref()
+                .map(|items| {
+                    items
+                        .iter()
+                        .map(|item| (item.column.clone(), item.direction.to_ascii_lowercase()))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            limit: self.limit,
+            offset: self.offset,
+            m2m: self.m2m.as_ref().map(|m2m| {
+                (
+                    m2m.join_table.clone(),
+                    m2m.source_col.clone(),
+                    m2m.target_col.clone(),
+                    query_value_semantic_string(&m2m.source_id),
+                )
+            }),
+        }
+    }
+}
+
+pub fn query_def_from_ir_payload(payload: QueryIrPayload) -> Result<QueryDef, String> {
+    let m2m: Option<M2mContext> = match payload.m2m {
+        Some(value) => serde_json::from_value(value)
+            .map(Some)
+            .map_err(|e| format!("invalid QueryIR m2m payload: {e}"))?,
+        None => None,
+    };
+    Ok(QueryDef {
+        model_name: payload.model_name,
+        where_clause: payload.where_clause.iter().map(query_node_from_ir).collect(),
+        order_by: if payload.order_by.is_empty() {
+            None
+        } else {
+            Some(
+                payload
+                    .order_by
+                    .iter()
+                    .map(|item| OrderBy {
+                        column: item.column.clone(),
+                        direction: item.direction.clone(),
+                    })
+                    .collect(),
+            )
+        },
+        limit: payload.limit,
+        offset: payload.offset,
+        m2m,
+        postgres_enum_udt: HashMap::new(),
+    })
+}
+
+fn query_node_to_ir(node: &QueryNode) -> QueryIrNode {
+    if node.is_compound {
+        let left = node
+            .left
+            .as_ref()
+            .map(|inner| Box::new(query_node_to_ir(inner)))
+            .unwrap_or_else(|| {
+                Box::new(QueryIrNode::Leaf {
+                    operator: "==".to_string(),
+                    column: "__invalid__".to_string(),
+                    value: QueryValue {
+                        kind: "null".to_string(),
+                        value: Value::Null,
+                    },
+                })
+            });
+        let right = node
+            .right
+            .as_ref()
+            .map(|inner| Box::new(query_node_to_ir(inner)))
+            .unwrap_or_else(|| {
+                Box::new(QueryIrNode::Leaf {
+                    operator: "==".to_string(),
+                    column: "__invalid__".to_string(),
+                    value: QueryValue {
+                        kind: "null".to_string(),
+                        value: Value::Null,
+                    },
+                })
+            });
+        return QueryIrNode::Compound {
+            operator: node.operator.clone(),
+            left,
+            right,
+        };
+    }
+
+    let value = node.value.clone().unwrap_or(Value::Null);
+    QueryIrNode::Leaf {
+        operator: node.operator.clone(),
+        column: node.column.clone().unwrap_or_default(),
+        value: QueryValue {
+            kind: query_value_kind(&value).to_string(),
+            value,
+        },
+    }
+}
+
+fn query_node_from_ir(node: &QueryIrNode) -> QueryNode {
+    match node {
+        QueryIrNode::Leaf {
+            operator,
+            column,
+            value,
+        } => QueryNode {
+            is_compound: false,
+            operator: operator.clone(),
+            column: Some(column.clone()),
+            value: if value.value.is_null() {
+                None
+            } else {
+                Some(value.value.clone())
+            },
+            left: None,
+            right: None,
+        },
+        QueryIrNode::Compound {
+            operator,
+            left,
+            right,
+        } => QueryNode {
+            is_compound: true,
+            operator: operator.clone(),
+            column: None,
+            value: None,
+            left: Some(Box::new(query_node_from_ir(left))),
+            right: Some(Box::new(query_node_from_ir(right))),
+        },
+    }
+}
+
+fn query_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(n) => {
+            if n.is_i64() || n.is_u64() {
+                "int"
+            } else {
+                "float"
+            }
+        }
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn query_node_semantic_string(node: &QueryNode) -> String {
+    if node.is_compound {
+        let left = node
+            .left
+            .as_ref()
+            .map(|inner| query_node_semantic_string(inner))
+            .unwrap_or_else(|| "<missing-left>".to_string());
+        let right = node
+            .right
+            .as_ref()
+            .map(|inner| query_node_semantic_string(inner))
+            .unwrap_or_else(|| "<missing-right>".to_string());
+        return format!("({left} {} {right})", node.operator.to_ascii_uppercase());
+    }
+
+    let column = node
+        .column
+        .as_ref()
+        .map_or_else(|| "<missing-column>".to_string(), Clone::clone);
+    let value = node
+        .value
+        .as_ref()
+        .map_or_else(|| "null".to_string(), query_value_semantic_string);
+    format!("{} {} {}", column, node.operator, value)
+}
+
+fn query_value_semantic_string(value: &Value) -> String {
+    match value {
+        Value::String(s) => format!("\"{s}\""),
+        Value::Null => "null".to_string(),
+        _ => value.to_string(),
     }
 }
 
@@ -764,5 +997,41 @@ mod tests {
             sql.contains("AS numeric"),
             "decimal cast preserved until follow-up: {sql}"
         );
+    }
+
+    #[test]
+    fn query_ir_roundtrip_preserves_semantics_signature() {
+        let query_def: QueryDef = serde_json::from_value(json!({
+            "model_name": "Widget",
+            "where_clause": [
+                {
+                    "is_compound": true,
+                    "operator": "OR",
+                    "left": {
+                        "is_compound": false,
+                        "column": "age",
+                        "operator": ">=",
+                        "value": 18
+                    },
+                    "right": {
+                        "is_compound": false,
+                        "column": "name",
+                        "operator": "LIKE",
+                        "value": "a%"
+                    }
+                }
+            ],
+            "order_by": [{"column": "age", "direction": "DESC"}],
+            "limit": 10,
+            "offset": 5,
+            "m2m": null
+        }))
+        .expect("query json must deserialize");
+        let before = query_def.semantic_signature();
+        let ir = query_def.to_ir_payload();
+        let roundtrip = super::query_def_from_ir_payload(ir).expect("QueryIR roundtrip");
+        let after = roundtrip.semantic_signature();
+
+        assert_eq!(before, after);
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -59,28 +59,46 @@ pub struct QuerySemanticSignature {
 }
 
 impl QueryDef {
-    pub fn to_condition_for_backend(&self, backend: SqlDialect) -> Condition {
+    pub fn to_condition_for_backend(
+        &self,
+        backend: SqlDialect,
+    ) -> Result<Condition, String> {
         let mut condition = Condition::all();
         for node in &self.where_clause {
-            condition = condition.add(self.node_to_condition_for_backend(node, backend));
+            condition = condition.add(self.node_to_condition_for_backend(node, backend)?);
         }
-        condition
+        Ok(condition)
     }
 
-    fn node_to_condition_for_backend(&self, node: &QueryNode, backend: SqlDialect) -> Condition {
+    fn node_to_condition_for_backend(
+        &self,
+        node: &QueryNode,
+        backend: SqlDialect,
+    ) -> Result<Condition, String> {
         if node.is_compound {
-            let left_cond =
-                self.node_to_condition_for_backend(node.left.as_ref().unwrap(), backend);
-            let right_cond =
-                self.node_to_condition_for_backend(node.right.as_ref().unwrap(), backend);
+            let left = node
+                .left
+                .as_ref()
+                .ok_or_else(|| "compound QueryNode is missing left child".to_string())?;
+            let right = node
+                .right
+                .as_ref()
+                .ok_or_else(|| "compound QueryNode is missing right child".to_string())?;
+            let left_cond = self.node_to_condition_for_backend(left, backend)?;
+            let right_cond = self.node_to_condition_for_backend(right, backend)?;
 
-            match node.operator.as_str() {
+            Ok(match node.operator.as_str() {
                 "OR" => Condition::any().add(left_cond).add(right_cond),
                 "AND" => Condition::all().add(left_cond).add(right_cond),
-                _ => Condition::all(), // Should not happen
-            }
+                op => {
+                    return Err(format!("unsupported compound QueryNode operator: {op}"));
+                }
+            })
         } else {
-            let col_name = node.column.as_ref().unwrap();
+            let col_name = node
+                .column
+                .as_ref()
+                .ok_or_else(|| "leaf QueryNode is missing column".to_string())?;
             let col = Expr::col(Alias::new(col_name));
 
             // Python `None` becomes JSON `null`, which serde deserializes as
@@ -149,7 +167,10 @@ impl QueryDef {
                     )),
                 }
             } else {
-                let val = node.value.as_ref().unwrap();
+                let val = node
+                    .value
+                    .as_ref()
+                    .ok_or_else(|| format!("leaf QueryNode for column '{col_name}' is missing value"))?;
                 match node.operator.as_str() {
                     "==" => col
                         .eq(self.value_rhs_simple_expr_for_backend(col_name, val, false, backend)),
@@ -157,8 +178,7 @@ impl QueryDef {
                         .ne(self.value_rhs_simple_expr_for_backend(col_name, val, false, backend)),
                     "<" => col
                         .lt(self.value_rhs_simple_expr_for_backend(col_name, val, false, backend)),
-                    "<=" => col
-                        .lte(self.value_rhs_simple_expr_for_backend(col_name, val, false, backend)),
+                    "<=" => col.lte(self.value_rhs_simple_expr_for_backend(col_name, val, false, backend)),
                     ">" => col
                         .gt(self.value_rhs_simple_expr_for_backend(col_name, val, false, backend)),
                     ">=" => col
@@ -190,7 +210,7 @@ impl QueryDef {
                         .eq(self.value_rhs_simple_expr_for_backend(col_name, val, false, backend)),
                 }
             };
-            Condition::all().add(expr)
+            Ok(Condition::all().add(expr))
         }
     }
 
@@ -515,7 +535,10 @@ mod tests {
         let mut select = Query::select();
         select
             .from(Alias::new("pending"))
-            .cond_where(q.to_condition_for_backend(BackendKind::Sqlite));
+            .cond_where(
+                q.to_condition_for_backend(BackendKind::Sqlite)
+                    .expect("valid test query"),
+            );
         let sql = select.to_string(SqliteQueryBuilder).to_lowercase();
         assert!(sql.contains("is null"), "expected IS NULL, got {sql}");
         assert!(
@@ -545,7 +568,10 @@ mod tests {
         let mut select = Query::select();
         select
             .from(Alias::new("pending"))
-            .cond_where(q.to_condition_for_backend(BackendKind::Sqlite));
+            .cond_where(
+                q.to_condition_for_backend(BackendKind::Sqlite)
+                    .expect("valid test query"),
+            );
         let sql = select.to_string(SqliteQueryBuilder).to_lowercase();
         assert!(
             sql.contains("is not null"),

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,4 +1,4 @@
-use crate::state::{MODEL_REGISTRY, SqlDialect};
+use crate::state::SqlDialect;
 use ferro_schema_ir::{
     QueryIrPayload, QueryNode as QueryIrNode, QueryOrderBy as QueryIrOrderBy, QueryValue,
 };
@@ -218,59 +218,14 @@ impl QueryDef {
         infer_uuid_without_schema: bool,
         backend: SqlDialect,
     ) -> SimpleExpr {
-        if let Value::String(s) = val {
-            if backend == SqlDialect::Postgres {
-                if let Some(tn) = crate::schema_bind::native_postgres_enum_udt_name(
-                    col_name,
-                    &self.postgres_enum_udt,
-                ) {
-                    return crate::schema_bind::postgres_enum_string_rhs_expr(s, tn);
-                }
-
-                if let Ok(parsed) = uuid::Uuid::parse_str(s) {
-                    let schema_uuid = model_column_is_uuid(&self.model_name, col_name);
-                    if schema_uuid || infer_uuid_without_schema {
-                        return Expr::value(sea_query::Value::Uuid(Some(Box::new(parsed))));
-                    }
-                }
-
-                if model_column_format(&self.model_name, col_name) == Some("date-time") {
-                    return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
-                        .cast_as("timestamptz");
-                }
-                if model_column_format(&self.model_name, col_name) == Some("date") {
-                    return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
-                        .cast_as("date");
-                }
-                if model_column_format(&self.model_name, col_name) == Some("binary") {
-                    return Expr::value(sea_query::Value::Bytes(Some(Box::new(
-                        s.as_bytes().to_vec(),
-                    ))));
-                }
-                if model_column_is_decimal(&self.model_name, col_name) {
-                    return Expr::value(sea_query::Value::String(Some(Box::new(s.clone()))))
-                        .cast_as("numeric");
-                }
-            }
-
-            if model_column_is_decimal(&self.model_name, col_name)
-                && let Ok(parsed) = s.parse::<f64>()
-            {
-                return Expr::value(sea_query::Value::Double(Some(parsed)));
-            }
-        }
-
-        // Typed-null pick from column metadata. This fixes the schema-driven
-        // half of #38 for UPDATE column values and query-filter predicates;
-        // without it, every NULL bind goes out as text. Unknown columns fall
-        // through to json_to_sea_value (which preserves legacy String(None))
-        // -- the bind layer's NullKind::String is the documented fallback.
-        if val.is_null()
-            && let Some(typed_null) = typed_null_for_column(&self.model_name, col_name)
-        {
-            return Expr::value(typed_null);
-        }
-        Expr::value(json_to_sea_value(val))
+        crate::codec::query_bind_expr(
+            &self.model_name,
+            col_name,
+            val,
+            infer_uuid_without_schema,
+            backend,
+            &self.postgres_enum_udt,
+        )
     }
 
     pub fn to_ir_payload(&self) -> QueryIrPayload {
@@ -496,175 +451,6 @@ fn query_value_semantic_string(value: &Value) -> String {
         Value::Null => "null".to_string(),
         _ => value.to_string(),
     }
-}
-
-/// Pick a typed SeaQuery `None` variant for a `NULL` value in
-/// `value_rhs_simple_expr_for_backend`. Returns `None` if the model or column
-/// isn't in the registry, or if the column type is one we still emit via
-/// `CAST` (temporal). The caller falls through to `json_to_sea_value` in
-/// either case, which preserves the legacy text-typed null.
-fn typed_null_for_column(model_name: &str, col_name: &str) -> Option<sea_query::Value> {
-    let registry = MODEL_REGISTRY.read().ok()?;
-    let schema = registry.get(model_name)?;
-    let props = schema.get("properties").and_then(|p| p.as_object())?;
-    let col_info = props.get(col_name)?;
-
-    if column_is_uuid_property(schema, col_name) {
-        return Some(sea_query::Value::Uuid(None));
-    }
-    if property_schema_is_decimal(col_info) {
-        // Decimal still uses cast_as("numeric") for non-null today; matching
-        // null path keeps emitter behavior aligned. Native numeric typed bind
-        // is deferred (plan §3 Scope Boundaries).
-        return Some(sea_query::Value::Double(None));
-    }
-    let format = property_schema_format(col_info);
-    if matches!(format, Some("date-time") | Some("date") | Some("time")) {
-        // Temporal typed nulls are deferred to issue #40.
-        return None;
-    }
-    if format == Some("binary") {
-        return Some(sea_query::Value::Bytes(None));
-    }
-
-    // Walk anyOf to find the non-null type variant -- this is how Pydantic
-    // shapes `T | None` schemas.
-    let json_type = col_info.get("type").and_then(|t| t.as_str()).or_else(|| {
-        col_info
-            .get("anyOf")
-            .and_then(|a| a.as_array())
-            .and_then(|types| {
-                types.iter().find_map(|t| {
-                    let s = t.get("type")?.as_str()?;
-                    if s != "null" { Some(s) } else { None }
-                })
-            })
-    });
-
-    match json_type {
-        Some("integer") => Some(sea_query::Value::BigInt(None)),
-        Some("number") => Some(sea_query::Value::Double(None)),
-        Some("boolean") => Some(sea_query::Value::Bool(None)),
-        Some("string") => Some(sea_query::Value::String(None)),
-        _ => None,
-    }
-}
-
-fn json_to_sea_value(value: &Value) -> sea_query::Value {
-    match value {
-        Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                sea_query::Value::BigInt(Some(i))
-            } else if let Some(f) = n.as_f64() {
-                sea_query::Value::Double(Some(f))
-            } else {
-                sea_query::Value::String(None)
-            }
-        }
-        Value::String(s) => sea_query::Value::String(Some(Box::new(s.clone()))),
-        Value::Bool(b) => sea_query::Value::Bool(Some(*b)),
-        Value::Null => sea_query::Value::String(None),
-        _ => sea_query::Value::String(Some(Box::new(value.to_string()))),
-    }
-}
-
-fn model_column_is_uuid(model_name: &str, col: &str) -> bool {
-    let Ok(registry) = MODEL_REGISTRY.read() else {
-        return false;
-    };
-    let Some(schema) = registry.get(model_name) else {
-        return false;
-    };
-    column_is_uuid_property(schema, col)
-}
-
-fn model_column_is_decimal(model_name: &str, col: &str) -> bool {
-    let Ok(registry) = MODEL_REGISTRY.read() else {
-        return false;
-    };
-    let Some(schema) = registry.get(model_name) else {
-        return false;
-    };
-    let Some(props) = schema.get("properties").and_then(|p| p.as_object()) else {
-        return false;
-    };
-    let Some(col_info) = props.get(col) else {
-        return false;
-    };
-    property_schema_is_decimal(col_info)
-}
-
-fn model_column_format(model_name: &str, col: &str) -> Option<&'static str> {
-    let Ok(registry) = MODEL_REGISTRY.read() else {
-        return None;
-    };
-    let schema = registry.get(model_name)?;
-    let props = schema.get("properties").and_then(|p| p.as_object())?;
-    let col_info = props.get(col)?;
-    match property_schema_format(col_info) {
-        Some("uuid") => Some("uuid"),
-        Some("date-time") => Some("date-time"),
-        Some("date") => Some("date"),
-        Some("binary") => Some("binary"),
-        _ => None,
-    }
-}
-
-fn column_is_uuid_property(schema: &Value, col: &str) -> bool {
-    let Some(props) = schema.get("properties").and_then(|p| p.as_object()) else {
-        return false;
-    };
-    let Some(col_info) = props.get(col) else {
-        return false;
-    };
-    property_schema_is_uuid(col_info)
-}
-
-pub(crate) fn property_schema_format(col_info: &Value) -> Option<&str> {
-    col_info.get("format").and_then(|f| f.as_str()).or_else(|| {
-        col_info
-            .get("anyOf")
-            .and_then(|a| a.as_array())
-            .and_then(|types| {
-                types
-                    .iter()
-                    .find_map(|t| t.get("format").and_then(|f| f.as_str()))
-            })
-    })
-}
-
-pub(crate) fn property_schema_is_decimal(col_info: &Value) -> bool {
-    col_info
-        .get("anyOf")
-        .and_then(|a| a.as_array())
-        .map(|types| {
-            let has_number = types
-                .iter()
-                .any(|t| t.get("type").and_then(|ty| ty.as_str()) == Some("number"));
-            let has_patterned_string = types.iter().any(|t| {
-                t.get("type").and_then(|ty| ty.as_str()) == Some("string")
-                    && t.get("pattern").is_some()
-            });
-            has_number && has_patterned_string
-        })
-        .unwrap_or(false)
-}
-
-/// JSON Schema fragment for one model field: `string` + `format: uuid` (incl. optional `anyOf`).
-pub(crate) fn property_schema_is_uuid(col_info: &Value) -> bool {
-    let format = property_schema_format(col_info);
-    let json_type = col_info.get("type").and_then(|t| t.as_str()).or_else(|| {
-        col_info
-            .get("anyOf")
-            .and_then(|a| a.as_array())
-            .and_then(|types| {
-                types.iter().find_map(|t| {
-                    let s = t.get("type")?.as_str()?;
-                    if s == "null" { None } else { Some(s) }
-                })
-            })
-    });
-    json_type == Some("string") && format == Some("uuid")
 }
 
 #[cfg(test)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -340,7 +340,11 @@ pub fn query_def_from_ir_payload(payload: QueryIrPayload) -> Result<QueryDef, St
     };
     Ok(QueryDef {
         model_name: payload.model_name,
-        where_clause: payload.where_clause.iter().map(query_node_from_ir).collect(),
+        where_clause: payload
+            .where_clause
+            .iter()
+            .map(query_node_from_ir)
+            .collect(),
         order_by: if payload.order_by.is_empty() {
             None
         } else {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -631,6 +631,27 @@ fn build_create_table_sqls(
     (table_sql, index_sqls)
 }
 
+fn shadow_compare_create_table_sqls(
+    name: &str,
+    schema: &serde_json::Value,
+    backend: SqlDialect,
+) -> Result<(), String> {
+    let legacy = build_create_table_sqls(name, schema, backend);
+    let schema_roundtrip: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(schema).map_err(|e| e.to_string())?)
+            .map_err(|e| e.to_string())?;
+    let shadow = build_create_table_sqls(name, &schema_roundtrip, backend);
+    if legacy == shadow {
+        return Ok(());
+    }
+    Err(format!(
+        "shadow create-table mismatch for '{}': legacy={} shadow={}",
+        name,
+        serde_json::to_string(&legacy).unwrap_or_else(|_| "<legacy>".to_string()),
+        serde_json::to_string(&shadow).unwrap_or_else(|_| "<shadow>".to_string()),
+    ))
+}
+
 /// Internal utility to create all registered tables in the database.
 ///
 /// This is used by both the `connect(auto_migrate=True)` flow and the
@@ -650,6 +671,17 @@ pub async fn internal_create_tables(engine: Arc<EngineHandle>) -> PyResult<()> {
 
     for (name, schema) in order_schemas_for_creation(schemas) {
         let (sql, index_sqls) = build_create_table_sqls(&name, &schema, backend);
+        if engine.is_shadow_runtime_enabled()
+            && let Err(diff) = shadow_compare_create_table_sqls(&name, &schema, backend)
+        {
+            crate::log_debug(format!("⚠️ Ferro shadow runtime mismatch: {diff}"));
+            if std::env::var("FERRO_SHADOW_RUNTIME_STRICT")
+                .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+                .unwrap_or(false)
+            {
+                return Err(pyo3::exceptions::PyRuntimeError::new_err(diff));
+            }
+        }
 
         engine.execute_sql(&sql).await.map_err(|e| {
             pyo3::exceptions::PyRuntimeError::new_err(format!(

--- a/src/state.rs
+++ b/src/state.rs
@@ -154,6 +154,51 @@ pub static TRANSACTION_REGISTRY: Lazy<DashMap<String, TransactionHandle>> = Lazy
 pub static IDENTITY_MAP: Lazy<DashMap<(String, String, String), Py<PyAny>>> =
     Lazy::new(DashMap::new);
 
+/// Session-scoped runtime state for Phase 6 sessionized execution.
+///
+/// A session pins connection routing and keeps transactional/identity state local
+/// to that session so concurrent sessions do not bleed mutable runtime state.
+pub struct SessionState {
+    pub connection_name: String,
+    pub transaction_registry: DashMap<String, TransactionHandle>,
+    pub identity_map: DashMap<(String, String, String), Py<PyAny>>,
+}
+
+impl SessionState {
+    pub fn new(connection_name: String) -> Self {
+        Self {
+            connection_name,
+            transaction_registry: DashMap::new(),
+            identity_map: DashMap::new(),
+        }
+    }
+}
+
+/// Global registry of active sessions.
+pub static SESSION_REGISTRY: Lazy<DashMap<String, Arc<SessionState>>> = Lazy::new(DashMap::new);
+
+pub fn register_session(connection_name: String) -> String {
+    let session_id = uuid::Uuid::new_v4().to_string();
+    SESSION_REGISTRY.insert(session_id.clone(), Arc::new(SessionState::new(connection_name)));
+    session_id
+}
+
+pub fn unregister_session(session_id: &str) -> bool {
+    SESSION_REGISTRY.remove(session_id).is_some()
+}
+
+pub fn session_state(session_id: &str) -> PyResult<Arc<SessionState>> {
+    SESSION_REGISTRY
+        .get(session_id)
+        .map(|entry| entry.value().clone())
+        .ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "Session '{}' is not active",
+                session_id
+            ))
+        })
+}
+
 /// A Rust-native representation of database values.
 ///
 /// Used during the GIL-free parsing phase to move data from the database

--- a/tests/fixtures/ir_vectors/README.md
+++ b/tests/fixtures/ir_vectors/README.md
@@ -1,0 +1,45 @@
+# IR golden vectors
+
+Phase 0 conformance vectors for IR contracts.
+
+## Purpose
+
+- Pin the canonical wire shape for `SchemaIR`, `QueryIR`, and `CodecIR`.
+- Provide deterministic fixtures that CI can validate before Phase 1 runtime cutover work.
+
+## File format
+
+Each vector is one JSON file with this envelope:
+
+```json
+{
+  "vector_name": "schema_invoice_baseline_v1",
+  "domain": "schema|query|codec",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "schema|query|codec",
+    "ir_version": 1,
+    "payload": {}
+  }
+}
+```
+
+Rules:
+
+- `domain` and `ir.ir_kind` must match.
+- `ir.ir_version` must equal `1` for Phase 0 vectors.
+- `expect_valid` currently supports only `true` fixtures (negative vectors can be added later).
+- Fixture file names use `<domain>_<scenario>_v1.json`.
+
+## Coverage requirements (Phase 0 minimum)
+
+- `schema`: one vector with parity-sensitive artifact names (`idx_*`, `uq_*`, `ck_*`, FK metadata).
+- `query`: one vector with compound predicates and typed value nodes.
+- `codec`: one vector with typed null and hydration ABI slot requirements.
+
+## How to extend
+
+1. Add a new JSON fixture in this directory.
+2. Keep `vector_name` unique.
+3. Update `tests/test_ir_vectors_contract.py` if new required fields are introduced.
+4. Ensure CI remains deterministic (no generated timestamps/random IDs in fixtures).

--- a/tests/fixtures/ir_vectors/codec_registry_core_v1.json
+++ b/tests/fixtures/ir_vectors/codec_registry_core_v1.json
@@ -1,0 +1,56 @@
+{
+  "vector_name": "codec_registry_core_v1",
+  "domain": "codec",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "codec",
+    "ir_version": 1,
+    "payload": {
+      "bind_rules": [
+        {
+          "logical_type": "uuid",
+          "db_type": "uuid",
+          "non_null_wire_kind": "uuid",
+          "null_wire_kind": "uuid_null"
+        },
+        {
+          "logical_type": "integer",
+          "db_type": "bigint",
+          "non_null_wire_kind": "i64",
+          "null_wire_kind": "i64_null"
+        },
+        {
+          "logical_type": "string",
+          "db_type": "text",
+          "non_null_wire_kind": "string",
+          "null_wire_kind": "string_null"
+        }
+      ],
+      "fetch_rules": [
+        {
+          "db_type": "uuid",
+          "wire_kind": "uuid",
+          "python_kind": "uuid.UUID"
+        },
+        {
+          "db_type": "bigint",
+          "wire_kind": "i64",
+          "python_kind": "int"
+        },
+        {
+          "db_type": "text",
+          "wire_kind": "string",
+          "python_kind": "str"
+        }
+      ],
+      "hydration_abi": {
+        "constructor_mode": "direct_dict",
+        "required_slots": [
+          "__pydantic_fields_set__",
+          "__pydantic_extra__",
+          "__pydantic_private__"
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/ir_vectors/codec_registry_core_v1.json
+++ b/tests/fixtures/ir_vectors/codec_registry_core_v1.json
@@ -24,6 +24,30 @@
           "db_type": "text",
           "non_null_wire_kind": "string",
           "null_wire_kind": "string_null"
+        },
+        {
+          "logical_type": "decimal",
+          "db_type": "numeric",
+          "non_null_wire_kind": "numeric_text",
+          "null_wire_kind": "numeric_null"
+        },
+        {
+          "logical_type": "datetime",
+          "db_type": "timestamptz",
+          "non_null_wire_kind": "timestamp_text",
+          "null_wire_kind": "timestamp_null"
+        },
+        {
+          "logical_type": "date",
+          "db_type": "date",
+          "non_null_wire_kind": "date_text",
+          "null_wire_kind": "date_null"
+        },
+        {
+          "logical_type": "enum",
+          "db_type": "enum",
+          "non_null_wire_kind": "enum_text",
+          "null_wire_kind": "enum_null"
         }
       ],
       "fetch_rules": [
@@ -41,6 +65,26 @@
           "db_type": "text",
           "wire_kind": "string",
           "python_kind": "str"
+        },
+        {
+          "db_type": "numeric",
+          "wire_kind": "numeric_text",
+          "python_kind": "decimal.Decimal"
+        },
+        {
+          "db_type": "timestamptz",
+          "wire_kind": "timestamp_text",
+          "python_kind": "datetime.datetime"
+        },
+        {
+          "db_type": "date",
+          "wire_kind": "date_text",
+          "python_kind": "datetime.date"
+        },
+        {
+          "db_type": "enum",
+          "wire_kind": "enum_text",
+          "python_kind": "enum.Enum"
         }
       ],
       "hydration_abi": {

--- a/tests/fixtures/ir_vectors/query_user_compound_v1.json
+++ b/tests/fixtures/ir_vectors/query_user_compound_v1.json
@@ -1,0 +1,58 @@
+{
+  "vector_name": "query_user_compound_v1",
+  "domain": "query",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "query",
+    "ir_version": 1,
+    "payload": {
+      "model_name": "User",
+      "where": [
+        {
+          "node_kind": "compound",
+          "operator": "AND",
+          "left": {
+            "node_kind": "leaf",
+            "column": "active",
+            "operator": "==",
+            "value": {
+              "kind": "bool",
+              "value": true
+            }
+          },
+          "right": {
+            "node_kind": "compound",
+            "operator": "OR",
+            "left": {
+              "node_kind": "leaf",
+              "column": "email",
+              "operator": "LIKE",
+              "value": {
+                "kind": "string",
+                "value": "%@ferro.dev"
+              }
+            },
+            "right": {
+              "node_kind": "leaf",
+              "column": "role",
+              "operator": "IN",
+              "value": {
+                "kind": "list",
+                "value": ["admin", "owner"]
+              }
+            }
+          }
+        }
+      ],
+      "order_by": [
+        {
+          "column": "id",
+          "direction": "asc"
+        }
+      ],
+      "limit": 100,
+      "offset": 0,
+      "m2m": null
+    }
+  }
+}

--- a/tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json
+++ b/tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json
@@ -1,0 +1,101 @@
+{
+  "vector_name": "schema_invoice_baseline_v1",
+  "domain": "schema",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "schema",
+    "ir_version": 1,
+    "payload": {
+      "dialect_agnostic": true,
+      "models": [
+        {
+          "model_name": "Invoice",
+          "table_name": "invoice",
+          "columns": [
+            {
+              "name": "id",
+              "logical_type": "integer",
+              "db_type": "bigint",
+              "nullable": false,
+              "primary_key": true,
+              "autoincrement": true,
+              "unique": false,
+              "index": false,
+              "default": null,
+              "format": null
+            },
+            {
+              "name": "number",
+              "logical_type": "string",
+              "db_type": "varchar(64)",
+              "nullable": false,
+              "primary_key": false,
+              "autoincrement": false,
+              "unique": true,
+              "index": false,
+              "default": null,
+              "format": null
+            },
+            {
+              "name": "customer_id",
+              "logical_type": "integer",
+              "db_type": "bigint",
+              "nullable": false,
+              "primary_key": false,
+              "autoincrement": false,
+              "unique": false,
+              "index": true,
+              "default": null,
+              "format": null
+            },
+            {
+              "name": "created_at",
+              "logical_type": "datetime",
+              "db_type": "timestamptz",
+              "nullable": false,
+              "primary_key": false,
+              "autoincrement": false,
+              "unique": false,
+              "index": true,
+              "default": "now()",
+              "format": "date-time"
+            }
+          ],
+          "foreign_keys": [
+            {
+              "column": "customer_id",
+              "to_table": "customer",
+              "to_column": "id",
+              "on_delete": "CASCADE",
+              "name": "fk_invoice_customer_id_customer"
+            }
+          ],
+          "indexes": [
+            {
+              "name": "idx_invoice_created_at",
+              "columns": ["created_at"],
+              "unique": false
+            },
+            {
+              "name": "idx_invoice_customer_id",
+              "columns": ["customer_id"],
+              "unique": false
+            }
+          ],
+          "uniques": [
+            {
+              "name": "uq_invoice_number",
+              "columns": ["number"]
+            }
+          ],
+          "checks": [
+            {
+              "name": "ck_invoice_number",
+              "expression": "length(number) > 0"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json
+++ b/tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json
@@ -1,0 +1,215 @@
+{
+  "vector_name": "schema_phase1_fixture_models_v1",
+  "domain": "schema",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "schema",
+    "ir_version": 1,
+    "payload": {
+      "dialect_agnostic": true,
+      "models": [
+        {
+          "model_name": "Member",
+          "table_name": "member",
+          "columns": [
+            {
+              "name": "email",
+              "logical_type": "string",
+              "db_type": "text",
+              "nullable": false,
+              "primary_key": false,
+              "autoincrement": false,
+              "unique": true,
+              "index": false,
+              "default": null,
+              "format": null
+            },
+            {
+              "name": "id",
+              "logical_type": "integer",
+              "db_type": "bigint",
+              "nullable": true,
+              "primary_key": true,
+              "autoincrement": true,
+              "unique": false,
+              "index": false,
+              "default": null,
+              "format": null
+            },
+            {
+              "name": "org_id",
+              "logical_type": "integer",
+              "db_type": "bigint",
+              "nullable": false,
+              "primary_key": false,
+              "autoincrement": false,
+              "unique": false,
+              "index": true,
+              "default": null,
+              "format": null
+            }
+          ],
+          "foreign_keys": [
+            {
+              "column": "org_id",
+              "to_table": "org",
+              "to_column": "id",
+              "on_delete": "CASCADE",
+              "name": "fk_member_org_id_org"
+            }
+          ],
+          "indexes": [
+            {
+              "name": "idx_member_org_id",
+              "columns": [
+                "org_id"
+              ],
+              "unique": false
+            }
+          ],
+          "uniques": [
+            {
+              "name": "uq_member_email",
+              "columns": [
+                "email"
+              ]
+            }
+          ],
+          "checks": []
+        },
+        {
+          "model_name": "Org",
+          "table_name": "org",
+          "columns": [
+            {
+              "name": "id",
+              "logical_type": "integer",
+              "db_type": "bigint",
+              "nullable": true,
+              "primary_key": true,
+              "autoincrement": true,
+              "unique": false,
+              "index": false,
+              "default": null,
+              "format": null
+            },
+            {
+              "name": "name",
+              "logical_type": "string",
+              "db_type": "text",
+              "nullable": false,
+              "primary_key": false,
+              "autoincrement": false,
+              "unique": false,
+              "index": true,
+              "default": null,
+              "format": null
+            },
+            {
+              "name": "slug",
+              "logical_type": "string",
+              "db_type": "text",
+              "nullable": false,
+              "primary_key": false,
+              "autoincrement": false,
+              "unique": true,
+              "index": false,
+              "default": null,
+              "format": null
+            }
+          ],
+          "foreign_keys": [],
+          "indexes": [
+            {
+              "name": "idx_org_name",
+              "columns": [
+                "name"
+              ],
+              "unique": false
+            }
+          ],
+          "uniques": [
+            {
+              "name": "uq_org_slug",
+              "columns": [
+                "slug"
+              ]
+            }
+          ],
+          "checks": []
+        },
+        {
+          "model_name": "Project",
+          "table_name": "project",
+          "columns": [
+            {
+              "name": "id",
+              "logical_type": "integer",
+              "db_type": "bigint",
+              "nullable": true,
+              "primary_key": true,
+              "autoincrement": true,
+              "unique": false,
+              "index": false,
+              "default": null,
+              "format": null
+            },
+            {
+              "name": "name",
+              "logical_type": "string",
+              "db_type": "text",
+              "nullable": false,
+              "primary_key": false,
+              "autoincrement": false,
+              "unique": false,
+              "index": false,
+              "default": null,
+              "format": null
+            },
+            {
+              "name": "org_id",
+              "logical_type": "integer",
+              "db_type": "bigint",
+              "nullable": false,
+              "primary_key": false,
+              "autoincrement": false,
+              "unique": false,
+              "index": true,
+              "default": null,
+              "format": null
+            }
+          ],
+          "foreign_keys": [
+            {
+              "column": "org_id",
+              "to_table": "org",
+              "to_column": "id",
+              "on_delete": "CASCADE",
+              "name": "fk_project_org_id_org"
+            }
+          ],
+          "indexes": [
+            {
+              "name": "idx_project_org_id",
+              "columns": [
+                "org_id"
+              ],
+              "unique": false
+            },
+            {
+              "name": "idx_project_org_id_name",
+              "columns": [
+                "org_id",
+                "name"
+              ],
+              "unique": false
+            }
+          ],
+          "uniques": [],
+          "checks": []
+        }
+      ]
+    }
+  },
+  "fingerprint": "e32e8b0dbb67269dc456904d344dca7cecd506aabe1837a544fc9fba5efc3d3d"
+}

--- a/tests/fixtures/shadow_reports/postgres.json
+++ b/tests/fixtures/shadow_reports/postgres.json
@@ -1,0 +1,47 @@
+{
+  "create_table": [
+    "CREATE TABLE IF NOT EXISTS \"shadowuser\" ( \"age\" integer, \"id\" serial PRIMARY KEY, \"name\" varchar )",
+    []
+  ],
+  "migration": [
+    [
+      "ALTER TABLE \"shadowuser\" ADD COLUMN \"age\" integer",
+      "ALTER TABLE \"shadowuser\" ADD COLUMN \"name\" varchar"
+    ],
+    []
+  ],
+  "query_compare": {
+    "legacy": {
+      "artifact": {
+        "bind_semantics": [
+          "I64(18)",
+          "String(\"a%\")",
+          "I64(5)",
+          "I64(1)"
+        ],
+        "operation": "select",
+        "semantic_signature": [
+          "age >= 18",
+          "name LIKE \"a%\""
+        ]
+      },
+      "sql": "SELECT \"shadowuser\".* FROM \"shadowuser\" WHERE \"age\" >= $1 AND \"name\" LIKE $2 ORDER BY \"age\" DESC LIMIT $3 OFFSET $4"
+    },
+    "matches": true,
+    "shadow": {
+      "artifact": {
+        "bind_semantics": [
+          "I64(18)",
+          "String(\"a%\")",
+          "I64(5)",
+          "I64(1)"
+        ],
+        "operation": "select",
+        "semantic_signature": [
+          "age >= 18",
+          "name LIKE \"a%\""
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/shadow_reports/sqlite.json
+++ b/tests/fixtures/shadow_reports/sqlite.json
@@ -1,0 +1,47 @@
+{
+  "create_table": [
+    "CREATE TABLE IF NOT EXISTS \"shadowuser\" ( \"age\" integer, \"id\" integer PRIMARY KEY AUTOINCREMENT, \"name\" varchar )",
+    []
+  ],
+  "migration": [
+    [
+      "ALTER TABLE \"shadowuser\" ADD COLUMN \"age\" integer",
+      "ALTER TABLE \"shadowuser\" ADD COLUMN \"name\" varchar"
+    ],
+    []
+  ],
+  "query_compare": {
+    "legacy": {
+      "artifact": {
+        "bind_semantics": [
+          "I64(18)",
+          "String(\"a%\")",
+          "I64(5)",
+          "I64(1)"
+        ],
+        "operation": "select",
+        "semantic_signature": [
+          "age >= 18",
+          "name LIKE \"a%\""
+        ]
+      },
+      "sql": "SELECT \"shadowuser\".* FROM \"shadowuser\" WHERE \"age\" >= ? AND \"name\" LIKE ? ORDER BY \"age\" DESC LIMIT ? OFFSET ?"
+    },
+    "matches": true,
+    "shadow": {
+      "artifact": {
+        "bind_semantics": [
+          "I64(18)",
+          "String(\"a%\")",
+          "I64(5)",
+          "I64(1)"
+        ],
+        "operation": "select",
+        "semantic_signature": [
+          "age >= 18",
+          "name LIKE \"a%\""
+        ]
+      }
+    }
+  }
+}

--- a/tests/test_alembic_bridge.py
+++ b/tests/test_alembic_bridge.py
@@ -15,7 +15,7 @@ from ferro import (
     clear_registry,
     reset_engine,
 )
-from ferro.migrations.alembic import _build_sa_table
+from ferro.migrations.alembic import _build_sa_table, _map_to_sa_type
 from ferro.migrations import get_metadata
 from ferro.schema_metadata import build_model_schema
 
@@ -78,10 +78,20 @@ def test_legacy_json_table_builder_emits_deprecation_warning():
         }
     }
     with pytest.deprecated_call(
-        match="_build_sa_table\\(\\) is deprecated.*Planned removal: v0\\.13\\.0"
+        match="_build_sa_table\\(\\) is deprecated.*Planned removal in v0\\.14\\.0"
     ):
         _build_sa_table(md, "legacydoc", schema, model_cls=None)
     assert "legacydoc" in md.tables
+
+
+def test_legacy_map_to_sa_type_emits_deprecation_warning():
+    schema = {"properties": {}}
+    col_info = {"type": "string"}
+    with pytest.deprecated_call(
+        match="_map_to_sa_type\\(\\) is deprecated.*Planned removal in v0\\.14\\.0"
+    ):
+        resolved = _map_to_sa_type(schema, col_info, "legacy_field")
+    assert isinstance(resolved, sa.String)
 
 
 def test_foreign_key_unique_true_propagates_to_shadow_column():

--- a/tests/test_alembic_bridge.py
+++ b/tests/test_alembic_bridge.py
@@ -15,6 +15,7 @@ from ferro import (
     clear_registry,
     reset_engine,
 )
+from ferro.migrations.alembic import _build_sa_table
 from ferro.migrations import get_metadata
 from ferro.schema_metadata import build_model_schema
 
@@ -66,6 +67,21 @@ def test_metadata_translation():
     fk = list(post_table.c.author_id.foreign_keys)[0]
     assert fk.target_fullname == "user.id"
     assert fk.ondelete == "CASCADE"
+
+
+def test_legacy_json_table_builder_emits_deprecation_warning():
+    md = sa.MetaData()
+    schema = {
+        "properties": {
+            "id": {"type": "integer", "primary_key": True, "autoincrement": True},
+            "name": {"type": "string"},
+        }
+    }
+    with pytest.deprecated_call(
+        match="_build_sa_table\\(\\) is deprecated.*Planned removal: v0\\.13\\.0"
+    ):
+        _build_sa_table(md, "legacydoc", schema, model_cls=None)
+    assert "legacydoc" in md.tables
 
 
 def test_foreign_key_unique_true_propagates_to_shadow_column():

--- a/tests/test_deprecated_operator_inventory.py
+++ b/tests/test_deprecated_operator_inventory.py
@@ -1,0 +1,51 @@
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+from tests import test_query_builder, test_query_typing
+
+
+def _marker_names(obj: object) -> set[str]:
+    marks = getattr(obj, "pytestmark", [])
+    if not isinstance(marks, list):
+        marks = [marks]
+    return {mark.name for mark in marks if hasattr(mark, "name")}
+
+
+def test_deprecated_operator_inventory_is_tracked():
+    expected_builder_tests = {
+        "test_model_where_clause",
+        "test_query_chaining_placeholders",
+    }
+    expected_typing_classes = {
+        "TestOperatorPathUnchanged",
+        "TestCombinedStyles",
+    }
+
+    marked_builder_tests = {
+        name
+        for name, value in vars(test_query_builder).items()
+        if name.startswith("test_")
+        and callable(value)
+        and "deprecated_operator_path" in _marker_names(value)
+    }
+    assert marked_builder_tests == expected_builder_tests
+
+    marked_typing_classes = {
+        name
+        for name, value in vars(test_query_typing).items()
+        if inspect.isclass(value) and "deprecated_operator_path" in _marker_names(value)
+    }
+    assert marked_typing_classes == expected_typing_classes
+
+
+def test_pytest_marker_documents_v013_removal_target():
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    content = pyproject.read_text(encoding="utf-8")
+    marker_entry = re.search(
+        r'deprecated_operator_path:[^"]*v0\.14\.0[^"]*',
+        content,
+    )
+    assert marker_entry is not None

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,74 @@
+import warnings
+
+import pytest
+
+from ferro._deprecations import (
+    IR_FIRST_DEPRECATION_REMOVE_IN,
+    IR_FIRST_DEPRECATION_SINCE,
+    deprecated,
+    deprecation_message,
+    enable_deprecation_warnings,
+    warn_deprecated,
+)
+
+
+def test_deprecation_message_includes_since_and_remove_in():
+    message = deprecation_message(
+        reason="Example API is deprecated.",
+        since=IR_FIRST_DEPRECATION_SINCE,
+        remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+    )
+    assert "Example API is deprecated." in message
+    assert f"Deprecated since {IR_FIRST_DEPRECATION_SINCE}." in message
+    assert f"Planned removal in {IR_FIRST_DEPRECATION_REMOVE_IN}." in message
+
+
+def test_deprecation_message_includes_reference_link():
+    message = deprecation_message(
+        reason="Example API is deprecated.",
+        since=IR_FIRST_DEPRECATION_SINCE,
+        remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+        reference="https://example.com/migrate",
+    )
+    assert message.endswith("See https://example.com/migrate.")
+
+
+def test_deprecated_decorator_emits_warning():
+    @deprecated(
+        reason="Legacy helper is deprecated.",
+        since=IR_FIRST_DEPRECATION_SINCE,
+        remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+    )
+    def legacy_helper() -> str:
+        return "ok"
+
+    with pytest.deprecated_call(
+        match=r"Legacy helper is deprecated\..*v0\.12\.0.*v0\.14\.0"
+    ):
+        assert legacy_helper() == "ok"
+
+
+def test_warn_deprecated_emits_warning():
+    with pytest.deprecated_call(match="Inline legacy path is deprecated.*v0\\.14\\.0"):
+        warn_deprecated(
+            reason="Inline legacy path is deprecated.",
+            since=IR_FIRST_DEPRECATION_SINCE,
+            remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
+        )
+
+
+def test_enable_deprecation_warnings_surfaces_library_deprecations():
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.resetwarnings()
+        enable_deprecation_warnings()
+
+        def _library_emitter() -> None:
+            warnings.warn("library deprecation", DeprecationWarning, stacklevel=1)
+
+        _library_emitter()
+
+    assert any(
+        issubclass(item.category, DeprecationWarning)
+        and str(item.message) == "library deprecation"
+        for item in captured
+    )

--- a/tests/test_documentation_features.py
+++ b/tests/test_documentation_features.py
@@ -264,7 +264,7 @@ async def test_refresh_method(db_url):
     user = await User.create(username="alice", email="alice@example.com")
 
     # Simulate external update
-    await User.where(User.id == user.id).update(email="updated@example.com")
+    await User.where(lambda t: t.id == user.id).update(email="updated@example.com")
 
     # Refresh instance
     await user.refresh()
@@ -337,7 +337,7 @@ async def test_where_equality(db_url):
     await User.create(username="alice", email="alice@example.com", is_active=True)
     await User.create(username="bob", email="bob@example.com", is_active=False)
 
-    active_users = await User.where(User.is_active == True).all()
+    active_users = await User.where(lambda t: t.is_active == True).all()  # noqa: E712
     assert len(active_users) == 1
     assert active_users[0].username == "alice"
 
@@ -352,11 +352,11 @@ async def test_where_comparison_operators(db_url):
         )
 
     # Greater than
-    expensive = await Product.where(Product.price > Decimal("20")).all()
+    expensive = await Product.where(lambda t: t.price > Decimal("20")).all()
     assert len(expensive) == 2  # 30 and 40
 
     # Less than or equal
-    cheap = await Product.where(Product.price <= Decimal("20")).all()
+    cheap = await Product.where(lambda t: t.price <= Decimal("20")).all()
     assert len(cheap) == 3  # 0, 10, 20
 
 
@@ -368,7 +368,7 @@ async def test_where_like_operator(db_url):
     await User.create(username="bob", email="bob@yahoo.com")
     await User.create(username="charlie", email="charlie@gmail.com")
 
-    gmail_users = await User.where(User.email.like("%gmail.com")).all()
+    gmail_users = await User.where(lambda t: t.email.like("%gmail.com")).all()
     assert len(gmail_users) == 2
 
 
@@ -384,7 +384,7 @@ async def test_where_in_operator(db_url):
 
     # Use enum values instead of enum instances
     staff = await User.where(
-        User.role.in_([UserRole.ADMIN.value, UserRole.MODERATOR.value])
+        lambda t: t.role.in_([UserRole.ADMIN.value, UserRole.MODERATOR.value])
     ).all()
     assert len(staff) == 2
 
@@ -407,7 +407,7 @@ async def test_logical_and_operator(db_url):
     )
 
     active_admins = await User.where(
-        (User.is_active == True) & (User.role == UserRole.ADMIN.value)
+        lambda t: (t.is_active == True) & (t.role == UserRole.ADMIN.value)  # noqa: E712
     ).all()
     assert len(active_admins) == 1
     assert active_admins[0].username == "alice"
@@ -424,7 +424,8 @@ async def test_logical_or_operator(db_url):
     )
 
     staff = await User.where(
-        (User.role == UserRole.ADMIN.value) | (User.role == UserRole.MODERATOR.value)
+        lambda t: (t.role == UserRole.ADMIN.value)
+        | (t.role == UserRole.MODERATOR.value)
     ).all()
     assert len(staff) == 2
 
@@ -471,11 +472,11 @@ async def test_query_first(db_url):
     await connect(db_url, auto_migrate=True)
     await User.create(username="alice", email="alice@example.com")
 
-    user = await User.where(User.username == "alice").first()
+    user = await User.where(lambda t: t.username == "alice").first()
     assert user is not None
     assert user.username == "alice"
 
-    none_user = await User.where(User.username == "nonexistent").first()
+    none_user = await User.where(lambda t: t.username == "nonexistent").first()
     assert none_user is None
 
 
@@ -487,7 +488,7 @@ async def test_query_count(db_url):
     await User.create(username="bob", email="bob@example.com", is_active=True)
     await User.create(username="charlie", email="charlie@example.com", is_active=False)
 
-    active_count = await User.where(User.is_active == True).count()
+    active_count = await User.where(lambda t: t.is_active == True).count()  # noqa: E712
     assert active_count == 2
 
 
@@ -497,10 +498,12 @@ async def test_query_exists(db_url):
     await connect(db_url, auto_migrate=True)
     await User.create(username="alice", email="alice@example.com", role=UserRole.ADMIN)
 
-    has_admin = await User.where(User.role == UserRole.ADMIN.value).exists()
+    has_admin = await User.where(lambda t: t.role == UserRole.ADMIN.value).exists()
     assert has_admin is True
 
-    has_moderator = await User.where(User.role == UserRole.MODERATOR.value).exists()
+    has_moderator = await User.where(
+        lambda t: t.role == UserRole.MODERATOR.value
+    ).exists()
     assert has_moderator is False
 
 
@@ -511,10 +514,12 @@ async def test_query_update(db_url):
     await User.create(username="alice", email="alice@example.com", is_active=True)
     await User.create(username="bob", email="bob@example.com", is_active=True)
 
-    count = await User.where(User.is_active == True).update(is_active=False)
+    count = await User.where(lambda t: t.is_active == True).update(  # noqa: E712
+        is_active=False
+    )
     assert count == 2
 
-    active_users = await User.where(User.is_active == True).all()
+    active_users = await User.where(lambda t: t.is_active == True).all()  # noqa: E712
     assert len(active_users) == 0
 
 
@@ -525,7 +530,7 @@ async def test_query_delete(db_url):
     await User.create(username="alice", email="alice@example.com", is_active=True)
     await User.create(username="bob", email="bob@example.com", is_active=False)
 
-    count = await User.where(User.is_active == False).delete()
+    count = await User.where(lambda t: t.is_active == False).delete()  # noqa: E712
     assert count == 1
 
     remaining = await User.all()
@@ -588,7 +593,7 @@ async def test_reverse_relation_filtering(db_url):
     )
     await Post.create(title="Draft", content="Content", author=author, published=False)
 
-    published = await author.posts.where(Post.published == True).all()
+    published = await author.posts.where(lambda t: t.published == True).all()  # noqa: E712
     assert len(published) == 1
     assert published[0].title == "Published"
 
@@ -604,7 +609,7 @@ async def test_shadow_field_access(db_url):
     assert post.author_id == author.id
 
     # Query by shadow field
-    posts = await Post.where(Post.author_id == author.id).all()
+    posts = await Post.where(lambda t: t.author_id == author.id).all()
     assert len(posts) == 1
 
 
@@ -796,15 +801,15 @@ async def test_tutorial_blog_example(db_url):
     comment2 = await Comment.create(text="Thanks for sharing", author=alice, post=post1)
 
     # Query: Find all published posts
-    published = await Post.where(Post.published == True).all()
+    published = await Post.where(lambda t: t.published == True).all()  # noqa: E712
     assert len(published) == 2
 
     # Query: Find posts by author
-    alice_posts = await Post.where(Post.author_id == alice.id).all()
+    alice_posts = await Post.where(lambda t: t.author_id == alice.id).all()
     assert len(alice_posts) == 2
 
     # Query: Get post with pattern matching
-    post = await Post.where(Post.title.like("%Fast%")).first()
+    post = await Post.where(lambda t: t.title.like("%Fast%")).first()
     assert post is not None
     assert post.title == "Why Ferro is Fast"
 
@@ -820,7 +825,7 @@ async def test_tutorial_blog_example(db_url):
     draft.published = True
     await draft.save()
 
-    published_after = await Post.where(Post.published == True).all()
+    published_after = await Post.where(lambda t: t.published == True).all()  # noqa: E712
     assert len(published_after) == 3
 
 

--- a/tests/test_hydration.py
+++ b/tests/test_hydration.py
@@ -10,6 +10,17 @@ pytestmark = pytest.mark.backend_matrix
 INIT_CALLED_COUNT = 0
 
 
+def _assert_pydantic_slots(
+    row: Model,
+    *,
+    expected_fields: set[str],
+    expected_extra: dict | None,
+) -> None:
+    assert row.__pydantic_fields_set__ == expected_fields
+    assert row.__pydantic_extra__ == expected_extra
+    assert row.__pydantic_private__ is None
+
+
 @pytest.mark.asyncio
 async def test_direct_injection_bypasses_init(db_url):
     """
@@ -68,9 +79,12 @@ async def test_hydrated_row_initializes_pydantic_slots(db_url):
 
     row = await SlotCheckUser.get(1)
     assert row is not None
+    _assert_pydantic_slots(
+        row,
+        expected_fields={"id", "name"},
+        expected_extra=None,
+    )
     assert dict(row)["name"] == "slot-check"
-    assert row.__pydantic_extra__ is None
-    assert row.__pydantic_private__ is None
     copied = row.model_copy()
     assert copied.name == row.name
     assert dict(copied)["name"] == "slot-check"
@@ -95,6 +109,59 @@ async def test_hydrated_extra_allow_starts_with_empty_extra_dict(db_url):
 
     row = await ExtraAllowUser.get(1)
     assert row is not None
-    assert row.__pydantic_extra__ == {}
-    assert row.__pydantic_private__ is None
+    _assert_pydantic_slots(
+        row,
+        expected_fields={"id", "name"},
+        expected_extra={},
+    )
     assert dict(row)["name"] == "ea"
+
+
+@pytest.mark.asyncio
+async def test_hydration_slots_match_across_get_all_and_first(db_url):
+    class SlotPathUser(Model):
+        id: int = Field(default=None, json_schema_extra={"primary_key": True})
+        name: str
+
+    await ferro.connect(db_url, auto_migrate=True)
+    await SlotPathUser(id=1, name="one").save()
+
+    ferro.reset_engine()
+    await ferro.connect(db_url, auto_migrate=True)
+
+    by_get = await SlotPathUser.get(1)
+    by_all = (await SlotPathUser.all())[0]
+    by_first = await SlotPathUser.where(SlotPathUser.id == 1).first()
+    assert by_get is not None
+    assert by_first is not None
+
+    for row in (by_get, by_all, by_first):
+        _assert_pydantic_slots(
+            row,
+            expected_fields={"id", "name"},
+            expected_extra=None,
+        )
+        assert row.name == "one"
+
+
+@pytest.mark.asyncio
+async def test_hydrated_extra_forbid_initializes_slots(db_url):
+    class ExtraForbidUser(Model):
+        model_config = ConfigDict(extra="forbid")
+
+        id: int = Field(default=None, json_schema_extra={"primary_key": True})
+        name: str
+
+    await ferro.connect(db_url, auto_migrate=True)
+    await ExtraForbidUser(id=1, name="ef").save()
+
+    ferro.reset_engine()
+    await ferro.connect(db_url, auto_migrate=True)
+
+    row = await ExtraForbidUser.get(1)
+    assert row is not None
+    _assert_pydantic_slots(
+        row,
+        expected_fields={"id", "name"},
+        expected_extra=None,
+    )

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -4,6 +4,10 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
+
+from ferro import clear_registry, reset_engine
+
 
 VECTORS_DIR = Path(__file__).parent / "fixtures" / "ir_vectors"
 SUPPORTED_DOMAINS = {"schema", "query", "codec"}
@@ -158,3 +162,58 @@ def test_ir_vectors_match_phase0_contract_envelope() -> None:
         )
         assert isinstance(ir["payload"], dict), f"{label}.ir.payload must be object"
         _validate_domain_payload(vector["domain"], ir["payload"], f"{label}.ir.payload")
+
+
+@pytest.fixture()
+def clean_model_registry() -> None:
+    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    reset_engine()
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+    yield
+    reset_engine()
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+
+
+def _load_vector(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_phase1_schema_compiler_matches_snapshot(clean_model_registry: None) -> None:
+    from ferro.ir import compile_registry_schema_ir, schema_ir_fingerprint
+    from ferro.relations import resolve_relationships
+
+    from tests.test_cross_emitter_parity import _build_fixture_models
+
+    _build_fixture_models()
+    resolve_relationships()
+
+    compiled = compile_registry_schema_ir()
+    snapshot = _load_vector(VECTORS_DIR / "schema_phase1_fixture_models_v1.json")
+
+    assert compiled == snapshot["ir"]
+    assert schema_ir_fingerprint(compiled) == snapshot["fingerprint"]
+
+
+def test_phase1_schema_compiler_is_deterministic(clean_model_registry: None) -> None:
+    from ferro.ir import compile_registry_schema_ir, schema_ir_fingerprint
+    from ferro.relations import resolve_relationships
+
+    from tests.test_cross_emitter_parity import _build_fixture_models
+
+    _build_fixture_models()
+    resolve_relationships()
+
+    first = compile_registry_schema_ir()
+    first_fp = schema_ir_fingerprint(first)
+    second = compile_registry_schema_ir()
+    second_fp = schema_ir_fingerprint(second)
+
+    assert first == second
+    assert first_fp == second_fp

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -1,18 +1,24 @@
 from __future__ import annotations
 
 import json
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from ferro import clear_registry, reset_engine
+from ferro import BackRef, Field, ManyToMany, Model, Relation, clear_registry, reset_engine
 
 
 VECTORS_DIR = Path(__file__).parent / "fixtures" / "ir_vectors"
 SUPPORTED_DOMAINS = {"schema", "query", "codec"}
 SUPPORTED_IR_VERSION = 1
 QUERY_OPERATORS = {"==", "!=", "<", "<=", ">", ">=", "IN", "LIKE", "AND", "OR"}
+
+
+class _DocFormat(StrEnum):
+    PDF = "pdf"
+    JSON = "json"
 
 
 def _load_vectors() -> list[tuple[Path, dict[str, Any]]]:
@@ -217,3 +223,43 @@ def test_phase1_schema_compiler_is_deterministic(clean_model_registry: None) -> 
 
     assert first == second
     assert first_fp == second_fp
+
+
+def test_schema_ir_compiler_emits_db_check_expression_for_closed_domain(
+    clean_model_registry: None,
+) -> None:
+    from ferro.ir import compile_registry_schema_ir
+    from ferro.relations import resolve_relationships
+
+    class Document(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        format: _DocFormat = Field(db_type="text", db_check=True)
+
+    resolve_relationships()
+    compiled = compile_registry_schema_ir()
+    models = compiled["payload"]["models"]
+    document = next(model for model in models if model["table_name"] == "document")
+    checks = document["checks"]
+    assert checks == [
+        {"name": "ck_document_format", "expression": "format IN ('pdf', 'json')"}
+    ]
+
+
+def test_schema_ir_compiler_includes_join_table_models(clean_model_registry: None) -> None:
+    from ferro.ir import compile_registry_schema_ir
+    from ferro.relations import resolve_relationships
+
+    class Tag(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+        posts: Relation[list["Post"]] = ManyToMany(related_name="tags")
+
+    class Post(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        title: str
+        tags: Relation[list["Tag"]] = BackRef()
+
+    resolve_relationships()
+    compiled = compile_registry_schema_ir()
+    table_names = {model["table_name"] for model in compiled["payload"]["models"]}
+    assert "tag_posts" in table_names

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+VECTORS_DIR = Path(__file__).parent / "fixtures" / "ir_vectors"
+SUPPORTED_DOMAINS = {"schema", "query", "codec"}
+SUPPORTED_IR_VERSION = 1
+QUERY_OPERATORS = {"==", "!=", "<", "<=", ">", ">=", "IN", "LIKE", "AND", "OR"}
+
+
+def _load_vectors() -> list[tuple[Path, dict[str, Any]]]:
+    loaded: list[tuple[Path, dict[str, Any]]] = []
+    for path in sorted(VECTORS_DIR.glob("*.json")):
+        loaded.append((path, json.loads(path.read_text(encoding="utf-8"))))
+    return loaded
+
+
+def _require_keys(obj: dict[str, Any], required: set[str], label: str) -> None:
+    missing = required - set(obj.keys())
+    assert not missing, f"{label} missing keys: {sorted(missing)}"
+
+
+def _validate_query_node(node: dict[str, Any], label: str) -> None:
+    _require_keys(node, {"node_kind", "operator"}, label)
+    node_kind = node["node_kind"]
+    operator = node["operator"]
+    assert node_kind in {"leaf", "compound"}, f"{label}.node_kind invalid: {node_kind!r}"
+    assert operator in QUERY_OPERATORS, f"{label}.operator invalid: {operator!r}"
+
+    if node_kind == "leaf":
+        _require_keys(node, {"column", "value"}, label)
+        assert isinstance(node["column"], str) and node["column"], (
+            f"{label}.column must be non-empty string"
+        )
+        value = node["value"]
+        assert isinstance(value, dict), f"{label}.value must be object"
+        _require_keys(value, {"kind", "value"}, f"{label}.value")
+        return
+
+    _require_keys(node, {"left", "right"}, label)
+    assert isinstance(node["left"], dict), f"{label}.left must be object"
+    assert isinstance(node["right"], dict), f"{label}.right must be object"
+    _validate_query_node(node["left"], f"{label}.left")
+    _validate_query_node(node["right"], f"{label}.right")
+
+
+def _validate_schema_payload(payload: dict[str, Any], label: str) -> None:
+    _require_keys(payload, {"dialect_agnostic", "models"}, label)
+    assert isinstance(payload["dialect_agnostic"], bool), (
+        f"{label}.dialect_agnostic must be bool"
+    )
+    models = payload["models"]
+    assert isinstance(models, list) and models, f"{label}.models must be non-empty list"
+    for i, model in enumerate(models):
+        model_label = f"{label}.models[{i}]"
+        assert isinstance(model, dict), f"{model_label} must be object"
+        _require_keys(
+            model,
+            {"model_name", "table_name", "columns", "foreign_keys", "indexes", "uniques", "checks"},
+            model_label,
+        )
+        assert isinstance(model["model_name"], str) and model["model_name"], (
+            f"{model_label}.model_name must be non-empty string"
+        )
+        assert isinstance(model["table_name"], str) and model["table_name"], (
+            f"{model_label}.table_name must be non-empty string"
+        )
+        assert isinstance(model["columns"], list) and model["columns"], (
+            f"{model_label}.columns must be non-empty list"
+        )
+
+
+def _validate_query_payload(payload: dict[str, Any], label: str) -> None:
+    _require_keys(payload, {"model_name", "where", "order_by", "limit", "offset", "m2m"}, label)
+    assert isinstance(payload["model_name"], str) and payload["model_name"], (
+        f"{label}.model_name must be non-empty string"
+    )
+    where_nodes = payload["where"]
+    assert isinstance(where_nodes, list) and where_nodes, f"{label}.where must be non-empty list"
+    for i, node in enumerate(where_nodes):
+        node_label = f"{label}.where[{i}]"
+        assert isinstance(node, dict), f"{node_label} must be object"
+        _validate_query_node(node, node_label)
+    assert isinstance(payload["order_by"], list), f"{label}.order_by must be list"
+    if payload["limit"] is not None:
+        assert isinstance(payload["limit"], int) and payload["limit"] >= 0, (
+            f"{label}.limit must be null or non-negative int"
+        )
+    if payload["offset"] is not None:
+        assert isinstance(payload["offset"], int) and payload["offset"] >= 0, (
+            f"{label}.offset must be null or non-negative int"
+        )
+    if payload["m2m"] is not None:
+        assert isinstance(payload["m2m"], dict), f"{label}.m2m must be null or object"
+
+
+def _validate_codec_payload(payload: dict[str, Any], label: str) -> None:
+    _require_keys(payload, {"bind_rules", "fetch_rules", "hydration_abi"}, label)
+    assert isinstance(payload["bind_rules"], list) and payload["bind_rules"], (
+        f"{label}.bind_rules must be non-empty list"
+    )
+    assert isinstance(payload["fetch_rules"], list) and payload["fetch_rules"], (
+        f"{label}.fetch_rules must be non-empty list"
+    )
+    hydration_abi = payload["hydration_abi"]
+    assert isinstance(hydration_abi, dict), f"{label}.hydration_abi must be object"
+    _require_keys(hydration_abi, {"constructor_mode", "required_slots"}, f"{label}.hydration_abi")
+    assert hydration_abi["constructor_mode"] == "direct_dict", (
+        f"{label}.hydration_abi.constructor_mode must be direct_dict"
+    )
+    required_slots = hydration_abi["required_slots"]
+    assert isinstance(required_slots, list) and required_slots, (
+        f"{label}.hydration_abi.required_slots must be non-empty list"
+    )
+
+
+def _validate_domain_payload(domain: str, payload: dict[str, Any], label: str) -> None:
+    if domain == "schema":
+        _validate_schema_payload(payload, label)
+    elif domain == "query":
+        _validate_query_payload(payload, label)
+    elif domain == "codec":
+        _validate_codec_payload(payload, label)
+    else:
+        raise AssertionError(f"{label}.domain unsupported: {domain}")
+
+
+def test_ir_vectors_directory_has_seed_vectors() -> None:
+    vectors = _load_vectors()
+    assert vectors, "Expected at least one IR vector fixture in tests/fixtures/ir_vectors"
+    found_domains = {payload["domain"] for _, payload in vectors if "domain" in payload}
+    assert SUPPORTED_DOMAINS.issubset(found_domains), (
+        f"Expected at least one vector for each domain: {sorted(SUPPORTED_DOMAINS)}"
+    )
+
+
+def test_ir_vectors_match_phase0_contract_envelope() -> None:
+    for path, vector in _load_vectors():
+        label = path.name
+        _require_keys(vector, {"vector_name", "domain", "expect_valid", "ir"}, label)
+        assert isinstance(vector["vector_name"], str) and vector["vector_name"], (
+            f"{label}.vector_name must be non-empty string"
+        )
+        assert vector["domain"] in SUPPORTED_DOMAINS, f"{label}.domain unsupported: {vector['domain']!r}"
+        assert vector["expect_valid"] is True, f"{label}.expect_valid must be true for Phase 0"
+
+        ir = vector["ir"]
+        assert isinstance(ir, dict), f"{label}.ir must be object"
+        _require_keys(ir, {"ir_kind", "ir_version", "payload"}, f"{label}.ir")
+        assert ir["ir_kind"] == vector["domain"], (
+            f"{label}.ir.ir_kind ({ir['ir_kind']!r}) must match domain ({vector['domain']!r})"
+        )
+        assert ir["ir_version"] == SUPPORTED_IR_VERSION, (
+            f"{label}.ir.ir_version must equal {SUPPORTED_IR_VERSION}"
+        )
+        assert isinstance(ir["payload"], dict), f"{label}.ir.payload must be object"
+        _validate_domain_payload(vector["domain"], ir["payload"], f"{label}.ir.payload")

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -115,6 +115,41 @@ def _validate_codec_payload(payload: dict[str, Any], label: str) -> None:
     assert isinstance(payload["fetch_rules"], list) and payload["fetch_rules"], (
         f"{label}.fetch_rules must be non-empty list"
     )
+    bind_rules = payload["bind_rules"]
+    fetch_rules = payload["fetch_rules"]
+    for i, rule in enumerate(bind_rules):
+        rule_label = f"{label}.bind_rules[{i}]"
+        assert isinstance(rule, dict), f"{rule_label} must be object"
+        _require_keys(
+            rule,
+            {"logical_type", "db_type", "non_null_wire_kind", "null_wire_kind"},
+            rule_label,
+        )
+    for i, rule in enumerate(fetch_rules):
+        rule_label = f"{label}.fetch_rules[{i}]"
+        assert isinstance(rule, dict), f"{rule_label} must be object"
+        _require_keys(rule, {"db_type", "wire_kind", "python_kind"}, rule_label)
+
+    bind_type_pairs = {(r["logical_type"], r["db_type"]) for r in bind_rules}
+    required_bind_pairs = {
+        ("uuid", "uuid"),
+        ("decimal", "numeric"),
+        ("datetime", "timestamptz"),
+        ("date", "date"),
+        ("enum", "enum"),
+    }
+    assert required_bind_pairs.issubset(bind_type_pairs), (
+        f"{label}.bind_rules missing required type pairs: "
+        f"{sorted(required_bind_pairs - bind_type_pairs)}"
+    )
+
+    fetch_db_types = {r["db_type"] for r in fetch_rules}
+    required_fetch_db_types = {"uuid", "numeric", "timestamptz", "date", "enum"}
+    assert required_fetch_db_types.issubset(fetch_db_types), (
+        f"{label}.fetch_rules missing required db types: "
+        f"{sorted(required_fetch_db_types - fetch_db_types)}"
+    )
+
     hydration_abi = payload["hydration_abi"]
     assert isinstance(hydration_abi, dict), f"{label}.hydration_abi must be object"
     _require_keys(hydration_abi, {"constructor_mode", "required_slots"}, f"{label}.hydration_abi")
@@ -125,6 +160,11 @@ def _validate_codec_payload(payload: dict[str, Any], label: str) -> None:
     assert isinstance(required_slots, list) and required_slots, (
         f"{label}.hydration_abi.required_slots must be non-empty list"
     )
+    assert {
+        "__pydantic_fields_set__",
+        "__pydantic_extra__",
+        "__pydantic_private__",
+    }.issubset(set(required_slots)), f"{label}.hydration_abi.required_slots missing required slots"
 
 
 def _validate_domain_payload(domain: str, payload: dict[str, Any], label: str) -> None:

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -212,19 +212,27 @@ def test_ir_vectors_match_phase0_contract_envelope() -> None:
 
 @pytest.fixture()
 def clean_model_registry() -> None:
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro import state as ferro_state
 
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    ferro_state._MODEL_REGISTRY_PY.clear()
+    ferro_state._PENDING_RELATIONS.clear()
+    ferro_state._JOIN_TABLE_REGISTRY.clear()
+    ferro_state._SCHEMA_IR_BY_MODEL.clear()
+    ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL.clear()
+    ferro_state._SCHEMA_IR_MODELSET = None
+    ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = None
     yield
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    ferro_state._MODEL_REGISTRY_PY.clear()
+    ferro_state._PENDING_RELATIONS.clear()
+    ferro_state._JOIN_TABLE_REGISTRY.clear()
+    ferro_state._SCHEMA_IR_BY_MODEL.clear()
+    ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL.clear()
+    ferro_state._SCHEMA_IR_MODELSET = None
+    ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = None
 
 
 def _load_vector(path: Path) -> dict[str, Any]:
@@ -263,6 +271,27 @@ def test_phase1_schema_compiler_is_deterministic(clean_model_registry: None) -> 
 
     assert first == second
     assert first_fp == second_fp
+
+
+def test_compile_registry_schema_ir_persists_modelset_cache(
+    clean_model_registry: None,
+) -> None:
+    from ferro import state as ferro_state
+    from ferro.ir import compile_registry_schema_ir, schema_ir_fingerprint
+    from ferro.relations import resolve_relationships
+
+    from tests.test_cross_emitter_parity import _build_fixture_models
+
+    _build_fixture_models()
+    resolve_relationships()
+
+    ferro_state._SCHEMA_IR_MODELSET = None
+    ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = None
+
+    compiled = compile_registry_schema_ir()
+
+    assert ferro_state._SCHEMA_IR_MODELSET == compiled
+    assert ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT == schema_ir_fingerprint(compiled)
 
 
 def test_schema_ir_compiler_emits_db_check_expression_for_closed_domain(

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -1,13 +1,14 @@
 import json
 import uuid
+import warnings
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from enum import Enum
 
 import pytest
 from ferro import Model, connect
-from ferro.query import Query, QueryNode
-from ferro.query.builder import _query_def_to_json
+from ferro.query import Query, QueryNode, col
+from ferro.query.builder import _query_ir_payload_to_json
 from ferro.query.nodes import _serialize_query_value
 from pydantic import Field
 
@@ -47,7 +48,7 @@ def test_serialize_query_value_normalizes_non_json_native_values():
     json.dumps(serialized)
 
 
-def test_query_def_to_json_serializes_m2m_context_without_mutating_query_state():
+def test_query_ir_payload_to_json_serializes_m2m_context_without_mutating_query_state():
     source_id = uuid.uuid4()
     query = Query(Model)._m2m(
         "post_tags",
@@ -57,18 +58,21 @@ def test_query_def_to_json_serializes_m2m_context_without_mutating_query_state()
     )
     query_def = {
         "model_name": "Tag",
-        "where_clause": [],
+        "where": [],
         "order_by": [],
         "limit": None,
         "offset": None,
         "m2m": query._m2m_context,
     }
 
-    query_json = _query_def_to_json(query_def)
+    query_json = _query_ir_payload_to_json(query_def)
+    payload = json.loads(query_json)
 
     assert query._m2m_context["source_id"] == source_id
     assert isinstance(query._m2m_context["source_id"], uuid.UUID)
-    assert json.loads(query_json)["m2m"]["source_id"] == str(source_id)
+    assert payload["ir_kind"] == "query"
+    assert payload["ir_version"] == 1
+    assert payload["payload"]["m2m"]["source_id"] == str(source_id)
 
 
 def test_query_node_to_dict_serializes_uuid_values_inside_in_filters():
@@ -77,6 +81,16 @@ def test_query_node_to_dict_serializes_uuid_values_inside_in_filters():
     node = QueryNode(column="run_id", operator="IN", value=[uid1, uid2])
 
     assert node.to_dict()["value"] == [str(uid1), str(uid2)]
+
+
+def test_query_node_to_ir_dict_uses_query_ir_shape():
+    node = QueryNode(column="age", operator=">=", value=18)
+    payload = node.to_ir_dict()
+
+    assert payload["node_kind"] == "leaf"
+    assert payload["column"] == "age"
+    assert payload["operator"] == ">="
+    assert payload["value"] == {"kind": "int", "value": 18}
 
 
 def test_field_proxy_operator_overloading():
@@ -99,6 +113,7 @@ def test_field_proxy_operator_overloading():
     assert expr.value == 18
 
 
+@pytest.mark.deprecated_operator_path
 def test_model_where_clause():
     """
     Test that Model.where() returns a Query object with the correct condition.
@@ -108,7 +123,8 @@ def test_model_where_clause():
         id: int = Field(json_schema_extra={"primary_key": True})
         age: int
 
-    query = QueryUser.where(QueryUser.age >= 21)
+    with pytest.deprecated_call(match="Operator predicate style"):
+        query = QueryUser.where(QueryUser.age >= 21)
 
     assert isinstance(query, Query)
     assert len(query.where_clause) == 1
@@ -117,6 +133,7 @@ def test_model_where_clause():
     assert query.where_clause[0].value == 21
 
 
+@pytest.mark.deprecated_operator_path
 def test_query_chaining_placeholders():
     """
     Test that Query object supports chaining (even if not yet executed).
@@ -126,7 +143,8 @@ def test_query_chaining_placeholders():
         id: int = Field(json_schema_extra={"primary_key": True})
         age: int
 
-    query = QueryUser.where(QueryUser.age >= 18).limit(10).offset(5)
+    with pytest.deprecated_call(match="Operator predicate style"):
+        query = QueryUser.where(QueryUser.age >= 18).limit(10).offset(5)
 
     assert query._limit == 10
     assert query._offset == 5
@@ -157,6 +175,18 @@ def test_in_operator_lshift():
         _ = QueryUser.username << "not a list"
 
 
+def test_col_style_where_does_not_emit_deprecation_warning():
+    class ColUser(Model):
+        id: int = Field(json_schema_extra={"primary_key": True})
+        age: int
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", DeprecationWarning)
+        query = ColUser.where(col(ColUser.age) >= 21)
+    assert isinstance(query, Query)
+    assert not [w for w in captured if issubclass(w.category, DeprecationWarning)]
+
+
 @pytest.mark.asyncio
 async def test_query_execution(db_url):
     """
@@ -177,19 +207,19 @@ async def test_query_execution(db_url):
     await FilterUser(id=3, username="alice", age=35).save()
 
     # 1. Test basic filter
-    results = await FilterUser.where(FilterUser.age >= 30).all()
+    results = await FilterUser.where(lambda t: t.age >= 30).all()
     assert len(results) == 2
     assert {r.username for r in results} == {"taylor", "alice"}
 
     # 2. Test IN filter
-    results_in = await FilterUser.where(FilterUser.username << ["jeff", "alice"]).all()
+    results_in = await FilterUser.where(lambda t: t.username << ["jeff", "alice"]).all()
     assert len(results_in) == 2
     assert {r.username for r in results_in} == {"jeff", "alice"}
 
     # 3. Test combined filters (Chaining)
-    results_chained = (
-        await FilterUser.where(FilterUser.age < 35).where(FilterUser.age > 20).all()
-    )
+    results_chained = await FilterUser.where(lambda t: t.age < 35).where(
+        lambda t: t.age > 20
+    ).all()
     assert len(results_chained) == 2
     assert {r.username for r in results_chained} == {"taylor", "jeff"}
 
@@ -208,12 +238,12 @@ async def test_query_first(db_url):
     await FirstUser(id=1, username="taylor").save()
 
     # 1. Match found
-    user = await FirstUser.where(FirstUser.username == "taylor").first()
+    user = await FirstUser.where(lambda t: t.username == "taylor").first()
     assert user is not None
     assert user.username == "taylor"
 
     # 2. No match found
-    no_user = await FirstUser.where(FirstUser.username == "nonexistent").first()
+    no_user = await FirstUser.where(lambda t: t.username == "nonexistent").first()
     assert no_user is None
 
 
@@ -235,7 +265,7 @@ async def test_sql_injection_protection(db_url):
 
     # If not parameterized, this might return the user.
     # If parameterized, it should look for the literal string and return None.
-    result = await SafeUser.where(SafeUser.username == injection_string).first()
+    result = await SafeUser.where(lambda t: t.username == injection_string).first()
 
     assert result is None
 
@@ -259,7 +289,7 @@ async def test_query_bitwise_logic(db_url):
     # 1. Test OR (|)
     # SQL: SELECT * FROM logicuser WHERE age < 30 OR username == 'alice'
     results_or = await LogicUser.where(
-        (LogicUser.age < 30) | (LogicUser.username == "alice")
+        lambda t: (t.age < 30) | (t.username == "alice")
     ).all()
     assert len(results_or) == 2
     assert {r.username for r in results_or} == {"jeff", "alice"}
@@ -267,7 +297,7 @@ async def test_query_bitwise_logic(db_url):
     # 2. Test nested AND (&) within WHERE
     # SQL: SELECT * FROM logicuser WHERE (age > 20) AND (username != 'taylor')
     results_and = await LogicUser.where(
-        (LogicUser.age > 20) & (LogicUser.username != "taylor")
+        lambda t: (t.age > 20) & (t.username != "taylor")
     ).all()
     assert len(results_and) == 2
     assert {r.username for r in results_and} == {"jeff", "alice"}
@@ -276,8 +306,7 @@ async def test_query_bitwise_logic(db_url):
     # SQL: SELECT * FROM logicuser WHERE (username == 'taylor' OR username == 'jeff') AND age > 28
     # Only taylor (30) matches both. jeff (25) is under 28.
     results_complex = await LogicUser.where(
-        ((LogicUser.username == "taylor") | (LogicUser.username == "jeff"))
-        & (LogicUser.age > 28)
+        lambda t: ((t.username == "taylor") | (t.username == "jeff")) & (t.age > 28)
     ).all()
     assert len(results_complex) == 1
     assert results_complex[0].username == "taylor"
@@ -300,10 +329,8 @@ async def test_query_bitwise_multiple_where(db_url):
     await LogicUser(id=3, username="alice", age=35).save()
 
     # (A OR B) AND (C)
-    query = LogicUser.where(
-        (LogicUser.username == "jeff") | (LogicUser.username == "alice")
-    )
-    query = query.where(LogicUser.age > 30)
+    query = LogicUser.where(lambda t: (t.username == "jeff") | (t.username == "alice"))
+    query = query.where(lambda t: t.age > 30)
 
     results = await query.all()
     assert len(results) == 1

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -123,7 +123,7 @@ def test_model_where_clause():
         id: int = Field(json_schema_extra={"primary_key": True})
         age: int
 
-    with pytest.deprecated_call(match="Operator predicate style"):
+    with pytest.deprecated_call(match="Operator predicate style.*v0\\.14\\.0"):
         query = QueryUser.where(QueryUser.age >= 21)
 
     assert isinstance(query, Query)
@@ -143,7 +143,7 @@ def test_query_chaining_placeholders():
         id: int = Field(json_schema_extra={"primary_key": True})
         age: int
 
-    with pytest.deprecated_call(match="Operator predicate style"):
+    with pytest.deprecated_call(match="Operator predicate style.*v0\\.14\\.0"):
         query = QueryUser.where(QueryUser.age >= 18).limit(10).offset(5)
 
     assert query._limit == 10

--- a/tests/test_query_typing.py
+++ b/tests/test_query_typing.py
@@ -43,14 +43,16 @@ def _clear_state():
 
 
 class TestColWrapper:
-    def test_col_returns_same_field_proxy(self):
-        """col(FieldProxy) is identity at runtime."""
+    def test_col_returns_field_proxy_with_same_column(self):
+        """col(FieldProxy) returns a typed query proxy for the same column."""
 
         class ColUser(Model):
             id: Annotated[int | None, FerroField(primary_key=True)] = None
             archived: bool = False
 
-        assert col(ColUser.archived) is ColUser.archived  # type: ignore[arg-type]
+        wrapped = col(ColUser.archived)  # type: ignore[arg-type]
+        assert isinstance(wrapped, FieldProxy)
+        assert wrapped.column == "archived"
 
     def test_col_eq_builds_query_node(self):
         """col(field) == value builds a QueryNode with the right shape."""
@@ -174,6 +176,8 @@ class TestLambdaPredicates:
 
 
 class TestOperatorPathUnchanged:
+    pytestmark = pytest.mark.deprecated_operator_path
+
     @pytest.mark.asyncio
     async def test_operator_eq_still_works(self, db_url):
         """The original ``Model.field == value`` form is unchanged at runtime.
@@ -193,7 +197,10 @@ class TestOperatorPathUnchanged:
         await OpUser(id=1, email="a@b.com").save()
         await OpUser(id=2, email="c@d.com").save()
 
-        rows = await OpUser.where(OpUser.email == "a@b.com").all()  # ty: ignore[no-matching-overload]
+        with pytest.deprecated_call(match="Operator predicate style"):
+            rows = await OpUser.where(
+                OpUser.email == "a@b.com"
+            ).all()  # ty: ignore[no-matching-overload]
         assert len(rows) == 1
         assert rows[0].email == "a@b.com"
 
@@ -204,6 +211,8 @@ class TestOperatorPathUnchanged:
 
 
 class TestCombinedStyles:
+    pytestmark = pytest.mark.deprecated_operator_path
+
     @pytest.mark.asyncio
     async def test_mixed_chain_executes(self, db_url):
         """Operator + col() + lambda chained together filter correctly."""
@@ -218,12 +227,13 @@ class TestCombinedStyles:
         await MixUser(id=1_001, role="admin", archived=True).save()
         await MixUser(id=2, role="user", archived=False).save()
 
-        rows = await (
-            MixUser.where(MixUser.id == 1)  # ty: ignore[no-matching-overload]
-            .where(col(MixUser.archived) == False)  # noqa: E712
-            .where(lambda t: t.role == "admin")
-            .all()
-        )
+        with pytest.deprecated_call(match="Operator predicate style"):
+            rows = await (
+                MixUser.where(MixUser.id == 1)  # ty: ignore[no-matching-overload]
+                .where(col(MixUser.archived) == False)  # noqa: E712
+                .where(lambda t: t.role == "admin")
+                .all()
+            )
         assert len(rows) == 1
         assert rows[0].id == 1
 

--- a/tests/test_query_typing.py
+++ b/tests/test_query_typing.py
@@ -197,7 +197,7 @@ class TestOperatorPathUnchanged:
         await OpUser(id=1, email="a@b.com").save()
         await OpUser(id=2, email="c@d.com").save()
 
-        with pytest.deprecated_call(match="Operator predicate style"):
+        with pytest.deprecated_call(match="Operator predicate style.*v0\\.14\\.0"):
             rows = await OpUser.where(
                 OpUser.email == "a@b.com"
             ).all()  # ty: ignore[no-matching-overload]
@@ -227,7 +227,7 @@ class TestCombinedStyles:
         await MixUser(id=1_001, role="admin", archived=True).save()
         await MixUser(id=2, role="user", archived=False).save()
 
-        with pytest.deprecated_call(match="Operator predicate style"):
+        with pytest.deprecated_call(match="Operator predicate style.*v0\\.14\\.0"):
             rows = await (
                 MixUser.where(MixUser.id == 1)  # ty: ignore[no-matching-overload]
                 .where(col(MixUser.archived) == False)  # noqa: E712

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -40,7 +40,9 @@ async def test_session_query_api_routes_to_bound_connection(tmp_path):
     assert fetched is not None
     assert fetched.label == "analytics"
 
-    with pytest.warns(DeprecationWarning, match="Implicit default-connection routing"):
+    with pytest.warns(
+        DeprecationWarning, match="Implicit default-connection routing.*v0\\.14\\.0"
+    ):
         default_rows = await SessionMarker.all()
     assert default_rows == []
 
@@ -89,9 +91,13 @@ async def test_legacy_unqualified_operation_warns(tmp_path):
     await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
     await ferro.create_tables()
 
-    with pytest.warns(DeprecationWarning, match="Implicit default-connection routing"):
+    with pytest.warns(
+        DeprecationWarning, match="Implicit default-connection routing.*v0\\.14\\.0"
+    ):
         created = await SessionMarker.create(id=10, label="legacy")
-    with pytest.warns(DeprecationWarning, match="Implicit default-connection routing"):
+    with pytest.warns(
+        DeprecationWarning, match="Implicit default-connection routing.*v0\\.14\\.0"
+    ):
         loaded = await SessionMarker.get(10)
 
     assert created.id == 10

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,98 @@
+from typing import Annotated
+
+import pytest
+
+import ferro
+
+
+pytestmark = pytest.mark.sqlite_only
+
+
+class SessionMarker(ferro.Model):
+    id: Annotated[int | None, ferro.FerroField(primary_key=True)] = None
+    label: str
+
+
+@pytest.fixture(autouse=True)
+def _ensure_models_registered():
+    from ferro.state import _MODEL_REGISTRY_PY
+
+    SessionMarker._reregister_ferro()
+    _MODEL_REGISTRY_PY[SessionMarker.__name__] = SessionMarker
+    yield
+
+
+@pytest.mark.asyncio
+async def test_session_query_api_routes_to_bound_connection(tmp_path):
+    app_db = tmp_path / "app.db"
+    analytics_db = tmp_path / "analytics.db"
+
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.connect(f"sqlite:{analytics_db}?mode=rwc", name="analytics")
+    await ferro.create_tables()
+    await ferro.create_tables(using="analytics")
+
+    async with ferro.engines.session("analytics") as session:
+        created = await SessionMarker.create(id=1, label="analytics")
+        fetched = await session.query(SessionMarker).where(lambda t: t.id == 1).first()
+
+    assert created.id == 1
+    assert fetched is not None
+    assert fetched.label == "analytics"
+
+    with pytest.warns(DeprecationWarning, match="Implicit default-connection routing"):
+        default_rows = await SessionMarker.all()
+    assert default_rows == []
+
+
+@pytest.mark.asyncio
+async def test_nested_sessions_shadow_and_restore(tmp_path):
+    app_db = tmp_path / "app.db"
+    analytics_db = tmp_path / "analytics.db"
+
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.connect(f"sqlite:{analytics_db}?mode=rwc", name="analytics")
+    await ferro.create_tables()
+    await ferro.create_tables(using="analytics")
+
+    async with ferro.engines.session("app"):
+        await SessionMarker.create(id=1, label="app")
+        async with ferro.engines.session("analytics"):
+            await SessionMarker.create(id=1, label="analytics")
+            inner_rows = await SessionMarker.all()
+            assert [row.label for row in inner_rows] == ["analytics"]
+        outer_rows = await SessionMarker.all()
+        assert [row.label for row in outer_rows] == ["app"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_session_override_beats_ambient(tmp_path):
+    app_db = tmp_path / "app.db"
+    analytics_db = tmp_path / "analytics.db"
+
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.connect(f"sqlite:{analytics_db}?mode=rwc", name="analytics")
+    await ferro.create_tables()
+    await ferro.create_tables(using="analytics")
+
+    async with ferro.engines.session("app") as app_session:
+        await SessionMarker.create(id=1, label="app")
+        async with ferro.engines.session("analytics"):
+            await SessionMarker.create(id=1, label="analytics")
+            rows = await SessionMarker.all(session=app_session)
+            assert [row.label for row in rows] == ["app"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_unqualified_operation_warns(tmp_path):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.create_tables()
+
+    with pytest.warns(DeprecationWarning, match="Implicit default-connection routing"):
+        created = await SessionMarker.create(id=10, label="legacy")
+    with pytest.warns(DeprecationWarning, match="Implicit default-connection routing"):
+        loaded = await SessionMarker.get(10)
+
+    assert created.id == 10
+    assert loaded.label == "legacy"

--- a/tests/test_shadow_reports.py
+++ b/tests/test_shadow_reports.py
@@ -10,7 +10,7 @@ from ferro._core import (
     _render_migration_sql_for_test,
     _shadow_compare_query_plan_for_test,
 )
-from ferro.query.builder import _query_def_to_json
+from ferro.query.builder import _query_ir_payload_to_json
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -25,12 +25,22 @@ def _report_for_backend(dialect: str) -> dict:
             "age": {"type": "integer"},
         }
     }
-    query_json = _query_def_to_json(
+    query_json = _query_ir_payload_to_json(
         {
             "model_name": "ShadowUser",
-            "where_clause": [
-                {"is_compound": False, "column": "age", "operator": ">=", "value": 18},
-                {"is_compound": False, "column": "name", "operator": "LIKE", "value": "a%"},
+            "where": [
+                {
+                    "node_kind": "leaf",
+                    "column": "age",
+                    "operator": ">=",
+                    "value": {"kind": "int", "value": 18},
+                },
+                {
+                    "node_kind": "leaf",
+                    "column": "name",
+                    "operator": "LIKE",
+                    "value": {"kind": "string", "value": "a%"},
+                },
             ],
             "order_by": [{"column": "age", "direction": "desc"}],
             "limit": 5,

--- a/tests/test_shadow_reports.py
+++ b/tests/test_shadow_reports.py
@@ -1,0 +1,102 @@
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import Field
+
+from ferro import Model, connect
+from ferro._core import (
+    _render_create_table_sql_for_test,
+    _render_migration_sql_for_test,
+    _shadow_compare_query_plan_for_test,
+)
+from ferro.query.builder import _query_def_to_json
+
+pytestmark = pytest.mark.backend_matrix
+
+SHADOW_FIXTURES = Path(__file__).parent / "fixtures" / "shadow_reports"
+
+
+def _report_for_backend(dialect: str) -> dict:
+    schema = {
+        "properties": {
+            "id": {"type": "integer", "primary_key": True, "autoincrement": True},
+            "name": {"type": "string", "ferro_nullable": True},
+            "age": {"type": "integer"},
+        }
+    }
+    query_json = _query_def_to_json(
+        {
+            "model_name": "ShadowUser",
+            "where_clause": [
+                {"is_compound": False, "column": "age", "operator": ">=", "value": 18},
+                {"is_compound": False, "column": "name", "operator": "LIKE", "value": "a%"},
+            ],
+            "order_by": [{"column": "age", "direction": "desc"}],
+            "limit": 5,
+            "offset": 1,
+            "m2m": None,
+        }
+    )
+    query_compare = json.loads(
+        _shadow_compare_query_plan_for_test(query_json, dialect, "select")
+    )
+    create_table_sql, create_table_extras = _render_create_table_sql_for_test(
+        "ShadowUser", json.dumps(schema), dialect
+    )
+    migration_stmts, migration_warns = _render_migration_sql_for_test(
+        "ShadowUser",
+        json.dumps(schema),
+        json.dumps(
+            [
+                {
+                    "name": "id",
+                    "declared_type": "integer",
+                    "is_primary_key": True,
+                    "is_nullable": False,
+                }
+            ]
+        ),
+        dialect,
+        True,
+        False,
+    )
+    return {
+        "query_compare": query_compare,
+        "create_table": [create_table_sql, list(create_table_extras)],
+        "migration": [list(migration_stmts), list(migration_warns)],
+    }
+
+
+def test_shadow_report_fixture_stable(db_backend: str) -> None:
+    report = _report_for_backend(db_backend)
+    fixture_path = SHADOW_FIXTURES / f"{db_backend}.json"
+    expected = json.loads(fixture_path.read_text(encoding="utf-8"))
+    assert report == expected
+
+
+@pytest.mark.asyncio
+async def test_shadow_runtime_strict_has_no_mismatch(monkeypatch: pytest.MonkeyPatch, db_url: str):
+    monkeypatch.setenv("FERRO_SHADOW_RUNTIME", "1")
+    monkeypatch.setenv("FERRO_SHADOW_RUNTIME_STRICT", "1")
+
+    class ShadowRuntimeUser(Model):
+        id: int = Field(json_schema_extra={"primary_key": True})
+        name: str
+        age: int
+
+    await connect(db_url, auto_migrate=True)
+    await ShadowRuntimeUser(id=1, name="alice", age=22).save()
+    await ShadowRuntimeUser(id=2, name="bob", age=17).save()
+
+    rows = await ShadowRuntimeUser.where(lambda t: t.age >= 18).all()
+    assert [row.name for row in rows] == ["alice"]
+
+    count = await ShadowRuntimeUser.where(lambda t: t.age >= 18).count()
+    assert count == 1
+
+    updated = await ShadowRuntimeUser.where(lambda t: t.name == "alice").update(age=23)
+    assert updated == 1
+
+    deleted = await ShadowRuntimeUser.where(lambda t: t.name == "bob").delete()
+    assert deleted == 1

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 
-def test_query_methods_use_query_def_serializer_instead_of_raw_json_dumps():
+def test_query_methods_use_query_ir_serializer_instead_of_raw_json_dumps():
     source = Path("src/ferro/query/builder.py").read_text(encoding="utf-8")
 
-    assert source.count("json.dumps(_serialize_query_value(query_def))") == 1
+    assert source.count("def _query_ir_payload_to_json(") == 1
     assert "json.dumps(query_def)" not in source

--- a/tests/test_typed_null_binds.py
+++ b/tests/test_typed_null_binds.py
@@ -178,12 +178,7 @@ async def test_uuid_pk_filter_by_string_does_not_send_text(db_url):
 @pytest.mark.asyncio
 @pytest.mark.backend_matrix
 async def test_insert_with_none_for_decimal(db_url):
-    """Nullable Decimal columns accept ``None`` on INSERT.
-
-    Decimal is currently bound as ``float8``-typed null on Postgres; native
-    ``numeric`` typed binds are deferred (plan §3 Scope Boundaries). This
-    test asserts user-facing behavior, not the wire-level type.
-    """
+    """Nullable Decimal columns accept ``None`` on INSERT with typed null binds."""
 
     class WithDecimal(Model):
         id: Annotated[int | None, FerroField(primary_key=True)] = None

--- a/tests/test_typed_null_binds.py
+++ b/tests/test_typed_null_binds.py
@@ -21,6 +21,7 @@ See ``docs/plans/2026-04-29-001-typed-null-binds-plan.md`` for context.
 import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
+import enum
 from typing import Annotated, Any
 
 import pytest
@@ -369,3 +370,43 @@ async def test_invalid_uuid_raises_pyvalueerror_or_pydantic_error(db_url):
         assert "withuuid" in msg.lower() or "WithUuid" in msg
         assert "run_id" in msg
         assert "not-a-uuid" in msg
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
+async def test_temporal_update_to_none_uses_unified_codec_path(db_url):
+    class TemporalUpdate(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        attached_at: datetime | None = None
+
+    await connect(db_url, auto_migrate=True)
+    row = await TemporalUpdate.create(attached_at=datetime.now(UTC))
+    updated = await TemporalUpdate.where(TemporalUpdate.id == row.id).update(attached_at=None)
+    assert updated == 1
+
+    fetched = await TemporalUpdate.get(row.id)
+    assert fetched is not None
+    assert fetched.attached_at is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_nullable_enum_null_and_value_roundtrip(db_url):
+    class RunState(str, enum.Enum):
+        READY = "ready"
+        DONE = "done"
+
+    class EnumNullRow(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        state: RunState | None = None
+
+    await connect(db_url, auto_migrate=True)
+    null_row = await EnumNullRow.create()
+    set_row = await EnumNullRow.create(state=RunState.READY)
+
+    fetched_null = await EnumNullRow.get(null_row.id)
+    fetched_set = await EnumNullRow.get(set_row.id)
+    assert fetched_null is not None
+    assert fetched_set is not None
+    assert fetched_null.state is None
+    assert fetched_set.state == RunState.READY

--- a/zensical.toml
+++ b/zensical.toml
@@ -30,6 +30,7 @@ nav = [
     { "Schema Migrations" = "guide/migrations.md" },
   ] },
   { "How-To" = [
+    { "Migrating to v0.12.0" = "howto/migrating-to-v0-12-0.md" },
     { "Testing" = "howto/testing.md" },
     { "Pagination" = "howto/pagination.md" },
     { "Timestamps" = "howto/timestamps.md" },


### PR DESCRIPTION
## Summary

This merges the **IR-first architecture program** (Phases 0–7) into `main`. Ferro now drives schema compilation, query execution, Alembic metadata, codec/hydration, and session routing from shared intermediate representations—eliminating whole classes of cross-emitter drift by construction.

**What users get in v0.12.0:**

- **SchemaIR** — compiled at class-creation time; Alembic `get_metadata()` derives from the SchemaIR modelset; golden-vector contract tests pin wire shapes
- **QueryIR** — typed query compilation end-to-end; lambda predicates are the recommended `where()` style
- **Codec registry + hydration ABI** — unified bind/fetch semantics; direct-to-dict hydration with Pydantic slot parity
- **Sessionized runtime** — `ferro.engines.session()` for explicit connection/transaction routing; legacy ambient routing deprecated through **v0.14.0**
- **Deprecation framework** — `ferro._deprecations` with `since` / `remove_in` / migration-guide `reference` links; warnings visible by default
- **Migration docs** — [Migrating to v0.12.0](docs/pages/howto/migrating-to-v0-12-0.md), maintainer guide, release checklist, roadmap evidence

**Known residual (accepted at merge; tracked in Phase 8):** runtime `auto_migrate` still executes the legacy enriched-JSON diff in `src/migrate.rs`. `crates/ferro-migrate` landed as a planner scaffold; executable DDL and runtime cutover are Phase 8 ([#117](https://github.com/syn54x/ferro-orm/issues/117)–[#120](https://github.com/syn54x/ferro-orm/issues/120), target `v0.13.0`).

**Explicitly deferred to Phase 9 (`v0.14.0`):** removal of compatibility shims (operator predicates, ambient routing, legacy Alembic JSON helpers). Epic [#107](https://github.com/syn54x/ferro-orm/issues/107) with sub-issues [#108](https://github.com/syn54x/ferro-orm/issues/108)–[#110](https://github.com/syn54x/ferro-orm/issues/110).

## Phase map (17 commits)

| Phase | Focus | Merged via |
| --- | --- | --- |
| 0 | IR contract freeze | #75 |
| 1 | IR core compiler + snapshots | #104 |
| 2 | Shadow runtime dual-run scaffolding | #105 |
| 3 | QueryIR cutover + operator deprecation track | #106 |
| 4 | SchemaIR DDL cutover + Alembic bridge | #112 |
| 5 | Codec registry + hydration ABI | #113 |
| 6 | Sessionized runtime state | #114 |
| 7 | Public release window + migration guides | #115 |
| — | Merge-readiness review fixes | `99ae829` |
| — | Doc/invariant alignment (architecture, roadmap, solutions) | `a022ebc`, `ec18b81` |

Canonical program doc: [`docs/plans/2026-06-19-001-ir-first-roadmap.md`](docs/plans/2026-06-19-001-ir-first-roadmap.md)

## Merge-readiness review (`99ae829`)

Pre-merge audit findings addressed on this branch:

- SchemaIR modelset cache now writes through `ferro.state` (not shadow `global`)
- Postgres decimal NULL bind parity across codec paths
- Query/insert builder errors propagate via `PyResult` instead of `unwrap()` (AGENTS.md I-3)
- Shadow CI aggregate gate fails closed when path-detection job fails
- Hand-written CHANGELOG entry removed (release flow generates it)

Documented in [`docs/solutions/architecture-patterns/ir-first-merge-readiness-review.md`](docs/solutions/architecture-patterns/ir-first-merge-readiness-review.md); invariant spec refreshed in [`docs/solutions/patterns/ir-invariants.md`](docs/solutions/patterns/ir-invariants.md).

## Test plan

- [x] `cargo test --no-default-features --features testing`
- [x] `cargo test -p ferro-schema-ir -p ferro-migrate`
- [x] `uv run pytest` (full suite)
- [x] `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres`
- [x] `uv run pytest -m deprecated_operator_path`
- [x] `uv run pytest tests/test_ir_vectors_contract.py tests/test_shadow_reports.py`
- [x] `uv run pytest tests/test_docs_examples.py`
- [x] `uv run zensical build --clean`
- [x] `uv run maturin build --release`
- [x] CI green on latest push (including shadow-reports gate)

## Pre-merge checklist

- [x] Merge-readiness review complete (`99ae829`)
- [x] `AGENTS.md` invariants I-1–I-3 spot-checked on merge-readiness diff
- [x] Architecture, roadmap, and migration guide aligned with Phase 8/9 sequencing
- [x] No open P0/P1 findings from review
- [ ] Final maintainer sign-off before merge to `main`
- [ ] CHANGELOG generated at release time (not hand-edited on branch)

## Issue status

Sub-phase work was closed in stacked PRs (#75, #104–#106, #112–#115). This PR is the **program integration** into `main`.

- **Phase 8** (runtime `ferro-migrate` cutover): epic [#117](https://github.com/syn54x/ferro-orm/issues/117), sub-issues [#118](https://github.com/syn54x/ferro-orm/issues/118)–[#120](https://github.com/syn54x/ferro-orm/issues/120) — open, post-merge
- **Phase 9** (shim removal): epic [#107](https://github.com/syn54x/ferro-orm/issues/107), sub-issues [#108](https://github.com/syn54x/ferro-orm/issues/108)–[#110](https://github.com/syn54x/ferro-orm/issues/110) — open, post-merge

- [x] Issue status updates for scoped sub-PR work are complete