### PR TITLE
docs(rust): add detailed docstrings for all public APIs

### DIFF
--- a/crates/ferro-migrate/src/lib.rs
+++ b/crates/ferro-migrate/src/lib.rs
@@ -1,34 +1,89 @@
+//! Schema IR diffing and coarse SQL emission for migration planning experiments.
+//!
+//! Compares two [`SchemaIrPayload`] snapshots and produces a [`MigrationPlan`]. Full typed
+//! `ADD COLUMN` / `ALTER COLUMN` DDL is still owned by the runtime auto-migrate path in
+//! `src/migrate.rs`; this crate expresses structural intent at the IR layer.
+
 use ferro_schema_ir::{IrEnvelope, SchemaIrPayload, SchemaModel};
 use std::collections::{BTreeMap, BTreeSet};
 
+/// SQL dialect tag for [`emit_sql`] placeholder rendering.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BackendDialect {
+    /// SQLite 3.
     Sqlite,
+    /// PostgreSQL.
     Postgres,
 }
 
+/// One structural change inferred from an IR diff.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MigrationOp {
-    AddTable { table: String },
-    DropTable { table: String },
-    AddColumn { table: String, column: String },
-    DropColumn { table: String, column: String },
-    AlterColumnType { table: String, column: String },
-    AlterColumnNullability { table: String, column: String },
+    /// A model exists in the new IR but not the old — table creation is delegated to the schema emitter.
+    AddTable {
+        /// Table to create.
+        table: String,
+    },
+    /// A model was removed — emits `DROP TABLE`.
+    DropTable {
+        /// Table to drop.
+        table: String,
+    },
+    /// A column exists on the model in the new IR but not in the live/old IR.
+    AddColumn {
+        /// Owning table.
+        table: String,
+        /// Column to add (typed DDL planned elsewhere).
+        column: String,
+    },
+    /// A column was removed from the model.
+    DropColumn {
+        /// Owning table.
+        table: String,
+        /// Column to drop.
+        column: String,
+    },
+    /// `db_type` changed for a column that exists in both snapshots.
+    AlterColumnType {
+        /// Owning table.
+        table: String,
+        /// Column whose storage type drifted.
+        column: String,
+    },
+    /// `nullable` changed for a column that exists in both snapshots.
+    AlterColumnNullability {
+        /// Owning table.
+        table: String,
+        /// Column whose nullability drifted.
+        column: String,
+    },
 }
 
+/// Ordered migration operations plus non-fatal warnings collected during planning.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct MigrationPlan {
+    /// Structural operations to apply (in order).
     pub operations: Vec<MigrationOp>,
+    /// Human-readable warnings (e.g. backend limitations) that do not abort planning.
     pub warnings: Vec<String>,
 }
 
 impl MigrationPlan {
+    /// Returns `true` when there are no operations to run.
     pub fn is_empty(&self) -> bool {
         self.operations.is_empty()
     }
 }
 
+/// Render coarse SQL (or comments) for each operation in `plan`.
+///
+/// # Arguments
+/// * `plan` — Operations produced by [`plan_from_ir`].
+/// * `dialect` — Target backend; affects comment text for unsupported alters on SQLite.
+///
+/// # Returns
+/// One SQL string (or explanatory comment line) per operation. `AddTable` / `AddColumn` /
+/// type-nullability alters are comments pointing callers at the full schema emitter.
 pub fn emit_sql(plan: &MigrationPlan, dialect: BackendDialect) -> Vec<String> {
     let mut sql = Vec::new();
     for operation in &plan.operations {
@@ -76,6 +131,18 @@ pub fn emit_sql(plan: &MigrationPlan, dialect: BackendDialect) -> Vec<String> {
     sql
 }
 
+/// Diff two schema IR envelopes and produce a [`MigrationPlan`].
+///
+/// Compares tables by `table_name` and columns by name within shared tables. Does not
+/// diff indexes, FKs, or checks yet — only table/column presence and `db_type` / `nullable`.
+///
+/// # Arguments
+/// * `old_ir` — Baseline schema snapshot.
+/// * `new_ir` — Desired schema snapshot.
+///
+/// # Returns
+/// A plan with add/drop/alter operations. Never fails; structural ambiguity is expressed
+/// as operations, not errors.
 pub fn plan_from_ir(
     old_ir: &IrEnvelope<SchemaIrPayload>,
     new_ir: &IrEnvelope<SchemaIrPayload>,

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -1,143 +1,235 @@
+//! Versioned intermediate representation (IR) types for Ferro schema, query, and codec contracts.
+//!
+//! Python builds IR envelopes and passes them across the FFI boundary as JSON. Rust deserializes
+//! into these types for query planning, shadow comparisons, and (eventually) full IR-first DDL.
+//! Fixture round-trip tests in this crate pin wire stability for `tests/fixtures/ir_vectors/`.
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Tagged envelope wrapping any Ferro IR payload.
+///
+/// Every IR document on the wire carries a kind and version so consumers can reject unknown
+/// formats before interpreting `payload`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct IrEnvelope<T> {
+    /// Discriminator for the payload shape (e.g. `"schema"`, `"query"`, `"codec"`).
     pub ir_kind: String,
+    /// Monotonic schema version for `ir_kind`; bump when the payload contract changes.
     pub ir_version: u32,
+    /// The deserialized IR body.
     pub payload: T,
 }
 
+/// Schema IR: registered models and their table-level artifacts.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SchemaIrPayload {
+    /// When true, column `db_type` tokens are backend-neutral until lowered by an emitter.
     pub dialect_agnostic: bool,
+    /// One entry per registered model, in registration order.
     pub models: Vec<SchemaModel>,
 }
 
+/// One model's logical schema as emitted from Python.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SchemaModel {
+    /// PascalCase model class name (e.g. `"User"`).
     pub model_name: String,
+    /// Physical table name (typically `model_name.to_lowercase()`).
     pub table_name: String,
+    /// Column definitions in declaration order.
     pub columns: Vec<SchemaColumn>,
+    /// Outgoing foreign keys from this table.
     pub foreign_keys: Vec<SchemaForeignKey>,
+    /// Non-unique indexes (single- and multi-column).
     pub indexes: Vec<SchemaIndex>,
+    /// Unique constraints (single- and multi-column).
     pub uniques: Vec<SchemaUnique>,
+    /// Check constraints (`db_check=True` and similar).
     pub checks: Vec<SchemaCheck>,
 }
 
+/// One column in schema IR.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SchemaColumn {
+    /// SQL column name.
     pub name: String,
+    /// Pydantic JSON Schema type family (e.g. `"string"`, `"integer"`).
     pub logical_type: String,
+    /// Canonical storage token (`text`, `uuid`, `timestamptz`, …) after Ferro lowering.
     pub db_type: String,
+    /// `true` when the user set an explicit `db_type=` on the field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub db_type_explicit: Option<bool>,
+    /// Whether the column allows SQL `NULL`.
     pub nullable: bool,
+    /// Primary-key column flag.
     pub primary_key: bool,
+    /// Autoincrement / serial semantics for integer PKs.
     pub autoincrement: bool,
+    /// Single-column `unique=True`.
     pub unique: bool,
+    /// Single-column `index=True`.
     pub index: bool,
+    /// Server-side default as JSON (scalar literals only on the wire).
     pub default: Option<Value>,
+    /// Pydantic `format` when present (`uuid`, `date-time`, …).
     pub format: Option<String>,
+    /// Allowed enum literals when the field is a string enum.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enum_values: Option<Vec<Value>>,
+    /// Postgres native enum type name when applicable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enum_type_name: Option<String>,
 }
 
+/// Foreign-key edge from `column` to `to_table.to_column`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SchemaForeignKey {
+    /// Local column (shadow `*_id` when using `ForeignKey`).
     pub column: String,
+    /// Referenced table.
     pub to_table: String,
+    /// Referenced column (usually the target PK).
     pub to_column: String,
+    /// `ON DELETE` action name when set (`CASCADE`, `SET NULL`, …).
     pub on_delete: Option<String>,
+    /// Explicit constraint name when provided.
     pub name: Option<String>,
 }
 
+/// B-tree index definition.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SchemaIndex {
+    /// Canonical index name (`idx_<table>_<col>` or composite variant).
     pub name: String,
+    /// Indexed columns in order.
     pub columns: Vec<String>,
+    /// `true` for `UNIQUE` indexes.
     pub unique: bool,
 }
 
+/// Unique constraint (may be backed by a unique index).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SchemaUnique {
+    /// Canonical unique name (`uq_<table>_<col>` or composite variant).
     pub name: String,
+    /// Constrained columns in order.
     pub columns: Vec<String>,
 }
 
+/// `CHECK` constraint on one or more columns.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SchemaCheck {
+    /// Canonical check name (`ck_<table>_<col>` for single-column checks).
     pub name: String,
+    /// SQL boolean expression inside the check.
     pub expression: String,
 }
 
+/// Query IR: filter, sort, pagination, and optional M2M join context.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueryIrPayload {
+    /// Model class name the query targets.
     pub model_name: String,
+    /// Root-level predicate nodes (implicitly AND-combined by the planner).
     #[serde(rename = "where")]
     pub where_clause: Vec<QueryNode>,
+    /// `ORDER BY` clauses in application order.
     pub order_by: Vec<QueryOrderBy>,
+    /// `LIMIT` when set.
     pub limit: Option<u64>,
+    /// `OFFSET` when set.
     pub offset: Option<u64>,
+    /// Many-to-many join metadata JSON, deserialized into [`M2mContext`] downstream.
     pub m2m: Option<Value>,
 }
 
+/// One `ORDER BY` term.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueryOrderBy {
+    /// Column name or qualified identifier.
     pub column: String,
+    /// Sort direction (`"asc"` or `"desc"`, case-insensitive in the planner).
     pub direction: String,
 }
 
+/// Predicate tree node in query IR (leaf comparison or compound AND/OR).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "node_kind")]
 pub enum QueryNode {
+    /// Column comparison (`==`, `!=`, `<`, `IN`, …) with a typed RHS.
     #[serde(rename = "leaf")]
     Leaf {
+        /// Comparison or membership operator token.
         operator: String,
+        /// Left-hand column name.
         column: String,
+        /// Typed right-hand value.
         value: QueryValue,
     },
+    /// Binary boolean combination of two child nodes.
     #[serde(rename = "compound")]
     Compound {
+        /// `"AND"` or `"OR"`.
         operator: String,
+        /// Left subtree.
         left: Box<QueryNode>,
+        /// Right subtree.
         right: Box<QueryNode>,
     },
 }
 
+/// Typed literal or parameter value on the RHS of a leaf predicate.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueryValue {
+    /// Wire kind discriminator (`"null"`, `"string"`, `"int"`, …).
     pub kind: String,
+    /// JSON-encoded value matching `kind`.
     pub value: Value,
 }
 
+/// Codec IR: bind/fetch rules and hydration ABI metadata for cross-language parity tests.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CodecIrPayload {
+    /// Rules for encoding Python/Rust values into SQL bind parameters.
     pub bind_rules: Vec<CodecBindRule>,
+    /// Rules for decoding wire values into Python-facing types.
     pub fetch_rules: Vec<CodecFetchRule>,
+    /// How hydrated instances must initialize Pydantic slots (see AGENTS.md I-2).
     pub hydration_abi: HydrationAbi,
 }
 
+/// Maps a logical column type to wire and null bind kinds.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CodecBindRule {
+    /// Pydantic JSON type family.
     pub logical_type: String,
+    /// Canonical `db_type` token.
     pub db_type: String,
+    /// Bind kind for non-null values.
     pub non_null_wire_kind: String,
+    /// Bind kind for SQL `NULL` (typed null binds on Postgres).
     pub null_wire_kind: String,
 }
 
+/// Maps a stored SQL type to wire and Python kinds after fetch.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CodecFetchRule {
+    /// Canonical or declared SQL type token.
     pub db_type: String,
+    /// Kind on the Rust wire (`EngineValue` family).
     pub wire_kind: String,
+    /// Python type name after hydration (`str`, `int`, `datetime`, …).
     pub python_kind: String,
 }
 
+/// Contract for direct-to-dict hydration without calling `BaseModel.__init__`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct HydrationAbi {
+    /// Construction mode (`"direct_dict"` today).
     pub constructor_mode: String,
+    /// Pydantic slot names that must be initialized on every hydrated instance.
     pub required_slots: Vec<String>,
 }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,3 +1,8 @@
+//! SQLx-backed database engine: pools, connections, typed binds, and row fetch.
+//!
+//! [`EngineHandle`] is the per-connection runtime entry point. All SQL execution flows through
+//! it so pool refresh, identity-map policy, and shadow-runtime hooks stay centralized.
+
 use sqlx::ColumnIndex;
 use sqlx::pool::PoolConnection;
 use sqlx::postgres::PgPoolOptions;
@@ -32,12 +37,16 @@ impl BackendKind {
 /// (see [`EngineHandle::refresh_pool`]).
 #[derive(Clone, Debug)]
 pub struct PoolSpec {
+    /// Classified backend for pool construction.
     pub backend: BackendKind,
+    /// Connection URL passed to SQLx (`sqlite:…`, `postgres://…`).
     pub url: String,
     /// Postgres `SET search_path` applied to every new connection
     /// (the `ferro_search_path` URL parameter).
     pub search_path: Option<String>,
+    /// Maximum pool size.
     pub max_connections: u32,
+    /// Minimum idle connections kept warm.
     pub min_connections: u32,
 }
 
@@ -121,9 +130,14 @@ impl BackendPool {
     }
 }
 
+/// A checked-out pool connection participating in a transaction or session.
+///
+/// Wrapped by [`crate::state::TransactionHandle`] and guarded by an async `Mutex`.
 #[allow(dead_code)]
 pub enum EngineConnection {
+    /// SQLite pool connection.
     Sqlite(PoolConnection<Sqlite>),
+    /// Postgres pool connection.
     Postgres(PoolConnection<Postgres>),
 }
 
@@ -148,12 +162,18 @@ pub enum NullKind {
     Untyped,
 }
 
+/// One bind parameter with optional SQL type tag for `NULL`.
 #[derive(Clone, Debug, PartialEq)]
 pub enum EngineBindValue {
+    /// Boolean bind.
     Bool(bool),
+    /// 64-bit integer bind.
     I64(i64),
+    /// Floating-point bind.
     F64(f64),
+    /// Text bind.
     String(String),
+    /// Binary bind.
     Bytes(Vec<u8>),
     /// Typed UUID bind. Required so non-null UUIDs reach Postgres with the
     /// correct OID instead of being coerced to `text` (which fails since PG
@@ -163,28 +183,44 @@ pub enum EngineBindValue {
     Null(NullKind),
 }
 
+/// One fetched row as ordered `(column_name, value)` pairs.
 #[derive(Clone, Debug, PartialEq)]
 pub struct EngineRow {
+    /// Column values in result-set order.
     pub values: Vec<(String, EngineValue)>,
 }
 
+/// Result metadata from `INSERT`/`UPDATE`/`DELETE` execution.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EngineExecuteResult {
+    /// Rows reported by the driver.
     pub rows_affected: u64,
+    /// SQLite `last_insert_rowid()` when available.
     pub last_insert_id: Option<i64>,
 }
 
+/// Scalar value on the engine wire before schema-aware decoding.
 #[derive(Clone, Debug, PartialEq)]
 pub enum EngineValue {
+    /// Boolean column.
     Bool(bool),
+    /// Integer column.
     I64(i64),
+    /// Floating-point column.
     F64(f64),
+    /// Text or text-cast column.
     String(String),
+    /// Binary column.
     Bytes(Vec<u8>),
+    /// SQL `NULL`.
     Null,
 }
 
 impl EngineValue {
+    /// Coerce to `i64` when the wire value is numeric or a parseable decimal string.
+    ///
+    /// # Returns
+    /// `Some(i64)` for `I64` variants and parseable `String` values; otherwise `None`.
     pub fn as_i64(&self) -> Option<i64> {
         match self {
             Self::I64(value) => Some(*value),
@@ -690,6 +726,7 @@ where
     }
 }
 
+/// Error returned when a connection URL scheme is not `sqlite:` or `postgres`/`postgresql`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnsupportedDatabaseUrl {
     scheme: String,

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,9 +1,16 @@
+//! Schema-driven value encoding and decoding between JSON, SeaQuery, and [`RustValue`].
+//!
+//! Centralizes bind-expression construction for INSERT/UPDATE/query paths and row decoding
+//! after GIL-free fetch. Postgres-specific casts (UUID, enum UDT, temporal, JSON text) live
+//! here so SQLite and Postgres stay observationally equivalent at the Python boundary.
+
 use crate::backend::{EngineRow, EngineValue};
 use crate::state::{MODEL_REGISTRY, RustValue, SqlDialect};
 use sea_query::{Alias, Expr, SelectStatement, SimpleExpr, Value as SeaValue};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 
+/// One ORM row after GIL-free decode: optional stringified PK plus column values.
 pub type ParsedRow = (Option<String>, Vec<(String, RustValue)>);
 
 fn json_type(col_info: &Value) -> Option<&str> {
@@ -135,6 +142,17 @@ fn model_schema_property(model_name: &str, col_name: &str) -> Option<Value> {
     Some(col_info.clone())
 }
 
+/// Expand a `SELECT` column list on Postgres so text-like columns hydrate identically to SQLite.
+///
+/// UUID, temporal, decimal, JSON, enum, and native enum UDT columns are wrapped in
+/// `CAST(... AS text)` in the projection. Other backends receive `SELECT *`.
+///
+/// # Arguments
+/// * `select` — SeaQuery select under construction (mutated in place).
+/// * `table_name` — Physical table name for column qualification.
+/// * `schema` — Model JSON schema (`properties` map).
+/// * `pg_native_enum_columns` — Columns whose live type is `typtype = 'e'` in `pg_catalog`.
+/// * `backend` — Active dialect; no-op expansion when not Postgres.
 pub fn apply_postgres_text_select_columns(
     select: &mut SelectStatement,
     table_name: &str,
@@ -187,6 +205,26 @@ pub fn apply_postgres_text_select_columns(
     }
 }
 
+/// Build a typed SeaQuery RHS expression for INSERT/UPDATE from JSON field values.
+///
+/// Uses model schema metadata plus live Postgres catalog hints (`enum_udt`, `uuid_columns`,
+/// `ts_cast`) to emit OID-correct binds. See `docs/solutions/patterns/typed-null-binds.md`.
+///
+/// # Arguments
+/// * `schema` — Full model JSON schema.
+/// * `table_name` — Table name (for UUID parse error messages).
+/// * `col_name` — Target column.
+/// * `value` — JSON value from the Python layer (`null` for SQL `NULL`).
+/// * `enum_udt` — Native Postgres enum type names by column.
+/// * `uuid_columns` — Columns stored as SQL `uuid` on Postgres.
+/// * `ts_cast` — Per-column `CAST` target for date/timestamp families.
+/// * `backend` — Active SQL dialect.
+///
+/// # Returns
+/// A SeaQuery `SimpleExpr` suitable for `.values([...])` or `.set(...)`.
+///
+/// # Errors
+/// Returns `PyValueError` when a Postgres UUID string fails to parse.
 #[allow(clippy::too_many_arguments)]
 pub fn schema_bind_expr(
     schema: &Value,
@@ -323,6 +361,21 @@ pub fn schema_bind_expr(
     Ok(expr)
 }
 
+/// Build a typed SeaQuery RHS for WHERE-clause predicates.
+///
+/// Differs from [`schema_bind_expr`] in that enum casting uses catalog introspection only
+/// (not schema `enum_type_name`) so auto-migrated TEXT enum columns keep text binds.
+///
+/// # Arguments
+/// * `model_name` — Model class name for registry schema lookup.
+/// * `col_name` — Filtered column.
+/// * `val` — JSON RHS from the query IR.
+/// * `infer_uuid_without_schema` — When true, parse UUID strings even if schema lacks `format: uuid`.
+/// * `backend` — Active SQL dialect.
+/// * `postgres_enum_udt` — Native enum UDT names from `pg_catalog`.
+///
+/// # Returns
+/// A SeaQuery expression for the predicate RHS.
 pub fn query_bind_expr(
     model_name: &str,
     col_name: &str,
@@ -404,6 +457,16 @@ pub fn query_bind_expr(
     Expr::value(json_value_to_sea_value(val))
 }
 
+/// Wrap a many-to-many join-column bind with Postgres UUID typing when needed.
+///
+/// # Arguments
+/// * `col_name` — Join table column (`source_id` or `target_id`).
+/// * `value` — SeaQuery value produced from the Python ID.
+/// * `uuid_columns` — UUID-typed columns on the join table (Postgres catalog).
+/// * `backend` — Active SQL dialect.
+///
+/// # Returns
+/// Expression with `Value::Uuid` when the column is a Postgres UUID; otherwise passes `value` through.
 pub fn m2m_bind_expr(
     col_name: &str,
     value: SeaValue,
@@ -421,6 +484,16 @@ pub fn m2m_bind_expr(
     Expr::value(value)
 }
 
+/// Coerce a JSON literal into a SeaQuery `Value` without schema context.
+///
+/// Used as the fallback arm of [`query_bind_expr`] for non-null primitives.
+/// JSON `null` maps to `String(None)` (untyped null) — prefer schema-aware paths for NULL.
+///
+/// # Arguments
+/// * `value` — JSON value from the query IR.
+///
+/// # Returns
+/// Best-effort SeaQuery `Value` (`BigInt`, `Double`, `Bool`, `String`, or untyped null).
 pub fn json_value_to_sea_value(value: &Value) -> SeaValue {
     match value {
         Value::Number(n) => {
@@ -439,6 +512,18 @@ pub fn json_value_to_sea_value(value: &Value) -> SeaValue {
     }
 }
 
+/// Decode one [`EngineValue`] into a [`RustValue`] using model column metadata.
+///
+/// Applies decimal, binary, boolean-as-integer (SQLite), UUID, temporal, and JSON rules
+/// before the generic scalar mapping.
+///
+/// # Arguments
+/// * `value` — Wire value from SQLx fetch.
+/// * `schema` — Model JSON schema.
+/// * `col_name` — Column being decoded.
+///
+/// # Returns
+/// Rust-native value ready for [`RustValue::into_py_any`].
 pub fn decode_engine_value(value: EngineValue, schema: &Value, col_name: &str) -> RustValue {
     let prop = schema
         .get("properties")
@@ -489,6 +574,15 @@ pub fn decode_engine_value(value: EngineValue, schema: &Value, col_name: &str) -
     }
 }
 
+/// Decode a batch of [`EngineRow`]s into GIL-free [`ParsedRow`] data.
+///
+/// # Arguments
+/// * `rows` — Raw rows from the engine.
+/// * `schema` — Model JSON schema for per-column decoding.
+/// * `pk_col` — Primary key column name when known (extracts stringified PK per row).
+///
+/// # Returns
+/// One `(pk, fields)` tuple per input row.
 pub fn typed_rows_to_parsed_data(
     rows: Vec<EngineRow>,
     schema: &Value,

--- a/src/hydration.rs
+++ b/src/hydration.rs
@@ -1,7 +1,18 @@
+//! Zero-copy model hydration (AGENTS.md I-2).
+//!
+//! Builds Pydantic model instances by writing `__dict__` and required Pydantic slots directly,
+//! without calling `BaseModel.__init__`. The Rust core must initialize every slot in
+//! `BaseModel.__slots__` that `__init__` would set (`__pydantic_fields_set__`,
+//! `__pydantic_extra__`, `__pydantic_private__`).
+
 use crate::state::RustValue;
 use pyo3::prelude::*;
 use std::collections::HashMap;
 
+/// Initialize Pydantic v2 hydration slots on a freshly allocated instance.
+///
+/// Mirrors `BaseModel.__init__` slot assignment so attribute access on hydrated instances
+/// matches conventionally constructed models.
 fn set_pydantic_hydration_slots<'py>(
     py: Python<'py>,
     cls: &Bound<'py, PyAny>,
@@ -22,6 +33,23 @@ fn set_pydantic_hydration_slots<'py>(
     Ok(())
 }
 
+/// Hydrate a model instance from pre-decoded column values.
+///
+/// Allocates via `cls.__new__(cls)`, writes fields into `__dict__`, sets
+/// `__ferro_connection_name`, and initializes Pydantic tracking slots.
+///
+/// # Arguments
+/// * `py` — Active Python interpreter token.
+/// * `cls` — Model class object (e.g. `User`).
+/// * `connection_name` — Registered connection name stored on the instance for routing.
+/// * `fields` — `(column_name, decoded_value)` pairs in query result order.
+/// * `py_col_names` — Interned `PyString` handles for column names (avoids per-row allocation).
+///
+/// # Returns
+/// A bound model instance with `__pydantic_fields_set__` populated for assigned columns.
+///
+/// # Errors
+/// Returns `PyErr` if `__new__`, dict/slot assignment, or `RustValue` → Python conversion fails.
 pub fn hydrate_model_instance<'py>(
     py: Python<'py>,
     cls: &Bound<'py, PyAny>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub fn emit_user_warning(message: &str) {
     });
 }
 
-/// Returns the current version of the Ferro core.
+/// Returns the current version of the Ferro core (`CARGO_PKG_VERSION`).
 #[pyfunction]
 fn version() -> String {
     env!("CARGO_PKG_VERSION").to_string()

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -674,6 +674,21 @@ fn backend_column_value_expr(
     crate::codec::m2m_bind_expr(col_name, value, uuid_columns, backend)
 }
 
+/// Begin a root database transaction or a nested savepoint.
+///
+/// Root transactions call `BEGIN` on a fresh pool connection. Nested transactions require
+/// `parent_tx_id` and issue `SAVEPOINT` on the parent's connection.
+///
+/// Args:
+///     parent_tx_id (str | None): Parent transaction for nested savepoints.
+///     using (str | None): Connection name for root transactions (ignored when nested).
+///     session_id (str | None): When set, store the handle in session-local registry.
+///
+/// Returns:
+///     str: Opaque transaction id for `commit_transaction` / `rollback_transaction`.
+///
+/// # Errors
+/// `PyValueError` when `using` is passed with a parent id. `PyRuntimeError` on BEGIN/SAVEPOINT failure.
 #[pyfunction]
 #[pyo3(signature = (parent_tx_id=None, using=None, session_id=None))]
 pub fn begin_transaction(
@@ -733,6 +748,17 @@ pub fn begin_transaction(
     })
 }
 
+/// Commit a transaction or release a nested savepoint.
+///
+/// Args:
+///     tx_id (str): Id returned by `begin_transaction`.
+///     session_id (str | None): Session scope when the transaction was opened.
+///
+/// Returns:
+///     None
+///
+/// # Errors
+/// `PyRuntimeError` when the id is unknown or `COMMIT` / `RELEASE SAVEPOINT` fails.
 #[pyfunction]
 #[pyo3(signature = (tx_id, session_id=None))]
 pub fn commit_transaction(
@@ -768,6 +794,17 @@ pub fn commit_transaction(
     })
 }
 
+/// Return the connection name a transaction was opened on.
+///
+/// Args:
+///     tx_id (str): Active transaction id.
+///     session_id (str | None): Session scope when the transaction was opened.
+///
+/// Returns:
+///     str: Registered connection name.
+///
+/// # Errors
+/// `PyRuntimeError` when the transaction id is not found.
 #[pyfunction]
 #[pyo3(signature = (tx_id, session_id=None))]
 pub fn transaction_connection_name(tx_id: String, session_id: Option<String>) -> PyResult<String> {
@@ -776,6 +813,17 @@ pub fn transaction_connection_name(tx_id: String, session_id: Option<String>) ->
         .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Transaction not found"))
 }
 
+/// Roll back a transaction or nested savepoint and clear the identity map.
+///
+/// Args:
+///     tx_id (str): Id returned by `begin_transaction`.
+///     session_id (str | None): Session scope when the transaction was opened.
+///
+/// Returns:
+///     None
+///
+/// # Errors
+/// `PyRuntimeError` when the id is unknown or rollback SQL fails.
 #[pyfunction]
 #[pyo3(signature = (tx_id, session_id=None))]
 pub fn rollback_transaction(
@@ -823,6 +871,16 @@ pub fn rollback_transaction(
     })
 }
 
+/// Open a session that pins connection routing and isolates transaction/identity state.
+///
+/// Args:
+///     using (str | None): Connection to bind; defaults to the selected default connection.
+///
+/// Returns:
+///     tuple[str, str]: `(session_id, connection_name)`.
+///
+/// # Errors
+/// Same routing errors as [`crate::state::connection_for_route`].
 #[pyfunction]
 #[pyo3(signature = (using=None))]
 pub fn open_session(using: Option<String>) -> PyResult<(String, String)> {
@@ -831,6 +889,16 @@ pub fn open_session(using: Option<String>) -> PyResult<(String, String)> {
     Ok((session_id, connection_name))
 }
 
+/// Close a session after all transactions have exited.
+///
+/// Args:
+///     session_id (str): Id returned by `open_session`.
+///
+/// Returns:
+///     None
+///
+/// # Errors
+/// `PyRuntimeError` when transactions are still active or the session is unknown.
 #[pyfunction]
 pub fn close_session(session_id: String) -> PyResult<()> {
     ensure_session_idle_for_close(&session_id)?;
@@ -1321,7 +1389,20 @@ pub fn save_record(
     })
 }
 
-/// Persists multiple model instances in a single batch operation.
+/// Persist multiple model instances in a single batch `INSERT`.
+///
+/// Args:
+///     name (str): Model class name.
+///     data_list_json (str): JSON array of record objects (column → value).
+///     tx_id (str | None): Optional active transaction.
+///     using (str | None): Connection override.
+///     session_id (str | None): Session-scoped routing when set.
+///
+/// Returns:
+///     int: Number of rows inserted.
+///
+/// # Errors
+/// `PyValueError` for invalid JSON; `PyRuntimeError` on registry/execute failures.
 #[pyfunction]
 #[pyo3(signature = (name, data_list_json, tx_id=None, using=None, session_id=None))]
 pub fn save_bulk_records(
@@ -1639,7 +1720,20 @@ pub fn fetch_filtered<'py>(
     })
 }
 
-/// Returns the number of records matching a filtered query.
+/// Return the number of rows matching a filtered query.
+///
+/// Args:
+///     name (str): Model class name.
+///     query_ir_json (str): Serialized Query IR envelope JSON.
+///     tx_id (str | None): Optional active transaction.
+///     using (str | None): Connection override.
+///     session_id (str | None): Session-scoped routing when set.
+///
+/// Returns:
+///     int: Row count.
+///
+/// # Errors
+/// `PyRuntimeError` on registry, planning, or SQL failures.
 #[pyfunction]
 #[pyo3(signature = (name, query_ir_json, tx_id=None, using=None, session_id=None))]
 pub fn count_filtered(
@@ -1752,7 +1846,19 @@ pub fn count_filtered(
     })
 }
 
-/// Registers a live Python object in the global Identity Map.
+/// Register a live Python instance in the identity map for deduplication.
+///
+/// Args:
+///     connection_name (str): Connection the instance belongs to.
+///     name (str): Model class name.
+///     pk_val (str): Stringified primary key.
+///     obj (PyAny): Model instance to cache.
+///
+/// Returns:
+///     None
+///
+/// # Errors
+/// `PyRuntimeError` when the identity map cannot be updated.
 #[pyfunction]
 #[pyo3(signature = (name, pk, obj, using=None, session_id=None))]
 pub fn register_instance(
@@ -1774,7 +1880,15 @@ pub fn register_instance(
     Ok(())
 }
 
-/// Evicts a specific model instance from the global Identity Map.
+/// Remove one instance from the identity map.
+///
+/// Args:
+///     connection_name (str): Connection the instance was loaded on.
+///     name (str): Model class name.
+///     pk_val (str): Stringified primary key.
+///
+/// Returns:
+///     None
 #[pyfunction]
 #[pyo3(signature = (name, pk, using=None, session_id=None))]
 pub fn evict_instance(
@@ -1865,7 +1979,20 @@ pub fn delete_record(
     })
 }
 
-/// Deletes records matching a filtered query.
+/// Delete rows matching a filtered query.
+///
+/// Args:
+///     name (str): Model class name.
+///     query_ir_json (str): Serialized Query IR envelope JSON.
+///     tx_id (str | None): Optional active transaction.
+///     using (str | None): Connection override.
+///     session_id (str | None): Session-scoped routing when set.
+///
+/// Returns:
+///     int: Rows deleted.
+///
+/// # Errors
+/// `PyRuntimeError` on planning or execute failure.
 #[pyfunction]
 #[pyo3(signature = (name, query_ir_json, tx_id=None, using=None, session_id=None))]
 pub fn delete_filtered(
@@ -1915,7 +2042,21 @@ pub fn delete_filtered(
     })
 }
 
-/// Updates records matching a filtered query with provided values.
+/// Update rows matching a filtered query with column values from JSON.
+///
+/// Args:
+///     name (str): Model class name.
+///     query_ir_json (str): Serialized Query IR envelope JSON.
+///     values_json (str): JSON object of column → value assignments.
+///     tx_id (str | None): Optional active transaction.
+///     using (str | None): Connection override.
+///     session_id (str | None): Session-scoped routing when set.
+///
+/// Returns:
+///     int: Rows updated. Clears the identity map for the model when enabled.
+///
+/// # Errors
+/// `PyValueError` for invalid values JSON; `PyRuntimeError` on execute failure.
 #[pyfunction]
 #[pyo3(signature = (name, query_ir_json, update_json, tx_id=None, using=None, session_id=None))]
 pub fn update_filtered(
@@ -1999,6 +2140,23 @@ pub fn update_filtered(
     })
 }
 
+/// Insert many-to-many association rows into a join table.
+///
+/// Args:
+///     join_table (str): Association table name.
+///     source_col (str): FK column for the source model.
+///     target_col (str): FK column for the target model.
+///     source_id: Source row primary key.
+///     target_ids: Target row primary keys to link.
+///     tx_id (str | None): Optional active transaction.
+///     using (str | None): Connection override.
+///     session_id (str | None): Session-scoped routing when set.
+///
+/// Returns:
+///     None
+///
+/// # Errors
+/// `PyValueError` when an id is `None` or INSERT values are invalid; `PyRuntimeError` on execute failure.
 #[pyfunction]
 #[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None, session_id=None))]
 #[allow(clippy::too_many_arguments)]
@@ -2060,6 +2218,23 @@ pub fn add_m2m_links<'py>(
     })
 }
 
+/// Delete specific many-to-many association rows from a join table.
+///
+/// Args:
+///     join_table (str): Association table name.
+///     source_col (str): FK column for the source model.
+///     target_col (str): FK column for the target model.
+///     source_id: Source row primary key.
+///     target_ids: Target ids to unlink (must match existing rows).
+///     tx_id (str | None): Optional active transaction.
+///     using (str | None): Connection override.
+///     session_id (str | None): Session-scoped routing when set.
+///
+/// Returns:
+///     None
+///
+/// # Errors
+/// `PyRuntimeError` on execute failure.
 #[pyfunction]
 #[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None, session_id=None))]
 #[allow(clippy::too_many_arguments)]
@@ -2119,6 +2294,21 @@ pub fn remove_m2m_links<'py>(
     })
 }
 
+/// Delete all many-to-many links for a source row from a join table.
+///
+/// Args:
+///     join_table (str): Association table name.
+///     source_col (str): FK column for the source model.
+///     source_id: Source row primary key.
+///     tx_id (str | None): Optional active transaction.
+///     using (str | None): Connection override.
+///     session_id (str | None): Session-scoped routing when set.
+///
+/// Returns:
+///     None
+///
+/// # Errors
+/// `PyRuntimeError` on execute failure.
 #[pyfunction]
 #[pyo3(signature = (join_table, source_col, source_id, tx_id=None, using=None, session_id=None))]
 pub fn clear_m2m_links<'py>(
@@ -2360,6 +2550,19 @@ pub fn raw_fetch_all<'py>(
 }
 
 /// Run a raw SQL query and return the first row as a dict, or `None`.
+///
+/// Args:
+///     sql (str): Parameterized SQL (`?` / `$n` placeholders).
+///     args: Bind parameters (marshalled to typed engine binds).
+///     tx_id (str | None): Optional active transaction.
+///     using (str | None): Connection override.
+///     session_id (str | None): Session-scoped routing when set.
+///
+/// Returns:
+///     dict[str, Any] | None: First row as wire-close primitives, or `None` when no rows.
+///
+/// Values are wire-close primitives (`str | int | float | bool | bytes | None`).
+/// UUID/datetime/JSON columns come back as strings — use the ORM for typed hydration.
 #[pyfunction]
 #[pyo3(signature = (sql, args, tx_id=None, using=None, session_id=None))]
 pub fn raw_fetch_one<'py>(
@@ -2398,6 +2601,18 @@ pub fn raw_fetch_one<'py>(
     })
 }
 
+/// Compare legacy and IR query planners for shadow-runtime parity tests.
+///
+/// Args:
+///     query_payload_json (str): Query IR envelope JSON or legacy query JSON.
+///     dialect (str): `"postgres"` or `"sqlite"`.
+///     operation (str): Planner operation label (default `"select"`).
+///
+/// Returns:
+///     str: Semantic diff or match summary for assertions in pytest.
+///
+/// # Errors
+/// `PyValueError` for unknown dialect or unparseable JSON.
 #[pyfunction]
 #[pyo3(name = "_shadow_compare_query_plan_for_test")]
 #[pyo3(signature = (query_payload_json, dialect, operation="select".to_string()))]

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,3 +1,8 @@
+//! Query IR lowering to SeaQuery `Condition`s and semantic signatures for shadow comparison.
+//!
+//! Accepts legacy JSON query trees and canonical [`QueryIrPayload`] from `ferro_schema_ir`,
+//! then builds backend-aware filter SQL with typed null/UUID/enum binds via [`crate::codec`].
+
 use crate::state::SqlDialect;
 use ferro_schema_ir::{
     QueryIrPayload, QueryNode as QueryIrNode, QueryOrderBy as QueryIrOrderBy, QueryValue,
@@ -7,40 +12,63 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
+/// Legacy JSON query predicate node (leaf or compound AND/OR).
+///
+/// Prefer deserializing [`ferro_schema_ir::QueryNode`] and converting via
+/// [`query_def_from_ir_payload`] for new code paths.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct QueryNode {
+    /// `true` when `operator` is `AND`/`OR` and `left`/`right` are set.
     pub is_compound: bool,
+    /// `AND`, `OR`, or a leaf operator (`==`, `!=`, `<`, `IN`, …).
     pub operator: String,
-    // Fields for simple node
+    /// Leaf column name (when `is_compound` is false).
     pub column: Option<String>,
+    /// Leaf RHS JSON value (when `is_compound` is false).
     pub value: Option<Value>,
-    // Fields for compound node
+    /// Left child for compound nodes.
     pub left: Option<Box<QueryNode>>,
+    /// Right child for compound nodes.
     pub right: Option<Box<QueryNode>>,
 }
 
+/// One `ORDER BY` term in a [`QueryDef`].
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct OrderBy {
+    /// Column identifier.
     pub column: String,
+    /// `"asc"` or `"desc"` (case-insensitive when rendered).
     pub direction: String,
 }
 
+/// Many-to-many join context for filtered relation loads.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct M2mContext {
+    /// Association/join table name.
     pub join_table: String,
+    /// FK column pointing at the source model.
     pub source_col: String,
+    /// FK column pointing at the target model.
     pub target_col: String,
+    /// Source row primary key (JSON scalar).
     pub source_id: Value,
 }
 
+/// Fully resolved query plan ready for SeaQuery rendering.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct QueryDef {
+    /// Target model class name.
     #[allow(dead_code)]
     pub model_name: String,
+    /// Root predicates (implicit AND).
     pub where_clause: Vec<QueryNode>,
+    /// Sort order when present.
     pub order_by: Option<Vec<OrderBy>>,
+    /// `LIMIT` clause.
     pub limit: Option<u64>,
+    /// `OFFSET` clause.
     pub offset: Option<u64>,
+    /// M2M join filter when loading through an association table.
     pub m2m: Option<M2mContext>,
     /// Populated from `pg_catalog` before building filter SQL. Not part of the
     /// Python query JSON payload.
@@ -48,17 +76,34 @@ pub struct QueryDef {
     pub postgres_enum_udt: HashMap<String, String>,
 }
 
+/// Canonical semantic fingerprint of a query for shadow-runtime parity checks.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QuerySemanticSignature {
+    /// Model being queried.
     pub model_name: String,
+    /// Normalized predicate strings in evaluation order.
     pub where_semantics: Vec<String>,
+    /// `(column, direction)` pairs for `ORDER BY`.
     pub order_by: Vec<(String, String)>,
+    /// Limit when set.
     pub limit: Option<u64>,
+    /// Offset when set.
     pub offset: Option<u64>,
+    /// `(join_table, source_col, target_col, source_id)` when M2M-filtered.
     pub m2m: Option<(String, String, String, String)>,
 }
 
 impl QueryDef {
+    /// Combine all root predicates into one SeaQuery `Condition` (AND of nodes).
+    ///
+    /// # Arguments
+    /// * `backend` — Dialect for typed binds and operator lowering.
+    ///
+    /// # Returns
+    /// `Condition::all()` with each `where_clause` node applied.
+    ///
+    /// # Errors
+    /// Returns `Err(String)` for malformed nodes or unsupported operators.
     pub fn to_condition_for_backend(
         &self,
         backend: SqlDialect,
@@ -248,6 +293,10 @@ impl QueryDef {
         )
     }
 
+    /// Serialize this plan back to canonical query IR (round-trip helper / shadow tests).
+    ///
+    /// # Returns
+    /// [`QueryIrPayload`] suitable for JSON encoding.
     pub fn to_ir_payload(&self) -> QueryIrPayload {
         QueryIrPayload {
             model_name: self.model_name.clone(),
@@ -274,6 +323,10 @@ impl QueryDef {
         }
     }
 
+    /// Build a stable semantic signature for shadow-runtime SQL comparison.
+    ///
+    /// # Returns
+    /// Normalized predicate strings and sort/M2M metadata independent of bind spelling.
     pub fn semantic_signature(&self) -> QuerySemanticSignature {
         QuerySemanticSignature {
             model_name: self.model_name.clone(),
@@ -306,6 +359,17 @@ impl QueryDef {
     }
 }
 
+/// Convert canonical query IR into a runtime [`QueryDef`].
+///
+/// # Arguments
+/// * `payload` — Deserialized [`QueryIrPayload`] from Python.
+///
+/// # Returns
+/// A `QueryDef` with legacy [`QueryNode`] trees and empty `postgres_enum_udt`
+/// (callers populate enum UDT from catalog before building SQL).
+///
+/// # Errors
+/// Returns `Err(String)` when the `m2m` JSON blob cannot deserialize into [`M2mContext`].
 pub fn query_def_from_ir_payload(payload: QueryIrPayload) -> Result<QueryDef, String> {
     let m2m: Option<M2mContext> = match payload.m2m {
         Some(value) => serde_json::from_value(value)

--- a/src/state.rs
+++ b/src/state.rs
@@ -30,6 +30,16 @@ pub static CONNECTION_REGISTRY: Lazy<RwLock<HashMap<String, Arc<EngineHandle>>>>
 pub static DEFAULT_CONNECTION_NAME: Lazy<RwLock<Option<String>>> = Lazy::new(|| RwLock::new(None));
 
 /// Resolve a connection name and engine by explicit connection name, or by the selected default.
+///
+/// # Arguments
+/// * `using` — Registered connection name, or `None` to use [`DEFAULT_CONNECTION_NAME`].
+///
+/// # Returns
+/// `(connection_name, engine)` for the resolved route.
+///
+/// # Errors
+/// * `PyValueError` — Unknown or invalid connection name.
+/// * `PyRuntimeError` — No default selected when required, registry lock failure, or engine missing.
 pub fn connection_for_route(using: Option<String>) -> PyResult<(String, Arc<EngineHandle>)> {
     let Some(connection_name) = using else {
         let default_name = DEFAULT_CONNECTION_NAME
@@ -108,21 +118,39 @@ pub fn connection_for_route(using: Option<String>) -> PyResult<(String, Arc<Engi
 }
 
 /// Resolve an engine by explicit connection name, or by the selected default.
+///
+/// # Arguments
+/// * `using` — Registered connection name, or `None` for the default connection.
+///
+/// # Returns
+/// Shared [`EngineHandle`] for the route.
+///
+/// # Errors
+/// Same as [`connection_for_route`].
 pub fn engine_for_connection(using: Option<String>) -> PyResult<Arc<EngineHandle>> {
     connection_for_route(using).map(|(_, engine)| engine)
 }
 
-/// Active transaction handle.
+/// Active transaction handle (root `BEGIN` or nested `SAVEPOINT`).
 #[derive(Clone)]
 pub struct TransactionHandle {
+    /// Shared mutex around the live [`EngineConnection`].
     pub conn: TransactionConnection,
+    /// Savepoint name when this is a nested transaction; `None` for the root.
     pub savepoint_name: Option<String>,
+    /// Connection name the transaction was opened on (for routing and identity map keys).
     pub connection_name: String,
 }
 
+/// Async mutex wrapper around a checked-out [`EngineConnection`].
 pub type TransactionConnection = Arc<Mutex<EngineConnection>>;
 
 impl TransactionHandle {
+    /// Create a root transaction handle after `BEGIN`.
+    ///
+    /// # Arguments
+    /// * `conn` — Checked-out connection that has started a transaction.
+    /// * `connection_name` — Registered Ferro connection name.
     pub fn root(conn: EngineConnection, connection_name: String) -> Self {
         Self {
             conn: Arc::new(Mutex::new(conn)),
@@ -131,6 +159,12 @@ impl TransactionHandle {
         }
     }
 
+    /// Create a nested transaction handle after `SAVEPOINT`.
+    ///
+    /// # Arguments
+    /// * `conn` — Parent transaction connection (shared with the root).
+    /// * `savepoint_name` — Generated savepoint identifier.
+    /// * `connection_name` — Registered Ferro connection name.
     pub fn nested(
         conn: TransactionConnection,
         savepoint_name: String,
@@ -159,12 +193,16 @@ pub static IDENTITY_MAP: Lazy<DashMap<(String, String, String), Py<PyAny>>> =
 /// A session pins connection routing and keeps transactional/identity state local
 /// to that session so concurrent sessions do not bleed mutable runtime state.
 pub struct SessionState {
+    /// Connection pinned for the lifetime of this session.
     pub connection_name: String,
+    /// Transactions opened within this session (isolated from global registry).
     pub transaction_registry: DashMap<String, TransactionHandle>,
+    /// Session-local identity map (isolated from global [`IDENTITY_MAP`]).
     pub identity_map: DashMap<(String, String, String), Py<PyAny>>,
 }
 
 impl SessionState {
+    /// Allocate empty session state for `connection_name`.
     pub fn new(connection_name: String) -> Self {
         Self {
             connection_name,
@@ -177,16 +215,40 @@ impl SessionState {
 /// Global registry of active sessions.
 pub static SESSION_REGISTRY: Lazy<DashMap<String, Arc<SessionState>>> = Lazy::new(DashMap::new);
 
+/// Register a new session bound to `connection_name`.
+///
+/// # Arguments
+/// * `connection_name` — Registered connection to pin for the session.
+///
+/// # Returns
+/// Opaque session UUID string for subsequent operations.
 pub fn register_session(connection_name: String) -> String {
     let session_id = uuid::Uuid::new_v4().to_string();
     SESSION_REGISTRY.insert(session_id.clone(), Arc::new(SessionState::new(connection_name)));
     session_id
 }
 
+/// Remove a session from [`SESSION_REGISTRY`].
+///
+/// # Arguments
+/// * `session_id` — Id returned by [`register_session`].
+///
+/// # Returns
+/// `true` when the session existed and was removed.
 pub fn unregister_session(session_id: &str) -> bool {
     SESSION_REGISTRY.remove(session_id).is_some()
 }
 
+/// Look up active session state.
+///
+/// # Arguments
+/// * `session_id` — Id returned by [`register_session`].
+///
+/// # Returns
+/// Shared [`SessionState`] for the session.
+///
+/// # Errors
+/// `PyRuntimeError` when the session id is unknown.
 pub fn session_state(session_id: &str) -> PyResult<Arc<SessionState>> {
     SESSION_REGISTRY
         .get(session_id)
@@ -203,6 +265,13 @@ pub(crate) const SESSION_CLOSE_ACTIVE_TRANSACTIONS_MSG: &str =
     "Cannot close session while transactions are active. \
      Exit all transaction() blocks before closing the session.";
 
+/// Guard that a session has no open transactions before close.
+///
+/// # Arguments
+/// * `session_id` — Session being closed.
+///
+/// # Errors
+/// `PyRuntimeError` with [`SESSION_CLOSE_ACTIVE_TRANSACTIONS_MSG`] when transactions remain.
 pub fn ensure_session_idle_for_close(session_id: &str) -> PyResult<()> {
     let session = session_state(session_id)?;
     if !session.transaction_registry.is_empty() {
@@ -219,16 +288,27 @@ pub fn ensure_session_idle_for_close(session_id: &str) -> PyResult<()> {
 /// into Rust memory before acquiring the Python GIL for object injection.
 #[derive(Clone, Debug)]
 pub enum RustValue {
+    /// 64-bit integer (SQLite booleans may arrive as 0/1).
     BigInt(i64),
+    /// IEEE double.
     Double(f64),
+    /// Plain text / enum label before Python coercion.
     String(String),
+    /// Boolean after schema-aware decode.
     Bool(bool),
+    /// ISO datetime string (`format: date-time`).
     DateTime(String),
+    /// ISO date string (`format: date`).
     Date(String),
+    /// Parsed JSON object or array column.
     Json(serde_json::Value),
+    /// Binary column bytes.
     Blob(Vec<u8>),
+    /// UUID string (`format: uuid`).
     Uuid(String),
+    /// Decimal/numeric as string (preserves precision).
     Decimal(String),
+    /// SQL `NULL`.
     None,
 }
 


### PR DESCRIPTION
## Description

Rust public APIs lacked consistent documentation across the engine, IR crates, and PyO3 FFI boundary. This adds module-level and item-level docstrings so contributors can navigate the backend without reading implementation details first.

## Changes

- Add `//!` module docs to `codec`, `query`, `hydration`, and `backend`
- Document all public types and functions in `ferro-schema-ir` and `ferro-migrate`
- Document engine-layer public items (`EngineBindValue`, `EngineRow`, `RustValue`, session/transaction helpers)
- Add Args/Returns/Errors docs to PyO3 exports in `operations.rs` (flows to Python `__doc__` where applicable)

## Bridge and Schema Impact

- [x] No Rust/Python bridge changes
- [ ] Python model/schema changed
- [ ] Rust core or SQL generation changed
- [ ] `src/ferro/_core.pyi` updated (if needed)
- [ ] Integration test added first for new behavior

## Migration / Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes included (details below)

## Documentation and Changelog

- [ ] No docs update needed
- [x] Docs updated (README/docs/inline docs)
- [ ] Changelog entry needed

## Related Issues

_No scoped issue — documentation-only maintenance._

## Exit Steps

- [x] Related completed issues are linked above with Closes/Fixes/Resolves (N/A)
- [x] Issue statuses are updated/auto-close on merge (N/A)

## Test plan

- [x] `cargo check`
- [x] `cargo test -p ferro-schema-ir -p ferro-migrate`

Made with [Cursor](https://cursor.com)