### PR TITLE
fix(session): serialize concurrent close teardown

### DIFF
--- a/src/ferro/session.py
+++ b/src/ferro/session.py
@@ -28,6 +28,7 @@ class Session:
     _enter_task: asyncio.Task[Any] | None = field(
         default=None, repr=False, compare=False
     )
+    _close_lock: asyncio.Lock | None = field(default=None, repr=False, compare=False)
 
     async def __aenter__(self) -> "Session":
         self.session_id, resolved_name = _core_open_session(self.connection_name)
@@ -59,26 +60,30 @@ class Session:
                 match this handle (same-context lifecycle misuse), or if
                 session-scoped transactions are still open.
         """
-        if self.session_id is None and self._token is None:
-            return
+        if self._close_lock is None:
+            self._close_lock = asyncio.Lock()
 
-        self._assert_close_allowed()
+        async with self._close_lock:
+            if self.session_id is None and self._token is None:
+                return
 
-        if self.session_id is not None:
-            session_id = self.session_id
-            _core_close_session(session_id)
-            self.session_id = None
+            self._assert_close_allowed()
 
-        if self._token is None:
+            if self.session_id is not None:
+                session_id = self.session_id
+                _core_close_session(session_id)
+                self.session_id = None
+
+            if self._token is None:
+                self._enter_context = None
+                self._enter_task = None
+                return
+
+            token = self._token
+            self._token = None
             self._enter_context = None
             self._enter_task = None
-            return
-
-        token = self._token
-        self._token = None
-        self._enter_context = None
-        self._enter_task = None
-        self._restore_ambient_session(token)
+            self._restore_ambient_session(token)
 
     def _assert_close_allowed(self) -> None:
         if self._token is None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -184,6 +184,35 @@ async def test_session_close_is_idempotent(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_concurrent_close_same_loop_is_idempotent(tmp_path):
+    app_db = tmp_path / "app.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", auto_migrate=True)
+
+    session = ferro.engines.session("default")
+    await session.__aenter__()
+    await SessionMarker.create(id=1, label="demo")
+
+    barrier = asyncio.Barrier(2)
+
+    async def close_after_barrier() -> None:
+        await barrier.wait()
+        await session.close()
+
+    results = await asyncio.gather(
+        close_after_barrier(),
+        close_after_barrier(),
+        return_exceptions=True,
+    )
+    assert not any(isinstance(r, BaseException) for r in results)
+    assert session.session_id is None
+
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="Session is closed.*Open a new session"):
+        await SessionMarker.all()
+
+
+@pytest.mark.asyncio
 async def test_nested_session_cross_context_close_inner_then_outer(tmp_path):
     app_db = tmp_path / "app.db"
     analytics_db = tmp_path / "analytics.db"


### PR DESCRIPTION
## Summary

- Add a per-`Session` `asyncio.Lock` so same-loop concurrent `close()` calls serialize teardown before Rust unregister and Python state clearing.
- Add barrier-synchronized concurrent close coverage in `tests/test_session.py`.
- Scope is same-loop concurrent close hardening only; cross-event-loop session ownership remains out of scope.

Closes #126

## Test plan

- [x] `uv run pytest tests/test_session.py -q`
- [ ] CI green on PR

## Exit steps

- [x] Issue closure keyword included (`Closes #126`)


Made with [Cursor](https://cursor.com)