### PR TITLE
feat(migrate): wire runtime auto_migrate to ferro-migrate IR planner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,5 @@ tokio = { version = "1.49", features = ["full"] }
 pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }
 uuid = { version = "1.11", features = ["v4"] }
 ferro-schema-ir = { path = "crates/ferro-schema-ir" }
+ferro-ddl-lowering = { path = "crates/ferro-ddl-lowering" }
 ferro-migrate = { path = "crates/ferro-migrate" }

--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -124,6 +124,7 @@ pub fn db_type_token_to_canonical(token: &str, dialect: Dialect) -> Option<Canon
         }),
         "date" => Some(CanonicalType::Date),
         "time" => Some(CanonicalType::Time),
+        "varchar" => Some(CanonicalType::Varchar(None)),
         other => parse_varchar_token(other).map(|n| CanonicalType::Varchar(Some(n))),
     }
 }

--- a/crates/ferro-migrate/src/emit.rs
+++ b/crates/ferro-migrate/src/emit.rs
@@ -415,6 +415,9 @@ fn emit_alter_column_type(
 
     match dialect {
         BackendDialect::Postgres => {
+            if old_col.postgres_native_enum {
+                return Ok(result);
+            }
             if new_col.enum_type_name.is_some() {
                 result.warnings.push(format!(
                     "Column '{}.{}' uses a native Postgres enum type; type reconciliation \

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -51,6 +51,7 @@ fn col(name: &str, db_type: &str, nullable: bool) -> SchemaColumn {
         format: None,
         enum_values: None,
         enum_type_name: None,
+        postgres_native_enum: false,
     }
 }
 

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -81,6 +81,9 @@ pub struct SchemaColumn {
     /// Postgres native enum type name when applicable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enum_type_name: Option<String>,
+    /// Live introspection only: column is a Postgres native enum UDT.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub postgres_native_enum: bool,
 }
 
 /// Foreign-key edge from `column` to `to_table.to_column`.

--- a/docs/brainstorms/2026-06-24-ir-p8-119-wire-automigrate-requirements.md
+++ b/docs/brainstorms/2026-06-24-ir-p8-119-wire-automigrate-requirements.md
@@ -1,0 +1,116 @@
+# Requirements: Wire runtime auto_migrate to ferro-migrate IR planner (#119)
+
+**Date:** 2026-06-24  
+**Epic:** [#117](https://github.com/syn54x/ferro-orm/issues/117)  
+**Issue:** [#119](https://github.com/syn54x/ferro-orm/issues/119)  
+**Phase:** 8 — Runtime migration IR cutover (`v0.13.0`)
+
+---
+
+## Problem
+
+`plan_table_migration` in `src/migrate.rs` already builds SchemaIR snapshots and calls `plan_from_ir` / `emit_sql`, but discards the results and still executes the legacy enriched-JSON `properties` diff walk. Runtime `connect(auto_migrate=True)` and `ferro.migrate` therefore do not use the IR pipeline that #118 completed.
+
+Two parallel planners exist with no runtime cutover. Phase 8 requires the IR path to become the **primary executor** while the legacy planner remains available as a **deprecated shadow reference** until Phase 9 ([#108](https://github.com/syn54x/ferro-orm/issues/108)).
+
+---
+
+## Goal
+
+Make `plan_table_migration` produce the same `(statements, drop_columns, warnings)` the executor already consumes, but sourced from `plan_from_ir` + `emit_sql_with_ir` instead of the JSON walk — with **observably identical behavior** for the supported `auto_migrate` capability matrix.
+
+---
+
+## Success criteria
+
+1. `plan_table_migration` executes the ferro-migrate IR pipeline as its only hot-path planner.
+2. Legacy JSON diff logic lives in an isolated, clearly deprecated helper (e.g. `plan_table_migration_legacy`) retained for #120 shadow comparison — not removed.
+3. `tests/test_migrate_plan.py` and `tests/test_auto_migrate.py` pass on SQLite + Postgres without changing public Python APIs.
+4. Semantics preserved: `migrate_updates`, `migrate_destructive`, fail-loud NOT NULL without default, Postgres type/nullability reconciliation, SQLite index-aware column drops at execution time, PK drop guard.
+5. No `_typed_plan` / `_typed_sql` discard scaffolding remains in the hot path.
+
+---
+
+## Scope
+
+### In scope
+
+- IR-primary `plan_table_migration` wiring in `src/migrate.rs`.
+- Map ferro-migrate `EmissionResult` + filtered `MigrationOp` list → runtime `MigrationPlan` (`statements`, `drop_columns`, `warnings`).
+- Respect `MigrateOptions`: `updates=false` → empty plan; `destructive=false` → omit `DropColumn` ops.
+- Keep `drop_columns` separate from `statements` so `execute_drop_column` can resolve SQLite index dependencies (executor unchanged).
+- Minimal IR adapter enrichment so existing render-level tests pass:
+  - `schema_json_to_schema_ir`: foreign keys, `db_check` constraints, `enum_type_name` where present in JSON schema.
+  - `live_columns_to_schema_ir`: Postgres native enum UDT marker on live columns (for “leave enum columns to Alembic” reconciliation).
+- Extract current JSON walk into `plan_table_migration_legacy`.
+- Map `EmissionError` → `PyValueError` with actionable messages (match legacy error tone).
+- Doc note: runtime IR cutover + deprecated legacy shadow path.
+
+### Out of scope (#120 / Phase 9)
+
+- IR vs legacy shadow comparison rewrite (`shadow_compare_migration_plan`).
+- `FERRO_SHADOW_RUNTIME` / `FERRO_SHADOW_RUNTIME_STRICT` CI enforcement.
+- Full single-sourcing of `schema_json_to_schema_ir` / `live_columns_to_schema_ir` with `build_column_plan` (consolidation when parity harness exists).
+- Removing the legacy planner ([#108](https://github.com/syn54x/ferro-orm/issues/108)).
+- Alembic / `create_tables` parity exit gates.
+
+---
+
+## Approaches considered
+
+### A. Thin adapter cutover (recommended)
+
+Wire IR plan + `emit_sql_with_ir` as primary. Enrich JSON→IR adapters only enough for `test_migrate_plan.py` parity. Extract legacy helper unchanged for #120.
+
+**Pros:** Smallest correct cutover; #118 emission logic is already tested; legacy preserved for shadow.  
+**Cons:** Temporary duplication between adapters and `build_column_plan` until #120 consolidates.
+
+### B. Consolidate adapters first, then wire
+
+Refactor `schema_json_to_schema_ir` to share `build_column_plan` metadata extraction before switching the hot path.
+
+**Pros:** Less duplication long-term.  
+**Cons:** Larger blast radius; mixes #119 execution wiring with #120 consolidation; harder to bisect parity failures.
+
+### C. Dual-run with legacy execution
+
+Run IR and legacy planners, compare, execute legacy until parity proven.
+
+**Rejected:** Violates I-7 (stop-gap). Phase 8 already defers removal, not primary execution, to shadow comparison in #120.
+
+---
+
+## Key decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Primary planner | `plan_from_ir` + `emit_sql_with_ir` | #118 deliverable; AGENTS.md I-1 alignment |
+| `drop_columns` handling | Partition `DropColumn` ops before emit; populate `drop_columns` vec | Executor relies on `execute_drop_column` for SQLite index deps |
+| Legacy planner | `plan_table_migration_legacy`, deprecated, not hot path | #120 shadow gate; Phase 9 removal |
+| Adapter scope | Minimal enrichment in #119 | Unblock render tests; full consolidation in #120 |
+| Shadow compare | No change in #119 | Owned by #120 |
+| Public API | Unchanged | `connect`, `migrate`, `_render_migration_sql_for_test` signatures stable |
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| IR adapters omit FK/check metadata → different ADD COLUMN SQL | Enrich `schema_json_to_schema_ir`; pin with existing `test_migrate_plan.py` |
+| Live enum UDT not modeled → spurious Postgres ALTER TYPE | Add live-side enum marker; skip type reconcile in emit when live column is native enum |
+| `emit_sql_with_ir` DROP in statements breaks executor | Never emit drops into `statements`; route to `drop_columns` |
+| SQLite cosmetic type drift false positives | Rely on #118 `sqlite_type_storage_drift`; existing reconcile tests |
+
+---
+
+## Dependencies
+
+- #118 merged (`emit_sql_with_ir` complete on integration branch).
+- `feat/ir-p8-migrate-cutover` integration branch.
+
+---
+
+## Outstanding questions
+
+None blocking — issue #119 and Phase 8 roadmap define scope. Adapter consolidation depth is explicitly deferred to #120.

--- a/docs/brainstorms/2026-06-24-ir-p8-119-wire-automigrate-requirements.md
+++ b/docs/brainstorms/2026-06-24-ir-p8-119-wire-automigrate-requirements.md
@@ -1,8 +1,8 @@
 # Requirements: Wire runtime auto_migrate to ferro-migrate IR planner (#119)
 
-**Date:** 2026-06-24  
-**Epic:** [#117](https://github.com/syn54x/ferro-orm/issues/117)  
-**Issue:** [#119](https://github.com/syn54x/ferro-orm/issues/119)  
+**Date:** 2026-06-24
+**Epic:** [#117](https://github.com/syn54x/ferro-orm/issues/117)
+**Issue:** [#119](https://github.com/syn54x/ferro-orm/issues/119)
 **Phase:** 8 — Runtime migration IR cutover (`v0.13.0`)
 
 ---
@@ -62,14 +62,14 @@ Make `plan_table_migration` produce the same `(statements, drop_columns, warning
 
 Wire IR plan + `emit_sql_with_ir` as primary. Enrich JSON→IR adapters only enough for `test_migrate_plan.py` parity. Extract legacy helper unchanged for #120.
 
-**Pros:** Smallest correct cutover; #118 emission logic is already tested; legacy preserved for shadow.  
+**Pros:** Smallest correct cutover; #118 emission logic is already tested; legacy preserved for shadow.
 **Cons:** Temporary duplication between adapters and `build_column_plan` until #120 consolidates.
 
 ### B. Consolidate adapters first, then wire
 
 Refactor `schema_json_to_schema_ir` to share `build_column_plan` metadata extraction before switching the hot path.
 
-**Pros:** Less duplication long-term.  
+**Pros:** Less duplication long-term.
 **Cons:** Larger blast radius; mixes #119 execution wiring with #120 consolidation; harder to bisect parity failures.
 
 ### C. Dual-run with legacy execution

--- a/docs/pages/concepts/architecture.md
+++ b/docs/pages/concepts/architecture.md
@@ -194,8 +194,10 @@ await connect("sqlite::memory:", auto_migrate=True)
 ```
 
 - `auto_migrate=True` creates missing tables for every registered model.
-- `migrate_updates=True` (0.11.0) additionally adds missing columns to existing tables, and on PostgreSQL reconciles type and nullability drift.
+- `migrate_updates=True` (0.11.0) additionally adds missing columns to existing tables, and on PostgreSQL reconciles type and nullability drift. Runtime updates are planned from **SchemaIR** diffing (`ferro-migrate`) and executed as backend-specific DDL.
 - `migrate_destructive=True` (0.11.0) additionally drops live columns no longer on the model (never whole tables).
+
+The legacy enriched-JSON migration planner remains in the codebase as a deprecated shadow reference until `v0.14.0` (Phase 9); parity against the IR path is gated in Phase 8 ([#120](https://github.com/syn54x/ferro-orm/issues/120)).
 
 For renames, primary-key changes, and complex transforms, use the [Alembic bridge](../guide/migrations.md). **SchemaIR** is the canonical contract for cross-emitter DDL parity — Alembic `get_metadata()` derives SQLAlchemy metadata from compiled SchemaIR so autogenerate agrees with Ferro's naming and type conventions. The enriched JSON schema in the Rust registry remains the runtime source for query bind typing and hydration metadata.
 

--- a/docs/plans/2026-06-24-001-feat-ir-p8-119-wire-automigrate-plan.md
+++ b/docs/plans/2026-06-24-001-feat-ir-p8-119-wire-automigrate-plan.md
@@ -13,8 +13,8 @@ origin: docs/brainstorms/2026-06-24-ir-p8-119-wire-automigrate-requirements.md
 
 Cut `plan_table_migration` over to `plan_from_ir` + `emit_sql_with_ir` as the sole hot-path planner. Extract the existing enriched-JSON diff into a deprecated `plan_table_migration_legacy` helper for #120 shadow comparison. Enrich JSON→IR adapters minimally so render-level and integration tests remain byte-identical.
 
-**Closes:** [#119](https://github.com/syn54x/ferro-orm/issues/119)  
-**Base branch:** `feat/ir-p8-migrate-cutover`  
+**Closes:** [#119](https://github.com/syn54x/ferro-orm/issues/119)
+**Base branch:** `feat/ir-p8-migrate-cutover`
 **Feature branch:** `feat/ir-p8-119-wire-automigrate`
 
 ---

--- a/docs/plans/2026-06-24-001-feat-ir-p8-119-wire-automigrate-plan.md
+++ b/docs/plans/2026-06-24-001-feat-ir-p8-119-wire-automigrate-plan.md
@@ -1,0 +1,301 @@
+---
+title: "feat: Wire runtime auto_migrate to ferro-migrate IR planner (#119)"
+date: 2026-06-24
+issue: 119
+epic: 117
+branch: feat/ir-p8-119-wire-automigrate
+origin: docs/brainstorms/2026-06-24-ir-p8-119-wire-automigrate-requirements.md
+---
+
+# feat: Wire runtime auto_migrate to ferro-migrate IR planner (#119)
+
+## Summary
+
+Cut `plan_table_migration` over to `plan_from_ir` + `emit_sql_with_ir` as the sole hot-path planner. Extract the existing enriched-JSON diff into a deprecated `plan_table_migration_legacy` helper for #120 shadow comparison. Enrich JSON→IR adapters minimally so render-level and integration tests remain byte-identical.
+
+**Closes:** [#119](https://github.com/syn54x/ferro-orm/issues/119)  
+**Base branch:** `feat/ir-p8-migrate-cutover`  
+**Feature branch:** `feat/ir-p8-119-wire-automigrate`
+
+---
+
+## Problem Frame
+
+Runtime auto-migrate still plans DDL via a legacy JSON `properties` walk in `src/migrate.rs` even though #118 implemented full IR-native SQL emission in `crates/ferro-migrate`. The typed plan is computed and thrown away (`_typed_plan`, `_typed_sql`). Phase 8 requires the IR pipeline to be the primary executor so runtime DDL and Alembic share one planner (AGENTS.md I-1).
+
+See origin: `docs/brainstorms/2026-06-24-ir-p8-119-wire-automigrate-requirements.md`.
+
+---
+
+## Requirements
+
+| ID | Requirement | Source |
+|----|-------------|--------|
+| R1 | `plan_table_migration` uses `plan_from_ir` + `emit_sql_with_ir` as primary path | #119 |
+| R2 | Legacy JSON walk isolated as deprecated `plan_table_migration_legacy` | #119, Phase 8 roadmap |
+| R3 | Behavior observably identical: updates/destructive flags, fail-loud NOT NULL, PG reconcile, SQLite drop execution | #119, `test_migrate_plan.py` |
+| R4 | `drop_columns` remain separate from `statements` for `execute_drop_column` | `src/migrate.rs` executor contract |
+| R5 | No public Python API changes | #119 migration impact |
+| R6 | `shadow_compare_migration_plan` unchanged (rewired in #120) | #119 scope boundary |
+
+---
+
+## Key Technical Decisions
+
+### KTD-1: Partition `DropColumn` before emission
+
+`emit_sql_with_ir` emits `ALTER TABLE … DROP COLUMN` into `statements`. The runtime executor intentionally keeps drops in `drop_columns` and runs `execute_drop_column` (SQLite index dependency resolution). **Do not** change the executor in #119.
+
+**Approach:** After `plan_from_ir`, split operations:
+
+1. Collect `DropColumn` op names into `plan.drop_columns` (with PK guard from `old_ir` before push).
+2. Build a filtered typed plan with non-drop ops only.
+3. Call `emit_sql_with_ir` on the filtered plan.
+
+### KTD-2: Minimal adapter enrichment (not full consolidation)
+
+`schema_json_to_schema_ir` today populates columns only — missing `foreign_keys` and `checks` that `emit_add_column` reads. `live_columns_to_schema_ir` does not mark Postgres native enum columns, so type reconciliation may diverge from legacy.
+
+Enrich adapters in #119 to pass existing tests. Full single-sourcing with `build_column_plan` is **deferred to #120** (see origin scope).
+
+### KTD-3: Postgres native enum skip uses live-side marker
+
+Legacy skips type reconciliation when `live.is_enum_udt`. `emit_alter_column_type` only checks `new_col.enum_type_name`. Add a serde-default live-only flag on `SchemaColumn` (e.g. `postgres_native_enum: bool`) set from `LiveColumn.is_enum_udt`, and teach `emit_alter_column_type` to no-op when the **old** column carries that flag — matching legacy semantics.
+
+### KTD-4: Error mapping at FFI boundary
+
+Map `ferro_migrate::EmissionError` → `pyo3::exceptions::PyValueError` in `plan_table_migration`, preserving message text expected by `test_migrate_plan.py` (`match=r"invoice\.created_at.*Alembic"` etc.).
+
+### KTD-5: `MigrateOptions` filtering at wiring layer
+
+`plan_from_ir` is options-agnostic. Apply options in `plan_table_migration`:
+
+- `!opts.updates` → return empty `MigrationPlan` immediately (existing behavior).
+- `!opts.destructive` → strip `DropColumn` ops before partition/emit.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TD
+    A[plan_table_migration] --> B{opts.updates?}
+    B -->|no| Z[empty MigrationPlan]
+    B -->|yes| C[schema_json_to_schema_ir]
+    C --> D[live_columns_to_schema_ir]
+    D --> E[plan_from_ir]
+    E --> F{opts.destructive?}
+    F -->|no| G[filter DropColumn ops]
+    F -->|yes| H[all ops]
+    G --> I[partition drops → drop_columns]
+    H --> I
+    I --> J[emit_sql_with_ir filtered ops]
+    J --> K[runtime MigrationPlan]
+    L[plan_table_migration_legacy] -.->|deprecated, #120 shadow| M[JSON properties walk]
+```
+
+**Runtime types (two `MigrationPlan` names):**
+
+| Layer | Type | Fields |
+|-------|------|--------|
+| ferro-migrate | `ferro_migrate::MigrationPlan` | `operations`, `warnings` |
+| Runtime executor | `migrate::MigrationPlan` | `statements`, `drop_columns`, `warnings` |
+
+Wiring converts typed ops + emission → executor plan.
+
+---
+
+## Implementation Units
+
+### U1. Live IR adapter: Postgres native enum marker
+
+**Goal:** Live columns that are Postgres enum UDTs skip type reconciliation, matching legacy.
+
+**Requirements:** R3
+
+**Files:**
+- `crates/ferro-schema-ir/src/lib.rs`
+- `src/migrate.rs` (`live_columns_to_schema_ir`)
+- `crates/ferro-migrate/src/emit.rs` (`emit_alter_column_type`)
+
+**Approach:**
+- Add `#[serde(default)] postgres_native_enum: bool` to `SchemaColumn`.
+- Set from `LiveColumn.is_enum_udt` in `live_columns_to_schema_ir`.
+- In `emit_alter_column_type` (Postgres arm): if `old_col.postgres_native_enum`, return empty result (no DDL, no warning — legacy emits neither).
+
+**Patterns to follow:** Legacy `plan_existing_column` guard `!live.is_enum_udt` in `src/migrate.rs`.
+
+**Test scenarios:**
+- Covers existing `test_pg_native_enum_columns_are_left_to_alembic` in `tests/test_migrate_plan.py` after U3 wiring.
+- Rust unit: live adapter sets flag when `is_enum_udt: true`.
+
+**Verification:** `test_migrate_plan.py::TestReconcileExisting::test_pg_native_enum_columns_are_left_to_alembic` passes after U3.
+
+---
+
+### U2. Model IR adapter: FK and check metadata
+
+**Goal:** `emit_add_column` receives enough `SchemaModel` metadata to emit FK and `db_check` follow-up DDL.
+
+**Requirements:** R3
+
+**Dependencies:** None (can land before U3)
+
+**Files:**
+- `src/migrate.rs` (`schema_json_to_schema_ir`)
+
+**Approach:** While walking `properties`, mirror metadata extraction from `build_column_plan` / `column_object_metadata`:
+- `foreign_key` object → `SchemaForeignKey { column, to_table, to_column: "id", on_delete, name: None }`
+- `db_check: true` → `SchemaCheck` with `db_check_constraint_name(table, col)` and expression from `build_check_constraint_sql` logic (extract shared expression helper or duplicate minimally with parity comment)
+
+Also populate `enum_type_name` on columns when present in JSON schema (for model-side enum deferral).
+
+**Patterns to follow:** `src/schema.rs` `build_column_plan`, `column_object_metadata`, `build_check_constraint_sql`.
+
+**Test scenarios:**
+- `test_fk_shadow_column_is_capability_relative` (Postgres + SQLite)
+- `test_indexed_column_add_emits_create_index`
+- `test_unique_column_strips_inline_unique_on_sqlite`
+- Any `db_check` cases in `test_migrate_plan.py` if present
+
+**Verification:** Render tests for FK/index/unique pass after U3 without legacy hot path.
+
+---
+
+### U3. IR-primary `plan_table_migration`
+
+**Goal:** Replace JSON walk with IR pipeline; map to executor `MigrationPlan`.
+
+**Requirements:** R1, R3, R4, R5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `src/migrate.rs`
+
+**Approach:**
+
+1. Add `plan_table_migration_ir(...) -> PyResult<MigrationPlan>` (or inline in `plan_table_migration`):
+   - Build `old_ir`, `new_ir`.
+   - `let typed = plan_from_ir(&old_ir, &new_ir)`.
+   - Filter ops per `opts.destructive`.
+   - Partition `DropColumn` → `drop_columns` with PK check against `old_ir` columns.
+   - `emit_sql_with_ir(&filtered, &old_ir, &new_ir, backend_dialect)?`.
+   - Merge `emission.statements` + `emission.warnings` into runtime plan.
+
+2. Replace `plan_table_migration` body to call IR path only.
+
+3. Remove `_typed_plan` / `_typed_sql` discard scaffolding.
+
+4. Import `emit_sql_with_ir` instead of legacy `emit_sql` shim where appropriate.
+
+**Error mapping:** `EmissionError` → `PyValueError::new_err(err.message)`.
+
+**Patterns to follow:** Existing early return for `!opts.updates`; destructive PK guard messages in legacy loop.
+
+**Test scenarios:**
+- Full `tests/test_migrate_plan.py` matrix (add, reconcile, destructive, updates=false).
+- `src/migrate.rs` existing unit tests for `plan_table_migration`.
+- `tests/test_auto_migrate.py` integration paths (execution + pool refresh).
+
+**Verification:**
+- `uv run pytest tests/test_migrate_plan.py -q`
+- `uv run pytest tests/test_auto_migrate.py -q`
+- `cargo test migrate` (Rust unit tests in `src/migrate.rs`)
+
+---
+
+### U4. Extract deprecated legacy planner
+
+**Goal:** Preserve JSON walk for #120 shadow without hot-path execution.
+
+**Requirements:** R2, R6
+
+**Dependencies:** U3
+
+**Files:**
+- `src/migrate.rs`
+
+**Approach:**
+- Move current JSON `properties` diff body to `#[deprecated(note = "Phase 9 removal; shadow reference for #120")] fn plan_table_migration_legacy(...)`.
+- Add module doc / comment pointing to #120 for shadow wiring.
+- Ensure no caller invokes legacy from `plan_table_migration`, `internal_migrate`, or `_render_migration_sql_for_test`.
+
+**Test scenarios:**
+- Compile-time: legacy function exists and is callable from tests only if needed in #120.
+- Grep guard: no hot-path call sites.
+
+**Verification:** `rg plan_table_migration_legacy src/` shows definition only (or test-only use).
+
+---
+
+### U5. Documentation
+
+**Goal:** Record runtime IR cutover and deprecated legacy shadow path.
+
+**Requirements:** #119 docs impact
+
+**Dependencies:** U3
+
+**Files:**
+- `docs/pages/concepts/architecture.md` (or migrations section referenced by issue)
+- `docs/plans/ir-first-migration-guide.md` — note #119 complete when merged
+
+**Approach:** Short paragraph: auto-migrate plans via SchemaIR diff + ferro-migrate emission; legacy JSON planner retained deprecated for shadow until v0.14.0.
+
+**Test expectation:** none — docs only.
+
+**Verification:** Docs build / link check if CI enforces.
+
+---
+
+## Scope Boundaries
+
+### Deferred to #120
+
+- Rewrite `shadow_compare_migration_plan` to diff IR vs `plan_table_migration_legacy`.
+- Parity gate vs `create_tables` / Alembic.
+- `FERRO_SHADOW_RUNTIME` CI enforcement.
+- Consolidate `schema_json_to_schema_ir` with `build_column_plan`.
+
+### Deferred to Phase 9 (#108)
+
+- Remove `plan_table_migration_legacy` and JSON walk entirely.
+
+### Deferred to Follow-Up Work
+
+- `DropTable` FK dependency ordering at runtime (pre-existing review note from #118; not required for single-table `plan_table_migration`).
+
+---
+
+## Verification (exit gate for #119)
+
+```text
+cargo test -p ferro-schema-ir -p ferro-migrate
+cargo test migrate
+uv run pytest tests/test_migrate_plan.py -q
+uv run pytest tests/test_auto_migrate.py -q
+uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py -q
+```
+
+PR body: `Closes #119`
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Subtle DDL drift between legacy and IR | `test_migrate_plan.py` pins exact SQL; legacy helper preserved for #120 shadow |
+| `SchemaColumn` wire format change | `serde(default)` on new field; IR vector fixtures unchanged for absent field |
+| Check constraint expression duplication | Comment + #120 consolidation; parity test coverage |
+
+---
+
+## Sources and Research
+
+- Issue [#119](https://github.com/syn54x/ferro-orm/issues/119) — scope and checklist
+- `docs/plans/2026-06-19-001-ir-first-roadmap.md` — Phase 8 deliverables
+- `src/migrate.rs` — current dual-path scaffolding, executor contract
+- `crates/ferro-migrate/src/emit.rs` — #118 emission semantics
+- `tests/test_migrate_plan.py` — canonical render-level expectations

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -25,7 +25,7 @@ use crate::introspect::{
 };
 use crate::schema::{
     CanonicalType, ColumnPlan, apply_canonical_type, build_column_plan, internal_create_tables,
-    order_schemas_for_creation,
+    order_schemas_for_creation, property_json_type_and_format,
 };
 use crate::state::{IDENTITY_MAP, MODEL_REGISTRY, SqlDialect, engine_for_connection};
 use pyo3::prelude::*;
@@ -81,10 +81,8 @@ fn infer_schema_db_type(raw_col: &serde_json::Value, resolved: &serde_json::Valu
     {
         return db_type.to_string();
     }
-    match (
-        resolved.get("type").and_then(|v| v.as_str()),
-        resolved.get("format").and_then(|v| v.as_str()),
-    ) {
+    let (json_type, format) = property_json_type_and_format(resolved);
+    match (json_type, format) {
         (_, Some("date-time")) => "timestamptz".to_string(),
         (_, Some("uuid")) => "uuid".to_string(),
         (_, Some("date")) => "date".to_string(),
@@ -92,6 +90,7 @@ fn infer_schema_db_type(raw_col: &serde_json::Value, resolved: &serde_json::Valu
         (Some("boolean"), _) => "boolean".to_string(),
         (Some("number"), _) => "double".to_string(),
         (Some("string"), _) => "varchar".to_string(),
+        (Some("object" | "array"), _) => "json".to_string(),
         _ => "text".to_string(),
     }
 }
@@ -149,9 +148,8 @@ fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> Ir
                 .map(|_| true);
             columns.push(SchemaColumn {
                 name: name.clone(),
-                logical_type: resolved
-                    .get("type")
-                    .and_then(|v| v.as_str())
+                logical_type: property_json_type_and_format(resolved)
+                    .0
                     .unwrap_or("unknown")
                     .to_string(),
                 db_type,
@@ -1494,6 +1492,31 @@ mod tests {
         let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
             .unwrap();
         assert!(plan.statements.is_empty(), "{:?}", plan.statements);
+    }
+
+    #[test]
+    fn optional_string_anyof_add_column_uses_varchar_spelling() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "motto": {
+                    "anyOf": [{"type": "string"}, {"type": "null"}],
+                    "default": null,
+                },
+            }
+        });
+        let live_cols = vec![LiveColumn {
+            is_primary_key: true,
+            ..live("id", "integer")
+        }];
+        let plan =
+            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+        let sql = &plan.statements[0];
+        assert!(sql.contains("ADD COLUMN \"motto\""), "{sql}");
+        assert!(
+            !sql.to_uppercase().contains(" TEXT "),
+            "Optional anyOf string columns must not render as TEXT: {sql}"
+        );
     }
 
     #[test]

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -7,12 +7,14 @@
 //! dropped. Capability matrix and semantics are documented on the Python
 //! `ferro.connect` / `ferro.migrate` APIs.
 //!
-//! Column DDL is produced by the same `build_column_plan` the CREATE TABLE
-//! emitter uses, so an auto-migrated database is byte-identical to a freshly
-//! created one (AGENTS.md § I-1).
+//! Column DDL for auto-migrate is planned via SchemaIR diffing (`plan_from_ir`) and
+//! lowered by `ferro-migrate` (`emit_sql_with_ir`), so an auto-migrated database
+//! matches a freshly created one (AGENTS.md § I-1). The legacy enriched-JSON
+//! planner (`plan_table_migration_legacy`) is retained for shadow comparison until
+//! Phase 9.
 
 use crate::backend::EngineHandle;
-use ferro_migrate::{BackendDialect, emit_sql, plan_from_ir};
+use ferro_migrate::{BackendDialect, MigrationOp, emit_sql_with_ir, plan_from_ir};
 use ferro_schema_ir::{
     IrEnvelope, SchemaCheck, SchemaColumn, SchemaForeignKey, SchemaIndex, SchemaIrPayload,
     SchemaModel, SchemaUnique,
@@ -32,33 +34,118 @@ use sea_query::{
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+fn resolve_col_schema<'a>(
+    schema: &'a serde_json::Value,
+    raw_col: &'a serde_json::Value,
+) -> &'a serde_json::Value {
+    if let Some(ref_path) = raw_col.get("$ref").and_then(|r| r.as_str()) {
+        if let Some(def_name) = ref_path.strip_prefix("#/$defs/") {
+            return schema
+                .get("$defs")
+                .and_then(|defs| defs.get(def_name))
+                .unwrap_or(raw_col);
+        }
+    }
+    raw_col
+}
+
+fn migrate_column_bool(
+    raw_col: &serde_json::Value,
+    resolved: &serde_json::Value,
+    key: &str,
+) -> Option<bool> {
+    raw_col
+        .get(key)
+        .or_else(|| resolved.get(key))
+        .and_then(|value| value.as_bool())
+}
+
+fn migrate_column_object<'a>(
+    raw_col: &'a serde_json::Value,
+    resolved: &'a serde_json::Value,
+    key: &str,
+) -> Option<&'a serde_json::Map<String, serde_json::Value>> {
+    raw_col
+        .get(key)
+        .or_else(|| resolved.get(key))
+        .and_then(|value| value.as_object())
+}
+
+/// Infer canonical `db_type` tokens when the schema omits an explicit `db_type=`.
+fn infer_schema_db_type(raw_col: &serde_json::Value, resolved: &serde_json::Value) -> String {
+    if let Some(db_type) = raw_col
+        .get("db_type")
+        .or_else(|| resolved.get("db_type"))
+        .and_then(|v| v.as_str())
+    {
+        return db_type.to_string();
+    }
+    match (
+        resolved.get("type").and_then(|v| v.as_str()),
+        resolved.get("format").and_then(|v| v.as_str()),
+    ) {
+        (_, Some("date-time")) => "timestamptz".to_string(),
+        (_, Some("uuid")) => "uuid".to_string(),
+        (_, Some("date")) => "date".to_string(),
+        (Some("integer"), _) => "int".to_string(),
+        (Some("boolean"), _) => "boolean".to_string(),
+        (Some("number"), _) => "double".to_string(),
+        (Some("string"), _) => "varchar".to_string(),
+        _ => "text".to_string(),
+    }
+}
+
+fn migrate_check_expression(col_name: &str, col_info: &serde_json::Value) -> Option<String> {
+    let values = col_info.get("enum").and_then(|v| v.as_array())?;
+    if values.is_empty() {
+        return None;
+    }
+    let rendered: Vec<String> = values
+        .iter()
+        .map(|v| match v {
+            serde_json::Value::String(s) => format!("'{}'", s.replace('\'', "''")),
+            serde_json::Value::Number(n) => n.to_string(),
+            serde_json::Value::Bool(b) => b.to_string(),
+            other => format!("'{}'", other.to_string().replace('\'', "''")),
+        })
+        .collect();
+    Some(format!("\"{}\" IN ({})", col_name, rendered.join(", ")))
+}
+
+fn schema_ir_column<'a>(
+    envelope: &'a IrEnvelope<SchemaIrPayload>,
+    table: &str,
+    column: &str,
+) -> Option<&'a SchemaColumn> {
+    envelope
+        .payload
+        .models
+        .iter()
+        .find(|model| model.table_name == table)
+        .and_then(|model| model.columns.iter().find(|col| col.name == column))
+}
+
+fn backend_dialect(backend: SqlDialect) -> BackendDialect {
+    match backend {
+        SqlDialect::Sqlite => BackendDialect::Sqlite,
+        SqlDialect::Postgres => BackendDialect::Postgres,
+    }
+}
+
 fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> IrEnvelope<SchemaIrPayload> {
     let mut columns = Vec::new();
+    let mut foreign_keys = Vec::new();
+    let mut checks = Vec::new();
     if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
         for (name, raw_col) in properties {
-            let resolved = if let Some(ref_path) = raw_col.get("$ref").and_then(|r| r.as_str()) {
-                if let Some(def_name) = ref_path.strip_prefix("#/$defs/") {
-                    schema
-                        .get("$defs")
-                        .and_then(|defs| defs.get(def_name))
-                        .unwrap_or(raw_col)
-                } else {
-                    raw_col
-                }
-            } else {
-                raw_col
-            };
-            let nullable = raw_col
-                .get("ferro_nullable")
-                .or_else(|| resolved.get("ferro_nullable"))
-                .and_then(|v| v.as_bool())
-                .unwrap_or(true);
-            let db_type = raw_col
+            let resolved = resolve_col_schema(schema, raw_col);
+            let nullable = migrate_column_bool(raw_col, resolved, "ferro_nullable").unwrap_or(true);
+            let db_type = infer_schema_db_type(raw_col, resolved);
+            let db_type_explicit = raw_col
                 .get("db_type")
                 .or_else(|| resolved.get("db_type"))
                 .and_then(|v| v.as_str())
-                .unwrap_or("text")
-                .to_string();
+                .map(|_| true);
             columns.push(SchemaColumn {
                 name: name.clone(),
                 logical_type: resolved
@@ -67,11 +154,7 @@ fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> Ir
                     .unwrap_or("unknown")
                     .to_string(),
                 db_type,
-                db_type_explicit: raw_col
-                    .get("db_type")
-                    .or_else(|| resolved.get("db_type"))
-                    .and_then(|v| v.as_str())
-                    .map(|_| true),
+                db_type_explicit,
                 nullable,
                 primary_key: resolved
                     .get("primary_key")
@@ -81,8 +164,8 @@ fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> Ir
                     .get("autoincrement")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false),
-                unique: resolved.get("unique").and_then(|v| v.as_bool()).unwrap_or(false),
-                index: resolved.get("index").and_then(|v| v.as_bool()).unwrap_or(false),
+                unique: migrate_column_bool(raw_col, resolved, "unique").unwrap_or(false),
+                index: migrate_column_bool(raw_col, resolved, "index").unwrap_or(false),
                 default: resolved.get("default").cloned(),
                 format: resolved
                     .get("format")
@@ -93,7 +176,40 @@ fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> Ir
                     .get("enum_type_name")
                     .and_then(|v| v.as_str())
                     .map(str::to_string),
+                postgres_native_enum: false,
             });
+
+            if let Some(fk_info) = migrate_column_object(raw_col, resolved, "foreign_key") {
+                let to_table = fk_info
+                    .get("to_table")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let on_delete = fk_info
+                    .get("on_delete")
+                    .and_then(|o| o.as_str())
+                    .map(str::to_string);
+                foreign_keys.push(SchemaForeignKey {
+                    column: name.clone(),
+                    to_table,
+                    to_column: fk_info
+                        .get("to_column")
+                        .and_then(|c| c.as_str())
+                        .unwrap_or("id")
+                        .to_string(),
+                    on_delete,
+                    name: None,
+                });
+            }
+
+            if migrate_column_bool(raw_col, resolved, "db_check").unwrap_or(false)
+                && let Some(expression) = migrate_check_expression(name, resolved)
+            {
+                checks.push(SchemaCheck {
+                    name: format!("ck_{table_lower}_{name}"),
+                    expression,
+                });
+            }
         }
     }
     columns.sort_by(|a, b| a.name.cmp(&b.name));
@@ -107,10 +223,10 @@ fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> Ir
                 model_name: table_lower.to_string(),
                 table_name: table_lower.to_string(),
                 columns,
-                foreign_keys: Vec::<SchemaForeignKey>::new(),
+                foreign_keys,
                 indexes: Vec::<SchemaIndex>::new(),
                 uniques: Vec::<SchemaUnique>::new(),
-                checks: Vec::<SchemaCheck>::new(),
+                checks,
             }],
         },
     }
@@ -118,6 +234,9 @@ fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> Ir
 
 fn declared_type_to_db_type(declared: &str) -> String {
     let lower = declared.to_ascii_lowercase();
+    if lower.contains("character varying") || lower == "varchar" {
+        return "varchar".to_string();
+    }
     if lower.contains("smallint") {
         return "smallint".to_string();
     }
@@ -162,6 +281,7 @@ fn live_columns_to_schema_ir(table_lower: &str, live: &[LiveColumn]) -> IrEnvelo
             format: None,
             enum_values: None,
             enum_type_name: None,
+            postgres_native_enum: col.is_enum_udt,
         })
         .collect();
     columns.sort_by(|a, b| a.name.cmp(&b.name));
@@ -411,17 +531,66 @@ pub fn plan_table_migration(
     backend: SqlDialect,
     opts: MigrateOptions,
 ) -> PyResult<MigrationPlan> {
+    if !opts.updates {
+        return Ok(MigrationPlan::new());
+    }
+
     let old_ir = live_columns_to_schema_ir(table_lower, live);
     let new_ir = schema_json_to_schema_ir(table_lower, schema);
-    let _typed_plan = plan_from_ir(&old_ir, &new_ir);
-    let _typed_sql = emit_sql(
-        &_typed_plan,
-        match backend {
-            SqlDialect::Sqlite => BackendDialect::Sqlite,
-            SqlDialect::Postgres => BackendDialect::Postgres,
-        },
-    );
+    let mut typed_plan = plan_from_ir(&old_ir, &new_ir);
 
+    if !opts.destructive {
+        typed_plan
+            .operations
+            .retain(|op| !matches!(op, MigrationOp::DropColumn { .. }));
+    }
+
+    let mut plan = MigrationPlan::new();
+    let mut exec_ops = Vec::new();
+
+    for operation in typed_plan.operations {
+        if let MigrationOp::DropColumn { table, column } = &operation {
+            let Some(old_col) = schema_ir_column(&old_ir, table, column) else {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Cannot drop column '{}.{}': column metadata missing from live IR context.",
+                    table, column
+                )));
+            };
+            if old_col.primary_key {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Cannot drop column '{}.{}': it is part of the primary key. \
+                     Primary-key changes must be migrated with Alembic.",
+                    table, column
+                )));
+            }
+            plan.drop_columns.push(column.clone());
+        } else {
+            exec_ops.push(operation);
+        }
+    }
+
+    let exec_plan = ferro_migrate::MigrationPlan {
+        operations: exec_ops,
+        warnings: typed_plan.warnings,
+    };
+    let emission = emit_sql_with_ir(&exec_plan, &old_ir, &new_ir, backend_dialect(backend))
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.message))?;
+
+    plan.statements = emission.statements;
+    plan.warnings = emission.warnings;
+    Ok(plan)
+}
+
+/// Deprecated enriched-JSON migration planner retained for #120 shadow comparison.
+/// Phase 9 ([#108](https://github.com/syn54x/ferro-orm/issues/108)) removes this path.
+#[allow(dead_code)]
+fn plan_table_migration_legacy(
+    table_lower: &str,
+    schema: &serde_json::Value,
+    live: &[LiveColumn],
+    backend: SqlDialect,
+    opts: MigrateOptions,
+) -> PyResult<MigrationPlan> {
     let mut plan = MigrationPlan::new();
     if !opts.updates {
         return Ok(plan);

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -14,6 +14,7 @@
 //! Phase 9.
 
 use crate::backend::EngineHandle;
+use ferro_ddl_lowering::db_check_constraint_name;
 use ferro_migrate::{BackendDialect, MigrationOp, emit_sql_with_ir, plan_from_ir};
 use ferro_schema_ir::{
     IrEnvelope, SchemaCheck, SchemaColumn, SchemaForeignKey, SchemaIndex, SchemaIrPayload,
@@ -206,7 +207,7 @@ fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> Ir
                 && let Some(expression) = migrate_check_expression(name, resolved)
             {
                 checks.push(SchemaCheck {
-                    name: format!("ck_{table_lower}_{name}"),
+                    name: db_check_constraint_name(table_lower, name),
                     expression,
                 });
             }
@@ -232,8 +233,28 @@ fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> Ir
     }
 }
 
+/// Map `information_schema.columns.data_type` spellings to the same `db_type`
+/// token vocabulary `infer_schema_db_type` uses for model columns (mirrors
+/// `pg_type_matches` on the legacy planner path).
 fn declared_type_to_db_type(declared: &str) -> String {
     let lower = declared.to_ascii_lowercase();
+    match lower.as_str() {
+        "boolean" => return "boolean".to_string(),
+        "double precision" | "real" => return "double".to_string(),
+        "numeric" => return "numeric".to_string(),
+        "json" | "jsonb" => return "json".to_string(),
+        "bytea" => return "bytea".to_string(),
+        "text" => return "text".to_string(),
+        "integer" => return "int".to_string(),
+        "smallint" => return "smallint".to_string(),
+        "bigint" => return "bigint".to_string(),
+        "uuid" => return "uuid".to_string(),
+        "date" => return "date".to_string(),
+        "time without time zone" => return "time".to_string(),
+        "timestamp without time zone" => return "timestamp".to_string(),
+        "timestamp with time zone" => return "timestamptz".to_string(),
+        _ => {}
+    }
     if lower.contains("character varying") || lower == "varchar" {
         return "varchar".to_string();
     }
@@ -1473,6 +1494,107 @@ mod tests {
         let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
             .unwrap();
         assert!(plan.statements.is_empty(), "{:?}", plan.statements);
+    }
+
+    #[test]
+    fn pg_matching_primitive_columns_emit_no_type_alter() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "is_active": {"type": "boolean"},
+                "amount": {"type": "number"},
+                "total": {"type": "number", "db_type": "numeric"},
+                "meta": {"type": "object", "db_type": "json"},
+            }
+        });
+        let live_cols = vec![
+            LiveColumn {
+                is_primary_key: true,
+                ..live("id", "integer")
+            },
+            live("is_active", "boolean"),
+            live("amount", "double precision"),
+            live("total", "numeric"),
+            LiveColumn {
+                declared_type: "jsonb".to_string(),
+                ..live("meta", "jsonb")
+            },
+        ];
+        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
+            .unwrap();
+        assert!(
+            !plan
+                .statements
+                .iter()
+                .any(|sql| sql.contains("ALTER COLUMN") && sql.contains(" TYPE ")),
+            "matching live/model types must not reconcile: {:?}",
+            plan.statements
+        );
+    }
+
+    #[test]
+    fn pg_db_check_add_column_emits_named_check_constraint() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "status": {
+                    "type": "string",
+                    "db_type": "text",
+                    "db_check": true,
+                    "enum": ["pending", "approved"],
+                },
+            }
+        });
+        let live_cols = vec![LiveColumn {
+            is_primary_key: true,
+            ..live("id", "integer")
+        }];
+        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
+            .unwrap();
+        assert!(
+            plan.statements.iter().any(|sql| {
+                sql.contains("ADD CONSTRAINT \"ck_doc_status\"")
+                    && sql.contains("CHECK (\"status\" IN ('pending', 'approved'))")
+            }),
+            "{:?}",
+            plan.statements
+        );
+    }
+
+    #[test]
+    fn pg_db_check_add_column_uses_truncated_constraint_name() {
+        let long_col = "a".repeat(70);
+        let table = "verylongtable";
+        let expected_name = db_check_constraint_name(table, &long_col);
+        assert_eq!(expected_name.chars().count(), 63);
+
+        let mut properties = serde_json::Map::new();
+        properties.insert("id".into(), json!({"type": "integer", "primary_key": true}));
+        properties.insert(
+            long_col.clone(),
+            json!({
+                "type": "string",
+                "db_type": "text",
+                "db_check": true,
+                "enum": ["pending", "approved"],
+            }),
+        );
+        let schema = json!({ "properties": properties });
+        let live_cols = vec![LiveColumn {
+            is_primary_key: true,
+            ..live("id", "integer")
+        }];
+        let plan =
+            plan_table_migration(table, &schema, &live_cols, SqlDialect::Postgres, UPDATES).unwrap();
+        let check_sql = plan
+            .statements
+            .iter()
+            .find(|sql| sql.contains("ADD CONSTRAINT"))
+            .expect("expected ADD CONSTRAINT for db_check column");
+        assert!(
+            check_sql.contains(&format!("ADD CONSTRAINT \"{expected_name}\"")),
+            "{check_sql}"
+        );
     }
 
     #[test]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -26,7 +26,9 @@ fn resolve_ref<'a>(
     col_info
 }
 
-fn property_json_type_and_format(col_info: &serde_json::Value) -> (Option<&str>, Option<&str>) {
+pub(crate) fn property_json_type_and_format(
+    col_info: &serde_json::Value,
+) -> (Option<&str>, Option<&str>) {
     let top_type = col_info.get("type").and_then(|t| t.as_str());
     let top_format = col_info.get("format").and_then(|f| f.as_str());
     if top_type.is_some() {


### PR DESCRIPTION
## Summary
- Cut `plan_table_migration` over to `plan_from_ir` + `emit_sql_with_ir` as the sole hot-path planner; `DropColumn` ops route to `drop_columns` for SQLite index-aware execution.
- Enriched `schema_json_to_schema_ir` (FK, checks, inferred `db_type`) and `live_columns_to_schema_ir` (`postgres_native_enum`) so render/integration tests stay byte-identical.
- Extracted deprecated `plan_table_migration_legacy` for #120 shadow comparison; documented runtime IR cutover in architecture guide.

Closes #119

## Test plan
- [x] `cargo test --no-default-features --features testing migrate`
- [x] `cargo test -p ferro-migrate -p ferro-schema-ir`
- [x] `uv run pytest tests/test_migrate_plan.py tests/test_auto_migrate.py -q`

## Exit steps
- [x] Issue closure encoded (`Closes #119`)

Made with [Cursor](https://cursor.com)