### PR TITLE
fix(session): reject close while transactions are active

### DIFF
--- a/docs/pages/guide/connections.md
+++ b/docs/pages/guide/connections.md
@@ -139,6 +139,8 @@ class App:
 
 `Session.close()` is safe across asyncio contexts and idempotent. Prefer explicit `session=` routing when ambient context may be unavailable in the closing task.
 
+Close raises `RuntimeError` if session-scoped transactions are still open — exit all `transaction()` blocks before closing the session.
+
 After a cross-context close, the enter task may still hold a stale ambient session object until a new session is opened; ambient operations then raise `RuntimeError` with a session-closed message (including when `using=` names another connection). If nested sessions are open, close inner sessions from the same task or via cross-context `close()` before closing the outer handle in the original task.
 
 Operations on a closed session handle (ambient or explicit `session=`) raise `RuntimeError` rather than falling back to legacy default routing.

--- a/docs/pages/guide/transactions.md
+++ b/docs/pages/guide/transactions.md
@@ -40,6 +40,8 @@ async with ferro.engines.session("analytics"):
 
 You can also pass an explicit session handle (`transaction(session=my_session)`) when ambient context is different and you need a deterministic override.
 
+`Session.close()` raises `RuntimeError` while session-scoped transactions are still open. Exit all `transaction()` blocks before closing the session.
+
 ## Raw SQL Inside a Transaction
 
 `transaction()` yields a `Transaction` handle exposing `execute` / `fetch_all` / `fetch_one` for raw SQL on the transaction's own connection — useful for Postgres GUCs (`set_config`, `SET LOCAL`), advisory locks, or any one-off statement that doesn't fit a model:

--- a/src/ferro/session.py
+++ b/src/ferro/session.py
@@ -56,7 +56,8 @@ class Session:
 
         Raises:
             RuntimeError: If the ambient session in this asyncio context does not
-                match this handle (same-context lifecycle misuse).
+                match this handle (same-context lifecycle misuse), or if
+                session-scoped transactions are still open.
         """
         if self.session_id is None and self._token is None:
             return

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -833,6 +833,13 @@ pub fn open_session(using: Option<String>) -> PyResult<(String, String)> {
 
 #[pyfunction]
 pub fn close_session(session_id: String) -> PyResult<()> {
+    let session = session_state(&session_id)?;
+    if !session.transaction_registry.is_empty() {
+        return Err(pyo3::exceptions::PyRuntimeError::new_err(
+            "Cannot close session while transactions are active. \
+             Exit all transaction() blocks before closing the session.",
+        ));
+    }
     if !unregister_session(&session_id) {
         return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
             "Session '{}' is not active",

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -9,8 +9,8 @@ use crate::backend::{
 use crate::query::{QueryDef, query_def_from_ir_payload};
 use crate::state::{
     IDENTITY_MAP, MODEL_REGISTRY, SqlDialect, TRANSACTION_REGISTRY,
-    TransactionConnection, TransactionHandle, connection_for_route, engine_for_connection,
-    register_session, session_state, unregister_session,
+    TransactionConnection, TransactionHandle, connection_for_route, ensure_session_idle_for_close,
+    engine_for_connection, register_session, session_state, unregister_session,
 };
 use ferro_schema_ir::{IrEnvelope, QueryIrPayload};
 use pyo3::prelude::*;
@@ -833,13 +833,7 @@ pub fn open_session(using: Option<String>) -> PyResult<(String, String)> {
 
 #[pyfunction]
 pub fn close_session(session_id: String) -> PyResult<()> {
-    let session = session_state(&session_id)?;
-    if !session.transaction_registry.is_empty() {
-        return Err(pyo3::exceptions::PyRuntimeError::new_err(
-            "Cannot close session while transactions are active. \
-             Exit all transaction() blocks before closing the session.",
-        ));
-    }
+    ensure_session_idle_for_close(&session_id)?;
     if !unregister_session(&session_id) {
         return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
             "Session '{}' is not active",

--- a/src/state.rs
+++ b/src/state.rs
@@ -199,6 +199,20 @@ pub fn session_state(session_id: &str) -> PyResult<Arc<SessionState>> {
         })
 }
 
+pub(crate) const SESSION_CLOSE_ACTIVE_TRANSACTIONS_MSG: &str =
+    "Cannot close session while transactions are active. \
+     Exit all transaction() blocks before closing the session.";
+
+pub fn ensure_session_idle_for_close(session_id: &str) -> PyResult<()> {
+    let session = session_state(session_id)?;
+    if !session.transaction_registry.is_empty() {
+        return Err(pyo3::exceptions::PyRuntimeError::new_err(
+            SESSION_CLOSE_ACTIVE_TRANSACTIONS_MSG,
+        ));
+    }
+    Ok(())
+}
+
 /// A Rust-native representation of database values.
 ///
 /// Used during the GIL-free parsing phase to move data from the database
@@ -260,5 +274,55 @@ impl RustValue {
             }
             RustValue::None => Ok(py.None().into_bound(py)),
         }
+    }
+}
+
+#[cfg(test)]
+mod session_close_tests {
+    use super::{TransactionHandle, register_session, unregister_session, SESSION_REGISTRY};
+    use crate::backend::EngineHandle;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    #[tokio::test]
+    async fn close_guard_uses_transaction_registry_emptiness() {
+        let session_id = register_session("default".to_string());
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("sqlite memory pool");
+        let engine = EngineHandle::new_sqlite(pool);
+        let conn = engine
+            .begin_transaction_connection()
+            .await
+            .expect("begin transaction connection");
+
+        {
+            let session = SESSION_REGISTRY
+                .get(&session_id)
+                .expect("session registered")
+                .value()
+                .clone();
+            session.transaction_registry.insert(
+                "tx-test".to_string(),
+                TransactionHandle::root(conn, "default".to_string()),
+            );
+            assert!(!session.transaction_registry.is_empty());
+        }
+
+        SESSION_REGISTRY
+            .get(&session_id)
+            .expect("session registered")
+            .transaction_registry
+            .clear();
+        assert!(
+            SESSION_REGISTRY
+                .get(&session_id)
+                .expect("session registered")
+                .transaction_registry
+                .is_empty()
+        );
+        assert!(unregister_session(&session_id));
     }
 }

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -346,6 +346,75 @@ async def test_transaction_after_cross_context_close_raises(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_close_rejected_during_active_transaction_cross_context(tmp_path):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", auto_migrate=True)
+
+    session = ferro.engines.session("default")
+    await session.__aenter__()
+
+    async with ferro.transaction():
+        close_error: BaseException | None = None
+
+        async def try_close() -> None:
+            nonlocal close_error
+            try:
+                await session.close()
+            except BaseException as exc:
+                close_error = exc
+
+        await asyncio.create_task(try_close())
+
+        assert isinstance(close_error, RuntimeError)
+        assert "transactions are active" in str(close_error)
+        assert session.session_id is not None
+
+        created = await SessionMarker.create(label="during-tx")
+        assert created.id is not None
+
+    fetched = await SessionMarker.where(lambda t: t.label == "during-tx").first()
+    assert fetched is not None
+
+    await session.close()
+    assert session.session_id is None
+
+
+@pytest.mark.asyncio
+async def test_close_rejected_during_active_transaction_same_context(tmp_path):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", auto_migrate=True)
+
+    session = ferro.engines.session("default")
+    await session.__aenter__()
+
+    async with ferro.transaction():
+        with pytest.raises(RuntimeError, match="transactions are active"):
+            await session.close()
+        assert session.session_id is not None
+
+    await session.close()
+    assert session.session_id is None
+
+
+@pytest.mark.asyncio
+async def test_close_rejected_during_nested_transaction(tmp_path):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", auto_migrate=True)
+
+    session = ferro.engines.session("default")
+    await session.__aenter__()
+
+    async with ferro.transaction():
+        async with ferro.transaction():
+            with pytest.raises(RuntimeError, match="transactions are active"):
+                await session.close()
+            assert session.session_id is not None
+
+    await session.close()
+    assert session.session_id is None
+
+
+@pytest.mark.asyncio
 async def test_aexit_preserves_body_exception_when_close_fails(tmp_path):
     from ferro.state import _CURRENT_SESSION
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 import warnings
 from contextlib import AsyncExitStack
 from typing import Annotated
@@ -345,6 +346,12 @@ async def test_transaction_after_cross_context_close_raises(tmp_path):
             pass
 
 
+_ACTIVE_TX_CLOSE_MSG = (
+    "Cannot close session while transactions are active. "
+    "Exit all transaction() blocks before closing the session."
+)
+
+
 @pytest.mark.asyncio
 async def test_close_rejected_during_active_transaction_cross_context(tmp_path):
     app_db = tmp_path / "app.db"
@@ -366,7 +373,7 @@ async def test_close_rejected_during_active_transaction_cross_context(tmp_path):
         await asyncio.create_task(try_close())
 
         assert isinstance(close_error, RuntimeError)
-        assert "transactions are active" in str(close_error)
+        assert str(close_error) == _ACTIVE_TX_CLOSE_MSG
         assert session.session_id is not None
 
         created = await SessionMarker.create(label="during-tx")
@@ -388,9 +395,61 @@ async def test_close_rejected_during_active_transaction_same_context(tmp_path):
     await session.__aenter__()
 
     async with ferro.transaction():
-        with pytest.raises(RuntimeError, match="transactions are active"):
+        with pytest.raises(RuntimeError, match=re.escape(_ACTIVE_TX_CLOSE_MSG)):
             await session.close()
         assert session.session_id is not None
+        created = await SessionMarker.create(label="same-context")
+        assert created.id is not None
+
+    fetched = await SessionMarker.where(lambda t: t.label == "same-context").first()
+    assert fetched is not None
+
+    await session.close()
+    assert session.session_id is None
+
+
+@pytest.mark.asyncio
+async def test_close_rejected_during_active_transaction_rollback(tmp_path):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", auto_migrate=True)
+
+    session = ferro.engines.session("default")
+    await session.__aenter__()
+
+    try:
+        async with ferro.transaction():
+            with pytest.raises(RuntimeError, match=re.escape(_ACTIVE_TX_CLOSE_MSG)):
+                await session.close()
+            assert session.session_id is not None
+            await SessionMarker.create(label="rolled-back")
+            raise RuntimeError("abort tx")
+    except RuntimeError:
+        pass
+
+    assert session.session_id is not None
+    assert not await SessionMarker.where(lambda t: t.label == "rolled-back").exists()
+
+    await session.close()
+    assert session.session_id is None
+
+
+@pytest.mark.asyncio
+async def test_close_rejected_with_explicit_transaction_session(tmp_path):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", auto_migrate=True)
+
+    session = ferro.engines.session("default")
+    await session.__aenter__()
+
+    async with ferro.transaction(session=session):
+        with pytest.raises(RuntimeError, match=re.escape(_ACTIVE_TX_CLOSE_MSG)):
+            await session.close()
+        assert session.session_id is not None
+        created = await SessionMarker.create(label="explicit-session")
+        assert created.id is not None
+
+    fetched = await SessionMarker.where(lambda t: t.label == "explicit-session").first()
+    assert fetched is not None
 
     await session.close()
     assert session.session_id is None
@@ -406,9 +465,20 @@ async def test_close_rejected_during_nested_transaction(tmp_path):
 
     async with ferro.transaction():
         async with ferro.transaction():
-            with pytest.raises(RuntimeError, match="transactions are active"):
+            with pytest.raises(RuntimeError, match=re.escape(_ACTIVE_TX_CLOSE_MSG)):
                 await session.close()
             assert session.session_id is not None
+            inner = await SessionMarker.create(label="nested-inner")
+            assert inner.id is not None
+
+        with pytest.raises(RuntimeError, match=re.escape(_ACTIVE_TX_CLOSE_MSG)):
+            await session.close()
+        assert session.session_id is not None
+        outer = await SessionMarker.create(label="nested-outer")
+        assert outer.id is not None
+
+    assert await SessionMarker.where(lambda t: t.label == "nested-inner").exists()
+    assert await SessionMarker.where(lambda t: t.label == "nested-outer").exists()
 
     await session.close()
     assert session.session_id is None


### PR DESCRIPTION
## Summary
- Reject `Session.close()` when the session has active session-scoped transactions by checking `transaction_registry` in Rust `close_session`
- Add regression tests for cross-context, same-context, and nested-transaction close attempts
- Document the constraint in the connections and transactions guides

Closes #125

## Test plan
- [x] `pytest tests/test_session.py -k close_rejected`
- [x] `pytest tests/test_session.py`
- [x] Full test suite (659 passed)

## Exit steps
- [x] Issue closure keyword included (`Closes #125`)

Made with [Cursor](https://cursor.com)