### PR TITLE
docs: use model-named lambda predicates in examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,13 +237,15 @@ preferred declaration style.
 Documentation and examples use the lambda predicate style for all queries:
 
 ```python
-adults = await User.where(lambda t: t.age >= 18).all()
+adults = await User.where(lambda user: user.age >= 18).all()
 ```
 
 Rules:
 
 - **Every query example** in docs, docstring `Examples:` sections, and
   `docs/examples/` scripts uses lambda predicates.
+- Name the lambda parameter after the model in **lowercase singular**
+  (`user` for `User`, `post` for `Post`) so filters read naturally.
 - When the predicate styles themselves are documented, present them in
   order **lambda > `col()` > operator**, with lambda labeled the officially
   recommended style.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install ferro-orm
 pip install "ferro-orm[alembic]"
 ```
 
-Ferro currently supports SQLite and PostgreSQL as runtime backends. Named multi-database routing and custom connection-pool kwargs are planned, but not part of the current public API.
+Ferro currently supports SQLite and PostgreSQL. Register multiple named connections with `connect(..., name="...")` when a process needs more than one database — see the [connections guide](https://syn54x.github.io/ferro-orm/guide/connections/).
 
 ## Quick Start
 
@@ -60,8 +60,8 @@ async def main():
     # Create
     alice = await User.create(username="alice")
 
-    # Query
-    active_users = await User.where(User.is_active == True).all()
+    # Query (lambda predicates — name the parameter after the model, e.g. user for User)
+    active_users = await User.where(lambda user: user.is_active == True).all()
     print(f"Found {len(active_users)} active users.")
 
 if __name__ == "__main__":

--- a/docs/examples/pagination.py
+++ b/docs/examples/pagination.py
@@ -24,7 +24,7 @@ async def get_page(page: int, per_page: int = 20) -> list[Article]:
 
 # --8<-- [start:keyset]
 async def get_after(after_id: int | None, limit: int = 20) -> list[Article]:
-    query = Article.select() if after_id is None else Article.where(lambda t: t.id > after_id)
+    query = Article.select() if after_id is None else Article.where(lambda article: article.id > after_id)
     return await query.order_by(Article.id).limit(limit).all()
 # --8<-- [end:keyset]
 

--- a/docs/examples/predicates.py
+++ b/docs/examples/predicates.py
@@ -28,7 +28,7 @@ async def main() -> None:
     )
 
     # --8<-- [start:filtering]
-    adults = await User.where(lambda t: t.age >= 18).all()
+    adults = await User.where(lambda user: user.age >= 18).all()
     # --8<-- [end:filtering]
     assert len(adults) == 3
 
@@ -44,14 +44,14 @@ async def main() -> None:
     assert len(active) == 3
 
     # --8<-- [start:lambda-style]
-    admins = await User.where(lambda t: (t.role == "admin") & (t.archived == False)).all()  # noqa: E712
+    admins = await User.where(lambda user: (user.role == "admin") & (user.archived == False)).all()  # noqa: E712
     # --8<-- [end:lambda-style]
     assert len(admins) == 1
 
     # --8<-- [start:operators]
-    teens = await User.where(lambda t: (t.age >= 13) & (t.age <= 19)).all()
-    a_names = await User.where(lambda t: t.name.like("a%")).all()
-    staff = await User.where(lambda t: t.role.in_(["admin", "moderator"])).all()
+    teens = await User.where(lambda user: (user.age >= 13) & (user.age <= 19)).all()
+    a_names = await User.where(lambda user: user.name.like("a%")).all()
+    staff = await User.where(lambda user: user.role.in_(["admin", "moderator"])).all()
     # --8<-- [end:operators]
     assert len(teens) == 2
     assert len(a_names) == 1
@@ -59,10 +59,10 @@ async def main() -> None:
 
     # --8<-- [start:combining]
     # & is AND, | is OR — parenthesize each side
-    flagged = await User.where(lambda t: (t.age < 18) | (t.archived == True)).all()  # noqa: E712
+    flagged = await User.where(lambda user: (user.age < 18) | (user.archived == True)).all()  # noqa: E712
 
     # Chained .where() calls also AND together
-    young_members = await User.where(lambda t: t.role == "member").where(lambda t: t.age < 21).all()
+    young_members = await User.where(lambda user: user.role == "member").where(lambda user: user.age < 21).all()
     # --8<-- [end:combining]
     assert len(flagged) == 2
     assert len(young_members) == 2
@@ -76,9 +76,9 @@ async def main() -> None:
 
     # --8<-- [start:terminals]
     everyone = await User.all()
-    first_admin = await User.where(lambda t: t.role == "admin").first()
+    first_admin = await User.where(lambda user: user.role == "admin").first()
     headcount = await User.select().count()
-    any_minors = await User.where(lambda t: t.age < 18).exists()
+    any_minors = await User.where(lambda user: user.age < 18).exists()
     # --8<-- [end:terminals]
     assert len(everyone) == 4
     assert first_admin is not None

--- a/docs/examples/predicates_annotated.py
+++ b/docs/examples/predicates_annotated.py
@@ -26,7 +26,7 @@ async def main() -> None:
         ]
     )
 
-    adults = await User.where(lambda t: t.age >= 18).all()
+    adults = await User.where(lambda user: user.age >= 18).all()
     assert len(adults) == 2
 
     print("predicates_annotated example ran successfully")

--- a/docs/examples/quickstart.py
+++ b/docs/examples/quickstart.py
@@ -57,7 +57,7 @@ async def main() -> None:
 
     # Filter, order, and slice
     published = (
-        await Post.where(lambda t: t.published == True)  # noqa: E712
+        await Post.where(lambda post: post.published == True)  # noqa: E712
         .order_by(Post.created_at, "desc")
         .limit(10)
         .all()
@@ -65,7 +65,7 @@ async def main() -> None:
 
     # Aggregate terminals
     total = await Post.select().count()
-    has_drafts = await Post.where(lambda t: t.published == False).exists()  # noqa: E712
+    has_drafts = await Post.where(lambda post: post.published == False).exists()  # noqa: E712
     # --8<-- [end:query]
     assert same_post is post  # identity map: same Python object
     assert len(published) == 2
@@ -77,7 +77,7 @@ async def main() -> None:
     author = await same_post.author
 
     # Reverse access: the BackRef is a chainable query
-    alice_posts = await author.posts.where(lambda t: t.published == True).all()  # noqa: E712
+    alice_posts = await author.posts.where(lambda post: post.published == True).all()  # noqa: E712
     # --8<-- [end:relationships]
     assert author.name == "Alice"
     assert len(alice_posts) == 2
@@ -88,10 +88,10 @@ async def main() -> None:
     await post.save()
 
     # Update many rows at once
-    updated = await Post.where(lambda t: t.published == False).update(published=True)  # noqa: E712
+    updated = await Post.where(lambda post: post.published == False).update(published=True)  # noqa: E712
 
     # Delete
-    deleted = await Post.where(lambda t: t.title == "Unfinished Draft").delete()
+    deleted = await Post.where(lambda post: post.title == "Unfinished Draft").delete()
     # --8<-- [end:update-delete]
     assert updated == 1
     assert deleted == 1

--- a/docs/examples/quickstart_annotated.py
+++ b/docs/examples/quickstart_annotated.py
@@ -39,7 +39,7 @@ async def main() -> None:
 
     assert post.id is not None
     assert (await post.author).email == "alice@example.com"
-    assert len(await alice.posts.where(lambda t: t.published == True).all()) == 1  # noqa: E712
+    assert len(await alice.posts.where(lambda post: post.published == True).all()) == 1  # noqa: E712
 
     print("quickstart_annotated example ran successfully")
 

--- a/docs/examples/soft_deletes.py
+++ b/docs/examples/soft_deletes.py
@@ -28,7 +28,7 @@ class SoftDeleteMixin:
 
     @classmethod
     def active(cls) -> Query:
-        return cls.where(lambda t: t.is_deleted == False)  # noqa: E712
+        return cls.where(lambda invoice: invoice.is_deleted == False)  # noqa: E712
 
 
 class Invoice(SoftDeleteMixin, Model):

--- a/docs/examples/soft_deletes_annotated.py
+++ b/docs/examples/soft_deletes_annotated.py
@@ -29,7 +29,7 @@ class SoftDeleteMixin:
 
     @classmethod
     def active(cls) -> Query:
-        return cls.where(lambda t: t.is_deleted == False)  # noqa: E712
+        return cls.where(lambda invoice: invoice.is_deleted == False)  # noqa: E712
 
 
 class Invoice(SoftDeleteMixin, Model):

--- a/docs/pages/api/queries.md
+++ b/docs/pages/api/queries.md
@@ -1,6 +1,6 @@
 # Queries
 
-`Model.where(...)` and `Model.select()` return a `Query` — an immutable, chainable builder that executes when awaited via `all()`, `first()`, `count()`, `exists()`, `update()`, or `delete()`. Predicates are lambda-first (`User.where(lambda t: t.age >= 18)`), `col()` is the compatibility bridge for operator-shaped predicates, and direct operator style is deprecated for `v0.14.0` removal. For migration steps, see [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md).
+`Model.where(...)` and `Model.select()` return a `Query` — an immutable, chainable builder that executes when awaited via `all()`, `first()`, `count()`, `exists()`, `update()`, or `delete()`. Predicates are lambda-first (`User.where(lambda user: user.age >= 18)`), `col()` is the compatibility bridge for operator-shaped predicates, and direct operator style is deprecated for `v0.14.0` removal. For migration steps, see [Migrating to v0.12.0](../howto/migrating-to-v0-12-0.md).
 
 ::: ferro.query.builder.Query
 

--- a/docs/pages/concepts/query-typing.md
+++ b/docs/pages/concepts/query-typing.md
@@ -13,13 +13,13 @@ The lambda and `col()` styles give you the runtime ergonomics back without forci
 ### 1. Lambda predicate (recommended)
 
 ```python
-rows = await User.where(lambda t: t.archived == False).all()
+rows = await User.where(lambda user: user.archived == False).all()
 rows = await User.where(
-    lambda t: (t.role == "admin") & (t.active == True)
+    lambda user: (user.role == "admin") & (user.active == True)
 ).all()
 ```
 
-This is the officially recommended style — use it for all new code. The lambda receives a `QueryProxy` whose attribute access yields a fresh `FieldProxy` for each name, so `t.archived == False` is a `QueryNode` from the type checker's point of view as well as at runtime. The call site stays free of `# type: ignore` even when comparing booleans, integers, or any other value type, and the full operator surface is available: `.like()`, `.in_()`, `&`, `|`, `== None`, and shadow FK columns (`t.author_id`).
+This is the officially recommended style — use it for all new code. Name the lambda parameter after the model in lowercase singular (`user` for `User`, `post` for `Post`) so predicates read like English. The lambda receives a `QueryProxy` whose attribute access yields a fresh `FieldProxy` for each name, so `user.archived == False` is a `QueryNode` from the type checker's point of view as well as at runtime. The call site stays free of `# type: ignore` even when comparing booleans, integers, or any other value type, and the full operator surface is available: `.like()`, `.in_()`, `&`, `|`, `== None`, and shadow FK columns (`user.author_id`).
 
 The proxy attribute type is currently `FieldProxy[Any]`, which is a deliberate scope decision (see [Scope boundaries](#scope-boundaries) below). Pyright still resolves the predicate's *return* type as `QueryNode` correctly.
 
@@ -62,7 +62,7 @@ You can mix all three on a single chain — useful mid-migration. They compose b
 from ferro.query import col
 
 rows = await (
-    User.where(lambda t: t.role == "admin")     # lambda (recommended)
+    User.where(lambda user: user.role == "admin")     # lambda (recommended)
     .where(col(User.archived) == False)         # col()
     .where(User.id == 1)                        # operator (legacy)
     .all()
@@ -72,7 +72,7 @@ rows = await (
 `Relation.where` (used on `BackRef` collections) accepts the same three shapes:
 
 ```python
-published = await author.posts.where(lambda t: t.published == True).all()
+published = await author.posts.where(lambda post: post.published == True).all()
 ```
 
 ## What This Doesn't Change
@@ -87,11 +87,11 @@ published = await author.posts.where(lambda t: t.published == True).all()
 
 The current implementation deliberately stops short of:
 
-- **Per-field types on the lambda proxy.** `t.archived` resolves to `FieldProxy[Any]`, not `FieldProxy[bool]`. Wiring per-field types through the proxy needs `@dataclass_transform` plumbing on the metaclass; that's future work.
+- **Per-field types on the lambda proxy.** `user.archived` resolves to `FieldProxy[Any]`, not `FieldProxy[bool]`. Wiring per-field types through the proxy needs `@dataclass_transform` plumbing on the metaclass; that's future work.
 - **A type-checker plugin.** Ferro stays plugin-free.
 - **A kwargs-style or template-string predicate API.** Both have been considered; neither shipped here.
 
-If `t.archived` resolving as `FieldProxy[Any]` ever bites you statically, drop back to `col(Model.archived) == ...` for that one comparison — that's exactly the role `col()` plays.
+If `user.archived` resolving as `FieldProxy[Any]` ever bites you statically, drop back to `col(Model.archived) == ...` for that one comparison — that's exactly the role `col()` plays.
 
 ## Reference
 

--- a/docs/pages/getting-started/quickstart.md
+++ b/docs/pages/getting-started/quickstart.md
@@ -54,7 +54,7 @@ A Ferro model is a Pydantic model — annotated fields become columns, and defau
 
 - `Post.get(pk)` fetches one row by primary key.
 - `where(...)` filters, `order_by(...)` sorts, `limit(...)` slices — and nothing touches the database until a terminal like `.all()`, `.first()`, `.count()`, or `.exists()` runs the query.
-- `lambda t: t.published == True` is a lambda predicate — the officially recommended query style. Two other styles exist for compatibility; see [Queries](../guide/queries.md#predicate-styles) for the comparison.
+- `lambda post: post.published == True` is a lambda predicate — the officially recommended query style. Name the parameter after the row type in lowercase singular (`user` for `User`, `post` for `Post`). Two other styles exist for compatibility; see [Queries](../guide/queries.md#predicate-styles) for the comparison.
 
 !!! note "What happened"
     Thanks to Ferro's identity map, `Post.get(post.id)` returns the *same Python object* as the `post` you created earlier — not a duplicate copy. One row, one instance.

--- a/docs/pages/guide/queries.md
+++ b/docs/pages/guide/queries.md
@@ -144,13 +144,13 @@ Queries are lazy — nothing hits the database until you await a terminal:
 Every `ForeignKey` field gets a shadow `*_id` column you can filter on like any scalar:
 
 ```python
-posts = await Post.where(lambda t: t.author_id == user.id).all()
+posts = await Post.where(lambda post: post.author_id == user.id).all()
 ```
 
 Reverse relations (`BackRef`) are chainable queries themselves — filter, order, and slice them before executing:
 
 ```python
-published = await author.posts.where(lambda t: t.published == True).all()  # noqa: E712
+published = await author.posts.where(lambda post: post.published == True).all()  # noqa: E712
 latest = await author.posts.order_by(Post.created_at, "desc").limit(5).all()
 n = await author.posts.count()
 ```

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -461,9 +461,11 @@ class Model(BaseModel, metaclass=ModelMetaclass):
 
         The recommended style is a lambda predicate of shape
         ``Callable[[QueryProxy[Self]], QueryNode]``, e.g.
-        ``User.where(lambda t: t.age >= 18)``. The lambda receives a
+        ``User.where(lambda user: user.age >= 18)``. The lambda receives a
         :class:`QueryProxy` whose attributes build comparisons as
         :class:`QueryNode` instances, so predicates type-check cleanly.
+        Name the parameter after the model in lowercase singular (``user`` for
+        ``User``, ``post`` for ``Post``).
         A prebuilt :class:`QueryNode` is also accepted, built either with
         :func:`ferro.query.col` (the type-safe escape hatch that preserves
         operator shape) or with operator syntax on class attributes. The
@@ -482,8 +484,8 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             A query object scoped to this model class.
 
         Examples:
-            >>> q1 = User.where(lambda t: t.archived == False)  # noqa: E712
-            >>> q2 = User.where(lambda t: t.id == 1)
+            >>> q1 = User.where(lambda user: user.archived == False)  # noqa: E712
+            >>> q2 = User.where(lambda user: user.id == 1)
             >>> isinstance(q1, Query) and isinstance(q2, Query)
             True
         """

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -42,7 +42,7 @@ def _query_ir_payload_to_json(query_payload: dict[str, Any]) -> str:
 @deprecated(
     reason=(
         "Operator predicate style (Model.field OP value) is deprecated; use lambda "
-        "predicates (`where(lambda t: ...)`) or col(Model.field) instead."
+        "predicates (`where(lambda user: ...)`) or col(Model.field) instead."
     ),
     since=IR_FIRST_DEPRECATION_SINCE,
     remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
@@ -139,7 +139,7 @@ class Query(Generic[T]):
         The recommended style is a lambda predicate of shape
         ``Callable[[QueryProxy[T]], QueryNode]``. The lambda receives a
         fresh :class:`QueryProxy` whose attributes return
-        :class:`FieldProxy` instances, so ``lambda t: t.archived == False``
+        :class:`FieldProxy` instances, so ``lambda user: user.archived == False``
         builds a comparison without static-typing friction. A prebuilt
         :class:`QueryNode` is also accepted, built either with
         :func:`ferro.query.col` (the type-safe escape hatch that preserves
@@ -161,8 +161,8 @@ class Query(Generic[T]):
                 or if the callable does not return a ``QueryNode``.
 
         Examples:
-            >>> q1 = User.where(lambda t: t.archived == False)  # noqa: E712
-            >>> q2 = User.where(lambda t: t.id == 1)
+            >>> q1 = User.where(lambda user: user.archived == False)  # noqa: E712
+            >>> q2 = User.where(lambda user: user.id == 1)
             >>> isinstance(q1, Query) and isinstance(q2, Query)
             True
         """
@@ -237,7 +237,7 @@ class Query(Generic[T]):
             A list of model instances.
 
         Examples:
-            >>> users = await User.where(lambda t: t.active == True).all()  # noqa: E712
+            >>> users = await User.where(lambda user: user.active == True).all()  # noqa: E712
             >>> isinstance(users, list)
             True
         """
@@ -269,7 +269,7 @@ class Query(Generic[T]):
             The count of matching records.
 
         Examples:
-            >>> total = await User.where(lambda t: t.active == True).count()  # noqa: E712
+            >>> total = await User.where(lambda user: user.active == True).count()  # noqa: E712
             >>> isinstance(total, int)
             True
         """
@@ -300,7 +300,7 @@ class Query(Generic[T]):
             The number of records updated.
 
         Examples:
-            >>> updated = await User.where(lambda t: t.id == 1).update(name="Taylor")
+            >>> updated = await User.where(lambda user: user.id == 1).update(name="Taylor")
             >>> isinstance(updated, int)
             True
         """
@@ -351,7 +351,7 @@ class Query(Generic[T]):
             The number of records deleted.
 
         Examples:
-            >>> deleted = await User.where(lambda t: t.disabled == True).delete()  # noqa: E712
+            >>> deleted = await User.where(lambda user: user.disabled == True).delete()  # noqa: E712
             >>> isinstance(deleted, int)
             True
         """
@@ -379,7 +379,7 @@ class Query(Generic[T]):
             True if records exist, otherwise False.
 
         Examples:
-            >>> found = await User.where(lambda t: t.email == "a@b.com").exists()
+            >>> found = await User.where(lambda user: user.email == "a@b.com").exists()
             >>> isinstance(found, bool)
             True
         """

--- a/src/ferro/query/nodes.py
+++ b/src/ferro/query/nodes.py
@@ -373,11 +373,11 @@ class QueryProxy(Generic[TModel]):
 
     A fresh ``QueryProxy`` is constructed each time a lambda predicate is
     evaluated. Any attribute access returns a :class:`FieldProxy` for the
-    accessed name, so ``lambda t: t.archived == False`` builds a
+    accessed name, so ``lambda user: user.archived == False`` builds a
     :class:`QueryNode` without ever asking the model class what type
     ``archived`` is. The ``TModel`` type parameter exists so user-supplied
-    lambdas can narrow ``t`` to a specific model in static analysis; the
-    proxy itself ignores the parameter at runtime.
+    lambdas can name the proxy after the model (``user`` for ``User``) in
+    static analysis; the proxy itself ignores the parameter at runtime.
 
     The proxy attribute return type is intentionally ``FieldProxy[Any]`` for
     now — wiring per-field types through a lambda parameter requires
@@ -385,7 +385,7 @@ class QueryProxy(Generic[TModel]):
     feature's scope.
 
     Examples:
-        >>> rows = await User.where(lambda t: t.archived == False).all()  # noqa: E712
+        >>> rows = await User.where(lambda user: user.archived == False).all()  # noqa: E712
     """
 
     __slots__ = ()


### PR DESCRIPTION
## Summary
- Replace generic `lambda t:` with model-specific names (`user`, `post`, `invoice`, `article`) in README, runnable `docs/examples/`, concept/guide pages, and Python docstrings
- Document the naming convention in AGENTS.md I-9 (`user` for `User`, `post` for `Post`, etc.)
- Refresh README quick start to lambda predicates and fix the outdated named-connections install note

## Test plan
- [x] Reviewed diffs for accidental formatting regressions (README badge shields restored)
- [ ] `uv run pytest tests/test_docs_examples.py` (local maturin build required)

## Bridge and Schema Impact

- [x] No Rust/Python bridge changes
- [ ] Python model/schema changed
- [ ] Rust core or SQL generation changed
- [ ] `src/ferro/_core.pyi` updated (if needed)
- [ ] Integration test added first for new behavior

## Migration / Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes included (details below)

## Documentation and Changelog

- [ ] No docs update needed
- [x] Docs updated (README/docs/inline docs)
- [ ] Changelog entry needed

## Related Issues

_No scoped issue — documentation convention alignment._

## Exit Steps

- [x] Related completed issues are linked above with Closes/Fixes/Resolves (N/A)
- [x] Issue statuses are updated/auto-close on merge (N/A)

_Supersedes #131 after branch rename to `docs/lambda-predicate-naming`._

Made with [Cursor](https://cursor.com)