### PR TITLE
fix: cross-context session teardown (Fixes #123)

### DIFF
--- a/docs/pages/api/connection.md
+++ b/docs/pages/api/connection.md
@@ -2,6 +2,8 @@
 
 Functions for managing database connections and the global model registry. `connect()` registers a (optionally named) connection pool; `reset_engine()` tears everything down; the registry helpers control schema creation and the identity map. Sessionized routing is exposed via `ferro.engines.session(name)` / `ferro.Session`. See the [Connections & Databases guide](../guide/connections.md).
 
+::: ferro.Session
+
 ::: ferro.connect
 
 ::: ferro.PoolConfig

--- a/docs/pages/guide/connections.md
+++ b/docs/pages/guide/connections.md
@@ -114,6 +114,33 @@ async with ferro.engines.session("analytics") as s:
 
 Inside an active session context, convenience APIs (`User.all()`, `User.where(...)`, `ferro.execute(...)`) automatically bind to that session's connection.
 
+### Request-scoped sessions
+
+For short units of work (HTTP handlers, scripts, tests), use `async with`:
+
+```python
+async with ferro.engines.session("analytics"):
+    rows = await User.where(lambda t: t.active == True).all()  # noqa: E712
+```
+
+### Long-lived sessions (GUI, app lifecycle)
+
+When startup and shutdown run in different asyncio tasks (for example Textual `on_mount` / `on_unmount`), open a session handle at startup and close it explicitly at shutdown:
+
+```python
+class App:
+    async def on_mount(self) -> None:
+        self.session = ferro.engines.session("default")
+        await self.session.__aenter__()
+
+    async def on_unmount(self) -> None:
+        await self.session.close()
+```
+
+`Session.close()` is safe across asyncio contexts and idempotent. Prefer explicit `session=` routing when ambient context may be unavailable in the closing task.
+
+`ferro.reset_engine()` tears down **all** connections and is intended for test isolation — not per-session app lifecycle teardown.
+
 Legacy implicit default-connection routing (calling unqualified operations outside a session) is still temporarily supported for compatibility, but now emits a deprecation warning and is on the `v0.14.0` removal track.
 Follow [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md) to remove these legacy call sites during the compatibility window.
 

--- a/docs/pages/guide/connections.md
+++ b/docs/pages/guide/connections.md
@@ -139,6 +139,10 @@ class App:
 
 `Session.close()` is safe across asyncio contexts and idempotent. Prefer explicit `session=` routing when ambient context may be unavailable in the closing task.
 
+After a cross-context close, the enter task may still hold a stale ambient session object until a new session is opened; ambient operations then raise `RuntimeError` with a session-closed message (including when `using=` names another connection). If nested sessions are open, close inner sessions from the same task or via cross-context `close()` before closing the outer handle in the original task.
+
+Operations on a closed session handle (ambient or explicit `session=`) raise `RuntimeError` rather than falling back to legacy default routing.
+
 `ferro.reset_engine()` tears down **all** connections and is intended for test isolation — not per-session app lifecycle teardown.
 
 Legacy implicit default-connection routing (calling unqualified operations outside a session) is still temporarily supported for compatibility, but now emits a deprecation warning and is on the `v0.14.0` removal track.

--- a/src/ferro/session.py
+++ b/src/ferro/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextvars
 from dataclasses import dataclass, field
 from typing import Any
@@ -24,50 +25,86 @@ class Session:
     _enter_context: contextvars.Context | None = field(
         default=None, repr=False, compare=False
     )
+    _enter_task: asyncio.Task[Any] | None = field(
+        default=None, repr=False, compare=False
+    )
 
     async def __aenter__(self) -> "Session":
         self.session_id, resolved_name = _core_open_session(self.connection_name)
         if self.connection_name is None:
             self.connection_name = resolved_name
-        self._enter_context = contextvars.copy_context()
         self._token = _CURRENT_SESSION.set(self)
+        self._enter_context = contextvars.copy_context()
+        self._enter_task = asyncio.current_task()
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
-        await self.close()
+        try:
+            await self.close()
+        except Exception as close_exc:
+            if exc_type is not None:
+                raise close_exc from exc
+            raise
 
     async def close(self) -> None:
         """Close this session and release its runtime state.
 
         Safe to call from a different asyncio context than ``__aenter__``.
         Repeated calls are no-ops.
+
+        Raises:
+            RuntimeError: If the ambient session in this asyncio context does not
+                match this handle (same-context lifecycle misuse).
         """
         if self.session_id is None and self._token is None:
             return
 
+        self._assert_close_allowed()
+
         if self.session_id is not None:
             session_id = self.session_id
-            self.session_id = None
             _core_close_session(session_id)
+            self.session_id = None
 
         if self._token is None:
             self._enter_context = None
+            self._enter_task = None
             return
 
         token = self._token
         self._token = None
         self._enter_context = None
+        self._enter_task = None
         self._restore_ambient_session(token)
+
+    def _assert_close_allowed(self) -> None:
+        if self._token is None:
+            return
+        if asyncio.current_task() is not self._enter_task:
+            return
+        ambient = _CURRENT_SESSION.get()
+        if ambient is self:
+            return
+        entered_ambient = (
+            self._enter_context.get(_CURRENT_SESSION)
+            if self._enter_context is not None
+            else None
+        )
+        if entered_ambient is self and ambient is not None:
+            raise RuntimeError(_SESSION_CLOSE_AMBIENT_MISMATCH)
 
     def _restore_ambient_session(self, token: Any) -> None:
         ambient = _CURRENT_SESSION.get()
+        if ambient is not self:
+            try:
+                _CURRENT_SESSION.reset(token)
+            except ValueError:
+                return
+            raise RuntimeError(_SESSION_CLOSE_AMBIENT_MISMATCH)
         try:
             _CURRENT_SESSION.reset(token)
         except ValueError:
-            # Token was created in a different asyncio context; skip reset.
             return
-        if ambient is not self:
-            raise RuntimeError(_SESSION_CLOSE_AMBIENT_MISMATCH)
 
     def query(self, model_cls):
         from .query import Query

--- a/src/ferro/session.py
+++ b/src/ferro/session.py
@@ -2,34 +2,72 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import contextvars
+from dataclasses import dataclass, field
 from typing import Any
 
 from ._core import close_session as _core_close_session
 from ._core import open_session as _core_open_session
 from .state import _CURRENT_SESSION
 
+_SESSION_CLOSE_AMBIENT_MISMATCH = (
+    "Session close failed: ambient session does not match the closing session. "
+    "This usually indicates session lifecycle misuse in the current asyncio context."
+)
+
 
 @dataclass(slots=True)
 class Session:
     connection_name: str | None = None
     session_id: str | None = None
-    _token: Any = None
+    _token: Any = field(default=None, repr=False, compare=False)
+    _enter_context: contextvars.Context | None = field(
+        default=None, repr=False, compare=False
+    )
 
     async def __aenter__(self) -> "Session":
         self.session_id, resolved_name = _core_open_session(self.connection_name)
         if self.connection_name is None:
             self.connection_name = resolved_name
+        self._enter_context = contextvars.copy_context()
         self._token = _CURRENT_SESSION.set(self)
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
-        if self._token is not None:
-            _CURRENT_SESSION.reset(self._token)
-            self._token = None
+        await self.close()
+
+    async def close(self) -> None:
+        """Close this session and release its runtime state.
+
+        Safe to call from a different asyncio context than ``__aenter__``.
+        Repeated calls are no-ops.
+        """
+        if self.session_id is None and self._token is None:
+            return
+
         if self.session_id is not None:
-            _core_close_session(self.session_id)
+            session_id = self.session_id
             self.session_id = None
+            _core_close_session(session_id)
+
+        if self._token is None:
+            self._enter_context = None
+            return
+
+        token = self._token
+        self._token = None
+        self._enter_context = None
+        self._restore_ambient_session(token)
+
+    def _restore_ambient_session(self, token: Any) -> None:
+        ambient = _CURRENT_SESSION.get()
+        try:
+            _CURRENT_SESSION.reset(token)
+        except ValueError:
+            # Token was created in a different asyncio context; skip reset.
+            return
+        if ambient is not self:
+            raise RuntimeError(_SESSION_CLOSE_AMBIENT_MISMATCH)
 
     def query(self, model_cls):
         from .query import Query

--- a/src/ferro/session.py
+++ b/src/ferro/session.py
@@ -42,9 +42,11 @@ class Session:
         try:
             await self.close()
         except Exception as close_exc:
-            if exc_type is not None:
-                raise close_exc from exc
-            raise
+            if exc_type is None:
+                raise
+            if exc is not None:
+                raise exc from close_exc
+            raise close_exc
 
     async def close(self) -> None:
         """Close this session and release its runtime state.

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -34,6 +34,16 @@ _LEGACY_DEFAULT_CONNECTION_REASON = (
     "ORM/raw operations."
 )
 
+_SESSION_CLOSED_MESSAGE = (
+    "Session is closed. Open a new session with "
+    "`async with ferro.engines.session(...)` or pass an active session handle."
+)
+
+
+def _ensure_active_session(session: SessionLike | None) -> None:
+    if session is not None and session.session_id is None:
+        raise RuntimeError(_SESSION_CLOSED_MESSAGE)
+
 # Global registry for models (Python side)
 _MODEL_REGISTRY_PY = {}
 
@@ -75,6 +85,8 @@ def resolve_operation_scope(
             )
         if explicit_session is None and using != effective_session.connection_name:
             effective_session = None
+
+    _ensure_active_session(effective_session)
 
     session_id = effective_session.session_id if effective_session is not None else None
 
@@ -123,6 +135,8 @@ def resolve_transaction_scope(
             )
         if explicit_session is None and using != effective_session.connection_name:
             effective_session = None
+
+    _ensure_active_session(effective_session)
 
     if parent_tx_id is not None:
         # Nested tx route is always inherited from parent.

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -86,6 +86,9 @@ def resolve_operation_scope(
         if explicit_session is None and using != effective_session.connection_name:
             effective_session = None
 
+    if explicit_session is None and ambient_session is not None:
+        _ensure_active_session(ambient_session)
+
     _ensure_active_session(effective_session)
 
     session_id = effective_session.session_id if effective_session is not None else None
@@ -135,6 +138,9 @@ def resolve_transaction_scope(
             )
         if explicit_session is None and using != effective_session.connection_name:
             effective_session = None
+
+    if explicit_session is None and ambient_session is not None:
+        _ensure_active_session(ambient_session)
 
     _ensure_active_session(effective_session)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -147,6 +147,9 @@ async def test_session_exit_from_different_asyncio_context_succeeds(tmp_path):
 
     await asyncio.create_task(close_stack())
 
+    with pytest.raises(RuntimeError, match="Session is closed.*Open a new session"):
+        await SessionMarker.all()
+
 
 @pytest.mark.asyncio
 async def test_session_close_from_different_context_succeeds(tmp_path):
@@ -162,6 +165,9 @@ async def test_session_close_from_different_context_succeeds(tmp_path):
 
     await asyncio.create_task(close_session())
     assert session.session_id is None
+
+    with pytest.raises(RuntimeError, match="Session is closed.*Open a new session"):
+        await SessionMarker.all()
 
 
 @pytest.mark.asyncio
@@ -198,7 +204,7 @@ async def test_nested_session_cross_context_close_inner_then_outer(tmp_path):
 
     await asyncio.create_task(close_inner())
 
-    with pytest.raises(RuntimeError, match="Session is closed"):
+    with pytest.raises(RuntimeError, match="Session is closed.*Open a new session"):
         await SessionMarker.all()
 
     rows = await SessionMarker.all(session=outer)
@@ -208,6 +214,10 @@ async def test_nested_session_cross_context_close_inner_then_outer(tmp_path):
         await outer.close()
 
     await asyncio.create_task(close_outer())
+    assert outer.session_id is None
+
+    with pytest.raises(RuntimeError, match="Session is closed.*Open a new session"):
+        await SessionMarker.all(session=outer)
 
 
 @pytest.mark.asyncio
@@ -226,7 +236,7 @@ async def test_ambient_operations_after_session_close_fail_with_session_closed_e
 
     await asyncio.create_task(close_session())
 
-    with pytest.raises(RuntimeError, match="Session is closed"):
+    with pytest.raises(RuntimeError, match="Session is closed.*Open a new session"):
         await SessionMarker.all()
 
 
@@ -241,7 +251,7 @@ async def test_explicit_session_query_after_close_fails_with_session_closed_erro
     await session.__aenter__()
     await session.close()
 
-    with pytest.raises(RuntimeError, match="Session is closed"):
+    with pytest.raises(RuntimeError, match="Session is closed.*Open a new session"):
         await session.query(SessionMarker).where(lambda t: t.id == 1).first()
 
 
@@ -262,3 +272,74 @@ async def test_same_context_exit_when_ambient_session_replaced_raises_clear_erro
 
     with pytest.raises(RuntimeError, match="ambient session does not match"):
         await outer.close()
+
+    assert outer.session_id is not None
+    assert _CURRENT_SESSION.get() is inner
+
+
+@pytest.mark.asyncio
+async def test_same_context_outer_close_after_inner_cross_context_close_raises(
+    tmp_path,
+):
+    app_db = tmp_path / "app.db"
+    analytics_db = tmp_path / "analytics.db"
+
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.connect(f"sqlite:{analytics_db}?mode=rwc", name="analytics")
+    await ferro.create_tables()
+    await ferro.create_tables(using="analytics")
+
+    outer = ferro.engines.session("app")
+    inner = ferro.engines.session("analytics")
+    await outer.__aenter__()
+    await inner.__aenter__()
+
+    async def close_inner() -> None:
+        await inner.close()
+
+    await asyncio.create_task(close_inner())
+
+    with pytest.raises(RuntimeError, match="ambient session does not match"):
+        await outer.close()
+
+    assert outer.session_id is not None
+
+
+@pytest.mark.asyncio
+async def test_stale_ambient_with_using_still_raises_session_closed(tmp_path):
+    app_db = tmp_path / "app.db"
+    analytics_db = tmp_path / "analytics.db"
+
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.connect(f"sqlite:{analytics_db}?mode=rwc", name="analytics")
+    await ferro.create_tables()
+    await ferro.create_tables(using="analytics")
+
+    session = ferro.engines.session("app")
+    await session.__aenter__()
+
+    async def close_session() -> None:
+        await session.close()
+
+    await asyncio.create_task(close_session())
+
+    with pytest.raises(RuntimeError, match="Session is closed.*Open a new session"):
+        await SessionMarker.all(using="analytics")
+
+
+@pytest.mark.asyncio
+async def test_transaction_after_cross_context_close_raises(tmp_path):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", auto_migrate=True)
+
+    session = ferro.engines.session("default")
+    await session.__aenter__()
+
+    async def close_session() -> None:
+        await session.close()
+
+    await asyncio.create_task(close_session())
+
+    with pytest.raises(RuntimeError, match="Session is closed.*Open a new session"):
+        async with ferro.transaction():
+            pass

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -343,3 +343,45 @@ async def test_transaction_after_cross_context_close_raises(tmp_path):
     with pytest.raises(RuntimeError, match="Session is closed.*Open a new session"):
         async with ferro.transaction():
             pass
+
+
+@pytest.mark.asyncio
+async def test_aexit_preserves_body_exception_when_close_fails(tmp_path):
+    from ferro.state import _CURRENT_SESSION
+
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.create_tables()
+
+    outer = ferro.engines.session("app")
+    inner = ferro.engines.session("analytics")
+    await outer.__aenter__()
+    _CURRENT_SESSION.set(inner)
+
+    body_error = ValueError("body failed")
+    with pytest.raises(ValueError, match="body failed") as exc_info:
+        await outer.__aexit__(ValueError, body_error, None)
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert "ambient session does not match" in str(exc_info.value.__cause__)
+
+
+@pytest.mark.asyncio
+async def test_aexit_preserves_cancelled_error_when_close_fails(tmp_path):
+    from ferro.state import _CURRENT_SESSION
+
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.create_tables()
+
+    outer = ferro.engines.session("app")
+    inner = ferro.engines.session("analytics")
+    await outer.__aenter__()
+    _CURRENT_SESSION.set(inner)
+
+    cancelled = asyncio.CancelledError("shutdown")
+    with pytest.raises(asyncio.CancelledError, match="shutdown") as exc_info:
+        await outer.__aexit__(asyncio.CancelledError, cancelled, None)
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert "ambient session does not match" in str(exc_info.value.__cause__)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,4 +1,6 @@
+import asyncio
 import warnings
+from contextlib import AsyncExitStack
 from typing import Annotated
 
 import pytest
@@ -128,3 +130,135 @@ async def test_legacy_unqualified_operation_warns(tmp_path):
 
     assert created.id == 10
     assert loaded.label == "legacy"
+
+
+@pytest.mark.asyncio
+async def test_session_exit_from_different_asyncio_context_succeeds(tmp_path):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", auto_migrate=True)
+
+    stack = AsyncExitStack()
+    await stack.__aenter__()
+    await stack.enter_async_context(ferro.engines.session("default"))
+    await SessionMarker.create(id=1, label="demo")
+
+    async def close_stack() -> None:
+        await stack.__aexit__(None, None, None)
+
+    await asyncio.create_task(close_stack())
+
+
+@pytest.mark.asyncio
+async def test_session_close_from_different_context_succeeds(tmp_path):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", auto_migrate=True)
+
+    session = ferro.engines.session("default")
+    await session.__aenter__()
+    await SessionMarker.create(id=2, label="demo")
+
+    async def close_session() -> None:
+        await session.close()
+
+    await asyncio.create_task(close_session())
+    assert session.session_id is None
+
+
+@pytest.mark.asyncio
+async def test_session_close_is_idempotent(tmp_path):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", auto_migrate=True)
+
+    session = ferro.engines.session("default")
+    await session.__aenter__()
+    await session.close()
+    await session.close()
+    assert session.session_id is None
+
+
+@pytest.mark.asyncio
+async def test_nested_session_cross_context_close_inner_then_outer(tmp_path):
+    app_db = tmp_path / "app.db"
+    analytics_db = tmp_path / "analytics.db"
+
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.connect(f"sqlite:{analytics_db}?mode=rwc", name="analytics")
+    await ferro.create_tables()
+    await ferro.create_tables(using="analytics")
+
+    outer = ferro.engines.session("app")
+    inner = ferro.engines.session("analytics")
+    await outer.__aenter__()
+    await SessionMarker.create(id=1, label="app")
+    await inner.__aenter__()
+    await SessionMarker.create(id=1, label="analytics")
+
+    async def close_inner() -> None:
+        await inner.close()
+
+    await asyncio.create_task(close_inner())
+
+    with pytest.raises(RuntimeError, match="Session is closed"):
+        await SessionMarker.all()
+
+    rows = await SessionMarker.all(session=outer)
+    assert [row.label for row in rows] == ["app"]
+
+    async def close_outer() -> None:
+        await outer.close()
+
+    await asyncio.create_task(close_outer())
+
+
+@pytest.mark.asyncio
+async def test_ambient_operations_after_session_close_fail_with_session_closed_error(
+    tmp_path,
+):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", auto_migrate=True)
+
+    session = ferro.engines.session("default")
+    await session.__aenter__()
+    await SessionMarker.create(id=3, label="demo")
+
+    async def close_session() -> None:
+        await session.close()
+
+    await asyncio.create_task(close_session())
+
+    with pytest.raises(RuntimeError, match="Session is closed"):
+        await SessionMarker.all()
+
+
+@pytest.mark.asyncio
+async def test_explicit_session_query_after_close_fails_with_session_closed_error(
+    tmp_path,
+):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", auto_migrate=True)
+
+    session = ferro.engines.session("default")
+    await session.__aenter__()
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="Session is closed"):
+        await session.query(SessionMarker).where(lambda t: t.id == 1).first()
+
+
+@pytest.mark.asyncio
+async def test_same_context_exit_when_ambient_session_replaced_raises_clear_error(
+    tmp_path,
+):
+    from ferro.state import _CURRENT_SESSION
+
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.create_tables()
+
+    outer = ferro.engines.session("app")
+    inner = ferro.engines.session("analytics")
+    await outer.__aenter__()
+    _CURRENT_SESSION.set(inner)
+
+    with pytest.raises(RuntimeError, match="ambient session does not match"):
+        await outer.close()


### PR DESCRIPTION
## Summary

- Add `Session.close()` for long-lived app lifecycles and make `__aexit__` delegate to it with cross-context-safe `ContextVar` handling.
- Fail loudly when ambient or explicit session handles are closed (`RuntimeError`), including when `using=` would previously bypass stale ambient routing.
- Harden same-context misuse detection (`_assert_close_allowed`) and preserve body/`CancelledError` as the primary exception when teardown also fails.
- Document request-scoped vs long-lived session patterns in the connections guide; expose `ferro.Session` in API docs.

Fixes #123

Related follow-ups (out of scope for this PR):
- #125 — close during active transaction
- #126 — concurrent `close()` race

## Test plan

- [x] `uv run pytest tests/test_session.py -q`
- [x] `uv run pytest tests/test_raw_sql.py tests/test_query_builder.py -q`
- [x] Issue #123 repro (AsyncExitStack enter/close across tasks) succeeds
- [ ] CI green

## Exit steps

- [x] Issue closure keywords included (`Fixes #123`)
- [ ] Merge after review

Made with [Cursor](https://cursor.com)