### PR TITLE
feat(migrate): complete ferro-migrate emit_sql for Phase 8 #118

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,8 @@ name: CI
 on:
   workflow_call:
   pull_request:
-    branches: [main, feat/ir-first]
   push:
-    branches: [main, feat/ir-first]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = [".", "crates/ferro-schema-ir", "crates/ferro-migrate"]
+members = [
+    ".",
+    "crates/ferro-schema-ir",
+    "crates/ferro-ddl-lowering",
+    "crates/ferro-migrate",
+]
 
 [package]
 name = "ferro"

--- a/crates/ferro-ddl-lowering/Cargo.toml
+++ b/crates/ferro-ddl-lowering/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
-name = "ferro-migrate"
+name = "ferro-ddl-lowering"
 version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ferro-ddl-lowering = { path = "../ferro-ddl-lowering" }
 ferro-schema-ir = { path = "../ferro-schema-ir" }
 sea-query = { version = "0.32", features = ["with-uuid"] }
 serde_json = "1.0"

--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -1,0 +1,356 @@
+//! Canonical DDL lowering shared across Ferro emitters (AGENTS.md I-1).
+//!
+//! Type tokens, constraint naming, and column-definition helpers used by
+//! `ferro-migrate` and (eventually) the runtime schema emitter.
+
+use ferro_schema_ir::SchemaColumn;
+use sea_query::{ColumnDef, ForeignKeyAction};
+
+/// SQL dialect for lowering canonical types to rendered DDL.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Dialect {
+    /// SQLite 3.
+    Sqlite,
+    /// PostgreSQL.
+    Postgres,
+}
+
+/// Canonical, backend-resolved column type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CanonicalType {
+    Integer,
+    SmallInt,
+    BigInt,
+    Double,
+    Decimal,
+    Boolean,
+    Json,
+    Text,
+    Varchar(Option<u32>),
+    Char(u32),
+    Uuid,
+    DateTime,
+    Timestamp,
+    TimestampTz,
+    Date,
+    Time,
+    Blob,
+}
+
+/// Apply a canonical type to a sea-query [`ColumnDef`].
+pub fn apply_canonical_type(col_def: &mut ColumnDef, canonical: CanonicalType) {
+    match canonical {
+        CanonicalType::Integer => {
+            col_def.integer();
+        }
+        CanonicalType::SmallInt => {
+            col_def.small_integer();
+        }
+        CanonicalType::BigInt => {
+            col_def.big_integer();
+        }
+        CanonicalType::Double => {
+            col_def.double();
+        }
+        CanonicalType::Decimal => {
+            col_def.decimal();
+        }
+        CanonicalType::Boolean => {
+            col_def.boolean();
+        }
+        CanonicalType::Json => {
+            col_def.json();
+        }
+        CanonicalType::Text => {
+            col_def.text();
+        }
+        CanonicalType::Varchar(None) => {
+            col_def.string();
+        }
+        CanonicalType::Varchar(Some(n)) => {
+            col_def.string_len(n);
+        }
+        CanonicalType::Char(n) => {
+            col_def.char_len(n);
+        }
+        CanonicalType::Uuid => {
+            col_def.uuid();
+        }
+        CanonicalType::DateTime => {
+            col_def.date_time();
+        }
+        CanonicalType::Timestamp => {
+            col_def.timestamp();
+        }
+        CanonicalType::TimestampTz => {
+            col_def.timestamp_with_time_zone();
+        }
+        CanonicalType::Date => {
+            col_def.date();
+        }
+        CanonicalType::Time => {
+            col_def.time();
+        }
+        CanonicalType::Blob => {
+            col_def.blob();
+        }
+    }
+}
+
+fn parse_varchar_token(token: &str) -> Option<u32> {
+    let body = token.strip_prefix("varchar(")?.strip_suffix(')')?;
+    let n: u32 = body.parse().ok()?;
+    if n == 0 { None } else { Some(n) }
+}
+
+/// Map a canonical `db_type` token to [`CanonicalType`].
+pub fn db_type_token_to_canonical(token: &str, dialect: Dialect) -> Option<CanonicalType> {
+    match token {
+        "text" => Some(CanonicalType::Text),
+        "smallint" => Some(CanonicalType::SmallInt),
+        "int" => Some(CanonicalType::Integer),
+        "bigint" => Some(CanonicalType::BigInt),
+        "uuid" => Some(match dialect {
+            Dialect::Sqlite => CanonicalType::Char(32),
+            Dialect::Postgres => CanonicalType::Uuid,
+        }),
+        "timestamp" => Some(match dialect {
+            Dialect::Sqlite => CanonicalType::DateTime,
+            Dialect::Postgres => CanonicalType::Timestamp,
+        }),
+        "timestamptz" => Some(match dialect {
+            Dialect::Sqlite => CanonicalType::DateTime,
+            Dialect::Postgres => CanonicalType::TimestampTz,
+        }),
+        "date" => Some(CanonicalType::Date),
+        "time" => Some(CanonicalType::Time),
+        other => parse_varchar_token(other).map(|n| CanonicalType::Varchar(Some(n))),
+    }
+}
+
+/// Resolve a [`SchemaColumn`] to its canonical storage type.
+pub fn canonical_from_schema_column(
+    col: &SchemaColumn,
+    dialect: Dialect,
+) -> Result<CanonicalType, String> {
+    if let Some(canonical) = db_type_token_to_canonical(&col.db_type, dialect) {
+        return Ok(canonical);
+    }
+    match (col.logical_type.as_str(), col.format.as_deref()) {
+        ("string", Some("date-time")) => Ok(CanonicalType::TimestampTz),
+        ("string", Some("date")) => Ok(CanonicalType::Date),
+        ("string", Some("uuid")) => Ok(CanonicalType::Uuid),
+        (_, Some("decimal")) => Ok(CanonicalType::Decimal),
+        ("string", Some("binary")) => Ok(CanonicalType::Blob),
+        ("integer", _) => Ok(CanonicalType::Integer),
+        ("string", _) => Ok(CanonicalType::Varchar(None)),
+        ("number", _) => Ok(CanonicalType::Double),
+        ("boolean", _) => Ok(match dialect {
+            Dialect::Sqlite => CanonicalType::Integer,
+            Dialect::Postgres => CanonicalType::Boolean,
+        }),
+        ("object" | "array", _) => Ok(CanonicalType::Json),
+        _ => Err(format!(
+            "unknown db_type '{}' on column '{}'",
+            col.db_type, col.name
+        )),
+    }
+}
+
+/// Single-column index name (`idx_<table>_<col>`).
+pub fn single_index_name(table_lower: &str, col_name: &str) -> String {
+    format!("idx_{table_lower}_{col_name}")
+}
+
+/// Single-column unique name with 63-char guard.
+pub fn single_unique_index_name(table_lower: &str, col_name: &str) -> String {
+    let raw = format!("uq_{table_lower}_{col_name}");
+    if raw.chars().count() > 63 {
+        return format!("{}_uq", raw.chars().take(60).collect::<String>());
+    }
+    raw
+}
+
+/// Composite index name (`idx_<table>_<cols>`).
+pub fn composite_index_name(table_lower: &str, col_names: &[&str]) -> String {
+    let joined = col_names.join("_");
+    let raw = format!("idx_{table_lower}_{joined}");
+    if raw.chars().count() > 63 {
+        return format!("{}_idx", raw.chars().take(59).collect::<String>());
+    }
+    raw
+}
+
+/// Composite unique name (`uq_<table>_<cols>`).
+pub fn composite_unique_index_name(table_lower: &str, col_names: &[&str]) -> String {
+    let joined = col_names.join("_");
+    let raw = format!("uq_{table_lower}_{joined}");
+    if raw.chars().count() > 63 {
+        return format!("{}_uq", raw.chars().take(60).collect::<String>());
+    }
+    raw
+}
+
+/// Check constraint name (`ck_<table>_<col>`).
+pub fn db_check_constraint_name(table_lower: &str, col_name: &str) -> String {
+    let raw = format!("ck_{table_lower}_{col_name}");
+    if raw.chars().count() > 63 {
+        return format!("{}_ck", raw.chars().take(60).collect::<String>());
+    }
+    raw
+}
+
+/// Postgres `ALTER COLUMN ... TYPE` target spelling.
+pub fn pg_alter_type_target(canonical: CanonicalType) -> String {
+    match canonical {
+        CanonicalType::Integer => "integer".to_string(),
+        CanonicalType::SmallInt => "smallint".to_string(),
+        CanonicalType::BigInt => "bigint".to_string(),
+        CanonicalType::Double => "double precision".to_string(),
+        CanonicalType::Decimal => "numeric".to_string(),
+        CanonicalType::Boolean => "boolean".to_string(),
+        CanonicalType::Json => "json".to_string(),
+        CanonicalType::Text => "text".to_string(),
+        CanonicalType::Varchar(None) => "varchar".to_string(),
+        CanonicalType::Varchar(Some(n)) => format!("varchar({n})"),
+        CanonicalType::Char(n) => format!("char({n})"),
+        CanonicalType::Uuid => "uuid".to_string(),
+        CanonicalType::DateTime | CanonicalType::Timestamp => "timestamp".to_string(),
+        CanonicalType::TimestampTz => "timestamptz".to_string(),
+        CanonicalType::Date => "date".to_string(),
+        CanonicalType::Time => "time".to_string(),
+        CanonicalType::Blob => "bytea".to_string(),
+    }
+}
+
+/// SQLite declared-type string for a canonical type (parity-pinned).
+pub fn sqlite_declared_type(canonical: CanonicalType) -> String {
+    match canonical {
+        CanonicalType::Integer => "integer".to_string(),
+        CanonicalType::SmallInt => "smallint".to_string(),
+        CanonicalType::BigInt => "bigint".to_string(),
+        CanonicalType::Double => "double".to_string(),
+        CanonicalType::Decimal => "real".to_string(),
+        CanonicalType::Boolean => "boolean".to_string(),
+        CanonicalType::Json => "json_text".to_string(),
+        CanonicalType::Text => "text".to_string(),
+        CanonicalType::Varchar(None) => "varchar".to_string(),
+        CanonicalType::Varchar(Some(n)) => format!("varchar({n})"),
+        CanonicalType::Char(n) => format!("char({n})"),
+        CanonicalType::Uuid => "uuid_text".to_string(),
+        CanonicalType::DateTime | CanonicalType::Timestamp => "datetime_text".to_string(),
+        CanonicalType::TimestampTz => "timestamp_with_timezone_text".to_string(),
+        CanonicalType::Date => "date_text".to_string(),
+        CanonicalType::Time => "time_text".to_string(),
+        CanonicalType::Blob => "blob".to_string(),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SqliteTypeClass {
+    Integer,
+    Text,
+    Blob,
+    Real,
+    Numeric,
+    Temporal,
+}
+
+/// Storage-semantics class of a declared SQLite type.
+pub(crate) fn sqlite_type_class(declared: &str) -> SqliteTypeClass {
+    let declared = declared.to_ascii_lowercase();
+    if declared.contains("date") || declared.contains("time") {
+        return SqliteTypeClass::Temporal;
+    }
+    if declared.contains("json") {
+        return SqliteTypeClass::Text;
+    }
+    if declared.contains("bool") || declared.contains("int") {
+        return SqliteTypeClass::Integer;
+    }
+    if declared.contains("char") || declared.contains("clob") || declared.contains("text") {
+        return SqliteTypeClass::Text;
+    }
+    if declared.is_empty() || declared.contains("blob") {
+        return SqliteTypeClass::Blob;
+    }
+    if declared.contains("real")
+        || declared.contains("floa")
+        || declared.contains("doub")
+        || declared.contains("num")
+        || declared.contains("dec")
+    {
+        return SqliteTypeClass::Real;
+    }
+    SqliteTypeClass::Numeric
+}
+
+/// Compare old and new SQLite declared types for storage-class drift.
+pub fn sqlite_type_storage_drift(old_db_type: &str, new_canonical: CanonicalType) -> bool {
+    let old_class = sqlite_type_class(old_db_type);
+    let new_class = sqlite_type_class(&sqlite_declared_type(new_canonical));
+    old_class != new_class
+}
+
+/// Quote a SQL identifier for Postgres/SQLite DDL.
+pub fn quote_ident(ident: &str) -> String {
+    format!("\"{}\"", ident.replace('"', "\"\""))
+}
+
+/// Map an `on_delete` action string to sea-query [`ForeignKeyAction`].
+pub fn fk_action_from_str(on_delete: Option<&str>) -> ForeignKeyAction {
+    match on_delete.unwrap_or("CASCADE").to_uppercase().as_str() {
+        "RESTRICT" => ForeignKeyAction::Restrict,
+        "SET NULL" => ForeignKeyAction::SetNull,
+        "SET DEFAULT" => ForeignKeyAction::SetDefault,
+        "NO ACTION" => ForeignKeyAction::NoAction,
+        _ => ForeignKeyAction::Cascade,
+    }
+}
+
+pub fn fk_action_sql(action: ForeignKeyAction) -> &'static str {
+    match action {
+        ForeignKeyAction::Restrict => "RESTRICT",
+        ForeignKeyAction::SetNull => "SET NULL",
+        ForeignKeyAction::SetDefault => "SET DEFAULT",
+        ForeignKeyAction::NoAction => "NO ACTION",
+        ForeignKeyAction::Cascade => "CASCADE",
+    }
+}
+
+/// Convert a JSON-schema scalar default into a sea-query literal.
+pub fn literal_default_value(default: &serde_json::Value) -> Option<sea_query::Value> {
+    match default {
+        serde_json::Value::Bool(value) => Some((*value).into()),
+        serde_json::Value::Number(value) => value
+            .as_i64()
+            .map(sea_query::Value::from)
+            .or_else(|| value.as_f64().map(sea_query::Value::from)),
+        serde_json::Value::String(value) => Some(value.clone().into()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn db_type_tokens_match_canonical_vocabulary() {
+        assert_eq!(
+            db_type_token_to_canonical("text", Dialect::Postgres),
+            Some(CanonicalType::Text)
+        );
+        assert_eq!(
+            db_type_token_to_canonical("varchar(40)", Dialect::Sqlite),
+            Some(CanonicalType::Varchar(Some(40)))
+        );
+    }
+
+    #[test]
+    fn naming_helpers_match_i1_conventions() {
+        assert_eq!(single_index_name("user", "email"), "idx_user_email");
+        assert_eq!(single_unique_index_name("user", "email"), "uq_user_email");
+        assert_eq!(db_check_constraint_name("user", "role"), "ck_user_role");
+    }
+}

--- a/crates/ferro-migrate/src/emit.rs
+++ b/crates/ferro-migrate/src/emit.rs
@@ -1,0 +1,581 @@
+//! Executable SQL emission from IR-backed migration plans.
+
+use crate::{BackendDialect, EmissionError, EmissionResult, MigrationOp, MigrationPlan};
+use ferro_ddl_lowering::{
+    self, apply_canonical_type, canonical_from_schema_column, db_check_constraint_name,
+    fk_action_from_str, fk_action_sql, literal_default_value, pg_alter_type_target, quote_ident,
+    single_index_name, single_unique_index_name, sqlite_declared_type, sqlite_type_storage_drift,
+    Dialect,
+};
+use ferro_schema_ir::{IrEnvelope, SchemaColumn, SchemaIrPayload, SchemaModel};
+use sea_query::{
+    Alias, ColumnDef, Index, PostgresQueryBuilder, SqliteQueryBuilder, Table,
+};
+use std::collections::BTreeMap;
+
+fn lowering_dialect(dialect: BackendDialect) -> Dialect {
+    match dialect {
+        BackendDialect::Sqlite => Dialect::Sqlite,
+        BackendDialect::Postgres => Dialect::Postgres,
+    }
+}
+
+fn index_models<'a>(models: &'a [SchemaModel]) -> BTreeMap<String, &'a SchemaModel> {
+    let mut indexed = BTreeMap::new();
+    for model in models {
+        indexed.insert(model.table_name.clone(), model);
+    }
+    indexed
+}
+
+fn find_model<'a>(
+    models: &'a BTreeMap<String, &'a SchemaModel>,
+    table: &str,
+) -> Result<&'a SchemaModel, EmissionError> {
+    models.get(table).copied().ok_or_else(|| EmissionError {
+        message: format!("model '{}' not found in IR context", table),
+    })
+}
+
+fn find_column<'a>(
+    model: &'a SchemaModel,
+    column: &str,
+) -> Result<&'a SchemaColumn, EmissionError> {
+    model
+        .columns
+        .iter()
+        .find(|c| c.name == column)
+        .ok_or_else(|| EmissionError {
+            message: format!("column '{}.{}' not found in IR context", model.table_name, column),
+        })
+}
+
+fn render_create_table(model: &SchemaModel, dialect: BackendDialect) -> Result<String, EmissionError> {
+    let ld = lowering_dialect(dialect);
+    let table_lower = model.table_name.as_str();
+    let mut table_stmt = Table::create()
+        .table(Alias::new(table_lower))
+        .if_not_exists()
+        .to_owned();
+
+    for col in &model.columns {
+        let canonical = canonical_from_schema_column(col, ld).map_err(|message| EmissionError {
+            message,
+        })?;
+        let mut col_def = ColumnDef::new(Alias::new(&col.name));
+        apply_canonical_type(&mut col_def, canonical);
+        if col.primary_key {
+            col_def.primary_key();
+            if col.autoincrement {
+                col_def.auto_increment();
+            }
+        }
+        if !col.nullable {
+            col_def.not_null();
+        }
+        if col.unique && dialect == BackendDialect::Postgres {
+            col_def.unique_key();
+        }
+        table_stmt.col(&mut col_def);
+    }
+
+    let sql = match dialect {
+        BackendDialect::Sqlite => table_stmt.build(SqliteQueryBuilder),
+        BackendDialect::Postgres => table_stmt.build(PostgresQueryBuilder),
+    };
+    Ok(sql)
+}
+
+fn render_index_sql(
+    table_lower: &str,
+    name: &str,
+    columns: &[String],
+    unique: bool,
+    dialect: BackendDialect,
+) -> String {
+    let mut stmt = Index::create()
+        .name(name)
+        .table(Alias::new(table_lower))
+        .if_not_exists()
+        .to_owned();
+    if unique {
+        stmt.unique();
+    }
+    for col in columns {
+        stmt.col(Alias::new(col));
+    }
+    match dialect {
+        BackendDialect::Sqlite => stmt.to_string(SqliteQueryBuilder),
+        BackendDialect::Postgres => stmt.to_string(PostgresQueryBuilder),
+    }
+}
+
+fn post_create_artifacts(
+    model: &SchemaModel,
+    dialect: BackendDialect,
+) -> Result<(Vec<String>, Vec<String>), EmissionError> {
+    let table_lower = model.table_name.as_str();
+    let mut statements = Vec::new();
+    let mut warnings = Vec::new();
+
+    for index in &model.indexes {
+        statements.push(render_index_sql(
+            table_lower,
+            &index.name,
+            &index.columns,
+            index.unique,
+            dialect,
+        ));
+    }
+
+    for unique in &model.uniques {
+        statements.push(render_index_sql(
+            table_lower,
+            &unique.name,
+            &unique.columns,
+            true,
+            dialect,
+        ));
+    }
+
+    for check in &model.checks {
+        match dialect {
+            BackendDialect::Postgres => {
+                statements.push(format!(
+                    "ALTER TABLE \"{table}\" ADD CONSTRAINT \"{name}\" CHECK ({expression})",
+                    table = table_lower,
+                    name = check.name,
+                    expression = check.expression,
+                ));
+            }
+            BackendDialect::Sqlite => {
+                warnings.push(format!(
+                    "Check constraint '{}' on table '{}' is not emitted on SQLite (requires table rebuild).",
+                    check.name, table_lower
+                ));
+            }
+        }
+    }
+
+    Ok((statements, warnings))
+}
+
+fn foreign_key_statements(
+    model: &SchemaModel,
+    dialect: BackendDialect,
+) -> Vec<String> {
+    let table_lower = model.table_name.as_str();
+    let mut statements = Vec::new();
+    for fk in &model.foreign_keys {
+        if dialect == BackendDialect::Postgres {
+            let on_delete = fk_action_from_str(fk.on_delete.as_deref());
+            statements.push(format!(
+                "ALTER TABLE {} ADD FOREIGN KEY ({}) REFERENCES {} ({}) ON DELETE {}",
+                quote_ident(table_lower),
+                quote_ident(&fk.column),
+                quote_ident(&fk.to_table),
+                quote_ident(&fk.to_column),
+                fk_action_sql(on_delete),
+            ));
+        }
+    }
+    statements
+}
+
+fn order_add_table_models<'a>(
+    models: Vec<&'a SchemaModel>,
+) -> Vec<&'a SchemaModel> {
+    let mut remaining: Vec<&SchemaModel> = models;
+    let mut ordered = Vec::new();
+    let mut created = std::collections::HashSet::new();
+
+    while !remaining.is_empty() {
+        let available: std::collections::HashSet<String> = remaining
+            .iter()
+            .map(|m| m.table_name.clone())
+            .collect();
+        let mut progress = false;
+        let mut index = 0;
+        while index < remaining.len() {
+            let deps: Vec<String> = remaining[index]
+                .foreign_keys
+                .iter()
+                .map(|fk| fk.to_table.clone())
+                .collect();
+            if deps
+                .iter()
+                .all(|dep| created.contains(dep) || !available.contains(dep))
+            {
+                let model = remaining.remove(index);
+                created.insert(model.table_name.clone());
+                ordered.push(model);
+                progress = true;
+            } else {
+                index += 1;
+            }
+        }
+        if !progress {
+            ordered.append(&mut remaining);
+            break;
+        }
+    }
+    ordered
+}
+
+fn emit_add_table_passes(
+    add_models: Vec<&SchemaModel>,
+    dialect: BackendDialect,
+    result: &mut EmissionResult,
+) -> Result<(), EmissionError> {
+    let ordered = order_add_table_models(add_models);
+    for model in &ordered {
+        result.statements.push(render_create_table(model, dialect)?);
+        let (artifacts, warnings) = post_create_artifacts(model, dialect)?;
+        result.statements.extend(artifacts);
+        result.warnings.extend(warnings);
+    }
+    for model in &ordered {
+        if dialect == BackendDialect::Sqlite {
+            for fk in &model.foreign_keys {
+                result.warnings.push(format!(
+                    "Foreign key '{}.{}' -> '{}' is not emitted on SQLite (requires table rebuild).",
+                    model.table_name, fk.column, fk.to_table
+                ));
+            }
+        } else {
+            result
+                .statements
+                .extend(foreign_key_statements(model, dialect));
+        }
+    }
+    Ok(())
+}
+
+fn emit_add_column(
+    table: &str,
+    column: &str,
+    model: &SchemaModel,
+    dialect: BackendDialect,
+) -> Result<EmissionResult, EmissionError> {
+    let col = find_column(model, column)?;
+    let ld = lowering_dialect(dialect);
+    let canonical = canonical_from_schema_column(col, ld).map_err(|message| EmissionError {
+        message,
+    })?;
+
+    if col.primary_key {
+        return Err(EmissionError {
+            message: format!(
+                "Cannot add column '{}.{}': it is a primary key, and primary keys cannot \
+                 be added to existing tables. Use Alembic for this migration.",
+                table, column
+            ),
+        });
+    }
+
+    let backfill_default = if col.nullable {
+        None
+    } else {
+        match col.default.as_ref().and_then(literal_default_value) {
+            Some(value) => Some(value),
+            None => {
+                return Err(EmissionError {
+                    message: format!(
+                        "Cannot add NOT NULL column '{}.{}' to an existing table: it has no \
+                         literal default to backfill existing rows. Make the field nullable, \
+                         give it a literal default, or use Alembic for this migration.",
+                        table, column
+                    ),
+                });
+            }
+        }
+    };
+
+    let inline_unique = col.unique && dialect == BackendDialect::Postgres;
+    let mut col_def = ColumnDef::new(Alias::new(column));
+    apply_canonical_type(&mut col_def, canonical);
+    if !col.nullable {
+        col_def.not_null();
+    }
+    if inline_unique {
+        col_def.unique_key();
+    }
+    if let Some(default_value) = &backfill_default {
+        col_def.default(default_value.clone());
+    }
+
+    let stmt = Table::alter()
+        .table(Alias::new(table))
+        .add_column(&mut col_def)
+        .to_owned();
+
+    let mut result = EmissionResult::default();
+    result.statements.push(match dialect {
+        BackendDialect::Sqlite => stmt.to_string(SqliteQueryBuilder),
+        BackendDialect::Postgres => stmt.to_string(PostgresQueryBuilder),
+    });
+
+    if backfill_default.is_some() && dialect == BackendDialect::Postgres {
+        result.statements.push(format!(
+            "ALTER TABLE {} ALTER COLUMN {} DROP DEFAULT",
+            quote_ident(table),
+            quote_ident(column)
+        ));
+    }
+
+    if col.unique && dialect == BackendDialect::Sqlite {
+        let index_name = single_unique_index_name(table, column);
+        let index_stmt = Index::create()
+            .unique()
+            .name(&index_name)
+            .table(Alias::new(table))
+            .col(Alias::new(column))
+            .if_not_exists()
+            .to_owned();
+        result
+            .statements
+            .push(index_stmt.to_string(SqliteQueryBuilder));
+        result.warnings.push(format!(
+            "Added unique column '{}.{}' as a unique index '{}' (SQLite cannot add an \
+             inline UNIQUE constraint to an existing table).",
+            table, column, index_name
+        ));
+    }
+
+    if col.index {
+        result.statements.push(render_index_sql(
+            table,
+            &single_index_name(table, column),
+            &[column.to_string()],
+            false,
+            dialect,
+        ));
+    }
+
+    for check in &model.checks {
+        if check.name == db_check_constraint_name(table, column) {
+            if dialect == BackendDialect::Postgres {
+                result.statements.push(format!(
+                    "ALTER TABLE \"{table}\" ADD CONSTRAINT \"{name}\" CHECK ({expression})",
+                    name = check.name,
+                    expression = check.expression,
+                ));
+            }
+        }
+    }
+
+    if let Some(fk) = model.foreign_keys.iter().find(|fk| fk.column == column) {
+        if dialect == BackendDialect::Postgres {
+            let on_delete = fk_action_from_str(fk.on_delete.as_deref());
+            result.statements.push(format!(
+                "ALTER TABLE {} ADD FOREIGN KEY ({}) REFERENCES {} ({}) ON DELETE {}",
+                quote_ident(table),
+                quote_ident(column),
+                quote_ident(&fk.to_table),
+                quote_ident(&fk.to_column),
+                fk_action_sql(on_delete),
+            ));
+        } else {
+            result.warnings.push(format!(
+                "Added foreign-key column '{}.{}' without its FOREIGN KEY constraint \
+                 (SQLite cannot add table constraints to an existing table). Referential \
+                 integrity for this column is not database-enforced; use Alembic if you \
+                 need the constraint.",
+                table, column
+            ));
+        }
+    }
+
+    Ok(result)
+}
+
+fn emit_alter_column_type(
+    table: &str,
+    column: &str,
+    old_col: &SchemaColumn,
+    new_col: &SchemaColumn,
+    dialect: BackendDialect,
+) -> EmissionResult {
+    let mut result = EmissionResult::default();
+    let ld = lowering_dialect(dialect);
+
+    match dialect {
+        BackendDialect::Postgres => {
+            if new_col.enum_type_name.is_some() {
+                result.warnings.push(format!(
+                    "Column '{}.{}' uses a native Postgres enum type; type reconciliation \
+                     is deferred to Alembic.",
+                    table, column
+                ));
+                return result;
+            }
+            if old_col.primary_key || new_col.primary_key {
+                return result;
+            }
+            let Ok(new_canonical) = canonical_from_schema_column(new_col, ld) else {
+                return result;
+            };
+            let target = pg_alter_type_target(new_canonical);
+            result.statements.push(format!(
+                "ALTER TABLE {table} ALTER COLUMN {col} TYPE {target} USING {col}::{target}",
+                table = quote_ident(table),
+                col = quote_ident(column),
+                target = target,
+            ));
+        }
+        BackendDialect::Sqlite => {
+            if old_col.primary_key || new_col.primary_key {
+                return result;
+            }
+            let Ok(new_canonical) = canonical_from_schema_column(new_col, ld) else {
+                return result;
+            };
+            if sqlite_type_storage_drift(&old_col.db_type, new_canonical) {
+                result.warnings.push(format!(
+                    "Column '{}.{}' is declared '{}' in the database but the model expects \
+                     '{}'. SQLite cannot change column types in place; use Alembic to \
+                     migrate this column.",
+                    table,
+                    column,
+                    old_col.db_type,
+                    sqlite_declared_type(new_canonical),
+                ));
+            }
+        }
+    }
+    result
+}
+
+fn emit_alter_column_nullability(
+    table: &str,
+    column: &str,
+    old_col: &SchemaColumn,
+    new_col: &SchemaColumn,
+    dialect: BackendDialect,
+) -> EmissionResult {
+    let mut result = EmissionResult::default();
+    if old_col.primary_key || new_col.primary_key {
+        return result;
+    }
+
+    match dialect {
+        BackendDialect::Postgres => {
+            if !new_col.nullable && old_col.nullable {
+                result.statements.push(format!(
+                    "ALTER TABLE {} ALTER COLUMN {} SET NOT NULL",
+                    quote_ident(table),
+                    quote_ident(column),
+                ));
+            } else if new_col.nullable && !old_col.nullable {
+                result.statements.push(format!(
+                    "ALTER TABLE {} ALTER COLUMN {} DROP NOT NULL",
+                    quote_ident(table),
+                    quote_ident(column),
+                ));
+            }
+        }
+        BackendDialect::Sqlite => {
+            if old_col.nullable != new_col.nullable {
+                result.warnings.push(format!(
+                    "Column '{}.{}' is {} in the database but the model expects {}. SQLite \
+                     cannot change column nullability in place; use Alembic to migrate \
+                     this column.",
+                    table,
+                    column,
+                    if old_col.nullable {
+                        "nullable"
+                    } else {
+                        "NOT NULL"
+                    },
+                    if new_col.nullable {
+                        "nullable"
+                    } else {
+                        "NOT NULL"
+                    },
+                ));
+            }
+        }
+    }
+    result
+}
+
+/// Render executable SQL for each operation in `plan` using IR metadata.
+pub fn emit_sql_with_ir(
+    plan: &MigrationPlan,
+    old_ir: &IrEnvelope<SchemaIrPayload>,
+    new_ir: &IrEnvelope<SchemaIrPayload>,
+    dialect: BackendDialect,
+) -> Result<EmissionResult, EmissionError> {
+    let old_models = index_models(&old_ir.payload.models);
+    let new_models = index_models(&new_ir.payload.models);
+
+    let mut result = EmissionResult {
+        statements: Vec::new(),
+        warnings: plan.warnings.clone(),
+    };
+
+    let add_table_models: Vec<&SchemaModel> = plan
+        .operations
+        .iter()
+        .filter_map(|op| match op {
+            MigrationOp::AddTable { table } => find_model(&new_models, table).ok(),
+            _ => None,
+        })
+        .collect();
+
+    if !add_table_models.is_empty() {
+        emit_add_table_passes(add_table_models, dialect, &mut result)?;
+    }
+
+    for operation in &plan.operations {
+        match operation {
+            MigrationOp::AddTable { .. } => {}
+            MigrationOp::DropTable { table } => {
+                result
+                    .statements
+                    .push(format!("DROP TABLE \"{}\"", table));
+            }
+            MigrationOp::AddColumn { table, column } => {
+                let model = find_model(&new_models, table)?;
+                let partial = emit_add_column(table, column, model, dialect)?;
+                result.statements.extend(partial.statements);
+                result.warnings.extend(partial.warnings);
+            }
+            MigrationOp::DropColumn { table, column } => {
+                result.statements.push(format!(
+                    "ALTER TABLE \"{}\" DROP COLUMN \"{}\"",
+                    table, column
+                ));
+            }
+            MigrationOp::AlterColumnType { table, column } => {
+                let old_model = find_model(&old_models, table)?;
+                let new_model = find_model(&new_models, table)?;
+                let old_col = find_column(old_model, column)?;
+                let new_col = find_column(new_model, column)?;
+                let partial = emit_alter_column_type(table, column, old_col, new_col, dialect);
+                result.statements.extend(partial.statements);
+                result.warnings.extend(partial.warnings);
+            }
+            MigrationOp::AlterColumnNullability { table, column } => {
+                let old_model = find_model(&old_models, table)?;
+                let new_model = find_model(&new_models, table)?;
+                let old_col = find_column(old_model, column)?;
+                let new_col = find_column(new_model, column)?;
+                let partial =
+                    emit_alter_column_nullability(table, column, old_col, new_col, dialect);
+                result.statements.extend(partial.statements);
+                result.warnings.extend(partial.warnings);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+pub(crate) use ferro_ddl_lowering::{
+    composite_index_name as test_composite_index_name,
+    composite_unique_index_name as test_composite_unique_index_name,
+    db_check_constraint_name as test_db_check_constraint_name,
+    single_index_name as test_single_index_name,
+};

--- a/crates/ferro-migrate/src/emit.rs
+++ b/crates/ferro-migrate/src/emit.rs
@@ -73,7 +73,7 @@ fn render_create_table(model: &SchemaModel, dialect: BackendDialect) -> Result<S
         if !col.nullable {
             col_def.not_null();
         }
-        if col.unique && dialect == BackendDialect::Postgres {
+        if col.unique {
             col_def.unique_key();
         }
         table_stmt.col(&mut col_def);
@@ -110,6 +110,17 @@ fn render_index_sql(
     }
 }
 
+fn single_column_unique_is_inline(model: &SchemaModel, unique_columns: &[String]) -> bool {
+    if unique_columns.len() != 1 {
+        return false;
+    }
+    let col_name = &unique_columns[0];
+    model
+        .columns
+        .iter()
+        .any(|col| col.name == *col_name && col.unique)
+}
+
 fn post_create_artifacts(
     model: &SchemaModel,
     dialect: BackendDialect,
@@ -129,6 +140,9 @@ fn post_create_artifacts(
     }
 
     for unique in &model.uniques {
+        if single_column_unique_is_inline(model, &unique.columns) {
+            continue;
+        }
         statements.push(render_index_sql(
             table_lower,
             &unique.name,
@@ -395,7 +409,7 @@ fn emit_alter_column_type(
     old_col: &SchemaColumn,
     new_col: &SchemaColumn,
     dialect: BackendDialect,
-) -> EmissionResult {
+) -> Result<EmissionResult, EmissionError> {
     let mut result = EmissionResult::default();
     let ld = lowering_dialect(dialect);
 
@@ -407,14 +421,19 @@ fn emit_alter_column_type(
                      is deferred to Alembic.",
                     table, column
                 ));
-                return result;
+                return Ok(result);
             }
             if old_col.primary_key || new_col.primary_key {
-                return result;
+                return Ok(result);
             }
-            let Ok(new_canonical) = canonical_from_schema_column(new_col, ld) else {
-                return result;
-            };
+            let new_canonical = canonical_from_schema_column(new_col, ld).map_err(|message| {
+                EmissionError {
+                    message: format!(
+                        "Cannot alter type for '{}.{}': {}",
+                        table, column, message
+                    ),
+                }
+            })?;
             let target = pg_alter_type_target(new_canonical);
             result.statements.push(format!(
                 "ALTER TABLE {table} ALTER COLUMN {col} TYPE {target} USING {col}::{target}",
@@ -425,11 +444,16 @@ fn emit_alter_column_type(
         }
         BackendDialect::Sqlite => {
             if old_col.primary_key || new_col.primary_key {
-                return result;
+                return Ok(result);
             }
-            let Ok(new_canonical) = canonical_from_schema_column(new_col, ld) else {
-                return result;
-            };
+            let new_canonical = canonical_from_schema_column(new_col, ld).map_err(|message| {
+                EmissionError {
+                    message: format!(
+                        "Cannot alter type for '{}.{}': {}",
+                        table, column, message
+                    ),
+                }
+            })?;
             if sqlite_type_storage_drift(&old_col.db_type, new_canonical) {
                 result.warnings.push(format!(
                     "Column '{}.{}' is declared '{}' in the database but the model expects \
@@ -443,7 +467,7 @@ fn emit_alter_column_type(
             }
         }
     }
-    result
+    Ok(result)
 }
 
 fn emit_alter_column_nullability(
@@ -514,14 +538,12 @@ pub fn emit_sql_with_ir(
         warnings: plan.warnings.clone(),
     };
 
-    let add_table_models: Vec<&SchemaModel> = plan
-        .operations
-        .iter()
-        .filter_map(|op| match op {
-            MigrationOp::AddTable { table } => find_model(&new_models, table).ok(),
-            _ => None,
-        })
-        .collect();
+    let mut add_table_models = Vec::new();
+    for operation in &plan.operations {
+        if let MigrationOp::AddTable { table } = operation {
+            add_table_models.push(find_model(&new_models, table)?);
+        }
+    }
 
     if !add_table_models.is_empty() {
         emit_add_table_passes(add_table_models, dialect, &mut result)?;
@@ -542,6 +564,17 @@ pub fn emit_sql_with_ir(
                 result.warnings.extend(partial.warnings);
             }
             MigrationOp::DropColumn { table, column } => {
+                let old_model = find_model(&old_models, table)?;
+                let old_col = find_column(old_model, column)?;
+                if old_col.primary_key {
+                    return Err(EmissionError {
+                        message: format!(
+                            "Cannot drop column '{}.{}': it is part of the primary key. \
+                             Primary-key changes must be migrated with Alembic.",
+                            table, column
+                        ),
+                    });
+                }
                 result.statements.push(format!(
                     "ALTER TABLE \"{}\" DROP COLUMN \"{}\"",
                     table, column
@@ -552,7 +585,7 @@ pub fn emit_sql_with_ir(
                 let new_model = find_model(&new_models, table)?;
                 let old_col = find_column(old_model, column)?;
                 let new_col = find_column(new_model, column)?;
-                let partial = emit_alter_column_type(table, column, old_col, new_col, dialect);
+                let partial = emit_alter_column_type(table, column, old_col, new_col, dialect)?;
                 result.statements.extend(partial.statements);
                 result.warnings.extend(partial.warnings);
             }

--- a/crates/ferro-migrate/src/lib.rs
+++ b/crates/ferro-migrate/src/lib.rs
@@ -1,13 +1,16 @@
-//! Schema IR diffing and coarse SQL emission for migration planning experiments.
+//! Schema IR diffing and SQL emission for migration planning.
 //!
-//! Compares two [`SchemaIrPayload`] snapshots and produces a [`MigrationPlan`]. Full typed
-//! `ADD COLUMN` / `ALTER COLUMN` DDL is still owned by the runtime auto-migrate path in
-//! `src/migrate.rs`; this crate expresses structural intent at the IR layer.
+//! Compares two [`SchemaIrPayload`] snapshots and produces a [`MigrationPlan`].
+//! [`emit_sql_with_ir`] lowers structural ops to executable backend-specific DDL.
+
+mod emit;
 
 use ferro_schema_ir::{IrEnvelope, SchemaIrPayload, SchemaModel};
 use std::collections::{BTreeMap, BTreeSet};
 
-/// SQL dialect tag for [`emit_sql`] placeholder rendering.
+pub use emit::emit_sql_with_ir;
+
+/// SQL dialect tag for migration SQL emission.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BackendDialect {
     /// SQLite 3.
@@ -16,10 +19,34 @@ pub enum BackendDialect {
     Postgres,
 }
 
+/// Executable SQL plus non-fatal warnings from [`emit_sql_with_ir`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EmissionResult {
+    /// DDL statements to execute in order.
+    pub statements: Vec<String>,
+    /// Human-readable warnings (backend limitations, skipped alters, …).
+    pub warnings: Vec<String>,
+}
+
+/// Hard failure during SQL emission (missing IR metadata, unsafe add, …).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EmissionError {
+    /// Actionable error message.
+    pub message: String,
+}
+
+impl std::fmt::Display for EmissionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for EmissionError {}
+
 /// One structural change inferred from an IR diff.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MigrationOp {
-    /// A model exists in the new IR but not the old — table creation is delegated to the schema emitter.
+    /// A model exists in the new IR but not the old.
     AddTable {
         /// Table to create.
         table: String,
@@ -33,7 +60,7 @@ pub enum MigrationOp {
     AddColumn {
         /// Owning table.
         table: String,
-        /// Column to add (typed DDL planned elsewhere).
+        /// Column to add.
         column: String,
     },
     /// A column was removed from the model.
@@ -75,15 +102,10 @@ impl MigrationPlan {
     }
 }
 
-/// Render coarse SQL (or comments) for each operation in `plan`.
+/// Render placeholder SQL (or comments) for each operation in `plan`.
 ///
-/// # Arguments
-/// * `plan` — Operations produced by [`plan_from_ir`].
-/// * `dialect` — Target backend; affects comment text for unsupported alters on SQLite.
-///
-/// # Returns
-/// One SQL string (or explanatory comment line) per operation. `AddTable` / `AddColumn` /
-/// type-nullability alters are comments pointing callers at the full schema emitter.
+/// Legacy shim retained until runtime cutover ([#119](https://github.com/syn54x/ferro-orm/issues/119))
+/// wires [`emit_sql_with_ir`]. `DropTable` / `DropColumn` are executable; other ops emit comments.
 pub fn emit_sql(plan: &MigrationPlan, dialect: BackendDialect) -> Vec<String> {
     let mut sql = Vec::new();
     for operation in &plan.operations {
@@ -132,17 +154,6 @@ pub fn emit_sql(plan: &MigrationPlan, dialect: BackendDialect) -> Vec<String> {
 }
 
 /// Diff two schema IR envelopes and produce a [`MigrationPlan`].
-///
-/// Compares tables by `table_name` and columns by name within shared tables. Does not
-/// diff indexes, FKs, or checks yet — only table/column presence and `db_type` / `nullable`.
-///
-/// # Arguments
-/// * `old_ir` — Baseline schema snapshot.
-/// * `new_ir` — Desired schema snapshot.
-///
-/// # Returns
-/// A plan with add/drop/alter operations. Never fails; structural ambiguity is expressed
-/// as operations, not errors.
 pub fn plan_from_ir(
     old_ir: &IrEnvelope<SchemaIrPayload>,
     new_ir: &IrEnvelope<SchemaIrPayload>,
@@ -242,97 +253,4 @@ fn diff_model_columns(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use ferro_schema_ir::{
-        SchemaCheck, SchemaColumn, SchemaForeignKey, SchemaIndex, SchemaUnique,
-    };
-
-    fn envelope(model: SchemaModel) -> IrEnvelope<SchemaIrPayload> {
-        IrEnvelope {
-            ir_kind: "schema".to_string(),
-            ir_version: 1,
-            payload: SchemaIrPayload {
-                dialect_agnostic: true,
-                models: vec![model],
-            },
-        }
-    }
-
-    fn schema_model(table: &str, cols: Vec<SchemaColumn>) -> SchemaModel {
-        SchemaModel {
-            model_name: table.to_string(),
-            table_name: table.to_string(),
-            columns: cols,
-            foreign_keys: Vec::<SchemaForeignKey>::new(),
-            indexes: Vec::<SchemaIndex>::new(),
-            uniques: Vec::<SchemaUnique>::new(),
-            checks: Vec::<SchemaCheck>::new(),
-        }
-    }
-
-    fn col(name: &str, db_type: &str, nullable: bool) -> SchemaColumn {
-        SchemaColumn {
-            name: name.to_string(),
-            logical_type: "string".to_string(),
-            db_type: db_type.to_string(),
-            db_type_explicit: None,
-            nullable,
-            primary_key: false,
-            autoincrement: false,
-            unique: false,
-            index: false,
-            default: None,
-            format: None,
-            enum_values: None,
-            enum_type_name: None,
-        }
-    }
-
-    #[test]
-    fn plan_from_ir_detects_add_drop_and_alter_ops() {
-        let old_ir = envelope(schema_model(
-            "doc",
-            vec![col("name", "text", false), col("legacy", "text", true)],
-        ));
-        let new_ir = envelope(schema_model(
-            "doc",
-            vec![col("name", "varchar(120)", true), col("status", "text", false)],
-        ));
-
-        let plan = plan_from_ir(&old_ir, &new_ir);
-        assert!(
-            plan.operations
-                .contains(&MigrationOp::AddColumn { table: "doc".to_string(), column: "status".to_string() })
-        );
-        assert!(
-            plan.operations
-                .contains(&MigrationOp::DropColumn { table: "doc".to_string(), column: "legacy".to_string() })
-        );
-        assert!(
-            plan.operations.contains(&MigrationOp::AlterColumnType {
-                table: "doc".to_string(),
-                column: "name".to_string()
-            })
-        );
-        assert!(
-            plan.operations.contains(&MigrationOp::AlterColumnNullability {
-                table: "doc".to_string(),
-                column: "name".to_string()
-            })
-        );
-    }
-
-    #[test]
-    fn emit_sql_renders_drop_column() {
-        let plan = MigrationPlan {
-            operations: vec![MigrationOp::DropColumn {
-                table: "doc".to_string(),
-                column: "legacy".to_string(),
-            }],
-            warnings: Vec::new(),
-        };
-        let sql = emit_sql(&plan, BackendDialect::Postgres);
-        assert_eq!(sql, vec!["ALTER TABLE \"doc\" DROP COLUMN \"legacy\"".to_string()]);
-    }
-}
+mod tests;

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -70,6 +70,15 @@ fn col_with_flags(
     }
 }
 
+fn pk_col(name: &str, db_type: &str) -> SchemaColumn {
+    SchemaColumn {
+        primary_key: true,
+        autoincrement: true,
+        nullable: false,
+        ..col(name, db_type, false)
+    }
+}
+
 fn assert_no_comment_placeholders(statements: &[String]) {
     for sql in statements {
         assert!(
@@ -217,6 +226,30 @@ fn emit_sql_with_ir_add_table_sqlite() {
     let result =
         emit_sql_with_ir(&plan, &empty_envelope(), &new_ir, BackendDialect::Sqlite).unwrap();
     assert!(result.statements[0].starts_with("CREATE TABLE"));
+}
+
+#[test]
+fn emit_sql_with_ir_add_table_unique_inline_sqlite() {
+    let model = SchemaModel {
+        columns: vec![col_with_flags("email", "text", true, true, false, None)],
+        uniques: vec![SchemaUnique {
+            name: "uq_user_email".to_string(),
+            columns: vec!["email".to_string()],
+        }],
+        ..schema_model("user", vec![])
+    };
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddTable {
+            table: "user".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &empty_envelope(), &new_ir, BackendDialect::Sqlite).unwrap();
+    assert_eq!(result.statements.len(), 1);
+    assert!(result.statements[0].contains("UNIQUE"));
+    assert!(!result.statements.iter().any(|s| s.contains("CREATE UNIQUE INDEX")));
 }
 
 #[test]
@@ -492,6 +525,57 @@ fn emit_sql_with_ir_unsafe_not_null_add_errors() {
     let err = emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap_err();
     assert!(err.message.contains("NOT NULL"));
     assert!(err.message.contains("no literal default"));
+}
+
+#[test]
+fn emit_sql_with_ir_drop_primary_key_column_errors() {
+    let old_ir = envelope(vec![schema_model("user", vec![pk_col("id", "int"), col("legacy", "text", true)])]);
+    let new_ir = envelope(vec![schema_model("user", vec![pk_col("id", "int")])]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::DropColumn {
+            table: "user".to_string(),
+            column: "id".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let err = emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap_err();
+    assert!(err.message.contains("primary key"));
+}
+
+#[test]
+fn emit_sql_with_ir_add_table_missing_model_errors() {
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddTable {
+            table: "missing".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let err =
+        emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Postgres)
+            .unwrap_err();
+    assert!(err.message.contains("model 'missing' not found"));
+}
+
+#[test]
+fn emit_sql_with_ir_alter_column_type_unknown_db_type_errors() {
+    let bad_col = SchemaColumn {
+        db_type: "not_a_real_token".to_string(),
+        logical_type: "unknown".to_string(),
+        ..col("name", "text", true)
+    };
+    let old_ir = envelope(vec![schema_model("user", vec![col("name", "text", true)])]);
+    let new_ir = envelope(vec![schema_model("user", vec![bad_col])]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnType {
+            table: "user".to_string(),
+            column: "name".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let err =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap_err();
+    assert!(err.message.contains("Cannot alter type"));
+    assert!(err.message.contains("unknown db_type"));
 }
 
 #[test]

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -1,0 +1,590 @@
+//! Unit tests for `ferro-migrate` planning and emission.
+
+use super::*;
+use crate::emit::{
+    test_composite_index_name, test_composite_unique_index_name, test_db_check_constraint_name,
+    test_single_index_name,
+};
+use ferro_schema_ir::{
+    SchemaCheck, SchemaColumn, SchemaForeignKey, SchemaIndex, SchemaUnique,
+};
+
+fn envelope(models: Vec<SchemaModel>) -> IrEnvelope<SchemaIrPayload> {
+    IrEnvelope {
+        ir_kind: "schema".to_string(),
+        ir_version: 1,
+        payload: SchemaIrPayload {
+            dialect_agnostic: true,
+            models,
+        },
+    }
+}
+
+fn empty_envelope() -> IrEnvelope<SchemaIrPayload> {
+    envelope(Vec::new())
+}
+
+fn schema_model(table: &str, cols: Vec<SchemaColumn>) -> SchemaModel {
+    SchemaModel {
+        model_name: table.to_string(),
+        table_name: table.to_string(),
+        columns: cols,
+        foreign_keys: Vec::<SchemaForeignKey>::new(),
+        indexes: Vec::<SchemaIndex>::new(),
+        uniques: Vec::<SchemaUnique>::new(),
+        checks: Vec::<SchemaCheck>::new(),
+    }
+}
+
+fn col(name: &str, db_type: &str, nullable: bool) -> SchemaColumn {
+    SchemaColumn {
+        name: name.to_string(),
+        logical_type: "string".to_string(),
+        db_type: db_type.to_string(),
+        db_type_explicit: None,
+        nullable,
+        primary_key: false,
+        autoincrement: false,
+        unique: false,
+        index: false,
+        default: None,
+        format: None,
+        enum_values: None,
+        enum_type_name: None,
+    }
+}
+
+fn col_with_flags(
+    name: &str,
+    db_type: &str,
+    nullable: bool,
+    unique: bool,
+    index: bool,
+    default: Option<serde_json::Value>,
+) -> SchemaColumn {
+    SchemaColumn {
+        unique,
+        index,
+        default,
+        ..col(name, db_type, nullable)
+    }
+}
+
+fn assert_no_comment_placeholders(statements: &[String]) {
+    for sql in statements {
+        assert!(
+            !sql.trim_start().starts_with("--"),
+            "comment placeholder found: {sql}"
+        );
+    }
+}
+
+#[test]
+fn plan_from_ir_detects_add_drop_and_alter_ops() {
+    let old_ir = envelope(vec![schema_model(
+        "doc",
+        vec![col("name", "text", false), col("legacy", "text", true)],
+    )]);
+    let new_ir = envelope(vec![schema_model(
+        "doc",
+        vec![col("name", "varchar(120)", true), col("status", "text", false)],
+    )]);
+
+    let plan = plan_from_ir(&old_ir, &new_ir);
+    assert!(plan.operations.contains(&MigrationOp::AddColumn {
+        table: "doc".to_string(),
+        column: "status".to_string(),
+    }));
+    assert!(plan.operations.contains(&MigrationOp::DropColumn {
+        table: "doc".to_string(),
+        column: "legacy".to_string(),
+    }));
+    assert!(plan.operations.contains(&MigrationOp::AlterColumnType {
+        table: "doc".to_string(),
+        column: "name".to_string(),
+    }));
+    assert!(plan.operations.contains(&MigrationOp::AlterColumnNullability {
+        table: "doc".to_string(),
+        column: "name".to_string(),
+    }));
+}
+
+#[test]
+fn plan_from_ir_add_and_drop_table() {
+    let old_ir = envelope(vec![schema_model("legacy", vec![col("id", "int", false)])]);
+    let new_ir = envelope(vec![schema_model("fresh", vec![col("id", "int", false)])]);
+    let plan = plan_from_ir(&old_ir, &new_ir);
+    assert!(plan.operations.contains(&MigrationOp::AddTable {
+        table: "fresh".to_string(),
+    }));
+    assert!(plan.operations.contains(&MigrationOp::DropTable {
+        table: "legacy".to_string(),
+    }));
+}
+
+#[test]
+fn emit_sql_renders_drop_column_postgres() {
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::DropColumn {
+            table: "doc".to_string(),
+            column: "legacy".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let sql = emit_sql(&plan, BackendDialect::Postgres);
+    assert_eq!(
+        sql,
+        vec!["ALTER TABLE \"doc\" DROP COLUMN \"legacy\"".to_string()]
+    );
+}
+
+#[test]
+fn emit_sql_renders_drop_column_sqlite() {
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::DropColumn {
+            table: "doc".to_string(),
+            column: "legacy".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let sql = emit_sql(&plan, BackendDialect::Sqlite);
+    assert_eq!(
+        sql,
+        vec!["ALTER TABLE \"doc\" DROP COLUMN \"legacy\"".to_string()]
+    );
+}
+
+#[test]
+fn emit_sql_with_ir_drop_table_postgres() {
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::DropTable {
+            table: "doc".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result = emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Postgres)
+        .unwrap();
+    assert_eq!(result.statements, vec!["DROP TABLE \"doc\"".to_string()]);
+    assert_no_comment_placeholders(&result.statements);
+}
+
+#[test]
+fn emit_sql_with_ir_drop_table_sqlite() {
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::DropTable {
+            table: "doc".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result = emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Sqlite)
+        .unwrap();
+    assert_eq!(result.statements, vec!["DROP TABLE \"doc\"".to_string()]);
+}
+
+#[test]
+fn emit_sql_with_ir_add_table_postgres() {
+    let model = schema_model(
+        "user",
+        vec![
+            col("id", "int", false),
+            col("email", "text", true),
+        ],
+    );
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddTable {
+            table: "user".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &empty_envelope(), &new_ir, BackendDialect::Postgres).unwrap();
+    assert!(result.statements[0].contains("CREATE TABLE"));
+    assert!(result.statements[0].contains("\"user\""));
+    assert_no_comment_placeholders(&result.statements);
+}
+
+#[test]
+fn emit_sql_with_ir_add_table_sqlite() {
+    let model = schema_model("user", vec![col("id", "int", false)]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddTable {
+            table: "user".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &empty_envelope(), &new_ir, BackendDialect::Sqlite).unwrap();
+    assert!(result.statements[0].starts_with("CREATE TABLE"));
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_nullable_postgres() {
+    let model = schema_model("user", vec![col("email", "text", true)]);
+    let old_ir = envelope(vec![schema_model("user", vec![col("id", "int", false)])]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "email".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap();
+    assert_eq!(result.statements.len(), 1);
+    assert!(result.statements[0].contains("ADD COLUMN"));
+    assert!(result.statements[0].contains("email"));
+    assert_no_comment_placeholders(&result.statements);
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_nullable_sqlite() {
+    let model = schema_model("user", vec![col("email", "text", true)]);
+    let old_ir = envelope(vec![schema_model("user", vec![col("id", "int", false)])]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "email".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Sqlite).unwrap();
+    assert!(result.statements[0].contains("ADD COLUMN"));
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_not_null_with_default_postgres() {
+    let model = schema_model(
+        "user",
+        vec![SchemaColumn {
+            default: Some(serde_json::json!(0)),
+            ..col("score", "int", false)
+        }],
+    );
+    let old_ir = envelope(vec![schema_model("user", vec![])]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "score".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap();
+    assert_eq!(result.statements.len(), 2);
+    assert!(result.statements[0].contains("NOT NULL"));
+    assert!(result.statements[1].contains("DROP DEFAULT"));
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_unique_sqlite() {
+    let model = schema_model(
+        "user",
+        vec![col_with_flags("email", "text", true, true, false, None)],
+    );
+    let old_ir = envelope(vec![schema_model("user", vec![])]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "email".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Sqlite).unwrap();
+    assert_eq!(result.statements.len(), 2);
+    assert!(result.statements[0].contains("ADD COLUMN"));
+    assert!(result.statements[1].contains("CREATE UNIQUE INDEX"));
+    assert!(result.warnings.iter().any(|w| w.contains("unique index")));
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_indexed() {
+    let model = schema_model(
+        "user",
+        vec![col_with_flags("email", "text", true, false, true, None)],
+    );
+    let old_ir = envelope(vec![schema_model("user", vec![])]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "email".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    for dialect in [BackendDialect::Sqlite, BackendDialect::Postgres] {
+        let result = emit_sql_with_ir(&plan, &old_ir, &new_ir, dialect).unwrap();
+        assert_eq!(result.statements.len(), 2);
+        assert!(result.statements[1].contains("CREATE INDEX"));
+        assert!(result.statements[1].contains(&test_single_index_name("user", "email")));
+    }
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_fk_postgres() {
+    let parent = schema_model("team", vec![col("id", "int", false)]);
+    let child = SchemaModel {
+        foreign_keys: vec![SchemaForeignKey {
+            column: "team_id".to_string(),
+            to_table: "team".to_string(),
+            to_column: "id".to_string(),
+            on_delete: Some("CASCADE".to_string()),
+            name: Some("fk_user_team_id_team".to_string()),
+        }],
+        columns: vec![col("team_id", "int", true)],
+        ..schema_model("user", vec![])
+    };
+    let old_ir = envelope(vec![parent.clone(), schema_model("user", vec![])]);
+    let new_ir = envelope(vec![parent, child]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "team_id".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap();
+    assert!(result.statements.iter().any(|s| s.contains("FOREIGN KEY")));
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_fk_sqlite_warns() {
+    let parent = schema_model("team", vec![col("id", "int", false)]);
+    let child = SchemaModel {
+        foreign_keys: vec![SchemaForeignKey {
+            column: "team_id".to_string(),
+            to_table: "team".to_string(),
+            to_column: "id".to_string(),
+            on_delete: None,
+            name: None,
+        }],
+        columns: vec![col("team_id", "int", true)],
+        ..schema_model("user", vec![])
+    };
+    let old_ir = envelope(vec![parent.clone(), schema_model("user", vec![])]);
+    let new_ir = envelope(vec![parent, child]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "team_id".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Sqlite).unwrap();
+    assert!(result.warnings.iter().any(|w| w.contains("FOREIGN KEY")));
+}
+
+#[test]
+fn emit_sql_with_ir_alter_column_type_postgres() {
+    let old_ir = envelope(vec![schema_model("user", vec![col("name", "text", true)])]);
+    let new_ir = envelope(vec![schema_model(
+        "user",
+        vec![col("name", "varchar(120)", true)],
+    )]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnType {
+            table: "user".to_string(),
+            column: "name".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap();
+    assert_eq!(result.statements.len(), 1);
+    assert!(result.statements[0].contains("ALTER COLUMN"));
+    assert!(result.statements[0].contains("TYPE"));
+    assert!(result.statements[0].contains("USING"));
+}
+
+#[test]
+fn emit_sql_with_ir_alter_column_type_sqlite_warns_only() {
+    let old_ir = envelope(vec![schema_model("user", vec![col("name", "text", true)])]);
+    let new_ir = envelope(vec![schema_model(
+        "user",
+        vec![col("name", "int", true)],
+    )]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnType {
+            table: "user".to_string(),
+            column: "name".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Sqlite).unwrap();
+    assert!(result.statements.is_empty());
+    assert!(result.warnings.iter().any(|w| w.contains("cannot change column types")));
+}
+
+#[test]
+fn emit_sql_with_ir_alter_column_nullability_postgres() {
+    let old_ir = envelope(vec![schema_model("user", vec![col("name", "text", true)])]);
+    let new_ir = envelope(vec![schema_model("user", vec![col("name", "text", false)])]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnNullability {
+            table: "user".to_string(),
+            column: "name".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap();
+    assert!(result.statements[0].contains("SET NOT NULL"));
+
+    let plan_drop = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnNullability {
+            table: "user".to_string(),
+            column: "name".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result_drop = emit_sql_with_ir(
+        &plan_drop,
+        &new_ir,
+        &old_ir,
+        BackendDialect::Postgres,
+    )
+    .unwrap();
+    assert!(result_drop.statements[0].contains("DROP NOT NULL"));
+}
+
+#[test]
+fn emit_sql_with_ir_alter_column_nullability_sqlite_warns_only() {
+    let old_ir = envelope(vec![schema_model("user", vec![col("name", "text", true)])]);
+    let new_ir = envelope(vec![schema_model("user", vec![col("name", "text", false)])]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnNullability {
+            table: "user".to_string(),
+            column: "name".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Sqlite).unwrap();
+    assert!(result.statements.is_empty());
+    assert!(result
+        .warnings
+        .iter()
+        .any(|w| w.contains("cannot change column nullability")));
+}
+
+#[test]
+fn emit_sql_with_ir_unsafe_not_null_add_errors() {
+    let model = schema_model("user", vec![col("score", "int", false)]);
+    let old_ir = envelope(vec![schema_model("user", vec![])]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "score".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let err = emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap_err();
+    assert!(err.message.contains("NOT NULL"));
+    assert!(err.message.contains("no literal default"));
+}
+
+#[test]
+fn emit_sql_i1_index_names() {
+    assert_eq!(test_single_index_name("user", "email"), "idx_user_email");
+    assert_eq!(
+        test_composite_index_name("user", &["a", "b"]),
+        "idx_user_a_b"
+    );
+}
+
+#[test]
+fn emit_sql_i1_unique_names() {
+    assert_eq!(
+        test_composite_unique_index_name("user", &["a", "b"]),
+        "uq_user_a_b"
+    );
+}
+
+#[test]
+fn emit_sql_i1_check_names() {
+    assert_eq!(test_db_check_constraint_name("user", "role"), "ck_user_role");
+}
+
+#[test]
+fn emit_sql_canonical_db_type_spelling() {
+    use ferro_ddl_lowering::{db_type_token_to_canonical, sqlite_declared_type, CanonicalType, Dialect};
+    let canonical = db_type_token_to_canonical("date", Dialect::Sqlite).unwrap();
+    assert_eq!(canonical, CanonicalType::Date);
+    assert_eq!(sqlite_declared_type(canonical), "date_text");
+}
+
+#[test]
+fn emit_sql_multi_op_ordering() {
+    let parent = schema_model("team", vec![col("id", "int", false)]);
+    let child = SchemaModel {
+        foreign_keys: vec![SchemaForeignKey {
+            column: "team_id".to_string(),
+            to_table: "team".to_string(),
+            to_column: "id".to_string(),
+            on_delete: None,
+            name: None,
+        }],
+        columns: vec![col("id", "int", false), col("team_id", "int", true)],
+        ..schema_model("user", vec![])
+    };
+    let old_ir = empty_envelope();
+    let new_ir = envelope(vec![parent, child]);
+    let plan = MigrationPlan {
+        operations: vec![
+            MigrationOp::AddTable {
+                table: "team".to_string(),
+            },
+            MigrationOp::AddTable {
+                table: "user".to_string(),
+            },
+        ],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap();
+    let create_positions: Vec<usize> = result
+        .statements
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| s.starts_with("CREATE TABLE"))
+        .map(|(i, _)| i)
+        .collect();
+    assert_eq!(create_positions.len(), 2);
+    let fk_pos = result
+        .statements
+        .iter()
+        .position(|s| s.contains("FOREIGN KEY"))
+        .expect("fk statement");
+    assert!(fk_pos > create_positions[1]);
+}
+
+#[test]
+fn emit_sql_no_comment_placeholders_on_full_plan() {
+    let old_ir = envelope(vec![schema_model(
+        "doc",
+        vec![col("name", "text", false)],
+    )]);
+    let new_ir = envelope(vec![schema_model(
+        "doc",
+        vec![
+            col("name", "varchar(40)", false),
+            col("extra", "text", true),
+        ],
+    )]);
+    let plan = plan_from_ir(&old_ir, &new_ir);
+    for dialect in [BackendDialect::Sqlite, BackendDialect::Postgres] {
+        let result = emit_sql_with_ir(&plan, &old_ir, &new_ir, dialect).unwrap();
+        assert_no_comment_placeholders(&result.statements);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ferro-ddl-lowering` crate with I-1-safe canonical type and constraint naming helpers
- Implement `emit_sql_with_ir` returning `EmissionResult` with executable DDL for all `MigrationOp` variants on SQLite and Postgres
- Keep legacy `emit_sql` shim unchanged for #119 runtime cutover
- Expand `cargo test -p ferro-migrate` coverage to 26 tests across the op × dialect matrix

## Test plan
- [x] `cargo test -p ferro-ddl-lowering -p ferro-migrate`
- [x] `cargo check -p ferro`
- [ ] Integration branch merge after #119/#120

Closes #118

## Exit steps
- [x] Issue closure keyword included (`Closes #118`)

Made with [Cursor](https://cursor.com)