### PR TITLE
feat: ir cutover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,8 @@ name: CI
 on:
   workflow_call:
   pull_request:
-    branches: [main, feat/ir-first]
   push:
-    branches: [main, feat/ir-first]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ If you add a new schema feature (e.g. partial indexes, exclusion constraints):
 2. Implement it in **both** the Alembic and Rust paths in the same PR.
 3. Add a parity test that asserts the names match.
 4. Do not edit `CHANGELOG.md` manually — release tooling records entries at
-   release time (see I-11).
+   release time (see I-10).
 
 ---
 
@@ -151,17 +151,7 @@ See `docs/solutions/README.md` for the frontmatter conventions.
 
 ---
 
-## I-6: No AI attribution in commits or PRs
-
-Never sign commits or pull requests with AI/agent attribution. No
-`Co-Authored-By: Claude ...` trailers, no "Generated with Claude Code"
-footers, no robot emoji bylines — in commit messages, PR titles, or PR
-bodies. This applies even when an agent's default behavior is to add them:
-this rule overrides those defaults for this repository.
-
----
-
-## I-7: No stop-gap solutions
+## I-6: No stop-gap solutions
 
 Every feature, bug fix, and improvement must be designed as the best,
 well-thought-out solution for the project with the library's future in
@@ -194,7 +184,7 @@ agent default that biases toward minimal or expedient changes.
 
 ---
 
-## I-8: Docs examples show both field-declaration styles
+## I-7: Docs examples show both field-declaration styles
 
 Ferro supports two equivalent ways to declare model fields: assignment
 (`name: str = Field(unique=True)`) and `Annotated` metadata
@@ -232,7 +222,7 @@ preferred declaration style.
 
 ---
 
-## I-9: Lambda predicates are the official query style
+## I-8: Lambda predicates are the official query style
 
 Documentation and examples use the lambda predicate style for all queries:
 
@@ -264,7 +254,7 @@ else uses lambda without restating the trade-offs.
 
 ---
 
-## I-10: PRs must close scoped issues explicitly
+## I-9: PRs must close scoped issues explicitly
 
 Issue closure is part of feature completion, not optional cleanup.
 
@@ -282,7 +272,7 @@ Rules:
 
 ---
 
-## I-11: Do not edit CHANGELOG.md manually
+## I-10: Do not edit CHANGELOG.md manually
 
 `CHANGELOG.md` is updated automatically by the release workflow (semantic
 release / release tooling). Agents and contributors must **not** add,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,5 @@ tokio = { version = "1.49", features = ["full"] }
 pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }
 uuid = { version = "1.11", features = ["v4"] }
 ferro-schema-ir = { path = "crates/ferro-schema-ir" }
+ferro-ddl-lowering = { path = "crates/ferro-ddl-lowering" }
 ferro-migrate = { path = "crates/ferro-migrate" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = [".", "crates/ferro-schema-ir", "crates/ferro-migrate"]
+members = [
+    ".",
+    "crates/ferro-schema-ir",
+    "crates/ferro-ddl-lowering",
+    "crates/ferro-migrate",
+]
 
 [package]
 name = "ferro"

--- a/crates/ferro-ddl-lowering/Cargo.toml
+++ b/crates/ferro-ddl-lowering/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
-name = "ferro-migrate"
+name = "ferro-ddl-lowering"
 version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ferro-ddl-lowering = { path = "../ferro-ddl-lowering" }
 ferro-schema-ir = { path = "../ferro-schema-ir" }
 sea-query = { version = "0.32", features = ["with-uuid"] }
 serde_json = "1.0"

--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -1,0 +1,356 @@
+//! Canonical DDL lowering shared across Ferro emitters (AGENTS.md I-1).
+//!
+//! Type tokens, constraint naming, and column-definition helpers used by
+//! `ferro-migrate` and (eventually) the runtime schema emitter.
+
+use ferro_schema_ir::SchemaColumn;
+use sea_query::{ColumnDef, ForeignKeyAction};
+
+/// SQL dialect for lowering canonical types to rendered DDL.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Dialect {
+    /// SQLite 3.
+    Sqlite,
+    /// PostgreSQL.
+    Postgres,
+}
+
+/// Canonical, backend-resolved column type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CanonicalType {
+    Integer,
+    SmallInt,
+    BigInt,
+    Double,
+    Decimal,
+    Boolean,
+    Json,
+    Text,
+    Varchar(Option<u32>),
+    Char(u32),
+    Uuid,
+    DateTime,
+    Timestamp,
+    TimestampTz,
+    Date,
+    Time,
+    Blob,
+}
+
+/// Apply a canonical type to a sea-query [`ColumnDef`].
+pub fn apply_canonical_type(col_def: &mut ColumnDef, canonical: CanonicalType) {
+    match canonical {
+        CanonicalType::Integer => {
+            col_def.integer();
+        }
+        CanonicalType::SmallInt => {
+            col_def.small_integer();
+        }
+        CanonicalType::BigInt => {
+            col_def.big_integer();
+        }
+        CanonicalType::Double => {
+            col_def.double();
+        }
+        CanonicalType::Decimal => {
+            col_def.decimal();
+        }
+        CanonicalType::Boolean => {
+            col_def.boolean();
+        }
+        CanonicalType::Json => {
+            col_def.json();
+        }
+        CanonicalType::Text => {
+            col_def.text();
+        }
+        CanonicalType::Varchar(None) => {
+            col_def.string();
+        }
+        CanonicalType::Varchar(Some(n)) => {
+            col_def.string_len(n);
+        }
+        CanonicalType::Char(n) => {
+            col_def.char_len(n);
+        }
+        CanonicalType::Uuid => {
+            col_def.uuid();
+        }
+        CanonicalType::DateTime => {
+            col_def.date_time();
+        }
+        CanonicalType::Timestamp => {
+            col_def.timestamp();
+        }
+        CanonicalType::TimestampTz => {
+            col_def.timestamp_with_time_zone();
+        }
+        CanonicalType::Date => {
+            col_def.date();
+        }
+        CanonicalType::Time => {
+            col_def.time();
+        }
+        CanonicalType::Blob => {
+            col_def.blob();
+        }
+    }
+}
+
+fn parse_varchar_token(token: &str) -> Option<u32> {
+    let body = token.strip_prefix("varchar(")?.strip_suffix(')')?;
+    let n: u32 = body.parse().ok()?;
+    if n == 0 { None } else { Some(n) }
+}
+
+/// Map a canonical `db_type` token to [`CanonicalType`].
+pub fn db_type_token_to_canonical(token: &str, dialect: Dialect) -> Option<CanonicalType> {
+    match token {
+        "text" => Some(CanonicalType::Text),
+        "smallint" => Some(CanonicalType::SmallInt),
+        "int" => Some(CanonicalType::Integer),
+        "bigint" => Some(CanonicalType::BigInt),
+        "uuid" => Some(match dialect {
+            Dialect::Sqlite => CanonicalType::Char(32),
+            Dialect::Postgres => CanonicalType::Uuid,
+        }),
+        "timestamp" => Some(match dialect {
+            Dialect::Sqlite => CanonicalType::DateTime,
+            Dialect::Postgres => CanonicalType::Timestamp,
+        }),
+        "timestamptz" => Some(match dialect {
+            Dialect::Sqlite => CanonicalType::DateTime,
+            Dialect::Postgres => CanonicalType::TimestampTz,
+        }),
+        "date" => Some(CanonicalType::Date),
+        "time" => Some(CanonicalType::Time),
+        other => parse_varchar_token(other).map(|n| CanonicalType::Varchar(Some(n))),
+    }
+}
+
+/// Resolve a [`SchemaColumn`] to its canonical storage type.
+pub fn canonical_from_schema_column(
+    col: &SchemaColumn,
+    dialect: Dialect,
+) -> Result<CanonicalType, String> {
+    if let Some(canonical) = db_type_token_to_canonical(&col.db_type, dialect) {
+        return Ok(canonical);
+    }
+    match (col.logical_type.as_str(), col.format.as_deref()) {
+        ("string", Some("date-time")) => Ok(CanonicalType::TimestampTz),
+        ("string", Some("date")) => Ok(CanonicalType::Date),
+        ("string", Some("uuid")) => Ok(CanonicalType::Uuid),
+        (_, Some("decimal")) => Ok(CanonicalType::Decimal),
+        ("string", Some("binary")) => Ok(CanonicalType::Blob),
+        ("integer", _) => Ok(CanonicalType::Integer),
+        ("string", _) => Ok(CanonicalType::Varchar(None)),
+        ("number", _) => Ok(CanonicalType::Double),
+        ("boolean", _) => Ok(match dialect {
+            Dialect::Sqlite => CanonicalType::Integer,
+            Dialect::Postgres => CanonicalType::Boolean,
+        }),
+        ("object" | "array", _) => Ok(CanonicalType::Json),
+        _ => Err(format!(
+            "unknown db_type '{}' on column '{}'",
+            col.db_type, col.name
+        )),
+    }
+}
+
+/// Single-column index name (`idx_<table>_<col>`).
+pub fn single_index_name(table_lower: &str, col_name: &str) -> String {
+    format!("idx_{table_lower}_{col_name}")
+}
+
+/// Single-column unique name with 63-char guard.
+pub fn single_unique_index_name(table_lower: &str, col_name: &str) -> String {
+    let raw = format!("uq_{table_lower}_{col_name}");
+    if raw.chars().count() > 63 {
+        return format!("{}_uq", raw.chars().take(60).collect::<String>());
+    }
+    raw
+}
+
+/// Composite index name (`idx_<table>_<cols>`).
+pub fn composite_index_name(table_lower: &str, col_names: &[&str]) -> String {
+    let joined = col_names.join("_");
+    let raw = format!("idx_{table_lower}_{joined}");
+    if raw.chars().count() > 63 {
+        return format!("{}_idx", raw.chars().take(59).collect::<String>());
+    }
+    raw
+}
+
+/// Composite unique name (`uq_<table>_<cols>`).
+pub fn composite_unique_index_name(table_lower: &str, col_names: &[&str]) -> String {
+    let joined = col_names.join("_");
+    let raw = format!("uq_{table_lower}_{joined}");
+    if raw.chars().count() > 63 {
+        return format!("{}_uq", raw.chars().take(60).collect::<String>());
+    }
+    raw
+}
+
+/// Check constraint name (`ck_<table>_<col>`).
+pub fn db_check_constraint_name(table_lower: &str, col_name: &str) -> String {
+    let raw = format!("ck_{table_lower}_{col_name}");
+    if raw.chars().count() > 63 {
+        return format!("{}_ck", raw.chars().take(60).collect::<String>());
+    }
+    raw
+}
+
+/// Postgres `ALTER COLUMN ... TYPE` target spelling.
+pub fn pg_alter_type_target(canonical: CanonicalType) -> String {
+    match canonical {
+        CanonicalType::Integer => "integer".to_string(),
+        CanonicalType::SmallInt => "smallint".to_string(),
+        CanonicalType::BigInt => "bigint".to_string(),
+        CanonicalType::Double => "double precision".to_string(),
+        CanonicalType::Decimal => "numeric".to_string(),
+        CanonicalType::Boolean => "boolean".to_string(),
+        CanonicalType::Json => "json".to_string(),
+        CanonicalType::Text => "text".to_string(),
+        CanonicalType::Varchar(None) => "varchar".to_string(),
+        CanonicalType::Varchar(Some(n)) => format!("varchar({n})"),
+        CanonicalType::Char(n) => format!("char({n})"),
+        CanonicalType::Uuid => "uuid".to_string(),
+        CanonicalType::DateTime | CanonicalType::Timestamp => "timestamp".to_string(),
+        CanonicalType::TimestampTz => "timestamptz".to_string(),
+        CanonicalType::Date => "date".to_string(),
+        CanonicalType::Time => "time".to_string(),
+        CanonicalType::Blob => "bytea".to_string(),
+    }
+}
+
+/// SQLite declared-type string for a canonical type (parity-pinned).
+pub fn sqlite_declared_type(canonical: CanonicalType) -> String {
+    match canonical {
+        CanonicalType::Integer => "integer".to_string(),
+        CanonicalType::SmallInt => "smallint".to_string(),
+        CanonicalType::BigInt => "bigint".to_string(),
+        CanonicalType::Double => "double".to_string(),
+        CanonicalType::Decimal => "real".to_string(),
+        CanonicalType::Boolean => "boolean".to_string(),
+        CanonicalType::Json => "json_text".to_string(),
+        CanonicalType::Text => "text".to_string(),
+        CanonicalType::Varchar(None) => "varchar".to_string(),
+        CanonicalType::Varchar(Some(n)) => format!("varchar({n})"),
+        CanonicalType::Char(n) => format!("char({n})"),
+        CanonicalType::Uuid => "uuid_text".to_string(),
+        CanonicalType::DateTime | CanonicalType::Timestamp => "datetime_text".to_string(),
+        CanonicalType::TimestampTz => "timestamp_with_timezone_text".to_string(),
+        CanonicalType::Date => "date_text".to_string(),
+        CanonicalType::Time => "time_text".to_string(),
+        CanonicalType::Blob => "blob".to_string(),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SqliteTypeClass {
+    Integer,
+    Text,
+    Blob,
+    Real,
+    Numeric,
+    Temporal,
+}
+
+/// Storage-semantics class of a declared SQLite type.
+pub(crate) fn sqlite_type_class(declared: &str) -> SqliteTypeClass {
+    let declared = declared.to_ascii_lowercase();
+    if declared.contains("date") || declared.contains("time") {
+        return SqliteTypeClass::Temporal;
+    }
+    if declared.contains("json") {
+        return SqliteTypeClass::Text;
+    }
+    if declared.contains("bool") || declared.contains("int") {
+        return SqliteTypeClass::Integer;
+    }
+    if declared.contains("char") || declared.contains("clob") || declared.contains("text") {
+        return SqliteTypeClass::Text;
+    }
+    if declared.is_empty() || declared.contains("blob") {
+        return SqliteTypeClass::Blob;
+    }
+    if declared.contains("real")
+        || declared.contains("floa")
+        || declared.contains("doub")
+        || declared.contains("num")
+        || declared.contains("dec")
+    {
+        return SqliteTypeClass::Real;
+    }
+    SqliteTypeClass::Numeric
+}
+
+/// Compare old and new SQLite declared types for storage-class drift.
+pub fn sqlite_type_storage_drift(old_db_type: &str, new_canonical: CanonicalType) -> bool {
+    let old_class = sqlite_type_class(old_db_type);
+    let new_class = sqlite_type_class(&sqlite_declared_type(new_canonical));
+    old_class != new_class
+}
+
+/// Quote a SQL identifier for Postgres/SQLite DDL.
+pub fn quote_ident(ident: &str) -> String {
+    format!("\"{}\"", ident.replace('"', "\"\""))
+}
+
+/// Map an `on_delete` action string to sea-query [`ForeignKeyAction`].
+pub fn fk_action_from_str(on_delete: Option<&str>) -> ForeignKeyAction {
+    match on_delete.unwrap_or("CASCADE").to_uppercase().as_str() {
+        "RESTRICT" => ForeignKeyAction::Restrict,
+        "SET NULL" => ForeignKeyAction::SetNull,
+        "SET DEFAULT" => ForeignKeyAction::SetDefault,
+        "NO ACTION" => ForeignKeyAction::NoAction,
+        _ => ForeignKeyAction::Cascade,
+    }
+}
+
+pub fn fk_action_sql(action: ForeignKeyAction) -> &'static str {
+    match action {
+        ForeignKeyAction::Restrict => "RESTRICT",
+        ForeignKeyAction::SetNull => "SET NULL",
+        ForeignKeyAction::SetDefault => "SET DEFAULT",
+        ForeignKeyAction::NoAction => "NO ACTION",
+        ForeignKeyAction::Cascade => "CASCADE",
+    }
+}
+
+/// Convert a JSON-schema scalar default into a sea-query literal.
+pub fn literal_default_value(default: &serde_json::Value) -> Option<sea_query::Value> {
+    match default {
+        serde_json::Value::Bool(value) => Some((*value).into()),
+        serde_json::Value::Number(value) => value
+            .as_i64()
+            .map(sea_query::Value::from)
+            .or_else(|| value.as_f64().map(sea_query::Value::from)),
+        serde_json::Value::String(value) => Some(value.clone().into()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn db_type_tokens_match_canonical_vocabulary() {
+        assert_eq!(
+            db_type_token_to_canonical("text", Dialect::Postgres),
+            Some(CanonicalType::Text)
+        );
+        assert_eq!(
+            db_type_token_to_canonical("varchar(40)", Dialect::Sqlite),
+            Some(CanonicalType::Varchar(Some(40)))
+        );
+    }
+
+    #[test]
+    fn naming_helpers_match_i1_conventions() {
+        assert_eq!(single_index_name("user", "email"), "idx_user_email");
+        assert_eq!(single_unique_index_name("user", "email"), "uq_user_email");
+        assert_eq!(db_check_constraint_name("user", "role"), "ck_user_role");
+    }
+}

--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -124,6 +124,7 @@ pub fn db_type_token_to_canonical(token: &str, dialect: Dialect) -> Option<Canon
         }),
         "date" => Some(CanonicalType::Date),
         "time" => Some(CanonicalType::Time),
+        "varchar" => Some(CanonicalType::Varchar(None)),
         other => parse_varchar_token(other).map(|n| CanonicalType::Varchar(Some(n))),
     }
 }

--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -103,6 +103,12 @@ fn parse_varchar_token(token: &str) -> Option<u32> {
     if n == 0 { None } else { Some(n) }
 }
 
+fn parse_char_token(token: &str) -> Option<u32> {
+    let body = token.strip_prefix("char(")?.strip_suffix(')')?;
+    let n: u32 = body.parse().ok()?;
+    if n == 0 { None } else { Some(n) }
+}
+
 /// Map a canonical `db_type` token to [`CanonicalType`].
 pub fn db_type_token_to_canonical(token: &str, dialect: Dialect) -> Option<CanonicalType> {
     match token {
@@ -124,8 +130,86 @@ pub fn db_type_token_to_canonical(token: &str, dialect: Dialect) -> Option<Canon
         }),
         "date" => Some(CanonicalType::Date),
         "time" => Some(CanonicalType::Time),
+        "boolean" => Some(match dialect {
+            Dialect::Sqlite => CanonicalType::Integer,
+            Dialect::Postgres => CanonicalType::Boolean,
+        }),
+        "double" => Some(CanonicalType::Double),
+        "numeric" => Some(CanonicalType::Decimal),
+        "json" => Some(CanonicalType::Json),
+        "bytea" => Some(CanonicalType::Blob),
         "varchar" => Some(CanonicalType::Varchar(None)),
-        other => parse_varchar_token(other).map(|n| CanonicalType::Varchar(Some(n))),
+        other => parse_varchar_token(other)
+            .map(|n| CanonicalType::Varchar(Some(n)))
+            .or_else(|| parse_char_token(other).map(CanonicalType::Char)),
+    }
+}
+
+/// Map `information_schema.columns` spellings to the canonical Ferro `db_type` token
+/// vocabulary (mirrors legacy `pg_type_matches` / sqlite storage classes).
+pub fn information_schema_to_db_type_token(
+    declared_type: &str,
+    char_max_len: Option<i64>,
+    dialect: Dialect,
+) -> String {
+    let lower = declared_type.to_ascii_lowercase();
+    let base = match lower.as_str() {
+        "boolean" => match dialect {
+            Dialect::Sqlite => "int",
+            Dialect::Postgres => "boolean",
+        },
+        "double precision" | "real" => "double",
+        "numeric" => "numeric",
+        "json" | "jsonb" => "json",
+        "bytea" => "bytea",
+        "text" => "text",
+        "integer" => "int",
+        "smallint" => "smallint",
+        "bigint" => "bigint",
+        "uuid" => "uuid",
+        "date" => "date",
+        "time without time zone" => "time",
+        "timestamp without time zone" => "timestamp",
+        "timestamp with time zone" => "timestamptz",
+        _ if lower.contains("character varying") || lower == "varchar" => "varchar",
+        _ if lower == "character" => "char",
+        _ if lower.contains("smallint") => "smallint",
+        _ if lower.contains("bigint") => "bigint",
+        _ if lower.contains("int") => "int",
+        _ if lower.contains("uuid") || lower.contains("char(32)") => "uuid",
+        _ if lower.contains("timestamp with time zone") => "timestamptz",
+        _ if lower.contains("timestamp") || lower.contains("datetime") => "timestamp",
+        _ if lower == "date" || lower.contains("date_") => "date",
+        _ if lower == "time" || lower.contains("time_") => "time",
+        _ => "text",
+    };
+    match base {
+        "varchar" => char_max_len
+            .and_then(|n| u32::try_from(n).ok())
+            .filter(|n| *n > 0)
+            .map(|n| format!("varchar({n})"))
+            .unwrap_or_else(|| "varchar".to_string()),
+        "char" => char_max_len
+            .and_then(|n| u32::try_from(n).ok())
+            .filter(|n| *n > 0)
+            .map(|n| format!("char({n})"))
+            .unwrap_or_else(|| "char".to_string()),
+        other => other.to_string(),
+    }
+}
+
+/// Whether two [`SchemaColumn`] snapshots differ in resolved storage type.
+pub fn schema_columns_storage_drift(
+    old_col: &SchemaColumn,
+    new_col: &SchemaColumn,
+    dialect: Dialect,
+) -> bool {
+    match (
+        canonical_from_schema_column(old_col, dialect),
+        canonical_from_schema_column(new_col, dialect),
+    ) {
+        (Ok(old_c), Ok(new_c)) => old_c != new_c,
+        _ => old_col.db_type != new_col.db_type,
     }
 }
 
@@ -353,5 +437,76 @@ mod tests {
         assert_eq!(single_index_name("user", "email"), "idx_user_email");
         assert_eq!(single_unique_index_name("user", "email"), "uq_user_email");
         assert_eq!(db_check_constraint_name("user", "role"), "ck_user_role");
+    }
+
+    #[test]
+    fn information_schema_to_db_type_token_maps_live_spellings() {
+        assert_eq!(
+            information_schema_to_db_type_token("INTEGER", None, Dialect::Sqlite),
+            "int"
+        );
+        assert_eq!(
+            information_schema_to_db_type_token("DATETIME", None, Dialect::Sqlite),
+            "timestamp"
+        );
+        assert_eq!(
+            information_schema_to_db_type_token("character varying", Some(40), Dialect::Postgres),
+            "varchar(40)"
+        );
+        assert_eq!(
+            information_schema_to_db_type_token("jsonb", None, Dialect::Postgres),
+            "json"
+        );
+        assert_eq!(
+            information_schema_to_db_type_token("boolean", None, Dialect::Sqlite),
+            "int"
+        );
+        assert_eq!(
+            information_schema_to_db_type_token("boolean", None, Dialect::Postgres),
+            "boolean"
+        );
+    }
+
+    fn drift_col(name: &str, db_type: &str) -> SchemaColumn {
+        SchemaColumn {
+            name: name.to_string(),
+            logical_type: "unknown".to_string(),
+            db_type: db_type.to_string(),
+            db_type_explicit: None,
+            nullable: true,
+            primary_key: false,
+            autoincrement: false,
+            unique: false,
+            index: false,
+            default: None,
+            format: None,
+            enum_values: None,
+            enum_type_name: None,
+            postgres_native_enum: false,
+        }
+    }
+
+    #[test]
+    fn schema_columns_storage_drift_compares_canonical_storage() {
+        let old = drift_col("meta", "json");
+        let new = drift_col("meta", "json");
+        assert!(!schema_columns_storage_drift(&old, &new, Dialect::Postgres));
+
+        let old = drift_col("meta", "jsonb");
+        let new = drift_col("meta", "json");
+        assert!(schema_columns_storage_drift(&old, &new, Dialect::Postgres));
+
+        let old = drift_col("total", "numeric");
+        let new = drift_col("total", "double");
+        assert!(schema_columns_storage_drift(&old, &new, Dialect::Postgres));
+
+        let old = drift_col("count", "varchar");
+        let new = drift_col("count", "int");
+        assert!(schema_columns_storage_drift(&old, &new, Dialect::Sqlite));
+        assert!(schema_columns_storage_drift(&old, &new, Dialect::Postgres));
+
+        let old = drift_col("created_at", "timestamp");
+        let new = drift_col("created_at", "timestamptz");
+        assert!(schema_columns_storage_drift(&old, &new, Dialect::Postgres));
     }
 }

--- a/crates/ferro-migrate/src/emit.rs
+++ b/crates/ferro-migrate/src/emit.rs
@@ -415,6 +415,9 @@ fn emit_alter_column_type(
 
     match dialect {
         BackendDialect::Postgres => {
+            if old_col.postgres_native_enum {
+                return Ok(result);
+            }
             if new_col.enum_type_name.is_some() {
                 result.warnings.push(format!(
                     "Column '{}.{}' uses a native Postgres enum type; type reconciliation \

--- a/crates/ferro-migrate/src/emit.rs
+++ b/crates/ferro-migrate/src/emit.rs
@@ -1,0 +1,614 @@
+//! Executable SQL emission from IR-backed migration plans.
+
+use crate::{BackendDialect, EmissionError, EmissionResult, MigrationOp, MigrationPlan};
+use ferro_ddl_lowering::{
+    self, apply_canonical_type, canonical_from_schema_column, db_check_constraint_name,
+    fk_action_from_str, fk_action_sql, literal_default_value, pg_alter_type_target, quote_ident,
+    single_index_name, single_unique_index_name, sqlite_declared_type, sqlite_type_storage_drift,
+    Dialect,
+};
+use ferro_schema_ir::{IrEnvelope, SchemaColumn, SchemaIrPayload, SchemaModel};
+use sea_query::{
+    Alias, ColumnDef, Index, PostgresQueryBuilder, SqliteQueryBuilder, Table,
+};
+use std::collections::BTreeMap;
+
+fn lowering_dialect(dialect: BackendDialect) -> Dialect {
+    match dialect {
+        BackendDialect::Sqlite => Dialect::Sqlite,
+        BackendDialect::Postgres => Dialect::Postgres,
+    }
+}
+
+fn index_models<'a>(models: &'a [SchemaModel]) -> BTreeMap<String, &'a SchemaModel> {
+    let mut indexed = BTreeMap::new();
+    for model in models {
+        indexed.insert(model.table_name.clone(), model);
+    }
+    indexed
+}
+
+fn find_model<'a>(
+    models: &'a BTreeMap<String, &'a SchemaModel>,
+    table: &str,
+) -> Result<&'a SchemaModel, EmissionError> {
+    models.get(table).copied().ok_or_else(|| EmissionError {
+        message: format!("model '{}' not found in IR context", table),
+    })
+}
+
+fn find_column<'a>(
+    model: &'a SchemaModel,
+    column: &str,
+) -> Result<&'a SchemaColumn, EmissionError> {
+    model
+        .columns
+        .iter()
+        .find(|c| c.name == column)
+        .ok_or_else(|| EmissionError {
+            message: format!("column '{}.{}' not found in IR context", model.table_name, column),
+        })
+}
+
+fn render_create_table(model: &SchemaModel, dialect: BackendDialect) -> Result<String, EmissionError> {
+    let ld = lowering_dialect(dialect);
+    let table_lower = model.table_name.as_str();
+    let mut table_stmt = Table::create()
+        .table(Alias::new(table_lower))
+        .if_not_exists()
+        .to_owned();
+
+    for col in &model.columns {
+        let canonical = canonical_from_schema_column(col, ld).map_err(|message| EmissionError {
+            message,
+        })?;
+        let mut col_def = ColumnDef::new(Alias::new(&col.name));
+        apply_canonical_type(&mut col_def, canonical);
+        if col.primary_key {
+            col_def.primary_key();
+            if col.autoincrement {
+                col_def.auto_increment();
+            }
+        }
+        if !col.nullable {
+            col_def.not_null();
+        }
+        if col.unique {
+            col_def.unique_key();
+        }
+        table_stmt.col(&mut col_def);
+    }
+
+    let sql = match dialect {
+        BackendDialect::Sqlite => table_stmt.build(SqliteQueryBuilder),
+        BackendDialect::Postgres => table_stmt.build(PostgresQueryBuilder),
+    };
+    Ok(sql)
+}
+
+fn render_index_sql(
+    table_lower: &str,
+    name: &str,
+    columns: &[String],
+    unique: bool,
+    dialect: BackendDialect,
+) -> String {
+    let mut stmt = Index::create()
+        .name(name)
+        .table(Alias::new(table_lower))
+        .if_not_exists()
+        .to_owned();
+    if unique {
+        stmt.unique();
+    }
+    for col in columns {
+        stmt.col(Alias::new(col));
+    }
+    match dialect {
+        BackendDialect::Sqlite => stmt.to_string(SqliteQueryBuilder),
+        BackendDialect::Postgres => stmt.to_string(PostgresQueryBuilder),
+    }
+}
+
+fn single_column_unique_is_inline(model: &SchemaModel, unique_columns: &[String]) -> bool {
+    if unique_columns.len() != 1 {
+        return false;
+    }
+    let col_name = &unique_columns[0];
+    model
+        .columns
+        .iter()
+        .any(|col| col.name == *col_name && col.unique)
+}
+
+fn post_create_artifacts(
+    model: &SchemaModel,
+    dialect: BackendDialect,
+) -> Result<(Vec<String>, Vec<String>), EmissionError> {
+    let table_lower = model.table_name.as_str();
+    let mut statements = Vec::new();
+    let mut warnings = Vec::new();
+
+    for index in &model.indexes {
+        statements.push(render_index_sql(
+            table_lower,
+            &index.name,
+            &index.columns,
+            index.unique,
+            dialect,
+        ));
+    }
+
+    for unique in &model.uniques {
+        if single_column_unique_is_inline(model, &unique.columns) {
+            continue;
+        }
+        statements.push(render_index_sql(
+            table_lower,
+            &unique.name,
+            &unique.columns,
+            true,
+            dialect,
+        ));
+    }
+
+    for check in &model.checks {
+        match dialect {
+            BackendDialect::Postgres => {
+                statements.push(format!(
+                    "ALTER TABLE \"{table}\" ADD CONSTRAINT \"{name}\" CHECK ({expression})",
+                    table = table_lower,
+                    name = check.name,
+                    expression = check.expression,
+                ));
+            }
+            BackendDialect::Sqlite => {
+                warnings.push(format!(
+                    "Check constraint '{}' on table '{}' is not emitted on SQLite (requires table rebuild).",
+                    check.name, table_lower
+                ));
+            }
+        }
+    }
+
+    Ok((statements, warnings))
+}
+
+fn foreign_key_statements(
+    model: &SchemaModel,
+    dialect: BackendDialect,
+) -> Vec<String> {
+    let table_lower = model.table_name.as_str();
+    let mut statements = Vec::new();
+    for fk in &model.foreign_keys {
+        if dialect == BackendDialect::Postgres {
+            let on_delete = fk_action_from_str(fk.on_delete.as_deref());
+            statements.push(format!(
+                "ALTER TABLE {} ADD FOREIGN KEY ({}) REFERENCES {} ({}) ON DELETE {}",
+                quote_ident(table_lower),
+                quote_ident(&fk.column),
+                quote_ident(&fk.to_table),
+                quote_ident(&fk.to_column),
+                fk_action_sql(on_delete),
+            ));
+        }
+    }
+    statements
+}
+
+fn order_add_table_models<'a>(
+    models: Vec<&'a SchemaModel>,
+) -> Vec<&'a SchemaModel> {
+    let mut remaining: Vec<&SchemaModel> = models;
+    let mut ordered = Vec::new();
+    let mut created = std::collections::HashSet::new();
+
+    while !remaining.is_empty() {
+        let available: std::collections::HashSet<String> = remaining
+            .iter()
+            .map(|m| m.table_name.clone())
+            .collect();
+        let mut progress = false;
+        let mut index = 0;
+        while index < remaining.len() {
+            let deps: Vec<String> = remaining[index]
+                .foreign_keys
+                .iter()
+                .map(|fk| fk.to_table.clone())
+                .collect();
+            if deps
+                .iter()
+                .all(|dep| created.contains(dep) || !available.contains(dep))
+            {
+                let model = remaining.remove(index);
+                created.insert(model.table_name.clone());
+                ordered.push(model);
+                progress = true;
+            } else {
+                index += 1;
+            }
+        }
+        if !progress {
+            ordered.append(&mut remaining);
+            break;
+        }
+    }
+    ordered
+}
+
+fn emit_add_table_passes(
+    add_models: Vec<&SchemaModel>,
+    dialect: BackendDialect,
+    result: &mut EmissionResult,
+) -> Result<(), EmissionError> {
+    let ordered = order_add_table_models(add_models);
+    for model in &ordered {
+        result.statements.push(render_create_table(model, dialect)?);
+        let (artifacts, warnings) = post_create_artifacts(model, dialect)?;
+        result.statements.extend(artifacts);
+        result.warnings.extend(warnings);
+    }
+    for model in &ordered {
+        if dialect == BackendDialect::Sqlite {
+            for fk in &model.foreign_keys {
+                result.warnings.push(format!(
+                    "Foreign key '{}.{}' -> '{}' is not emitted on SQLite (requires table rebuild).",
+                    model.table_name, fk.column, fk.to_table
+                ));
+            }
+        } else {
+            result
+                .statements
+                .extend(foreign_key_statements(model, dialect));
+        }
+    }
+    Ok(())
+}
+
+fn emit_add_column(
+    table: &str,
+    column: &str,
+    model: &SchemaModel,
+    dialect: BackendDialect,
+) -> Result<EmissionResult, EmissionError> {
+    let col = find_column(model, column)?;
+    let ld = lowering_dialect(dialect);
+    let canonical = canonical_from_schema_column(col, ld).map_err(|message| EmissionError {
+        message,
+    })?;
+
+    if col.primary_key {
+        return Err(EmissionError {
+            message: format!(
+                "Cannot add column '{}.{}': it is a primary key, and primary keys cannot \
+                 be added to existing tables. Use Alembic for this migration.",
+                table, column
+            ),
+        });
+    }
+
+    let backfill_default = if col.nullable {
+        None
+    } else {
+        match col.default.as_ref().and_then(literal_default_value) {
+            Some(value) => Some(value),
+            None => {
+                return Err(EmissionError {
+                    message: format!(
+                        "Cannot add NOT NULL column '{}.{}' to an existing table: it has no \
+                         literal default to backfill existing rows. Make the field nullable, \
+                         give it a literal default, or use Alembic for this migration.",
+                        table, column
+                    ),
+                });
+            }
+        }
+    };
+
+    let inline_unique = col.unique && dialect == BackendDialect::Postgres;
+    let mut col_def = ColumnDef::new(Alias::new(column));
+    apply_canonical_type(&mut col_def, canonical);
+    if !col.nullable {
+        col_def.not_null();
+    }
+    if inline_unique {
+        col_def.unique_key();
+    }
+    if let Some(default_value) = &backfill_default {
+        col_def.default(default_value.clone());
+    }
+
+    let stmt = Table::alter()
+        .table(Alias::new(table))
+        .add_column(&mut col_def)
+        .to_owned();
+
+    let mut result = EmissionResult::default();
+    result.statements.push(match dialect {
+        BackendDialect::Sqlite => stmt.to_string(SqliteQueryBuilder),
+        BackendDialect::Postgres => stmt.to_string(PostgresQueryBuilder),
+    });
+
+    if backfill_default.is_some() && dialect == BackendDialect::Postgres {
+        result.statements.push(format!(
+            "ALTER TABLE {} ALTER COLUMN {} DROP DEFAULT",
+            quote_ident(table),
+            quote_ident(column)
+        ));
+    }
+
+    if col.unique && dialect == BackendDialect::Sqlite {
+        let index_name = single_unique_index_name(table, column);
+        let index_stmt = Index::create()
+            .unique()
+            .name(&index_name)
+            .table(Alias::new(table))
+            .col(Alias::new(column))
+            .if_not_exists()
+            .to_owned();
+        result
+            .statements
+            .push(index_stmt.to_string(SqliteQueryBuilder));
+        result.warnings.push(format!(
+            "Added unique column '{}.{}' as a unique index '{}' (SQLite cannot add an \
+             inline UNIQUE constraint to an existing table).",
+            table, column, index_name
+        ));
+    }
+
+    if col.index {
+        result.statements.push(render_index_sql(
+            table,
+            &single_index_name(table, column),
+            &[column.to_string()],
+            false,
+            dialect,
+        ));
+    }
+
+    for check in &model.checks {
+        if check.name == db_check_constraint_name(table, column) {
+            if dialect == BackendDialect::Postgres {
+                result.statements.push(format!(
+                    "ALTER TABLE \"{table}\" ADD CONSTRAINT \"{name}\" CHECK ({expression})",
+                    name = check.name,
+                    expression = check.expression,
+                ));
+            }
+        }
+    }
+
+    if let Some(fk) = model.foreign_keys.iter().find(|fk| fk.column == column) {
+        if dialect == BackendDialect::Postgres {
+            let on_delete = fk_action_from_str(fk.on_delete.as_deref());
+            result.statements.push(format!(
+                "ALTER TABLE {} ADD FOREIGN KEY ({}) REFERENCES {} ({}) ON DELETE {}",
+                quote_ident(table),
+                quote_ident(column),
+                quote_ident(&fk.to_table),
+                quote_ident(&fk.to_column),
+                fk_action_sql(on_delete),
+            ));
+        } else {
+            result.warnings.push(format!(
+                "Added foreign-key column '{}.{}' without its FOREIGN KEY constraint \
+                 (SQLite cannot add table constraints to an existing table). Referential \
+                 integrity for this column is not database-enforced; use Alembic if you \
+                 need the constraint.",
+                table, column
+            ));
+        }
+    }
+
+    Ok(result)
+}
+
+fn emit_alter_column_type(
+    table: &str,
+    column: &str,
+    old_col: &SchemaColumn,
+    new_col: &SchemaColumn,
+    dialect: BackendDialect,
+) -> Result<EmissionResult, EmissionError> {
+    let mut result = EmissionResult::default();
+    let ld = lowering_dialect(dialect);
+
+    match dialect {
+        BackendDialect::Postgres => {
+            if new_col.enum_type_name.is_some() {
+                result.warnings.push(format!(
+                    "Column '{}.{}' uses a native Postgres enum type; type reconciliation \
+                     is deferred to Alembic.",
+                    table, column
+                ));
+                return Ok(result);
+            }
+            if old_col.primary_key || new_col.primary_key {
+                return Ok(result);
+            }
+            let new_canonical = canonical_from_schema_column(new_col, ld).map_err(|message| {
+                EmissionError {
+                    message: format!(
+                        "Cannot alter type for '{}.{}': {}",
+                        table, column, message
+                    ),
+                }
+            })?;
+            let target = pg_alter_type_target(new_canonical);
+            result.statements.push(format!(
+                "ALTER TABLE {table} ALTER COLUMN {col} TYPE {target} USING {col}::{target}",
+                table = quote_ident(table),
+                col = quote_ident(column),
+                target = target,
+            ));
+        }
+        BackendDialect::Sqlite => {
+            if old_col.primary_key || new_col.primary_key {
+                return Ok(result);
+            }
+            let new_canonical = canonical_from_schema_column(new_col, ld).map_err(|message| {
+                EmissionError {
+                    message: format!(
+                        "Cannot alter type for '{}.{}': {}",
+                        table, column, message
+                    ),
+                }
+            })?;
+            if sqlite_type_storage_drift(&old_col.db_type, new_canonical) {
+                result.warnings.push(format!(
+                    "Column '{}.{}' is declared '{}' in the database but the model expects \
+                     '{}'. SQLite cannot change column types in place; use Alembic to \
+                     migrate this column.",
+                    table,
+                    column,
+                    old_col.db_type,
+                    sqlite_declared_type(new_canonical),
+                ));
+            }
+        }
+    }
+    Ok(result)
+}
+
+fn emit_alter_column_nullability(
+    table: &str,
+    column: &str,
+    old_col: &SchemaColumn,
+    new_col: &SchemaColumn,
+    dialect: BackendDialect,
+) -> EmissionResult {
+    let mut result = EmissionResult::default();
+    if old_col.primary_key || new_col.primary_key {
+        return result;
+    }
+
+    match dialect {
+        BackendDialect::Postgres => {
+            if !new_col.nullable && old_col.nullable {
+                result.statements.push(format!(
+                    "ALTER TABLE {} ALTER COLUMN {} SET NOT NULL",
+                    quote_ident(table),
+                    quote_ident(column),
+                ));
+            } else if new_col.nullable && !old_col.nullable {
+                result.statements.push(format!(
+                    "ALTER TABLE {} ALTER COLUMN {} DROP NOT NULL",
+                    quote_ident(table),
+                    quote_ident(column),
+                ));
+            }
+        }
+        BackendDialect::Sqlite => {
+            if old_col.nullable != new_col.nullable {
+                result.warnings.push(format!(
+                    "Column '{}.{}' is {} in the database but the model expects {}. SQLite \
+                     cannot change column nullability in place; use Alembic to migrate \
+                     this column.",
+                    table,
+                    column,
+                    if old_col.nullable {
+                        "nullable"
+                    } else {
+                        "NOT NULL"
+                    },
+                    if new_col.nullable {
+                        "nullable"
+                    } else {
+                        "NOT NULL"
+                    },
+                ));
+            }
+        }
+    }
+    result
+}
+
+/// Render executable SQL for each operation in `plan` using IR metadata.
+pub fn emit_sql_with_ir(
+    plan: &MigrationPlan,
+    old_ir: &IrEnvelope<SchemaIrPayload>,
+    new_ir: &IrEnvelope<SchemaIrPayload>,
+    dialect: BackendDialect,
+) -> Result<EmissionResult, EmissionError> {
+    let old_models = index_models(&old_ir.payload.models);
+    let new_models = index_models(&new_ir.payload.models);
+
+    let mut result = EmissionResult {
+        statements: Vec::new(),
+        warnings: plan.warnings.clone(),
+    };
+
+    let mut add_table_models = Vec::new();
+    for operation in &plan.operations {
+        if let MigrationOp::AddTable { table } = operation {
+            add_table_models.push(find_model(&new_models, table)?);
+        }
+    }
+
+    if !add_table_models.is_empty() {
+        emit_add_table_passes(add_table_models, dialect, &mut result)?;
+    }
+
+    for operation in &plan.operations {
+        match operation {
+            MigrationOp::AddTable { .. } => {}
+            MigrationOp::DropTable { table } => {
+                result
+                    .statements
+                    .push(format!("DROP TABLE \"{}\"", table));
+            }
+            MigrationOp::AddColumn { table, column } => {
+                let model = find_model(&new_models, table)?;
+                let partial = emit_add_column(table, column, model, dialect)?;
+                result.statements.extend(partial.statements);
+                result.warnings.extend(partial.warnings);
+            }
+            MigrationOp::DropColumn { table, column } => {
+                let old_model = find_model(&old_models, table)?;
+                let old_col = find_column(old_model, column)?;
+                if old_col.primary_key {
+                    return Err(EmissionError {
+                        message: format!(
+                            "Cannot drop column '{}.{}': it is part of the primary key. \
+                             Primary-key changes must be migrated with Alembic.",
+                            table, column
+                        ),
+                    });
+                }
+                result.statements.push(format!(
+                    "ALTER TABLE \"{}\" DROP COLUMN \"{}\"",
+                    table, column
+                ));
+            }
+            MigrationOp::AlterColumnType { table, column } => {
+                let old_model = find_model(&old_models, table)?;
+                let new_model = find_model(&new_models, table)?;
+                let old_col = find_column(old_model, column)?;
+                let new_col = find_column(new_model, column)?;
+                let partial = emit_alter_column_type(table, column, old_col, new_col, dialect)?;
+                result.statements.extend(partial.statements);
+                result.warnings.extend(partial.warnings);
+            }
+            MigrationOp::AlterColumnNullability { table, column } => {
+                let old_model = find_model(&old_models, table)?;
+                let new_model = find_model(&new_models, table)?;
+                let old_col = find_column(old_model, column)?;
+                let new_col = find_column(new_model, column)?;
+                let partial =
+                    emit_alter_column_nullability(table, column, old_col, new_col, dialect);
+                result.statements.extend(partial.statements);
+                result.warnings.extend(partial.warnings);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+pub(crate) use ferro_ddl_lowering::{
+    composite_index_name as test_composite_index_name,
+    composite_unique_index_name as test_composite_unique_index_name,
+    db_check_constraint_name as test_db_check_constraint_name,
+    single_index_name as test_single_index_name,
+};

--- a/crates/ferro-migrate/src/lib.rs
+++ b/crates/ferro-migrate/src/lib.rs
@@ -1,13 +1,16 @@
-//! Schema IR diffing and coarse SQL emission for migration planning experiments.
+//! Schema IR diffing and SQL emission for migration planning.
 //!
-//! Compares two [`SchemaIrPayload`] snapshots and produces a [`MigrationPlan`]. Full typed
-//! `ADD COLUMN` / `ALTER COLUMN` DDL is still owned by the runtime auto-migrate path in
-//! `src/migrate.rs`; this crate expresses structural intent at the IR layer.
+//! Compares two [`SchemaIrPayload`] snapshots and produces a [`MigrationPlan`].
+//! [`emit_sql_with_ir`] lowers structural ops to executable backend-specific DDL.
+
+mod emit;
 
 use ferro_schema_ir::{IrEnvelope, SchemaIrPayload, SchemaModel};
 use std::collections::{BTreeMap, BTreeSet};
 
-/// SQL dialect tag for [`emit_sql`] placeholder rendering.
+pub use emit::emit_sql_with_ir;
+
+/// SQL dialect tag for migration SQL emission.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BackendDialect {
     /// SQLite 3.
@@ -16,10 +19,34 @@ pub enum BackendDialect {
     Postgres,
 }
 
+/// Executable SQL plus non-fatal warnings from [`emit_sql_with_ir`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EmissionResult {
+    /// DDL statements to execute in order.
+    pub statements: Vec<String>,
+    /// Human-readable warnings (backend limitations, skipped alters, …).
+    pub warnings: Vec<String>,
+}
+
+/// Hard failure during SQL emission (missing IR metadata, unsafe add, …).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EmissionError {
+    /// Actionable error message.
+    pub message: String,
+}
+
+impl std::fmt::Display for EmissionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for EmissionError {}
+
 /// One structural change inferred from an IR diff.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MigrationOp {
-    /// A model exists in the new IR but not the old — table creation is delegated to the schema emitter.
+    /// A model exists in the new IR but not the old.
     AddTable {
         /// Table to create.
         table: String,
@@ -33,7 +60,7 @@ pub enum MigrationOp {
     AddColumn {
         /// Owning table.
         table: String,
-        /// Column to add (typed DDL planned elsewhere).
+        /// Column to add.
         column: String,
     },
     /// A column was removed from the model.
@@ -75,15 +102,10 @@ impl MigrationPlan {
     }
 }
 
-/// Render coarse SQL (or comments) for each operation in `plan`.
+/// Render placeholder SQL (or comments) for each operation in `plan`.
 ///
-/// # Arguments
-/// * `plan` — Operations produced by [`plan_from_ir`].
-/// * `dialect` — Target backend; affects comment text for unsupported alters on SQLite.
-///
-/// # Returns
-/// One SQL string (or explanatory comment line) per operation. `AddTable` / `AddColumn` /
-/// type-nullability alters are comments pointing callers at the full schema emitter.
+/// Legacy shim retained until runtime cutover ([#119](https://github.com/syn54x/ferro-orm/issues/119))
+/// wires [`emit_sql_with_ir`]. `DropTable` / `DropColumn` are executable; other ops emit comments.
 pub fn emit_sql(plan: &MigrationPlan, dialect: BackendDialect) -> Vec<String> {
     let mut sql = Vec::new();
     for operation in &plan.operations {
@@ -132,17 +154,6 @@ pub fn emit_sql(plan: &MigrationPlan, dialect: BackendDialect) -> Vec<String> {
 }
 
 /// Diff two schema IR envelopes and produce a [`MigrationPlan`].
-///
-/// Compares tables by `table_name` and columns by name within shared tables. Does not
-/// diff indexes, FKs, or checks yet — only table/column presence and `db_type` / `nullable`.
-///
-/// # Arguments
-/// * `old_ir` — Baseline schema snapshot.
-/// * `new_ir` — Desired schema snapshot.
-///
-/// # Returns
-/// A plan with add/drop/alter operations. Never fails; structural ambiguity is expressed
-/// as operations, not errors.
 pub fn plan_from_ir(
     old_ir: &IrEnvelope<SchemaIrPayload>,
     new_ir: &IrEnvelope<SchemaIrPayload>,
@@ -242,97 +253,4 @@ fn diff_model_columns(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use ferro_schema_ir::{
-        SchemaCheck, SchemaColumn, SchemaForeignKey, SchemaIndex, SchemaUnique,
-    };
-
-    fn envelope(model: SchemaModel) -> IrEnvelope<SchemaIrPayload> {
-        IrEnvelope {
-            ir_kind: "schema".to_string(),
-            ir_version: 1,
-            payload: SchemaIrPayload {
-                dialect_agnostic: true,
-                models: vec![model],
-            },
-        }
-    }
-
-    fn schema_model(table: &str, cols: Vec<SchemaColumn>) -> SchemaModel {
-        SchemaModel {
-            model_name: table.to_string(),
-            table_name: table.to_string(),
-            columns: cols,
-            foreign_keys: Vec::<SchemaForeignKey>::new(),
-            indexes: Vec::<SchemaIndex>::new(),
-            uniques: Vec::<SchemaUnique>::new(),
-            checks: Vec::<SchemaCheck>::new(),
-        }
-    }
-
-    fn col(name: &str, db_type: &str, nullable: bool) -> SchemaColumn {
-        SchemaColumn {
-            name: name.to_string(),
-            logical_type: "string".to_string(),
-            db_type: db_type.to_string(),
-            db_type_explicit: None,
-            nullable,
-            primary_key: false,
-            autoincrement: false,
-            unique: false,
-            index: false,
-            default: None,
-            format: None,
-            enum_values: None,
-            enum_type_name: None,
-        }
-    }
-
-    #[test]
-    fn plan_from_ir_detects_add_drop_and_alter_ops() {
-        let old_ir = envelope(schema_model(
-            "doc",
-            vec![col("name", "text", false), col("legacy", "text", true)],
-        ));
-        let new_ir = envelope(schema_model(
-            "doc",
-            vec![col("name", "varchar(120)", true), col("status", "text", false)],
-        ));
-
-        let plan = plan_from_ir(&old_ir, &new_ir);
-        assert!(
-            plan.operations
-                .contains(&MigrationOp::AddColumn { table: "doc".to_string(), column: "status".to_string() })
-        );
-        assert!(
-            plan.operations
-                .contains(&MigrationOp::DropColumn { table: "doc".to_string(), column: "legacy".to_string() })
-        );
-        assert!(
-            plan.operations.contains(&MigrationOp::AlterColumnType {
-                table: "doc".to_string(),
-                column: "name".to_string()
-            })
-        );
-        assert!(
-            plan.operations.contains(&MigrationOp::AlterColumnNullability {
-                table: "doc".to_string(),
-                column: "name".to_string()
-            })
-        );
-    }
-
-    #[test]
-    fn emit_sql_renders_drop_column() {
-        let plan = MigrationPlan {
-            operations: vec![MigrationOp::DropColumn {
-                table: "doc".to_string(),
-                column: "legacy".to_string(),
-            }],
-            warnings: Vec::new(),
-        };
-        let sql = emit_sql(&plan, BackendDialect::Postgres);
-        assert_eq!(sql, vec!["ALTER TABLE \"doc\" DROP COLUMN \"legacy\"".to_string()]);
-    }
-}
+mod tests;

--- a/crates/ferro-migrate/src/lib.rs
+++ b/crates/ferro-migrate/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod emit;
 
+use ferro_ddl_lowering::{schema_columns_storage_drift, Dialect};
 use ferro_schema_ir::{IrEnvelope, SchemaIrPayload, SchemaModel};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -157,7 +158,12 @@ pub fn emit_sql(plan: &MigrationPlan, dialect: BackendDialect) -> Vec<String> {
 pub fn plan_from_ir(
     old_ir: &IrEnvelope<SchemaIrPayload>,
     new_ir: &IrEnvelope<SchemaIrPayload>,
+    dialect: BackendDialect,
 ) -> MigrationPlan {
+    let ddl_dialect = match dialect {
+        BackendDialect::Sqlite => Dialect::Sqlite,
+        BackendDialect::Postgres => Dialect::Postgres,
+    };
     let old_models = index_models(&old_ir.payload.models);
     let new_models = index_models(&new_ir.payload.models);
     let mut plan = MigrationPlan::default();
@@ -183,7 +189,7 @@ pub fn plan_from_ir(
         let Some(new_model) = new_models.get(*table) else {
             continue;
         };
-        diff_model_columns(*table, old_model, new_model, &mut plan);
+        diff_model_columns(*table, old_model, new_model, ddl_dialect, &mut plan);
     }
 
     plan
@@ -201,6 +207,7 @@ fn diff_model_columns(
     table: &str,
     old_model: &SchemaModel,
     new_model: &SchemaModel,
+    dialect: Dialect,
     plan: &mut MigrationPlan,
 ) {
     let old_cols: BTreeMap<&str, _> = old_model
@@ -237,7 +244,7 @@ fn diff_model_columns(
         let Some(new_col) = new_cols.get(*col) else {
             continue;
         };
-        if old_col.db_type != new_col.db_type {
+        if schema_columns_storage_drift(old_col, new_col, dialect) {
             plan.operations.push(MigrationOp::AlterColumnType {
                 table: table.to_string(),
                 column: (*col).to_string(),

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -100,7 +100,7 @@ fn plan_from_ir_detects_add_drop_and_alter_ops() {
         vec![col("name", "varchar(120)", true), col("status", "text", false)],
     )]);
 
-    let plan = plan_from_ir(&old_ir, &new_ir);
+    let plan = plan_from_ir(&old_ir, &new_ir, BackendDialect::Sqlite);
     assert!(plan.operations.contains(&MigrationOp::AddColumn {
         table: "doc".to_string(),
         column: "status".to_string(),
@@ -123,7 +123,7 @@ fn plan_from_ir_detects_add_drop_and_alter_ops() {
 fn plan_from_ir_add_and_drop_table() {
     let old_ir = envelope(vec![schema_model("legacy", vec![col("id", "int", false)])]);
     let new_ir = envelope(vec![schema_model("fresh", vec![col("id", "int", false)])]);
-    let plan = plan_from_ir(&old_ir, &new_ir);
+    let plan = plan_from_ir(&old_ir, &new_ir, BackendDialect::Sqlite);
     assert!(plan.operations.contains(&MigrationOp::AddTable {
         table: "fresh".to_string(),
     }));
@@ -667,7 +667,7 @@ fn emit_sql_no_comment_placeholders_on_full_plan() {
             col("extra", "text", true),
         ],
     )]);
-    let plan = plan_from_ir(&old_ir, &new_ir);
+    let plan = plan_from_ir(&old_ir, &new_ir, BackendDialect::Sqlite);
     for dialect in [BackendDialect::Sqlite, BackendDialect::Postgres] {
         let result = emit_sql_with_ir(&plan, &old_ir, &new_ir, dialect).unwrap();
         assert_no_comment_placeholders(&result.statements);

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -51,6 +51,7 @@ fn col(name: &str, db_type: &str, nullable: bool) -> SchemaColumn {
         format: None,
         enum_values: None,
         enum_type_name: None,
+        postgres_native_enum: false,
     }
 }
 

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -1,0 +1,674 @@
+//! Unit tests for `ferro-migrate` planning and emission.
+
+use super::*;
+use crate::emit::{
+    test_composite_index_name, test_composite_unique_index_name, test_db_check_constraint_name,
+    test_single_index_name,
+};
+use ferro_schema_ir::{
+    SchemaCheck, SchemaColumn, SchemaForeignKey, SchemaIndex, SchemaUnique,
+};
+
+fn envelope(models: Vec<SchemaModel>) -> IrEnvelope<SchemaIrPayload> {
+    IrEnvelope {
+        ir_kind: "schema".to_string(),
+        ir_version: 1,
+        payload: SchemaIrPayload {
+            dialect_agnostic: true,
+            models,
+        },
+    }
+}
+
+fn empty_envelope() -> IrEnvelope<SchemaIrPayload> {
+    envelope(Vec::new())
+}
+
+fn schema_model(table: &str, cols: Vec<SchemaColumn>) -> SchemaModel {
+    SchemaModel {
+        model_name: table.to_string(),
+        table_name: table.to_string(),
+        columns: cols,
+        foreign_keys: Vec::<SchemaForeignKey>::new(),
+        indexes: Vec::<SchemaIndex>::new(),
+        uniques: Vec::<SchemaUnique>::new(),
+        checks: Vec::<SchemaCheck>::new(),
+    }
+}
+
+fn col(name: &str, db_type: &str, nullable: bool) -> SchemaColumn {
+    SchemaColumn {
+        name: name.to_string(),
+        logical_type: "string".to_string(),
+        db_type: db_type.to_string(),
+        db_type_explicit: None,
+        nullable,
+        primary_key: false,
+        autoincrement: false,
+        unique: false,
+        index: false,
+        default: None,
+        format: None,
+        enum_values: None,
+        enum_type_name: None,
+    }
+}
+
+fn col_with_flags(
+    name: &str,
+    db_type: &str,
+    nullable: bool,
+    unique: bool,
+    index: bool,
+    default: Option<serde_json::Value>,
+) -> SchemaColumn {
+    SchemaColumn {
+        unique,
+        index,
+        default,
+        ..col(name, db_type, nullable)
+    }
+}
+
+fn pk_col(name: &str, db_type: &str) -> SchemaColumn {
+    SchemaColumn {
+        primary_key: true,
+        autoincrement: true,
+        nullable: false,
+        ..col(name, db_type, false)
+    }
+}
+
+fn assert_no_comment_placeholders(statements: &[String]) {
+    for sql in statements {
+        assert!(
+            !sql.trim_start().starts_with("--"),
+            "comment placeholder found: {sql}"
+        );
+    }
+}
+
+#[test]
+fn plan_from_ir_detects_add_drop_and_alter_ops() {
+    let old_ir = envelope(vec![schema_model(
+        "doc",
+        vec![col("name", "text", false), col("legacy", "text", true)],
+    )]);
+    let new_ir = envelope(vec![schema_model(
+        "doc",
+        vec![col("name", "varchar(120)", true), col("status", "text", false)],
+    )]);
+
+    let plan = plan_from_ir(&old_ir, &new_ir);
+    assert!(plan.operations.contains(&MigrationOp::AddColumn {
+        table: "doc".to_string(),
+        column: "status".to_string(),
+    }));
+    assert!(plan.operations.contains(&MigrationOp::DropColumn {
+        table: "doc".to_string(),
+        column: "legacy".to_string(),
+    }));
+    assert!(plan.operations.contains(&MigrationOp::AlterColumnType {
+        table: "doc".to_string(),
+        column: "name".to_string(),
+    }));
+    assert!(plan.operations.contains(&MigrationOp::AlterColumnNullability {
+        table: "doc".to_string(),
+        column: "name".to_string(),
+    }));
+}
+
+#[test]
+fn plan_from_ir_add_and_drop_table() {
+    let old_ir = envelope(vec![schema_model("legacy", vec![col("id", "int", false)])]);
+    let new_ir = envelope(vec![schema_model("fresh", vec![col("id", "int", false)])]);
+    let plan = plan_from_ir(&old_ir, &new_ir);
+    assert!(plan.operations.contains(&MigrationOp::AddTable {
+        table: "fresh".to_string(),
+    }));
+    assert!(plan.operations.contains(&MigrationOp::DropTable {
+        table: "legacy".to_string(),
+    }));
+}
+
+#[test]
+fn emit_sql_renders_drop_column_postgres() {
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::DropColumn {
+            table: "doc".to_string(),
+            column: "legacy".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let sql = emit_sql(&plan, BackendDialect::Postgres);
+    assert_eq!(
+        sql,
+        vec!["ALTER TABLE \"doc\" DROP COLUMN \"legacy\"".to_string()]
+    );
+}
+
+#[test]
+fn emit_sql_renders_drop_column_sqlite() {
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::DropColumn {
+            table: "doc".to_string(),
+            column: "legacy".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let sql = emit_sql(&plan, BackendDialect::Sqlite);
+    assert_eq!(
+        sql,
+        vec!["ALTER TABLE \"doc\" DROP COLUMN \"legacy\"".to_string()]
+    );
+}
+
+#[test]
+fn emit_sql_with_ir_drop_table_postgres() {
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::DropTable {
+            table: "doc".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result = emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Postgres)
+        .unwrap();
+    assert_eq!(result.statements, vec!["DROP TABLE \"doc\"".to_string()]);
+    assert_no_comment_placeholders(&result.statements);
+}
+
+#[test]
+fn emit_sql_with_ir_drop_table_sqlite() {
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::DropTable {
+            table: "doc".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result = emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Sqlite)
+        .unwrap();
+    assert_eq!(result.statements, vec!["DROP TABLE \"doc\"".to_string()]);
+}
+
+#[test]
+fn emit_sql_with_ir_add_table_postgres() {
+    let model = schema_model(
+        "user",
+        vec![
+            col("id", "int", false),
+            col("email", "text", true),
+        ],
+    );
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddTable {
+            table: "user".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &empty_envelope(), &new_ir, BackendDialect::Postgres).unwrap();
+    assert!(result.statements[0].contains("CREATE TABLE"));
+    assert!(result.statements[0].contains("\"user\""));
+    assert_no_comment_placeholders(&result.statements);
+}
+
+#[test]
+fn emit_sql_with_ir_add_table_sqlite() {
+    let model = schema_model("user", vec![col("id", "int", false)]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddTable {
+            table: "user".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &empty_envelope(), &new_ir, BackendDialect::Sqlite).unwrap();
+    assert!(result.statements[0].starts_with("CREATE TABLE"));
+}
+
+#[test]
+fn emit_sql_with_ir_add_table_unique_inline_sqlite() {
+    let model = SchemaModel {
+        columns: vec![col_with_flags("email", "text", true, true, false, None)],
+        uniques: vec![SchemaUnique {
+            name: "uq_user_email".to_string(),
+            columns: vec!["email".to_string()],
+        }],
+        ..schema_model("user", vec![])
+    };
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddTable {
+            table: "user".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &empty_envelope(), &new_ir, BackendDialect::Sqlite).unwrap();
+    assert_eq!(result.statements.len(), 1);
+    assert!(result.statements[0].contains("UNIQUE"));
+    assert!(!result.statements.iter().any(|s| s.contains("CREATE UNIQUE INDEX")));
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_nullable_postgres() {
+    let model = schema_model("user", vec![col("email", "text", true)]);
+    let old_ir = envelope(vec![schema_model("user", vec![col("id", "int", false)])]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "email".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap();
+    assert_eq!(result.statements.len(), 1);
+    assert!(result.statements[0].contains("ADD COLUMN"));
+    assert!(result.statements[0].contains("email"));
+    assert_no_comment_placeholders(&result.statements);
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_nullable_sqlite() {
+    let model = schema_model("user", vec![col("email", "text", true)]);
+    let old_ir = envelope(vec![schema_model("user", vec![col("id", "int", false)])]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "email".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Sqlite).unwrap();
+    assert!(result.statements[0].contains("ADD COLUMN"));
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_not_null_with_default_postgres() {
+    let model = schema_model(
+        "user",
+        vec![SchemaColumn {
+            default: Some(serde_json::json!(0)),
+            ..col("score", "int", false)
+        }],
+    );
+    let old_ir = envelope(vec![schema_model("user", vec![])]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "score".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap();
+    assert_eq!(result.statements.len(), 2);
+    assert!(result.statements[0].contains("NOT NULL"));
+    assert!(result.statements[1].contains("DROP DEFAULT"));
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_unique_sqlite() {
+    let model = schema_model(
+        "user",
+        vec![col_with_flags("email", "text", true, true, false, None)],
+    );
+    let old_ir = envelope(vec![schema_model("user", vec![])]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "email".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Sqlite).unwrap();
+    assert_eq!(result.statements.len(), 2);
+    assert!(result.statements[0].contains("ADD COLUMN"));
+    assert!(result.statements[1].contains("CREATE UNIQUE INDEX"));
+    assert!(result.warnings.iter().any(|w| w.contains("unique index")));
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_indexed() {
+    let model = schema_model(
+        "user",
+        vec![col_with_flags("email", "text", true, false, true, None)],
+    );
+    let old_ir = envelope(vec![schema_model("user", vec![])]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "email".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    for dialect in [BackendDialect::Sqlite, BackendDialect::Postgres] {
+        let result = emit_sql_with_ir(&plan, &old_ir, &new_ir, dialect).unwrap();
+        assert_eq!(result.statements.len(), 2);
+        assert!(result.statements[1].contains("CREATE INDEX"));
+        assert!(result.statements[1].contains(&test_single_index_name("user", "email")));
+    }
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_fk_postgres() {
+    let parent = schema_model("team", vec![col("id", "int", false)]);
+    let child = SchemaModel {
+        foreign_keys: vec![SchemaForeignKey {
+            column: "team_id".to_string(),
+            to_table: "team".to_string(),
+            to_column: "id".to_string(),
+            on_delete: Some("CASCADE".to_string()),
+            name: Some("fk_user_team_id_team".to_string()),
+        }],
+        columns: vec![col("team_id", "int", true)],
+        ..schema_model("user", vec![])
+    };
+    let old_ir = envelope(vec![parent.clone(), schema_model("user", vec![])]);
+    let new_ir = envelope(vec![parent, child]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "team_id".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap();
+    assert!(result.statements.iter().any(|s| s.contains("FOREIGN KEY")));
+}
+
+#[test]
+fn emit_sql_with_ir_add_column_fk_sqlite_warns() {
+    let parent = schema_model("team", vec![col("id", "int", false)]);
+    let child = SchemaModel {
+        foreign_keys: vec![SchemaForeignKey {
+            column: "team_id".to_string(),
+            to_table: "team".to_string(),
+            to_column: "id".to_string(),
+            on_delete: None,
+            name: None,
+        }],
+        columns: vec![col("team_id", "int", true)],
+        ..schema_model("user", vec![])
+    };
+    let old_ir = envelope(vec![parent.clone(), schema_model("user", vec![])]);
+    let new_ir = envelope(vec![parent, child]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "team_id".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Sqlite).unwrap();
+    assert!(result.warnings.iter().any(|w| w.contains("FOREIGN KEY")));
+}
+
+#[test]
+fn emit_sql_with_ir_alter_column_type_postgres() {
+    let old_ir = envelope(vec![schema_model("user", vec![col("name", "text", true)])]);
+    let new_ir = envelope(vec![schema_model(
+        "user",
+        vec![col("name", "varchar(120)", true)],
+    )]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnType {
+            table: "user".to_string(),
+            column: "name".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap();
+    assert_eq!(result.statements.len(), 1);
+    assert!(result.statements[0].contains("ALTER COLUMN"));
+    assert!(result.statements[0].contains("TYPE"));
+    assert!(result.statements[0].contains("USING"));
+}
+
+#[test]
+fn emit_sql_with_ir_alter_column_type_sqlite_warns_only() {
+    let old_ir = envelope(vec![schema_model("user", vec![col("name", "text", true)])]);
+    let new_ir = envelope(vec![schema_model(
+        "user",
+        vec![col("name", "int", true)],
+    )]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnType {
+            table: "user".to_string(),
+            column: "name".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Sqlite).unwrap();
+    assert!(result.statements.is_empty());
+    assert!(result.warnings.iter().any(|w| w.contains("cannot change column types")));
+}
+
+#[test]
+fn emit_sql_with_ir_alter_column_nullability_postgres() {
+    let old_ir = envelope(vec![schema_model("user", vec![col("name", "text", true)])]);
+    let new_ir = envelope(vec![schema_model("user", vec![col("name", "text", false)])]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnNullability {
+            table: "user".to_string(),
+            column: "name".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap();
+    assert!(result.statements[0].contains("SET NOT NULL"));
+
+    let plan_drop = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnNullability {
+            table: "user".to_string(),
+            column: "name".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result_drop = emit_sql_with_ir(
+        &plan_drop,
+        &new_ir,
+        &old_ir,
+        BackendDialect::Postgres,
+    )
+    .unwrap();
+    assert!(result_drop.statements[0].contains("DROP NOT NULL"));
+}
+
+#[test]
+fn emit_sql_with_ir_alter_column_nullability_sqlite_warns_only() {
+    let old_ir = envelope(vec![schema_model("user", vec![col("name", "text", true)])]);
+    let new_ir = envelope(vec![schema_model("user", vec![col("name", "text", false)])]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnNullability {
+            table: "user".to_string(),
+            column: "name".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Sqlite).unwrap();
+    assert!(result.statements.is_empty());
+    assert!(result
+        .warnings
+        .iter()
+        .any(|w| w.contains("cannot change column nullability")));
+}
+
+#[test]
+fn emit_sql_with_ir_unsafe_not_null_add_errors() {
+    let model = schema_model("user", vec![col("score", "int", false)]);
+    let old_ir = envelope(vec![schema_model("user", vec![])]);
+    let new_ir = envelope(vec![model]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddColumn {
+            table: "user".to_string(),
+            column: "score".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let err = emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap_err();
+    assert!(err.message.contains("NOT NULL"));
+    assert!(err.message.contains("no literal default"));
+}
+
+#[test]
+fn emit_sql_with_ir_drop_primary_key_column_errors() {
+    let old_ir = envelope(vec![schema_model("user", vec![pk_col("id", "int"), col("legacy", "text", true)])]);
+    let new_ir = envelope(vec![schema_model("user", vec![pk_col("id", "int")])]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::DropColumn {
+            table: "user".to_string(),
+            column: "id".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let err = emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap_err();
+    assert!(err.message.contains("primary key"));
+}
+
+#[test]
+fn emit_sql_with_ir_add_table_missing_model_errors() {
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AddTable {
+            table: "missing".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let err =
+        emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Postgres)
+            .unwrap_err();
+    assert!(err.message.contains("model 'missing' not found"));
+}
+
+#[test]
+fn emit_sql_with_ir_alter_column_type_unknown_db_type_errors() {
+    let bad_col = SchemaColumn {
+        db_type: "not_a_real_token".to_string(),
+        logical_type: "unknown".to_string(),
+        ..col("name", "text", true)
+    };
+    let old_ir = envelope(vec![schema_model("user", vec![col("name", "text", true)])]);
+    let new_ir = envelope(vec![schema_model("user", vec![bad_col])]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnType {
+            table: "user".to_string(),
+            column: "name".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let err =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap_err();
+    assert!(err.message.contains("Cannot alter type"));
+    assert!(err.message.contains("unknown db_type"));
+}
+
+#[test]
+fn emit_sql_i1_index_names() {
+    assert_eq!(test_single_index_name("user", "email"), "idx_user_email");
+    assert_eq!(
+        test_composite_index_name("user", &["a", "b"]),
+        "idx_user_a_b"
+    );
+}
+
+#[test]
+fn emit_sql_i1_unique_names() {
+    assert_eq!(
+        test_composite_unique_index_name("user", &["a", "b"]),
+        "uq_user_a_b"
+    );
+}
+
+#[test]
+fn emit_sql_i1_check_names() {
+    assert_eq!(test_db_check_constraint_name("user", "role"), "ck_user_role");
+}
+
+#[test]
+fn emit_sql_canonical_db_type_spelling() {
+    use ferro_ddl_lowering::{db_type_token_to_canonical, sqlite_declared_type, CanonicalType, Dialect};
+    let canonical = db_type_token_to_canonical("date", Dialect::Sqlite).unwrap();
+    assert_eq!(canonical, CanonicalType::Date);
+    assert_eq!(sqlite_declared_type(canonical), "date_text");
+}
+
+#[test]
+fn emit_sql_multi_op_ordering() {
+    let parent = schema_model("team", vec![col("id", "int", false)]);
+    let child = SchemaModel {
+        foreign_keys: vec![SchemaForeignKey {
+            column: "team_id".to_string(),
+            to_table: "team".to_string(),
+            to_column: "id".to_string(),
+            on_delete: None,
+            name: None,
+        }],
+        columns: vec![col("id", "int", false), col("team_id", "int", true)],
+        ..schema_model("user", vec![])
+    };
+    let old_ir = empty_envelope();
+    let new_ir = envelope(vec![parent, child]);
+    let plan = MigrationPlan {
+        operations: vec![
+            MigrationOp::AddTable {
+                table: "team".to_string(),
+            },
+            MigrationOp::AddTable {
+                table: "user".to_string(),
+            },
+        ],
+        warnings: Vec::new(),
+    };
+    let result =
+        emit_sql_with_ir(&plan, &old_ir, &new_ir, BackendDialect::Postgres).unwrap();
+    let create_positions: Vec<usize> = result
+        .statements
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| s.starts_with("CREATE TABLE"))
+        .map(|(i, _)| i)
+        .collect();
+    assert_eq!(create_positions.len(), 2);
+    let fk_pos = result
+        .statements
+        .iter()
+        .position(|s| s.contains("FOREIGN KEY"))
+        .expect("fk statement");
+    assert!(fk_pos > create_positions[1]);
+}
+
+#[test]
+fn emit_sql_no_comment_placeholders_on_full_plan() {
+    let old_ir = envelope(vec![schema_model(
+        "doc",
+        vec![col("name", "text", false)],
+    )]);
+    let new_ir = envelope(vec![schema_model(
+        "doc",
+        vec![
+            col("name", "varchar(40)", false),
+            col("extra", "text", true),
+        ],
+    )]);
+    let plan = plan_from_ir(&old_ir, &new_ir);
+    for dialect in [BackendDialect::Sqlite, BackendDialect::Postgres] {
+        let result = emit_sql_with_ir(&plan, &old_ir, &new_ir, dialect).unwrap();
+        assert_no_comment_placeholders(&result.statements);
+    }
+}

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -81,6 +81,9 @@ pub struct SchemaColumn {
     /// Postgres native enum type name when applicable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enum_type_name: Option<String>,
+    /// Live introspection only: column is a Postgres native enum UDT.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub postgres_native_enum: bool,
 }
 
 /// Foreign-key edge from `column` to `to_table.to_column`.

--- a/docs/brainstorms/2026-06-24-ir-p8-119-wire-automigrate-requirements.md
+++ b/docs/brainstorms/2026-06-24-ir-p8-119-wire-automigrate-requirements.md
@@ -76,7 +76,7 @@ Refactor `schema_json_to_schema_ir` to share `build_column_plan` metadata extrac
 
 Run IR and legacy planners, compare, execute legacy until parity proven.
 
-**Rejected:** Violates I-7 (stop-gap). Phase 8 already defers removal, not primary execution, to shadow comparison in #120.
+**Rejected:** Violates I-6 (stop-gap). Phase 8 already defers removal, not primary execution, to shadow comparison in #120.
 
 ---
 

--- a/docs/brainstorms/2026-06-24-ir-p8-119-wire-automigrate-requirements.md
+++ b/docs/brainstorms/2026-06-24-ir-p8-119-wire-automigrate-requirements.md
@@ -1,0 +1,116 @@
+# Requirements: Wire runtime auto_migrate to ferro-migrate IR planner (#119)
+
+**Date:** 2026-06-24
+**Epic:** [#117](https://github.com/syn54x/ferro-orm/issues/117)
+**Issue:** [#119](https://github.com/syn54x/ferro-orm/issues/119)
+**Phase:** 8 — Runtime migration IR cutover (`v0.13.0`)
+
+---
+
+## Problem
+
+`plan_table_migration` in `src/migrate.rs` already builds SchemaIR snapshots and calls `plan_from_ir` / `emit_sql`, but discards the results and still executes the legacy enriched-JSON `properties` diff walk. Runtime `connect(auto_migrate=True)` and `ferro.migrate` therefore do not use the IR pipeline that #118 completed.
+
+Two parallel planners exist with no runtime cutover. Phase 8 requires the IR path to become the **primary executor** while the legacy planner remains available as a **deprecated shadow reference** until Phase 9 ([#108](https://github.com/syn54x/ferro-orm/issues/108)).
+
+---
+
+## Goal
+
+Make `plan_table_migration` produce the same `(statements, drop_columns, warnings)` the executor already consumes, but sourced from `plan_from_ir` + `emit_sql_with_ir` instead of the JSON walk — with **observably identical behavior** for the supported `auto_migrate` capability matrix.
+
+---
+
+## Success criteria
+
+1. `plan_table_migration` executes the ferro-migrate IR pipeline as its only hot-path planner.
+2. Legacy JSON diff logic lives in an isolated, clearly deprecated helper (e.g. `plan_table_migration_legacy`) retained for #120 shadow comparison — not removed.
+3. `tests/test_migrate_plan.py` and `tests/test_auto_migrate.py` pass on SQLite + Postgres without changing public Python APIs.
+4. Semantics preserved: `migrate_updates`, `migrate_destructive`, fail-loud NOT NULL without default, Postgres type/nullability reconciliation, SQLite index-aware column drops at execution time, PK drop guard.
+5. No `_typed_plan` / `_typed_sql` discard scaffolding remains in the hot path.
+
+---
+
+## Scope
+
+### In scope
+
+- IR-primary `plan_table_migration` wiring in `src/migrate.rs`.
+- Map ferro-migrate `EmissionResult` + filtered `MigrationOp` list → runtime `MigrationPlan` (`statements`, `drop_columns`, `warnings`).
+- Respect `MigrateOptions`: `updates=false` → empty plan; `destructive=false` → omit `DropColumn` ops.
+- Keep `drop_columns` separate from `statements` so `execute_drop_column` can resolve SQLite index dependencies (executor unchanged).
+- Minimal IR adapter enrichment so existing render-level tests pass:
+  - `schema_json_to_schema_ir`: foreign keys, `db_check` constraints, `enum_type_name` where present in JSON schema.
+  - `live_columns_to_schema_ir`: Postgres native enum UDT marker on live columns (for “leave enum columns to Alembic” reconciliation).
+- Extract current JSON walk into `plan_table_migration_legacy`.
+- Map `EmissionError` → `PyValueError` with actionable messages (match legacy error tone).
+- Doc note: runtime IR cutover + deprecated legacy shadow path.
+
+### Out of scope (#120 / Phase 9)
+
+- IR vs legacy shadow comparison rewrite (`shadow_compare_migration_plan`).
+- `FERRO_SHADOW_RUNTIME` / `FERRO_SHADOW_RUNTIME_STRICT` CI enforcement.
+- Full single-sourcing of `schema_json_to_schema_ir` / `live_columns_to_schema_ir` with `build_column_plan` (consolidation when parity harness exists).
+- Removing the legacy planner ([#108](https://github.com/syn54x/ferro-orm/issues/108)).
+- Alembic / `create_tables` parity exit gates.
+
+---
+
+## Approaches considered
+
+### A. Thin adapter cutover (recommended)
+
+Wire IR plan + `emit_sql_with_ir` as primary. Enrich JSON→IR adapters only enough for `test_migrate_plan.py` parity. Extract legacy helper unchanged for #120.
+
+**Pros:** Smallest correct cutover; #118 emission logic is already tested; legacy preserved for shadow.
+**Cons:** Temporary duplication between adapters and `build_column_plan` until #120 consolidates.
+
+### B. Consolidate adapters first, then wire
+
+Refactor `schema_json_to_schema_ir` to share `build_column_plan` metadata extraction before switching the hot path.
+
+**Pros:** Less duplication long-term.
+**Cons:** Larger blast radius; mixes #119 execution wiring with #120 consolidation; harder to bisect parity failures.
+
+### C. Dual-run with legacy execution
+
+Run IR and legacy planners, compare, execute legacy until parity proven.
+
+**Rejected:** Violates I-7 (stop-gap). Phase 8 already defers removal, not primary execution, to shadow comparison in #120.
+
+---
+
+## Key decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Primary planner | `plan_from_ir` + `emit_sql_with_ir` | #118 deliverable; AGENTS.md I-1 alignment |
+| `drop_columns` handling | Partition `DropColumn` ops before emit; populate `drop_columns` vec | Executor relies on `execute_drop_column` for SQLite index deps |
+| Legacy planner | `plan_table_migration_legacy`, deprecated, not hot path | #120 shadow gate; Phase 9 removal |
+| Adapter scope | Minimal enrichment in #119 | Unblock render tests; full consolidation in #120 |
+| Shadow compare | No change in #119 | Owned by #120 |
+| Public API | Unchanged | `connect`, `migrate`, `_render_migration_sql_for_test` signatures stable |
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| IR adapters omit FK/check metadata → different ADD COLUMN SQL | Enrich `schema_json_to_schema_ir`; pin with existing `test_migrate_plan.py` |
+| Live enum UDT not modeled → spurious Postgres ALTER TYPE | Add live-side enum marker; skip type reconcile in emit when live column is native enum |
+| `emit_sql_with_ir` DROP in statements breaks executor | Never emit drops into `statements`; route to `drop_columns` |
+| SQLite cosmetic type drift false positives | Rely on #118 `sqlite_type_storage_drift`; existing reconcile tests |
+
+---
+
+## Dependencies
+
+- #118 merged (`emit_sql_with_ir` complete on integration branch).
+- `feat/ir-p8-migrate-cutover` integration branch.
+
+---
+
+## Outstanding questions
+
+None blocking — issue #119 and Phase 8 roadmap define scope. Adapter consolidation depth is explicitly deferred to #120.

--- a/docs/brainstorms/2026-06-25-ir-p8-120-parity-gate-requirements.md
+++ b/docs/brainstorms/2026-06-25-ir-p8-120-parity-gate-requirements.md
@@ -1,0 +1,119 @@
+# Requirements: Migration parity gate and IR vs legacy shadow (#120)
+
+**Date:** 2026-06-25
+**Epic:** [#117](https://github.com/syn54x/ferro-orm/issues/117)
+**Issue:** [#120](https://github.com/syn54x/ferro-orm/issues/120)
+**Phase:** 8 — Runtime migration IR cutover (`v0.13.0`)
+
+---
+
+## Problem
+
+#119 cut `plan_table_migration` over to `plan_from_ir` + `emit_sql_with_ir`, but the Phase 8 parity gate is not yet real:
+
+1. **`shadow_compare_migration_plan` is a no-op check** — it runs the IR path twice (JSON roundtrip self-compare), not IR vs `plan_table_migration_legacy`. `FERRO_SHADOW_RUNTIME_STRICT=1` in CI therefore cannot catch IR↔legacy drift.
+2. **Adapters are duplicated** — `schema_json_to_schema_ir` / `live_columns_to_schema_ir` in `src/migrate.rs` partially mirror `build_column_plan` / `canonical_column_type`. #119 fixed known gaps (anyOf strings, Postgres type tokens, `db_check` naming) via targeted patches; consolidation was deferred here.
+3. **Cross-emitter exit coverage is thin** — `test_cross_emitter_parity.py` pins Alembic vs auto-migrate for create and migrate_updates sentinel paths, but there is no systematic IR-vs-legacy matrix across the `auto_migrate` capability ladder.
+
+Until this work lands, Phase 8 cannot close with confidence that runtime IR migration matches the legacy planner and the Alembic/`create_tables` emitters (AGENTS.md I-1).
+
+---
+
+## Goal
+
+Make **IR vs legacy planner parity** a enforced, test-backed contract for the supported `auto_migrate` capability matrix (SQLite + Postgres), and keep **Alembic / `create_tables` exit tests** green as the external DDL parity sentinel.
+
+---
+
+## Success criteria
+
+1. `shadow_compare_migration_plan` diffs **IR primary** (`plan_table_migration`) vs **`plan_table_migration_legacy`** on `statements`, `drop_columns`, and `warnings`.
+2. With `FERRO_SHADOW_RUNTIME=1` and `FERRO_SHADOW_RUNTIME_STRICT=1`, `internal_migrate` fails loudly when IR and legacy disagree (existing hook in `src/migrate.rs`; behavior becomes meaningful).
+3. Explicit parity tests cover the capability matrix: add column (nullable, NOT NULL + default, indexed, unique, FK, `db_check`), Postgres type/nullability reconcile, destructive drops, PK drop guard, empty plan when `updates=false`.
+4. `tests/test_cross_emitter_parity.py` and existing `test_migrate_plan.py` / `test_auto_migrate.py` remain green on SQLite + Postgres.
+5. JSON→IR adapters are **single-sourced or shared** with `build_column_plan` / `property_json_type_and_format` where feasible — no independent type-inference tables that can drift again.
+6. Legacy planner remains **deprecated, not removed** (Phase 9 / [#108](https://github.com/syn54x/ferro-orm/issues/108)).
+
+---
+
+## Scope
+
+### In scope
+
+- Rewire `shadow_compare_migration_plan` (IR vs legacy).
+- Rust unit/integration parity suite: IR plan == legacy plan per scenario (both backends where applicable).
+- Optional test-only FFI helper to expose migration shadow diff for `tests/test_shadow_reports.py` fixtures (mirror query shadow pattern).
+- Adapter consolidation: route `schema_json_to_schema_ir` column metadata through shared lowering (`build_column_plan` outputs or extracted shared helpers in `src/schema.rs` / `ferro-ddl-lowering`).
+- Update `docs/solutions/patterns/cross-emitter-ddl-parity.md` or add `docs/solutions/patterns/ir-legacy-migration-parity.md` with the shadow gate recipe.
+- Mark legacy JSON walk `#[deprecated]` with planned removal `v0.14.0` (note in module docs; Rust deprecation attribute where applicable).
+- Phase 8 roadmap / migration-guide checkbox updates when merged.
+
+### Out of scope (Phase 9 / #108)
+
+- Removing `plan_table_migration_legacy` or the JSON properties walk.
+- New public Python APIs.
+- Alembic bridge rewrites beyond existing parity tests.
+- Runtime dual-execution (execute legacy when IR differs) — rejected per I-6.
+
+---
+
+## Approaches considered
+
+### A. Shadow rewire + explicit parity matrix + adapter consolidation (recommended)
+
+1. Fix `shadow_compare_migration_plan` first so CI strict mode is meaningful.
+2. Add parameterized Rust tests that assert byte-identical plans for IR vs legacy across the matrix.
+3. Consolidate adapters onto `build_column_plan` / shared helpers; delete duplicate inference in `infer_schema_db_type` where redundant.
+
+**Pros:** Matches Phase 8 roadmap ordering; failures bisect cleanly (shadow → unit matrix → consolidation).
+**Cons:** Consolidation may surface latent diffs requiring emitter or legacy alignment decisions.
+
+### B. Consolidate adapters first, then shadow
+
+Refactor adapters before turning on IR vs legacy compare.
+
+**Pros:** Fewer expected diffs when shadow first runs.
+**Cons:** Larger initial diff; shadow stays false confidence until the end; harder to prove consolidation didn't change behavior without the matrix.
+
+### C. Python-only parity tests (no shadow rewire)
+
+Add pytest that calls a new `_shadow_compare_migration_plan_for_test` without wiring runtime strict compare.
+
+**Rejected:** Leaves `FERRO_SHADOW_RUNTIME_STRICT` meaningless on migrate path; duplicates the enforcement surface.
+
+---
+
+## Key decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Shadow compare | IR (`plan_table_migration`) vs `plan_table_migration_legacy` | Phase 8 deliverable; #119 preserved legacy for this |
+| Compare fields | `statements`, `drop_columns`, `warnings` (order-sensitive for statements) | Matches existing shadow shape |
+| Strict failure | Keep existing `PyRuntimeError` on strict mismatch | Consistent with query/create-table shadow |
+| Adapter strategy | Shared lowering via `build_column_plan` / `property_json_type_and_format` | I-1; eliminates duplicate inference |
+| Legacy removal | Deferred to Phase 9 | Parity confidence required first |
+| Known intentional SQLite divergences | Document + exclude from matrix where Alembic parity tests already carve out (inline UNIQUE/FK on ADD COLUMN) | `test_cross_emitter_parity.py` precedent |
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| IR vs legacy byte diffs on edge cases (warnings text, statement order) | Normalize compare or sort where order is immaterial; pin exact order only where executor depends on it |
+| Consolidation changes IR output | Land matrix tests before deleting duplicate adapter logic; fix IR to match legacy (legacy is reference until Phase 9) |
+| Shadow strict breaks CI on first rewire | Run matrix locally first; fix #119 residual gaps before enabling strict in same PR |
+| `plan_table_migration_legacy` rots | `#[cfg(test)]` direct calls + shadow hook keep it exercised |
+
+---
+
+## Dependencies
+
+- #118 and #119 merged on `feat/ir-p8-migrate-cutover`.
+- `plan_table_migration_legacy` present in `src/migrate.rs`.
+
+---
+
+## Outstanding questions
+
+None blocking — issue #120 and Phase 8 roadmap define scope. If consolidation reveals systematic legacy bugs, fix IR to match legacy for in-scope matrix (legacy is the shadow reference until Phase 9), or document an intentional change with Alembic parity proof.

--- a/docs/examples/predicates_annotated.py
+++ b/docs/examples/predicates_annotated.py
@@ -1,4 +1,4 @@
-"""Annotated-style companion to predicates.py (AGENTS.md I-8)."""
+"""Annotated-style companion to predicates.py (AGENTS.md I-7)."""
 
 import asyncio
 

--- a/docs/examples/quickstart_annotated.py
+++ b/docs/examples/quickstart_annotated.py
@@ -1,4 +1,4 @@
-"""Annotated-style companion to quickstart.py (AGENTS.md I-8).
+"""Annotated-style companion to quickstart.py (AGENTS.md I-7).
 
 Same models as docs/examples/quickstart.py, declared with ``Annotated``
 metadata instead of assignment. Field options move into ``Annotated[...]``;

--- a/docs/examples/relationships_annotated.py
+++ b/docs/examples/relationships_annotated.py
@@ -1,4 +1,4 @@
-"""Annotated-style companion to relationships.py (AGENTS.md I-8).
+"""Annotated-style companion to relationships.py (AGENTS.md I-7).
 
 Field options move into ``Annotated[...]``. The relationship declarations
 themselves are identical in both styles: forward FKs are always

--- a/docs/examples/soft_deletes_annotated.py
+++ b/docs/examples/soft_deletes_annotated.py
@@ -1,4 +1,4 @@
-"""Annotated-style companion to soft_deletes.py (AGENTS.md I-8)."""
+"""Annotated-style companion to soft_deletes.py (AGENTS.md I-7)."""
 
 import asyncio
 

--- a/docs/examples/timestamps_annotated.py
+++ b/docs/examples/timestamps_annotated.py
@@ -1,4 +1,4 @@
-"""Annotated-style companion to timestamps.py (AGENTS.md I-8)."""
+"""Annotated-style companion to timestamps.py (AGENTS.md I-7)."""
 
 import asyncio
 

--- a/docs/pages/concepts/architecture.md
+++ b/docs/pages/concepts/architecture.md
@@ -194,8 +194,10 @@ await connect("sqlite::memory:", auto_migrate=True)
 ```
 
 - `auto_migrate=True` creates missing tables for every registered model.
-- `migrate_updates=True` (0.11.0) additionally adds missing columns to existing tables, and on PostgreSQL reconciles type and nullability drift.
+- `migrate_updates=True` (0.11.0) additionally adds missing columns to existing tables, and on PostgreSQL reconciles type and nullability drift. Runtime updates are planned from **SchemaIR** diffing (`ferro-migrate`) and executed as backend-specific DDL.
 - `migrate_destructive=True` (0.11.0) additionally drops live columns no longer on the model (never whole tables).
+
+The legacy enriched-JSON migration planner remains in the codebase as a deprecated shadow reference until `v0.14.0` (Phase 9); parity against the IR path is gated in Phase 8 ([#120](https://github.com/syn54x/ferro-orm/issues/120)).
 
 For renames, primary-key changes, and complex transforms, use the [Alembic bridge](../guide/migrations.md). **SchemaIR** is the canonical contract for cross-emitter DDL parity — Alembic `get_metadata()` derives SQLAlchemy metadata from compiled SchemaIR so autogenerate agrees with Ferro's naming and type conventions. The enriched JSON schema in the Rust registry remains the runtime source for query bind typing and hydration metadata.
 

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -438,14 +438,16 @@ Issue references:
 
 **Deliverables**
 - [ ] `ferro-migrate` `emit_sql` emits executable DDL for all `MigrationOp` variants on SQLite and Postgres (no comment placeholders).
-- [ ] `plan_table_migration` executes the IR plan; legacy enriched-JSON diff walk removed from `src/migrate.rs`.
-- [ ] Shadow/parity gate: IR migration path matches `create_tables` and Alembic for the `auto_migrate` capability matrix.
+- [ ] `plan_table_migration` executes the IR plan as the primary runtime path; legacy enriched-JSON diff walk **deprecated** but retained for shadow comparison (removal deferred to Phase 9).
+- [ ] Shadow/parity gate: IR migration path matches legacy planner, `create_tables`, and Alembic for the `auto_migrate` capability matrix.
+- [ ] `shadow_compare_migration_plan` compares IR vs legacy output (not legacy roundtrip); `FERRO_SHADOW_RUNTIME` / `FERRO_SHADOW_RUNTIME_STRICT` enforce drift in CI.
 - [ ] Duplicate `schema_json_to_schema_ir` / `live_columns_to_schema_ir` lowering consolidated or single-sourced where feasible.
 
 **Exit gate**
 - [ ] `cargo test -p ferro-migrate` green with full op coverage.
 - [ ] `tests/test_auto_migrate.py` and `tests/test_migrate_plan.py` green on SQLite + Postgres backend matrix.
-- [ ] No discarded `_typed_plan` scaffolding in `migrate.rs`.
+- [ ] IR planner is live; no discarded `_typed_plan` scaffolding in `migrate.rs`.
+- [ ] Legacy JSON diff planner deprecated and shadow-compared; **not** removed (Phase 9).
 
 **Verification commands**
 - `cargo test -p ferro-schema-ir -p ferro-migrate`
@@ -467,7 +469,7 @@ Issue references:
 - Complete migration by removing deprecated compatibility shims in `v0.14.0`.
 
 **Deliverables**
-- [ ] Legacy compatibility code paths removed.
+- [ ] Legacy compatibility code paths removed (operator-style predicates, ambient session routing, private Alembic JSON helpers, **deprecated enriched-JSON migration planner** in `src/migrate.rs`).
 - [ ] Deprecated-compat test inventory removed (all `deprecated_operator_path` tests deleted or rewritten).
 - [ ] Final migration-guide cutover notes for `v0.14.0`.
 - [ ] Release checklist and changelog entries for shim removal.
@@ -614,6 +616,7 @@ Append updates as concise entries.
 - `2026-06-19` - Phase 9 issue set created and linked: epic [#107](https://github.com/syn54x/ferro-orm/issues/107) with sub-issues [#108](https://github.com/syn54x/ferro-orm/issues/108), [#109](https://github.com/syn54x/ferro-orm/issues/109), [#110](https://github.com/syn54x/ferro-orm/issues/110) (originally filed as Phase 8; renumbered 2026-06-23).
 - `2026-06-23` - Phase 8 issue set created and linked: epic [#117](https://github.com/syn54x/ferro-orm/issues/117) with sub-issues [#118](https://github.com/syn54x/ferro-orm/issues/118), [#119](https://github.com/syn54x/ferro-orm/issues/119), [#120](https://github.com/syn54x/ferro-orm/issues/120).
 - `2026-06-23` - Sequencing update: inserted Phase 8 (`ferro-migrate` runtime cutover, `v0.13.0`); prior shim-removal phase renumbered to Phase 9 (`v0.14.0`). Phase 4 exit gates corrected to reflect Alembic-only cutover on `feat/ir-first`.
+- `2026-06-24` - Phase 8 scope update: legacy enriched-JSON migration planner is deprecated and shadow-compared in Phase 8; hard removal moves to Phase 9 (`v0.14.0`) after parity confidence.
 - `2026-06-19` - Phase 4 working-branch implementation landed: added `ferro-migrate` (`SchemaIR(old,new)` diff + SQL emission entrypoint), expanded SchemaIR fidelity (enum/check/join-table coverage), switched Alembic metadata derivation to SchemaIR, and added deprecation warnings for superseded JSON-only Alembic helpers (target removal `v0.14.0`).
 - `2026-06-22` - Phase 5 working-branch implementation landed: added unified codec registry module (`src/codec.rs`) across insert/update/filter/m2m/fetch paths, extracted single hydration ABI helper (`src/hydration.rs`) with required Pydantic slot initialization, and expanded codec conformance vectors/tests for null/uuid/decimal/temporal/enum semantics.
 - `2026-06-22` - Phase 6 working-branch implementation landed: introduced sessionized runtime API (`engines.session` / `Session`) and ambient session routing, moved transaction/identity-map hot-path state to session scope in Rust with compatibility fallback + deprecation warnings, added session lifecycle tests, and synchronized migration/guide/API/invariant docs.

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -438,16 +438,16 @@ Issue references:
 
 **Deliverables**
 - [ ] `ferro-migrate` `emit_sql` emits executable DDL for all `MigrationOp` variants on SQLite and Postgres (no comment placeholders).
-- [ ] `plan_table_migration` executes the IR plan as the primary runtime path; legacy enriched-JSON diff walk **deprecated** but retained for shadow comparison (removal deferred to Phase 9).
-- [ ] Shadow/parity gate: IR migration path matches legacy planner, `create_tables`, and Alembic for the `auto_migrate` capability matrix.
-- [ ] `shadow_compare_migration_plan` compares IR vs legacy output (not legacy roundtrip); `FERRO_SHADOW_RUNTIME` / `FERRO_SHADOW_RUNTIME_STRICT` enforce drift in CI.
-- [ ] Duplicate `schema_json_to_schema_ir` / `live_columns_to_schema_ir` lowering consolidated or single-sourced where feasible.
+- [x] `plan_table_migration` executes the IR plan as the primary runtime path; legacy enriched-JSON diff walk **deprecated** but retained for shadow comparison (removal deferred to Phase 9).
+- [x] Shadow/parity gate: IR migration path matches legacy planner, `create_tables`, and Alembic for the `auto_migrate` capability matrix.
+- [x] `shadow_compare_migration_plan` compares IR vs legacy output (not legacy roundtrip); `FERRO_SHADOW_RUNTIME` / `FERRO_SHADOW_RUNTIME_STRICT` enforce drift in CI.
+- [x] Duplicate `schema_json_to_schema_ir` / `live_columns_to_schema_ir` lowering consolidated or single-sourced where feasible.
 
 **Exit gate**
 - [ ] `cargo test -p ferro-migrate` green with full op coverage.
 - [ ] `tests/test_auto_migrate.py` and `tests/test_migrate_plan.py` green on SQLite + Postgres backend matrix.
 - [ ] IR planner is live; no discarded `_typed_plan` scaffolding in `migrate.rs`.
-- [ ] Legacy JSON diff planner deprecated and shadow-compared; **not** removed (Phase 9).
+- [x] Legacy JSON diff planner deprecated and shadow-compared; **not** removed (Phase 9).
 
 **Verification commands**
 - `cargo test -p ferro-schema-ir -p ferro-migrate`

--- a/docs/plans/2026-06-24-001-feat-ir-p8-119-wire-automigrate-plan.md
+++ b/docs/plans/2026-06-24-001-feat-ir-p8-119-wire-automigrate-plan.md
@@ -1,0 +1,301 @@
+---
+title: "feat: Wire runtime auto_migrate to ferro-migrate IR planner (#119)"
+date: 2026-06-24
+issue: 119
+epic: 117
+branch: feat/ir-p8-119-wire-automigrate
+origin: docs/brainstorms/2026-06-24-ir-p8-119-wire-automigrate-requirements.md
+---
+
+# feat: Wire runtime auto_migrate to ferro-migrate IR planner (#119)
+
+## Summary
+
+Cut `plan_table_migration` over to `plan_from_ir` + `emit_sql_with_ir` as the sole hot-path planner. Extract the existing enriched-JSON diff into a deprecated `plan_table_migration_legacy` helper for #120 shadow comparison. Enrich JSON→IR adapters minimally so render-level and integration tests remain byte-identical.
+
+**Closes:** [#119](https://github.com/syn54x/ferro-orm/issues/119)
+**Base branch:** `feat/ir-p8-migrate-cutover`
+**Feature branch:** `feat/ir-p8-119-wire-automigrate`
+
+---
+
+## Problem Frame
+
+Runtime auto-migrate still plans DDL via a legacy JSON `properties` walk in `src/migrate.rs` even though #118 implemented full IR-native SQL emission in `crates/ferro-migrate`. The typed plan is computed and thrown away (`_typed_plan`, `_typed_sql`). Phase 8 requires the IR pipeline to be the primary executor so runtime DDL and Alembic share one planner (AGENTS.md I-1).
+
+See origin: `docs/brainstorms/2026-06-24-ir-p8-119-wire-automigrate-requirements.md`.
+
+---
+
+## Requirements
+
+| ID | Requirement | Source |
+|----|-------------|--------|
+| R1 | `plan_table_migration` uses `plan_from_ir` + `emit_sql_with_ir` as primary path | #119 |
+| R2 | Legacy JSON walk isolated as deprecated `plan_table_migration_legacy` | #119, Phase 8 roadmap |
+| R3 | Behavior observably identical: updates/destructive flags, fail-loud NOT NULL, PG reconcile, SQLite drop execution | #119, `test_migrate_plan.py` |
+| R4 | `drop_columns` remain separate from `statements` for `execute_drop_column` | `src/migrate.rs` executor contract |
+| R5 | No public Python API changes | #119 migration impact |
+| R6 | `shadow_compare_migration_plan` unchanged (rewired in #120) | #119 scope boundary |
+
+---
+
+## Key Technical Decisions
+
+### KTD-1: Partition `DropColumn` before emission
+
+`emit_sql_with_ir` emits `ALTER TABLE … DROP COLUMN` into `statements`. The runtime executor intentionally keeps drops in `drop_columns` and runs `execute_drop_column` (SQLite index dependency resolution). **Do not** change the executor in #119.
+
+**Approach:** After `plan_from_ir`, split operations:
+
+1. Collect `DropColumn` op names into `plan.drop_columns` (with PK guard from `old_ir` before push).
+2. Build a filtered typed plan with non-drop ops only.
+3. Call `emit_sql_with_ir` on the filtered plan.
+
+### KTD-2: Minimal adapter enrichment (not full consolidation)
+
+`schema_json_to_schema_ir` today populates columns only — missing `foreign_keys` and `checks` that `emit_add_column` reads. `live_columns_to_schema_ir` does not mark Postgres native enum columns, so type reconciliation may diverge from legacy.
+
+Enrich adapters in #119 to pass existing tests. Full single-sourcing with `build_column_plan` is **deferred to #120** (see origin scope).
+
+### KTD-3: Postgres native enum skip uses live-side marker
+
+Legacy skips type reconciliation when `live.is_enum_udt`. `emit_alter_column_type` only checks `new_col.enum_type_name`. Add a serde-default live-only flag on `SchemaColumn` (e.g. `postgres_native_enum: bool`) set from `LiveColumn.is_enum_udt`, and teach `emit_alter_column_type` to no-op when the **old** column carries that flag — matching legacy semantics.
+
+### KTD-4: Error mapping at FFI boundary
+
+Map `ferro_migrate::EmissionError` → `pyo3::exceptions::PyValueError` in `plan_table_migration`, preserving message text expected by `test_migrate_plan.py` (`match=r"invoice\.created_at.*Alembic"` etc.).
+
+### KTD-5: `MigrateOptions` filtering at wiring layer
+
+`plan_from_ir` is options-agnostic. Apply options in `plan_table_migration`:
+
+- `!opts.updates` → return empty `MigrationPlan` immediately (existing behavior).
+- `!opts.destructive` → strip `DropColumn` ops before partition/emit.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TD
+    A[plan_table_migration] --> B{opts.updates?}
+    B -->|no| Z[empty MigrationPlan]
+    B -->|yes| C[schema_json_to_schema_ir]
+    C --> D[live_columns_to_schema_ir]
+    D --> E[plan_from_ir]
+    E --> F{opts.destructive?}
+    F -->|no| G[filter DropColumn ops]
+    F -->|yes| H[all ops]
+    G --> I[partition drops → drop_columns]
+    H --> I
+    I --> J[emit_sql_with_ir filtered ops]
+    J --> K[runtime MigrationPlan]
+    L[plan_table_migration_legacy] -.->|deprecated, #120 shadow| M[JSON properties walk]
+```
+
+**Runtime types (two `MigrationPlan` names):**
+
+| Layer | Type | Fields |
+|-------|------|--------|
+| ferro-migrate | `ferro_migrate::MigrationPlan` | `operations`, `warnings` |
+| Runtime executor | `migrate::MigrationPlan` | `statements`, `drop_columns`, `warnings` |
+
+Wiring converts typed ops + emission → executor plan.
+
+---
+
+## Implementation Units
+
+### U1. Live IR adapter: Postgres native enum marker
+
+**Goal:** Live columns that are Postgres enum UDTs skip type reconciliation, matching legacy.
+
+**Requirements:** R3
+
+**Files:**
+- `crates/ferro-schema-ir/src/lib.rs`
+- `src/migrate.rs` (`live_columns_to_schema_ir`)
+- `crates/ferro-migrate/src/emit.rs` (`emit_alter_column_type`)
+
+**Approach:**
+- Add `#[serde(default)] postgres_native_enum: bool` to `SchemaColumn`.
+- Set from `LiveColumn.is_enum_udt` in `live_columns_to_schema_ir`.
+- In `emit_alter_column_type` (Postgres arm): if `old_col.postgres_native_enum`, return empty result (no DDL, no warning — legacy emits neither).
+
+**Patterns to follow:** Legacy `plan_existing_column` guard `!live.is_enum_udt` in `src/migrate.rs`.
+
+**Test scenarios:**
+- Covers existing `test_pg_native_enum_columns_are_left_to_alembic` in `tests/test_migrate_plan.py` after U3 wiring.
+- Rust unit: live adapter sets flag when `is_enum_udt: true`.
+
+**Verification:** `test_migrate_plan.py::TestReconcileExisting::test_pg_native_enum_columns_are_left_to_alembic` passes after U3.
+
+---
+
+### U2. Model IR adapter: FK and check metadata
+
+**Goal:** `emit_add_column` receives enough `SchemaModel` metadata to emit FK and `db_check` follow-up DDL.
+
+**Requirements:** R3
+
+**Dependencies:** None (can land before U3)
+
+**Files:**
+- `src/migrate.rs` (`schema_json_to_schema_ir`)
+
+**Approach:** While walking `properties`, mirror metadata extraction from `build_column_plan` / `column_object_metadata`:
+- `foreign_key` object → `SchemaForeignKey { column, to_table, to_column: "id", on_delete, name: None }`
+- `db_check: true` → `SchemaCheck` with `db_check_constraint_name(table, col)` and expression from `build_check_constraint_sql` logic (extract shared expression helper or duplicate minimally with parity comment)
+
+Also populate `enum_type_name` on columns when present in JSON schema (for model-side enum deferral).
+
+**Patterns to follow:** `src/schema.rs` `build_column_plan`, `column_object_metadata`, `build_check_constraint_sql`.
+
+**Test scenarios:**
+- `test_fk_shadow_column_is_capability_relative` (Postgres + SQLite)
+- `test_indexed_column_add_emits_create_index`
+- `test_unique_column_strips_inline_unique_on_sqlite`
+- Any `db_check` cases in `test_migrate_plan.py` if present
+
+**Verification:** Render tests for FK/index/unique pass after U3 without legacy hot path.
+
+---
+
+### U3. IR-primary `plan_table_migration`
+
+**Goal:** Replace JSON walk with IR pipeline; map to executor `MigrationPlan`.
+
+**Requirements:** R1, R3, R4, R5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `src/migrate.rs`
+
+**Approach:**
+
+1. Add `plan_table_migration_ir(...) -> PyResult<MigrationPlan>` (or inline in `plan_table_migration`):
+   - Build `old_ir`, `new_ir`.
+   - `let typed = plan_from_ir(&old_ir, &new_ir)`.
+   - Filter ops per `opts.destructive`.
+   - Partition `DropColumn` → `drop_columns` with PK check against `old_ir` columns.
+   - `emit_sql_with_ir(&filtered, &old_ir, &new_ir, backend_dialect)?`.
+   - Merge `emission.statements` + `emission.warnings` into runtime plan.
+
+2. Replace `plan_table_migration` body to call IR path only.
+
+3. Remove `_typed_plan` / `_typed_sql` discard scaffolding.
+
+4. Import `emit_sql_with_ir` instead of legacy `emit_sql` shim where appropriate.
+
+**Error mapping:** `EmissionError` → `PyValueError::new_err(err.message)`.
+
+**Patterns to follow:** Existing early return for `!opts.updates`; destructive PK guard messages in legacy loop.
+
+**Test scenarios:**
+- Full `tests/test_migrate_plan.py` matrix (add, reconcile, destructive, updates=false).
+- `src/migrate.rs` existing unit tests for `plan_table_migration`.
+- `tests/test_auto_migrate.py` integration paths (execution + pool refresh).
+
+**Verification:**
+- `uv run pytest tests/test_migrate_plan.py -q`
+- `uv run pytest tests/test_auto_migrate.py -q`
+- `cargo test migrate` (Rust unit tests in `src/migrate.rs`)
+
+---
+
+### U4. Extract deprecated legacy planner
+
+**Goal:** Preserve JSON walk for #120 shadow without hot-path execution.
+
+**Requirements:** R2, R6
+
+**Dependencies:** U3
+
+**Files:**
+- `src/migrate.rs`
+
+**Approach:**
+- Move current JSON `properties` diff body to `#[deprecated(note = "Phase 9 removal; shadow reference for #120")] fn plan_table_migration_legacy(...)`.
+- Add module doc / comment pointing to #120 for shadow wiring.
+- Ensure no caller invokes legacy from `plan_table_migration`, `internal_migrate`, or `_render_migration_sql_for_test`.
+
+**Test scenarios:**
+- Compile-time: legacy function exists and is callable from tests only if needed in #120.
+- Grep guard: no hot-path call sites.
+
+**Verification:** `rg plan_table_migration_legacy src/` shows definition only (or test-only use).
+
+---
+
+### U5. Documentation
+
+**Goal:** Record runtime IR cutover and deprecated legacy shadow path.
+
+**Requirements:** #119 docs impact
+
+**Dependencies:** U3
+
+**Files:**
+- `docs/pages/concepts/architecture.md` (or migrations section referenced by issue)
+- `docs/plans/ir-first-migration-guide.md` — note #119 complete when merged
+
+**Approach:** Short paragraph: auto-migrate plans via SchemaIR diff + ferro-migrate emission; legacy JSON planner retained deprecated for shadow until v0.14.0.
+
+**Test expectation:** none — docs only.
+
+**Verification:** Docs build / link check if CI enforces.
+
+---
+
+## Scope Boundaries
+
+### Deferred to #120
+
+- Rewrite `shadow_compare_migration_plan` to diff IR vs `plan_table_migration_legacy`.
+- Parity gate vs `create_tables` / Alembic.
+- `FERRO_SHADOW_RUNTIME` CI enforcement.
+- Consolidate `schema_json_to_schema_ir` with `build_column_plan`.
+
+### Deferred to Phase 9 (#108)
+
+- Remove `plan_table_migration_legacy` and JSON walk entirely.
+
+### Deferred to Follow-Up Work
+
+- `DropTable` FK dependency ordering at runtime (pre-existing review note from #118; not required for single-table `plan_table_migration`).
+
+---
+
+## Verification (exit gate for #119)
+
+```text
+cargo test -p ferro-schema-ir -p ferro-migrate
+cargo test migrate
+uv run pytest tests/test_migrate_plan.py -q
+uv run pytest tests/test_auto_migrate.py -q
+uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py -q
+```
+
+PR body: `Closes #119`
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Subtle DDL drift between legacy and IR | `test_migrate_plan.py` pins exact SQL; legacy helper preserved for #120 shadow |
+| `SchemaColumn` wire format change | `serde(default)` on new field; IR vector fixtures unchanged for absent field |
+| Check constraint expression duplication | Comment + #120 consolidation; parity test coverage |
+
+---
+
+## Sources and Research
+
+- Issue [#119](https://github.com/syn54x/ferro-orm/issues/119) — scope and checklist
+- `docs/plans/2026-06-19-001-ir-first-roadmap.md` — Phase 8 deliverables
+- `src/migrate.rs` — current dual-path scaffolding, executor contract
+- `crates/ferro-migrate/src/emit.rs` — #118 emission semantics
+- `tests/test_migrate_plan.py` — canonical render-level expectations

--- a/docs/plans/2026-06-25-001-feat-ir-p8-120-parity-gate-plan.md
+++ b/docs/plans/2026-06-25-001-feat-ir-p8-120-parity-gate-plan.md
@@ -1,0 +1,286 @@
+---
+title: "feat: Migration parity gate and IR vs legacy shadow (#120)"
+date: 2026-06-25
+issue: 120
+epic: 117
+branch: feat/ir-p8-120-parity-gate
+origin: docs/brainstorms/2026-06-25-ir-p8-120-parity-gate-requirements.md
+---
+
+# feat: Migration parity gate and IR vs legacy shadow (#120)
+
+## Summary
+
+Rewire `shadow_compare_migration_plan` to diff the IR-primary planner against `plan_table_migration_legacy`, add an explicit IR-vs-legacy parity test matrix on SQLite + Postgres, consolidate JSON→IR adapters onto shared `build_column_plan` lowering, and keep Alembic/`create_tables` exit tests green so Phase 8 can close with a real enforcement gate.
+
+**Closes:** [#120](https://github.com/syn54x/ferro-orm/issues/120)
+**Base branch:** `feat/ir-p8-migrate-cutover`
+**Feature branch:** `feat/ir-p8-120-parity-gate`
+
+---
+
+## Problem Frame
+
+#119 made `plan_from_ir` + `emit_sql_with_ir` the runtime hot path, but `shadow_compare_migration_plan` still self-compares the IR planner via JSON roundtrip — so `FERRO_SHADOW_RUNTIME_STRICT` does not detect IR↔legacy drift. Adapter logic in `src/migrate.rs` partially duplicates `build_column_plan`, and Phase 8 requires a enforced parity gate before Phase 9 removes the legacy walk.
+
+See origin: `docs/brainstorms/2026-06-25-ir-p8-120-parity-gate-requirements.md`.
+
+---
+
+## Requirements
+
+| ID | Requirement | Source |
+|----|-------------|--------|
+| R1 | `shadow_compare_migration_plan` compares IR vs `plan_table_migration_legacy` | #120, Phase 8 roadmap |
+| R2 | `FERRO_SHADOW_RUNTIME` / `FERRO_SHADOW_RUNTIME_STRICT` enforce migrate drift in CI | #120, `.github/workflows/ci.yml` |
+| R3 | Parity matrix: add/drop column, type/nullability, destructive, PK guard, `updates=false` | #120 checklist |
+| R4 | IR migrate path remains Alembic-indistinguishable (`test_cross_emitter_parity.py`) | AGENTS.md I-1 |
+| R5 | Consolidate `schema_json_to_schema_ir` / `live_columns_to_schema_ir` with shared lowering | Phase 8 roadmap |
+| R6 | Legacy planner deprecated, not removed | Phase 9 / #108 |
+
+---
+
+## Key Technical Decisions
+
+### KTD-1: Legacy is the shadow reference until Phase 9
+
+When IR and legacy disagree, **default to aligning IR** (emitters + adapters) to legacy output for in-scope scenarios. Legacy encodes years of `test_migrate_plan.py` pins; removing it in Phase 9 requires proven parity, not premature IR-only semantics.
+
+Exception: if legacy is objectively wrong vs Alembic/`create_tables`, fix both IR and legacy in the same PR with cross-emitter test proof.
+
+### KTD-2: Shadow compare shape
+
+```text
+primary  = plan_table_migration(...)           // IR path
+reference = plan_table_migration_legacy(...)
+compare: statements, drop_columns, warnings (exact match)
+```
+
+Remove the JSON/live roundtrip self-compare. Error message should name both sides and table (existing format is fine; update labels from `legacy`/`shadow` to `ir`/`legacy`).
+
+### KTD-3: Adapter consolidation without new emitters
+
+Build `schema_json_to_schema_ir` columns from `build_column_plan` + existing schema JSON:
+
+- Map `ColumnPlan` → `SchemaColumn` (db_type token from canonical type / existing schema metadata).
+- Reuse `property_json_type_and_format` for logical type (already exported `pub(crate)` from `src/schema.rs`).
+- Keep `checks` / `foreign_keys` at model level in IR envelope (today's structure).
+
+`live_columns_to_schema_ir` stays live-introspection driven; align `declared_type_to_db_type` with `canonical_column_type` inverse or share a single Postgres `information_schema` → token map in `ferro-ddl-lowering`.
+
+Do **not** add a third independent inference function.
+
+### KTD-4: Test-only shadow FFI (optional but recommended)
+
+Add `_shadow_compare_migration_plan_for_test` (mirror `_shadow_compare_query_plan_for_test`) returning structured diff JSON for `tests/test_shadow_reports.py` fixtures. Keeps shadow semantics visible in the backend-matrix fixture gate without parsing log lines.
+
+### KTD-5: Statement ordering
+
+IR and legacy must agree on statement **order** where the executor depends on it (e.g. ADD COLUMN before CREATE INDEX). Where order is immaterial, prefer fixing the IR emitter to match legacy rather than sorting in compare (sorting hides emitter bugs).
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TD
+    subgraph runtime [internal_migrate hot path]
+        A[plan_table_migration IR] --> B[execute DDL]
+    end
+    subgraph shadow [FERRO_SHADOW_RUNTIME]
+        A --> C[shadow_compare_migration_plan]
+        D[plan_table_migration_legacy] --> C
+        C -->|mismatch| E{STRICT?}
+        E -->|yes| F[PyRuntimeError]
+        E -->|no| G[log warning]
+    end
+    subgraph tests [CI gates]
+        H[IR vs legacy matrix tests] --> C
+        I[test_cross_emitter_parity] --> J[Alembic vs migrated DB]
+        K[test_migrate_plan.py] --> A
+    end
+```
+
+---
+
+## Implementation Units
+
+### U1. Rewire migration shadow compare
+
+**Goal:** `shadow_compare_migration_plan` diffs IR vs legacy; strict runtime enforcement becomes meaningful.
+
+**Requirements:** R1, R2
+
+**Dependencies:** none
+
+**Files:**
+- `src/migrate.rs` (`shadow_compare_migration_plan`, call site in `internal_migrate`)
+- `src/lib.rs` (optional test export)
+
+**Approach:**
+- Replace roundtrip `shadow` call with `plan_table_migration_legacy`.
+- Rename error labels (`ir` vs `legacy`).
+- Add `#[deprecated(note = "Removal planned v0.14.0 — Phase 9 #108")]` on `plan_table_migration_legacy` (Rust) + module doc cross-link.
+
+**Test scenarios:**
+- Unit: given fixture schema/live from existing `migrate::tests`, `shadow_compare_migration_plan` returns `Ok(())` when IR matches legacy.
+- Unit: deliberate mismatch test (e.g. temporarily diverge mock) proves `Err` shape — or use snapshot of error formatting only if mock is too heavy; prefer testing via matrix in U2 instead.
+- Integration: `test_shadow_runtime_strict_has_no_mismatch` still passes with env vars set (exercises migrate shadow on connect).
+
+**Verification:** `cargo test --no-default-features --features testing migrate::tests` + `uv run pytest tests/test_shadow_reports.py -q`.
+
+---
+
+### U2. IR vs legacy parity matrix (Rust)
+
+**Goal:** Every supported `auto_migrate` scenario asserts `plan_table_migration` == `plan_table_migration_legacy`.
+
+**Requirements:** R3
+
+**Dependencies:** U1
+
+**Files:**
+- `src/migrate.rs` (`#[cfg(test)]` helper `assert_ir_legacy_parity(...)`)
+- Reuse/extend scenarios in `migrate::tests` module
+
+**Approach:**
+- Helper runs both planners, asserts `statements`, `drop_columns`, `warnings` equality.
+- Parameterize over existing tests' schema/live fixtures (add column, PG alter, nullability, destructive, PK drop error, enum UDT skip, db_check add, optional anyOf string).
+- Run each scenario for `SqlDialect::Sqlite` and `SqlDialect::Postgres` where applicable.
+
+**Test scenarios:**
+- Covers: nullable add, NOT NULL + literal default, indexed add, unique add (SQLite warning parity), FK add (PG FK SQL + SQLite warning), `db_check` add on PG, PG type mismatch alter, PG nullability SET/DROP NOT NULL, destructive drop collection, `updates=false` empty plan, PK drop error on destructive.
+- Explicit: `optional_string_anyof` + `pg_matching_primitive_columns` scenarios included.
+
+**Verification:** `cargo test --no-default-features --features testing migrate::tests`.
+
+---
+
+### U3. Consolidate JSON→IR adapters
+
+**Goal:** Single-source column lowering; delete redundant `infer_schema_db_type` duplication where `build_column_plan` already decides canonical types.
+
+**Requirements:** R5
+
+**Dependencies:** U2 (matrix must be green before deleting duplicate logic)
+
+**Files:**
+- `src/migrate.rs` (`schema_json_to_schema_ir`, `live_columns_to_schema_ir`)
+- `src/schema.rs` (optional: `column_plan_to_schema_column` helper)
+- `crates/ferro-ddl-lowering/src/lib.rs` (optional: live type token map)
+
+**Approach:**
+- Add `pub(crate)` helper mapping `ColumnPlan` + raw JSON metadata → `SchemaColumn` + push FK/check/index flags into model-level IR vectors.
+- `infer_schema_db_type` becomes thin wrapper or removed in favor of canonical token from `ColumnPlan`.
+- Keep `postgres_native_enum` on live adapter; consider moving `declared_type_to_db_type` next to `db_type_token_to_canonical` in ferro-ddl-lowering.
+
+**Test scenarios:**
+- U2 matrix stays green after refactor (primary gate).
+- `schema_json_to_schema_ir` roundtrip: optional `anyOf` string → `varchar` token, `db_check` name uses `db_check_constraint_name`.
+
+**Verification:** U2 + `cargo test -p ferro-ddl-lowering`.
+
+---
+
+### U4. Cross-emitter exit tests
+
+**Goal:** Alembic `compare_metadata` stays empty after IR migrate path; no regressions on create-table parity.
+
+**Requirements:** R4
+
+**Dependencies:** U1–U3
+
+**Files:**
+- `tests/test_cross_emitter_parity.py`
+- `tests/test_auto_migrate.py` (only if gaps found)
+
+**Approach:**
+- Run full `test_cross_emitter_parity.py` — extend only if matrix reveals uncovered Alembic diff (e.g. additional migrate_updates sentinel cases).
+- Do not weaken `_ignore_unreliable_alembic_diffs` to force green.
+
+**Test scenarios:**
+- Existing: `test_alembic_autogen_after_migrate_updates_is_idempotent[sqlite]`
+- Existing: create-table parity tests
+- Add only if U2/U3 expose a gap: e.g. Postgres migrate_updates + `db_check` add column Alembic idempotency
+
+**Verification:** `uv run pytest tests/test_cross_emitter_parity.py tests/test_migrate_plan.py tests/test_auto_migrate.py -q`.
+
+---
+
+### U5. Shadow fixtures, docs, Phase 8 checklist
+
+**Goal:** CI shadow report fixtures reflect real compare semantics; institutional memory updated.
+
+**Requirements:** R2, R6
+
+**Dependencies:** U1, U4
+
+**Files:**
+- `tests/test_shadow_reports.py`
+- `tests/fixtures/shadow_reports/*.json` (if migration section needs structured compare output)
+- `docs/solutions/patterns/` (new or extend `cross-emitter-ddl-parity.md`)
+- `docs/plans/2026-06-19-001-ir-first-roadmap.md` (Phase 8 checkboxes when merging)
+- `docs/plans/ir-first-migration-guide.md` (#120 row)
+
+**Approach:**
+- If U1 adds `_shadow_compare_migration_plan_for_test`, extend `_report_for_backend` migration section with `migration_compare` payload; update fixtures.
+- Document shadow gate recipe: when to run strict, how to interpret IR vs legacy diffs, link to matrix tests.
+
+**Test scenarios:**
+- `test_shadow_report_fixture_stable` per backend
+- `test_shadow_runtime_strict_has_no_mismatch`
+
+**Verification:** `uv run pytest tests/test_shadow_reports.py -q` with `FERRO_SHADOW_RUNTIME=1` in CI env.
+
+---
+
+## Scope Boundaries
+
+### Deferred to Phase 9 (#108)
+
+- Delete `plan_table_migration_legacy` and JSON properties walk.
+- Remove `#[allow(dead_code)]` / deprecation shims.
+
+### Deferred to Follow-Up Work
+
+- Canonical type comparison inside `plan_from_ir` (raw `db_type` string compare) — only if matrix exposes varchar-length or alias false positives after U3.
+- `char_max_len` live IR for Postgres varchar narrowing — separate issue if matrix shows gap.
+
+### Non-goals
+
+- Public API changes.
+- Runtime dual-execution fallback.
+
+---
+
+## Risks and Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| First shadow rewire fails CI strict | Land U2 matrix fixes in same PR before merge |
+| Adapter consolidation churn | U2 first; small helper extractions |
+| Warning text drift IR vs legacy | Pin warnings in matrix asserts |
+
+**Depends on:** #118, #119 merged to `feat/ir-p8-migrate-cutover`.
+
+---
+
+## Verification (exit gate for #120)
+
+```bash
+cargo test --no-default-features --features testing migrate
+cargo test -p ferro-schema-ir -p ferro-migrate -p ferro-ddl-lowering
+uv run pytest tests/test_migrate_plan.py tests/test_auto_migrate.py tests/test_cross_emitter_parity.py tests/test_shadow_reports.py -q
+uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py -q
+```
+
+PR body: `Closes #120`
+
+---
+
+## References
+
+- Origin: `docs/brainstorms/2026-06-25-ir-p8-120-parity-gate-requirements.md`
+- Prior cutover: `docs/plans/2026-06-24-001-feat-ir-p8-119-wire-automigrate-plan.md`
+- I-1 pattern: `docs/solutions/patterns/cross-emitter-ddl-parity.md`
+- Phase 8 roadmap: `docs/plans/2026-06-19-001-ir-first-roadmap.md`

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -139,12 +139,12 @@ Runtime migration IR cutover (target: `v0.13.0`).
 | --- | --- | --- | --- | --- |
 | [#117](https://github.com/syn54x/ferro-orm/issues/117) | Coordinate `ferro-migrate` runtime cutover and parity exit gates | none | No action — internal planner cutover | Epic |
 | [#118](https://github.com/syn54x/ferro-orm/issues/118) | Complete executable SQL emission from `MigrationPlan` for all ops (SQLite + Postgres) | none | No action | Continues #90 scaffold |
-| [#119](https://github.com/syn54x/ferro-orm/issues/119) | Wire `auto_migrate` / `plan_table_migration` to execute ferro-migrate IR plans | none | No action — behavior must remain observably identical | Retires discarded `_typed_plan` path |
-| [#120](https://github.com/syn54x/ferro-orm/issues/120) | Parity gate + remove legacy JSON diff path in `src/migrate.rs` | none | No action | AGENTS.md I-1 enforcement |
+| [#119](https://github.com/syn54x/ferro-orm/issues/119) | Wire `auto_migrate` / `plan_table_migration` to execute ferro-migrate IR plans | none | No action — behavior must remain observably identical | IR planner becomes primary; legacy path deprecated |
+| [#120](https://github.com/syn54x/ferro-orm/issues/120) | Parity gate + shadow comparison (IR vs legacy, `create_tables`, Alembic) | none | No action | Legacy planner retained deprecated; removal in Phase 9 |
 
 - **Migration impact:** `none` for public APIs — `connect(auto_migrate=...)` and `ferro.migrate` signatures unchanged.
-- **Internal change:** `auto_migrate` executes `ferro-migrate` `SchemaIR(old,new)` plans instead of the legacy enriched-JSON diff walk in `src/migrate.rs`.
-- **Parity requirement:** auto-migrated schema artifacts must remain byte-identical to `create_tables` and Alembic (AGENTS.md I-1).
+- **Internal change:** `auto_migrate` executes `ferro-migrate` `SchemaIR(old,new)` plans as the primary path. The legacy enriched-JSON diff walk in `src/migrate.rs` is **deprecated** and kept for shadow comparison until Phase 9 removal.
+- **Parity requirement:** IR planner output must match the legacy planner, `create_tables`, and Alembic for the `auto_migrate` capability matrix (AGENTS.md I-1).
 
 ### Phase 9
 
@@ -162,4 +162,5 @@ Planned cutover checklist:
 - Remove deprecated operator-style predicate support.
 - Remove ambient default-connection routing outside an active session.
 - Remove private Alembic JSON helper APIs (`_build_sa_table`, `_map_to_sa_type`).
+- Remove deprecated enriched-JSON migration planner in `src/migrate.rs` (shadow reference only after Phase 8).
 - Remove or rewrite all tests tagged `deprecated_operator_path`.

--- a/docs/solutions/patterns/cross-emitter-ddl-parity.md
+++ b/docs/solutions/patterns/cross-emitter-ddl-parity.md
@@ -8,7 +8,7 @@ related_files:
   - src/schema.rs
   - tests/test_alembic_autogenerate.py
   - tests/test_schema_constraints.py
-related_issues: [32]
+related_issues: [32, 120]
 related_prs: [36]
 captured: 2026-04-28
 ---
@@ -96,3 +96,30 @@ token × dialect plus `ck_<table>_<col>` parity).
 
 If you see any of those, the cross-emitter parity invariant has been broken.
 The fix is _always_ to align both emitters, never to silence the diff.
+
+## Migration planner shadow gate (Phase 8 / #120)
+
+Auto-migrate has two Rust planners until Phase 9 ([#108](https://github.com/syn54x/ferro-orm/issues/108)):
+
+- **Primary:** `plan_table_migration` — SchemaIR diff (`plan_from_ir`) + `emit_sql_with_ir`.
+- **Reference:** `plan_table_migration_legacy` — enriched-JSON walk via `build_column_plan`.
+
+`shadow_compare_migration_plan` in `src/migrate.rs` diffs IR vs legacy on
+`statements`, `drop_columns`, and `warnings`. When `FERRO_SHADOW_RUNTIME=1` is
+set, `internal_migrate` runs this compare on every table diff; with
+`FERRO_SHADOW_RUNTIME_STRICT=1`, a mismatch aborts the migration.
+
+**When IR and legacy disagree**, align the IR path to legacy (KTD-1 in the
+#120 plan) unless legacy is objectively wrong vs Alembic/`create_tables` — then
+fix both in the same PR with cross-emitter proof.
+
+**CI enforcement:**
+
+- `cargo test migrate::tests::ir_legacy_parity_matrix` — explicit matrix.
+- `tests/test_shadow_reports.py` — `_shadow_compare_migration_plan_for_test` fixtures.
+- `tests/test_cross_emitter_parity.py` — Alembic vs post-migrate database.
+
+**Adapter rule:** `schema_json_to_schema_ir` must derive column `db_type` /
+nullability / PK metadata from `build_column_plan` (via `canonical_to_db_type_token`
+in `src/schema.rs`). Do not add a third independent inference function in
+`src/migrate.rs`.

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -55,6 +55,17 @@ def _render_migration_sql_for_test(
     """
     ...
 
+def _shadow_compare_migration_plan_for_test(
+    name: str,
+    schema_json: str,
+    live_columns_json: str,
+    dialect: str,
+    updates: bool = True,
+    destructive: bool = False,
+) -> str:
+    """Test-only: compare IR-primary vs legacy migration planners."""
+    ...
+
 def _shadow_compare_query_plan_for_test(
     query_payload_json: str, dialect: str, operation: str = "select"
 ) -> str:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,10 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m
     )?)?;
     m.add_function(wrap_pyfunction!(
+        migrate::_shadow_compare_migration_plan_for_test,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
         migrate::_render_migration_sql_for_test,
         m
     )?)?;

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -7,12 +7,15 @@
 //! dropped. Capability matrix and semantics are documented on the Python
 //! `ferro.connect` / `ferro.migrate` APIs.
 //!
-//! Column DDL is produced by the same `build_column_plan` the CREATE TABLE
-//! emitter uses, so an auto-migrated database is byte-identical to a freshly
-//! created one (AGENTS.md § I-1).
+//! Column DDL for auto-migrate is planned via SchemaIR diffing (`plan_from_ir`) and
+//! lowered by `ferro-migrate` (`emit_sql_with_ir`), so an auto-migrated database
+//! matches a freshly created one (AGENTS.md § I-1). The legacy enriched-JSON
+//! planner (`plan_table_migration_legacy`) is retained for shadow comparison until
+//! Phase 9.
 
 use crate::backend::EngineHandle;
-use ferro_migrate::{BackendDialect, emit_sql, plan_from_ir};
+use ferro_ddl_lowering::db_check_constraint_name;
+use ferro_migrate::{BackendDialect, MigrationOp, emit_sql_with_ir, plan_from_ir};
 use ferro_schema_ir::{
     IrEnvelope, SchemaCheck, SchemaColumn, SchemaForeignKey, SchemaIndex, SchemaIrPayload,
     SchemaModel, SchemaUnique,
@@ -22,7 +25,7 @@ use crate::introspect::{
 };
 use crate::schema::{
     CanonicalType, ColumnPlan, apply_canonical_type, build_column_plan, internal_create_tables,
-    order_schemas_for_creation,
+    order_schemas_for_creation, property_json_type_and_format,
 };
 use crate::state::{IDENTITY_MAP, MODEL_REGISTRY, SqlDialect, engine_for_connection};
 use pyo3::prelude::*;
@@ -32,46 +35,125 @@ use sea_query::{
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+fn resolve_col_schema<'a>(
+    schema: &'a serde_json::Value,
+    raw_col: &'a serde_json::Value,
+) -> &'a serde_json::Value {
+    if let Some(ref_path) = raw_col.get("$ref").and_then(|r| r.as_str()) {
+        if let Some(def_name) = ref_path.strip_prefix("#/$defs/") {
+            return schema
+                .get("$defs")
+                .and_then(|defs| defs.get(def_name))
+                .unwrap_or(raw_col);
+        }
+    }
+    raw_col
+}
+
+fn migrate_column_bool(
+    raw_col: &serde_json::Value,
+    resolved: &serde_json::Value,
+    key: &str,
+) -> Option<bool> {
+    raw_col
+        .get(key)
+        .or_else(|| resolved.get(key))
+        .and_then(|value| value.as_bool())
+}
+
+fn migrate_column_object<'a>(
+    raw_col: &'a serde_json::Value,
+    resolved: &'a serde_json::Value,
+    key: &str,
+) -> Option<&'a serde_json::Map<String, serde_json::Value>> {
+    raw_col
+        .get(key)
+        .or_else(|| resolved.get(key))
+        .and_then(|value| value.as_object())
+}
+
+/// Infer canonical `db_type` tokens when the schema omits an explicit `db_type=`.
+fn infer_schema_db_type(raw_col: &serde_json::Value, resolved: &serde_json::Value) -> String {
+    if let Some(db_type) = raw_col
+        .get("db_type")
+        .or_else(|| resolved.get("db_type"))
+        .and_then(|v| v.as_str())
+    {
+        return db_type.to_string();
+    }
+    let (json_type, format) = property_json_type_and_format(resolved);
+    match (json_type, format) {
+        (_, Some("date-time")) => "timestamptz".to_string(),
+        (_, Some("uuid")) => "uuid".to_string(),
+        (_, Some("date")) => "date".to_string(),
+        (Some("integer"), _) => "int".to_string(),
+        (Some("boolean"), _) => "boolean".to_string(),
+        (Some("number"), _) => "double".to_string(),
+        (Some("string"), _) => "varchar".to_string(),
+        (Some("object" | "array"), _) => "json".to_string(),
+        _ => "text".to_string(),
+    }
+}
+
+fn migrate_check_expression(col_name: &str, col_info: &serde_json::Value) -> Option<String> {
+    let values = col_info.get("enum").and_then(|v| v.as_array())?;
+    if values.is_empty() {
+        return None;
+    }
+    let rendered: Vec<String> = values
+        .iter()
+        .map(|v| match v {
+            serde_json::Value::String(s) => format!("'{}'", s.replace('\'', "''")),
+            serde_json::Value::Number(n) => n.to_string(),
+            serde_json::Value::Bool(b) => b.to_string(),
+            other => format!("'{}'", other.to_string().replace('\'', "''")),
+        })
+        .collect();
+    Some(format!("\"{}\" IN ({})", col_name, rendered.join(", ")))
+}
+
+fn schema_ir_column<'a>(
+    envelope: &'a IrEnvelope<SchemaIrPayload>,
+    table: &str,
+    column: &str,
+) -> Option<&'a SchemaColumn> {
+    envelope
+        .payload
+        .models
+        .iter()
+        .find(|model| model.table_name == table)
+        .and_then(|model| model.columns.iter().find(|col| col.name == column))
+}
+
+fn backend_dialect(backend: SqlDialect) -> BackendDialect {
+    match backend {
+        SqlDialect::Sqlite => BackendDialect::Sqlite,
+        SqlDialect::Postgres => BackendDialect::Postgres,
+    }
+}
+
 fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> IrEnvelope<SchemaIrPayload> {
     let mut columns = Vec::new();
+    let mut foreign_keys = Vec::new();
+    let mut checks = Vec::new();
     if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
         for (name, raw_col) in properties {
-            let resolved = if let Some(ref_path) = raw_col.get("$ref").and_then(|r| r.as_str()) {
-                if let Some(def_name) = ref_path.strip_prefix("#/$defs/") {
-                    schema
-                        .get("$defs")
-                        .and_then(|defs| defs.get(def_name))
-                        .unwrap_or(raw_col)
-                } else {
-                    raw_col
-                }
-            } else {
-                raw_col
-            };
-            let nullable = raw_col
-                .get("ferro_nullable")
-                .or_else(|| resolved.get("ferro_nullable"))
-                .and_then(|v| v.as_bool())
-                .unwrap_or(true);
-            let db_type = raw_col
+            let resolved = resolve_col_schema(schema, raw_col);
+            let nullable = migrate_column_bool(raw_col, resolved, "ferro_nullable").unwrap_or(true);
+            let db_type = infer_schema_db_type(raw_col, resolved);
+            let db_type_explicit = raw_col
                 .get("db_type")
                 .or_else(|| resolved.get("db_type"))
                 .and_then(|v| v.as_str())
-                .unwrap_or("text")
-                .to_string();
+                .map(|_| true);
             columns.push(SchemaColumn {
                 name: name.clone(),
-                logical_type: resolved
-                    .get("type")
-                    .and_then(|v| v.as_str())
+                logical_type: property_json_type_and_format(resolved)
+                    .0
                     .unwrap_or("unknown")
                     .to_string(),
                 db_type,
-                db_type_explicit: raw_col
-                    .get("db_type")
-                    .or_else(|| resolved.get("db_type"))
-                    .and_then(|v| v.as_str())
-                    .map(|_| true),
+                db_type_explicit,
                 nullable,
                 primary_key: resolved
                     .get("primary_key")
@@ -81,8 +163,8 @@ fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> Ir
                     .get("autoincrement")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false),
-                unique: resolved.get("unique").and_then(|v| v.as_bool()).unwrap_or(false),
-                index: resolved.get("index").and_then(|v| v.as_bool()).unwrap_or(false),
+                unique: migrate_column_bool(raw_col, resolved, "unique").unwrap_or(false),
+                index: migrate_column_bool(raw_col, resolved, "index").unwrap_or(false),
                 default: resolved.get("default").cloned(),
                 format: resolved
                     .get("format")
@@ -93,7 +175,40 @@ fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> Ir
                     .get("enum_type_name")
                     .and_then(|v| v.as_str())
                     .map(str::to_string),
+                postgres_native_enum: false,
             });
+
+            if let Some(fk_info) = migrate_column_object(raw_col, resolved, "foreign_key") {
+                let to_table = fk_info
+                    .get("to_table")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let on_delete = fk_info
+                    .get("on_delete")
+                    .and_then(|o| o.as_str())
+                    .map(str::to_string);
+                foreign_keys.push(SchemaForeignKey {
+                    column: name.clone(),
+                    to_table,
+                    to_column: fk_info
+                        .get("to_column")
+                        .and_then(|c| c.as_str())
+                        .unwrap_or("id")
+                        .to_string(),
+                    on_delete,
+                    name: None,
+                });
+            }
+
+            if migrate_column_bool(raw_col, resolved, "db_check").unwrap_or(false)
+                && let Some(expression) = migrate_check_expression(name, resolved)
+            {
+                checks.push(SchemaCheck {
+                    name: db_check_constraint_name(table_lower, name),
+                    expression,
+                });
+            }
         }
     }
     columns.sort_by(|a, b| a.name.cmp(&b.name));
@@ -107,17 +222,40 @@ fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> Ir
                 model_name: table_lower.to_string(),
                 table_name: table_lower.to_string(),
                 columns,
-                foreign_keys: Vec::<SchemaForeignKey>::new(),
+                foreign_keys,
                 indexes: Vec::<SchemaIndex>::new(),
                 uniques: Vec::<SchemaUnique>::new(),
-                checks: Vec::<SchemaCheck>::new(),
+                checks,
             }],
         },
     }
 }
 
+/// Map `information_schema.columns.data_type` spellings to the same `db_type`
+/// token vocabulary `infer_schema_db_type` uses for model columns (mirrors
+/// `pg_type_matches` on the legacy planner path).
 fn declared_type_to_db_type(declared: &str) -> String {
     let lower = declared.to_ascii_lowercase();
+    match lower.as_str() {
+        "boolean" => return "boolean".to_string(),
+        "double precision" | "real" => return "double".to_string(),
+        "numeric" => return "numeric".to_string(),
+        "json" | "jsonb" => return "json".to_string(),
+        "bytea" => return "bytea".to_string(),
+        "text" => return "text".to_string(),
+        "integer" => return "int".to_string(),
+        "smallint" => return "smallint".to_string(),
+        "bigint" => return "bigint".to_string(),
+        "uuid" => return "uuid".to_string(),
+        "date" => return "date".to_string(),
+        "time without time zone" => return "time".to_string(),
+        "timestamp without time zone" => return "timestamp".to_string(),
+        "timestamp with time zone" => return "timestamptz".to_string(),
+        _ => {}
+    }
+    if lower.contains("character varying") || lower == "varchar" {
+        return "varchar".to_string();
+    }
     if lower.contains("smallint") {
         return "smallint".to_string();
     }
@@ -162,6 +300,7 @@ fn live_columns_to_schema_ir(table_lower: &str, live: &[LiveColumn]) -> IrEnvelo
             format: None,
             enum_values: None,
             enum_type_name: None,
+            postgres_native_enum: col.is_enum_udt,
         })
         .collect();
     columns.sort_by(|a, b| a.name.cmp(&b.name));
@@ -411,17 +550,66 @@ pub fn plan_table_migration(
     backend: SqlDialect,
     opts: MigrateOptions,
 ) -> PyResult<MigrationPlan> {
+    if !opts.updates {
+        return Ok(MigrationPlan::new());
+    }
+
     let old_ir = live_columns_to_schema_ir(table_lower, live);
     let new_ir = schema_json_to_schema_ir(table_lower, schema);
-    let _typed_plan = plan_from_ir(&old_ir, &new_ir);
-    let _typed_sql = emit_sql(
-        &_typed_plan,
-        match backend {
-            SqlDialect::Sqlite => BackendDialect::Sqlite,
-            SqlDialect::Postgres => BackendDialect::Postgres,
-        },
-    );
+    let mut typed_plan = plan_from_ir(&old_ir, &new_ir);
 
+    if !opts.destructive {
+        typed_plan
+            .operations
+            .retain(|op| !matches!(op, MigrationOp::DropColumn { .. }));
+    }
+
+    let mut plan = MigrationPlan::new();
+    let mut exec_ops = Vec::new();
+
+    for operation in typed_plan.operations {
+        if let MigrationOp::DropColumn { table, column } = &operation {
+            let Some(old_col) = schema_ir_column(&old_ir, table, column) else {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Cannot drop column '{}.{}': column metadata missing from live IR context.",
+                    table, column
+                )));
+            };
+            if old_col.primary_key {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Cannot drop column '{}.{}': it is part of the primary key. \
+                     Primary-key changes must be migrated with Alembic.",
+                    table, column
+                )));
+            }
+            plan.drop_columns.push(column.clone());
+        } else {
+            exec_ops.push(operation);
+        }
+    }
+
+    let exec_plan = ferro_migrate::MigrationPlan {
+        operations: exec_ops,
+        warnings: typed_plan.warnings,
+    };
+    let emission = emit_sql_with_ir(&exec_plan, &old_ir, &new_ir, backend_dialect(backend))
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.message))?;
+
+    plan.statements = emission.statements;
+    plan.warnings = emission.warnings;
+    Ok(plan)
+}
+
+/// Deprecated enriched-JSON migration planner retained for #120 shadow comparison.
+/// Phase 9 ([#108](https://github.com/syn54x/ferro-orm/issues/108)) removes this path.
+#[allow(dead_code)]
+fn plan_table_migration_legacy(
+    table_lower: &str,
+    schema: &serde_json::Value,
+    live: &[LiveColumn],
+    backend: SqlDialect,
+    opts: MigrateOptions,
+) -> PyResult<MigrationPlan> {
     let mut plan = MigrationPlan::new();
     if !opts.updates {
         return Ok(plan);
@@ -1304,6 +1492,132 @@ mod tests {
         let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
             .unwrap();
         assert!(plan.statements.is_empty(), "{:?}", plan.statements);
+    }
+
+    #[test]
+    fn optional_string_anyof_add_column_uses_varchar_spelling() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "motto": {
+                    "anyOf": [{"type": "string"}, {"type": "null"}],
+                    "default": null,
+                },
+            }
+        });
+        let live_cols = vec![LiveColumn {
+            is_primary_key: true,
+            ..live("id", "integer")
+        }];
+        let plan =
+            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+        let sql = &plan.statements[0];
+        assert!(sql.contains("ADD COLUMN \"motto\""), "{sql}");
+        assert!(
+            !sql.to_uppercase().contains(" TEXT "),
+            "Optional anyOf string columns must not render as TEXT: {sql}"
+        );
+    }
+
+    #[test]
+    fn pg_matching_primitive_columns_emit_no_type_alter() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "is_active": {"type": "boolean"},
+                "amount": {"type": "number"},
+                "total": {"type": "number", "db_type": "numeric"},
+                "meta": {"type": "object", "db_type": "json"},
+            }
+        });
+        let live_cols = vec![
+            LiveColumn {
+                is_primary_key: true,
+                ..live("id", "integer")
+            },
+            live("is_active", "boolean"),
+            live("amount", "double precision"),
+            live("total", "numeric"),
+            LiveColumn {
+                declared_type: "jsonb".to_string(),
+                ..live("meta", "jsonb")
+            },
+        ];
+        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
+            .unwrap();
+        assert!(
+            !plan
+                .statements
+                .iter()
+                .any(|sql| sql.contains("ALTER COLUMN") && sql.contains(" TYPE ")),
+            "matching live/model types must not reconcile: {:?}",
+            plan.statements
+        );
+    }
+
+    #[test]
+    fn pg_db_check_add_column_emits_named_check_constraint() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "status": {
+                    "type": "string",
+                    "db_type": "text",
+                    "db_check": true,
+                    "enum": ["pending", "approved"],
+                },
+            }
+        });
+        let live_cols = vec![LiveColumn {
+            is_primary_key: true,
+            ..live("id", "integer")
+        }];
+        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
+            .unwrap();
+        assert!(
+            plan.statements.iter().any(|sql| {
+                sql.contains("ADD CONSTRAINT \"ck_doc_status\"")
+                    && sql.contains("CHECK (\"status\" IN ('pending', 'approved'))")
+            }),
+            "{:?}",
+            plan.statements
+        );
+    }
+
+    #[test]
+    fn pg_db_check_add_column_uses_truncated_constraint_name() {
+        let long_col = "a".repeat(70);
+        let table = "verylongtable";
+        let expected_name = db_check_constraint_name(table, &long_col);
+        assert_eq!(expected_name.chars().count(), 63);
+
+        let mut properties = serde_json::Map::new();
+        properties.insert("id".into(), json!({"type": "integer", "primary_key": true}));
+        properties.insert(
+            long_col.clone(),
+            json!({
+                "type": "string",
+                "db_type": "text",
+                "db_check": true,
+                "enum": ["pending", "approved"],
+            }),
+        );
+        let schema = json!({ "properties": properties });
+        let live_cols = vec![LiveColumn {
+            is_primary_key: true,
+            ..live("id", "integer")
+        }];
+        let plan =
+            plan_table_migration(table, &schema, &live_cols, SqlDialect::Postgres, UPDATES).unwrap();
+        let check_sql = plan
+            .statements
+            .iter()
+            .find(|sql| sql.contains("ADD CONSTRAINT"))
+            .expect("expected ADD CONSTRAINT for db_check column");
+        assert!(
+            check_sql.contains(&format!("ADD CONSTRAINT \"{expected_name}\"")),
+            "{check_sql}"
+        );
     }
 
     #[test]

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -14,7 +14,10 @@
 //! Phase 9.
 
 use crate::backend::EngineHandle;
-use ferro_ddl_lowering::db_check_constraint_name;
+use ferro_ddl_lowering::{
+    Dialect, db_check_constraint_name, information_schema_to_db_type_token,
+    schema_columns_storage_drift,
+};
 use ferro_migrate::{BackendDialect, MigrationOp, emit_sql_with_ir, plan_from_ir};
 use ferro_schema_ir::{
     IrEnvelope, SchemaCheck, SchemaColumn, SchemaForeignKey, SchemaIndex, SchemaIrPayload,
@@ -24,7 +27,8 @@ use crate::introspect::{
     LiveColumn, live_table_columns, quote_ident, sqlite_indexes_covering_column,
 };
 use crate::schema::{
-    CanonicalType, ColumnPlan, apply_canonical_type, build_column_plan, internal_create_tables,
+    CanonicalType, ColumnPlan, apply_canonical_type, build_column_plan,
+    canonical_to_db_type_token, internal_create_tables,
     order_schemas_for_creation, property_json_type_and_format,
 };
 use crate::state::{IDENTITY_MAP, MODEL_REGISTRY, SqlDialect, engine_for_connection};
@@ -72,29 +76,6 @@ fn migrate_column_object<'a>(
         .and_then(|value| value.as_object())
 }
 
-/// Infer canonical `db_type` tokens when the schema omits an explicit `db_type=`.
-fn infer_schema_db_type(raw_col: &serde_json::Value, resolved: &serde_json::Value) -> String {
-    if let Some(db_type) = raw_col
-        .get("db_type")
-        .or_else(|| resolved.get("db_type"))
-        .and_then(|v| v.as_str())
-    {
-        return db_type.to_string();
-    }
-    let (json_type, format) = property_json_type_and_format(resolved);
-    match (json_type, format) {
-        (_, Some("date-time")) => "timestamptz".to_string(),
-        (_, Some("uuid")) => "uuid".to_string(),
-        (_, Some("date")) => "date".to_string(),
-        (Some("integer"), _) => "int".to_string(),
-        (Some("boolean"), _) => "boolean".to_string(),
-        (Some("number"), _) => "double".to_string(),
-        (Some("string"), _) => "varchar".to_string(),
-        (Some("object" | "array"), _) => "json".to_string(),
-        _ => "text".to_string(),
-    }
-}
-
 fn migrate_check_expression(col_name: &str, col_info: &serde_json::Value) -> Option<String> {
     let values = col_info.get("enum").and_then(|v| v.as_array())?;
     if values.is_empty() {
@@ -132,20 +113,25 @@ fn backend_dialect(backend: SqlDialect) -> BackendDialect {
     }
 }
 
-fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> IrEnvelope<SchemaIrPayload> {
+fn schema_json_to_schema_ir(
+    table_lower: &str,
+    schema: &serde_json::Value,
+    backend: SqlDialect,
+) -> IrEnvelope<SchemaIrPayload> {
     let mut columns = Vec::new();
     let mut foreign_keys = Vec::new();
     let mut checks = Vec::new();
     if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
         for (name, raw_col) in properties {
             let resolved = resolve_col_schema(schema, raw_col);
-            let nullable = migrate_column_bool(raw_col, resolved, "ferro_nullable").unwrap_or(true);
-            let db_type = infer_schema_db_type(raw_col, resolved);
+            let col_plan = build_column_plan(table_lower, name, raw_col, schema, backend);
             let db_type_explicit = raw_col
                 .get("db_type")
                 .or_else(|| resolved.get("db_type"))
-                .and_then(|v| v.as_str())
-                .map(|_| true);
+                .and_then(|v| v.as_str());
+            let db_type = db_type_explicit
+                .map(str::to_string)
+                .unwrap_or_else(|| canonical_to_db_type_token(col_plan.canonical, backend));
             columns.push(SchemaColumn {
                 name: name.clone(),
                 logical_type: property_json_type_and_format(resolved)
@@ -153,17 +139,11 @@ fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> Ir
                     .unwrap_or("unknown")
                     .to_string(),
                 db_type,
-                db_type_explicit,
-                nullable,
-                primary_key: resolved
-                    .get("primary_key")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false),
-                autoincrement: resolved
-                    .get("autoincrement")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false),
-                unique: migrate_column_bool(raw_col, resolved, "unique").unwrap_or(false),
+                db_type_explicit: db_type_explicit.map(|_| true),
+                nullable: col_plan.is_nullable,
+                primary_key: col_plan.is_primary_key,
+                autoincrement: col_plan.autoincrement,
+                unique: col_plan.is_unique,
                 index: migrate_column_bool(raw_col, resolved, "index").unwrap_or(false),
                 default: resolved.get("default").cloned(),
                 format: resolved
@@ -231,65 +211,25 @@ fn schema_json_to_schema_ir(table_lower: &str, schema: &serde_json::Value) -> Ir
     }
 }
 
-/// Map `information_schema.columns.data_type` spellings to the same `db_type`
-/// token vocabulary `infer_schema_db_type` uses for model columns (mirrors
-/// `pg_type_matches` on the legacy planner path).
-fn declared_type_to_db_type(declared: &str) -> String {
-    let lower = declared.to_ascii_lowercase();
-    match lower.as_str() {
-        "boolean" => return "boolean".to_string(),
-        "double precision" | "real" => return "double".to_string(),
-        "numeric" => return "numeric".to_string(),
-        "json" | "jsonb" => return "json".to_string(),
-        "bytea" => return "bytea".to_string(),
-        "text" => return "text".to_string(),
-        "integer" => return "int".to_string(),
-        "smallint" => return "smallint".to_string(),
-        "bigint" => return "bigint".to_string(),
-        "uuid" => return "uuid".to_string(),
-        "date" => return "date".to_string(),
-        "time without time zone" => return "time".to_string(),
-        "timestamp without time zone" => return "timestamp".to_string(),
-        "timestamp with time zone" => return "timestamptz".to_string(),
-        _ => {}
-    }
-    if lower.contains("character varying") || lower == "varchar" {
-        return "varchar".to_string();
-    }
-    if lower.contains("smallint") {
-        return "smallint".to_string();
-    }
-    if lower.contains("bigint") {
-        return "bigint".to_string();
-    }
-    if lower.contains("int") {
-        return "int".to_string();
-    }
-    if lower.contains("uuid") || lower.contains("char(32)") {
-        return "uuid".to_string();
-    }
-    if lower.contains("timestamp with time zone") {
-        return "timestamptz".to_string();
-    }
-    if lower.contains("timestamp") || lower.contains("datetime") {
-        return "timestamp".to_string();
-    }
-    if lower == "date" || lower.contains("date_") {
-        return "date".to_string();
-    }
-    if lower == "time" || lower.contains("time_") {
-        return "time".to_string();
-    }
-    "text".to_string()
-}
-
-fn live_columns_to_schema_ir(table_lower: &str, live: &[LiveColumn]) -> IrEnvelope<SchemaIrPayload> {
+fn live_columns_to_schema_ir(
+    table_lower: &str,
+    live: &[LiveColumn],
+    backend: SqlDialect,
+) -> IrEnvelope<SchemaIrPayload> {
+    let dialect = match backend {
+        SqlDialect::Sqlite => ferro_ddl_lowering::Dialect::Sqlite,
+        SqlDialect::Postgres => ferro_ddl_lowering::Dialect::Postgres,
+    };
     let mut columns: Vec<SchemaColumn> = live
         .iter()
         .map(|col| SchemaColumn {
             name: col.name.clone(),
             logical_type: "unknown".to_string(),
-            db_type: declared_type_to_db_type(&col.declared_type),
+            db_type: information_schema_to_db_type_token(
+                &col.declared_type,
+                col.char_max_len,
+                dialect,
+            ),
             db_type_explicit: None,
             nullable: col.is_nullable,
             primary_key: col.is_primary_key,
@@ -365,41 +305,6 @@ impl MigrationPlan {
 
     fn is_empty(&self) -> bool {
         self.statements.is_empty() && self.drop_columns.is_empty()
-    }
-}
-
-/// The `information_schema.data_type` spelling Postgres reports for each
-/// canonical type, used to detect drift between model and live schema.
-fn pg_type_matches(canonical: CanonicalType, live: &LiveColumn) -> bool {
-    let data_type = live.declared_type.as_str();
-    match canonical {
-        CanonicalType::Integer => data_type == "integer",
-        CanonicalType::SmallInt => data_type == "smallint",
-        CanonicalType::BigInt => data_type == "bigint",
-        CanonicalType::Double => data_type == "double precision",
-        CanonicalType::Decimal => data_type == "numeric",
-        CanonicalType::Boolean => data_type == "boolean",
-        CanonicalType::Json => data_type == "json",
-        CanonicalType::Text => data_type == "text",
-        CanonicalType::Varchar(None) => {
-            data_type == "character varying" && live.char_max_len.is_none()
-        }
-        CanonicalType::Varchar(Some(n)) => {
-            data_type == "character varying" && live.char_max_len == Some(i64::from(n))
-        }
-        CanonicalType::Char(n) => {
-            data_type == "character" && live.char_max_len == Some(i64::from(n))
-        }
-        CanonicalType::Uuid => data_type == "uuid",
-        // DateTime is the SQLite rendering of the timestamp tokens; treat it
-        // like a plain timestamp if it ever reaches a Postgres comparison.
-        CanonicalType::DateTime | CanonicalType::Timestamp => {
-            data_type == "timestamp without time zone"
-        }
-        CanonicalType::TimestampTz => data_type == "timestamp with time zone",
-        CanonicalType::Date => data_type == "date",
-        CanonicalType::Time => data_type == "time without time zone",
-        CanonicalType::Blob => data_type == "bytea",
     }
 }
 
@@ -554,9 +459,9 @@ pub fn plan_table_migration(
         return Ok(MigrationPlan::new());
     }
 
-    let old_ir = live_columns_to_schema_ir(table_lower, live);
-    let new_ir = schema_json_to_schema_ir(table_lower, schema);
-    let mut typed_plan = plan_from_ir(&old_ir, &new_ir);
+    let old_ir = live_columns_to_schema_ir(table_lower, live, backend);
+    let new_ir = schema_json_to_schema_ir(table_lower, schema, backend);
+    let mut typed_plan = plan_from_ir(&old_ir, &new_ir, backend_dialect(backend));
 
     if !opts.destructive {
         typed_plan
@@ -602,7 +507,6 @@ pub fn plan_table_migration(
 
 /// Deprecated enriched-JSON migration planner retained for #120 shadow comparison.
 /// Phase 9 ([#108](https://github.com/syn54x/ferro-orm/issues/108)) removes this path.
-#[allow(dead_code)]
 fn plan_table_migration_legacy(
     table_lower: &str,
     schema: &serde_json::Value,
@@ -621,17 +525,23 @@ fn plan_table_migration_legacy(
     let mut model_columns: HashSet<&str> = HashSet::new();
 
     if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
-        for (col_name, raw_col_info) in properties {
-            model_columns.insert(col_name.as_str());
-            let col_plan = build_column_plan(table_lower, col_name, raw_col_info, schema, backend);
+        let mut col_names: Vec<&str> = properties.keys().map(String::as_str).collect();
+        col_names.sort_unstable();
+        for col_name in col_names {
+            let raw_col_info = &properties[col_name];
+            model_columns.insert(col_name);
+            let col_plan =
+                build_column_plan(table_lower, col_name, raw_col_info, schema, backend);
 
-            match live_by_name.get(col_name.as_str()) {
+            match live_by_name.get(col_name) {
                 None => plan_missing_column(table_lower, col_name, &col_plan, backend, &mut plan)?,
                 Some(live_col) => {
                     plan_existing_column(
                         table_lower,
                         col_name,
                         &col_plan,
+                        raw_col_info,
+                        schema,
                         live_col,
                         backend,
                         &mut plan,
@@ -642,6 +552,7 @@ fn plan_table_migration_legacy(
     }
 
     if opts.destructive {
+        let mut drop_columns: Vec<String> = Vec::new();
         for live_col in live {
             if model_columns.contains(live_col.name.as_str()) {
                 continue;
@@ -653,8 +564,10 @@ fn plan_table_migration_legacy(
                     table_lower, live_col.name
                 )));
             }
-            plan.drop_columns.push(live_col.name.clone());
+            drop_columns.push(live_col.name.clone());
         }
+        drop_columns.sort();
+        plan.drop_columns = drop_columns;
     }
 
     Ok(plan)
@@ -667,31 +580,21 @@ fn shadow_compare_migration_plan(
     backend: SqlDialect,
     opts: MigrateOptions,
 ) -> Result<(), String> {
-    let legacy = plan_table_migration(table_lower, schema, live, backend, opts)
+    let ir = plan_table_migration(table_lower, schema, live, backend, opts)
         .map_err(|e| e.to_string())?;
-    let schema_roundtrip: serde_json::Value =
-        serde_json::from_str(&serde_json::to_string(schema).map_err(|e| e.to_string())?)
-            .map_err(|e| e.to_string())?;
-    let live_roundtrip = live.to_vec();
-    let shadow = plan_table_migration(
-        table_lower,
-        &schema_roundtrip,
-        &live_roundtrip,
-        backend,
-        opts,
-    )
-    .map_err(|e| e.to_string())?;
-    if legacy.statements == shadow.statements
-        && legacy.drop_columns == shadow.drop_columns
-        && legacy.warnings == shadow.warnings
+    let legacy = plan_table_migration_legacy(table_lower, schema, live, backend, opts)
+        .map_err(|e| e.to_string())?;
+    if ir.statements == legacy.statements
+        && ir.drop_columns == legacy.drop_columns
+        && ir.warnings == legacy.warnings
     {
         return Ok(());
     }
     Err(format!(
-        "shadow migration-plan mismatch for '{}': legacy={} shadow={}",
+        "shadow migration-plan mismatch for '{}': ir={} legacy={}",
         table_lower,
-        serde_json::to_string(&legacy.statements).unwrap_or_else(|_| "<legacy>".to_string()),
-        serde_json::to_string(&shadow.statements).unwrap_or_else(|_| "<shadow>".to_string())
+        serde_json::to_string(&ir.statements).unwrap_or_else(|_| "<ir>".to_string()),
+        serde_json::to_string(&legacy.statements).unwrap_or_else(|_| "<legacy>".to_string())
     ))
 }
 
@@ -817,6 +720,30 @@ fn plan_missing_column(
     Ok(())
 }
 
+fn schema_column_for_drift(
+    name: &str,
+    db_type: String,
+    nullable: bool,
+    primary_key: bool,
+) -> SchemaColumn {
+    SchemaColumn {
+        name: name.to_string(),
+        logical_type: "unknown".to_string(),
+        db_type,
+        db_type_explicit: None,
+        nullable,
+        primary_key,
+        autoincrement: false,
+        unique: false,
+        index: false,
+        default: None,
+        format: None,
+        enum_values: None,
+        enum_type_name: None,
+        postgres_native_enum: false,
+    }
+}
+
 /// Reconcile an existing live column with the model definition. Postgres gets
 /// native `ALTER COLUMN` DDL; SQLite cannot alter columns in place, so drift
 /// surfaces as warnings (and is usually cosmetic there thanks to type
@@ -825,6 +752,8 @@ fn plan_existing_column(
     table_lower: &str,
     col_name: &str,
     col_plan: &ColumnPlan,
+    raw_col_info: &serde_json::Value,
+    schema: &serde_json::Value,
     live: &LiveColumn,
     backend: SqlDialect,
     plan: &mut MigrationPlan,
@@ -836,8 +765,26 @@ fn plan_existing_column(
 
     match backend {
         SqlDialect::Postgres => {
+            let dialect = Dialect::Postgres;
+            let resolved = resolve_col_schema(schema, raw_col_info);
+            let model_db_type = raw_col_info
+                .get("db_type")
+                .or_else(|| resolved.get("db_type"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| canonical_to_db_type_token(col_plan.canonical, backend));
+            let live_db_type = information_schema_to_db_type_token(
+                &live.declared_type,
+                live.char_max_len,
+                dialect,
+            );
+            let live_col = schema_column_for_drift(col_name, live_db_type, live.is_nullable, false);
+            let model_col =
+                schema_column_for_drift(col_name, model_db_type, col_plan.is_nullable, false);
             // Native enum columns only exist via Alembic; leave them to it.
-            if !live.is_enum_udt && !pg_type_matches(col_plan.canonical, live) {
+            if !live.is_enum_udt
+                && schema_columns_storage_drift(&live_col, &model_col, dialect)
+            {
                 let target = pg_alter_type_target(col_plan.canonical);
                 plan.statements.push(format!(
                     "ALTER TABLE {table} ALTER COLUMN {col} TYPE {target} USING {col}::{target}",
@@ -861,13 +808,18 @@ fn plan_existing_column(
             }
         }
         SqlDialect::Sqlite => {
+            let live_db_type = information_schema_to_db_type_token(
+                &live.declared_type,
+                live.char_max_len,
+                Dialect::Sqlite,
+            );
             let expected = sqlite_declared_type(col_plan.canonical);
-            if sqlite_type_class(&live.declared_type) != sqlite_type_class(&expected) {
+            if sqlite_type_class(&live_db_type) != sqlite_type_class(&expected) {
                 plan.warnings.push(format!(
                     "Column '{}.{}' is declared '{}' in the database but the model expects \
                      '{}'. SQLite cannot change column types in place; use Alembic to \
                      migrate this column.",
-                    table_lower, col_name, live.declared_type, expected
+                    table_lower, col_name, live_db_type, expected
                 ));
             }
             if col_plan.is_nullable != live.is_nullable {
@@ -1120,6 +1072,62 @@ pub fn _render_migration_sql_for_test(
     Ok((statements, plan.warnings))
 }
 
+fn migration_plan_snapshot(plan: &MigrationPlan) -> serde_json::Value {
+    serde_json::json!({
+        "statements": plan.statements,
+        "drop_columns": plan.drop_columns,
+        "warnings": plan.warnings,
+    })
+}
+
+/// Test-only: compare IR-primary vs legacy migration planners for shadow fixtures.
+///
+/// Returns JSON with `matches`, `ir`, and `legacy` plan snapshots.
+#[pyfunction]
+#[pyo3(name = "_shadow_compare_migration_plan_for_test")]
+#[pyo3(signature = (name, schema_json, live_columns_json, dialect, updates=true, destructive=false))]
+pub fn _shadow_compare_migration_plan_for_test(
+    name: String,
+    schema_json: String,
+    live_columns_json: String,
+    dialect: String,
+    updates: bool,
+    destructive: bool,
+) -> PyResult<String> {
+    let backend = match dialect.as_str() {
+        "postgres" => SqlDialect::Postgres,
+        "sqlite" => SqlDialect::Sqlite,
+        other => {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Unknown dialect {:?}; expected 'postgres' or 'sqlite'",
+                other
+            )));
+        }
+    };
+    let schema: serde_json::Value = serde_json::from_str(&schema_json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("Invalid JSON schema: {}", e))
+    })?;
+    let live: Vec<LiveColumn> = serde_json::from_str(&live_columns_json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("Invalid live-columns JSON: {}", e))
+    })?;
+
+    let table_lower = name.to_lowercase();
+    let opts = MigrateOptions::laddered(updates, destructive);
+    let ir = plan_table_migration(&table_lower, &schema, &live, backend, opts)?;
+    let legacy = plan_table_migration_legacy(&table_lower, &schema, &live, backend, opts)?;
+    let matches = ir.statements == legacy.statements
+        && ir.drop_columns == legacy.drop_columns
+        && ir.warnings == legacy.warnings;
+    let payload = serde_json::json!({
+        "matches": matches,
+        "ir": migration_plan_snapshot(&ir),
+        "legacy": migration_plan_snapshot(&legacy),
+    });
+    serde_json::to_string(&payload).map_err(|e| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to encode JSON: {e}"))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1155,6 +1163,66 @@ mod tests {
         })
     }
 
+    fn plan_with_ir_legacy_parity(
+        table: &str,
+        schema: &serde_json::Value,
+        live: &[LiveColumn],
+        backend: SqlDialect,
+        opts: MigrateOptions,
+    ) -> MigrationPlan {
+        let ir = plan_table_migration(table, schema, live, backend, opts)
+            .unwrap_or_else(|e| panic!("IR planner failed for '{table}': {e}"));
+        let legacy = plan_table_migration_legacy(table, schema, live, backend, opts)
+            .unwrap_or_else(|e| panic!("legacy planner failed for '{table}': {e}"));
+        assert_eq!(
+            ir.statements, legacy.statements,
+            "statements mismatch on {table:?} ({backend:?})"
+        );
+        assert_eq!(
+            ir.drop_columns, legacy.drop_columns,
+            "drop_columns mismatch on {table:?} ({backend:?})"
+        );
+        assert_eq!(
+            ir.warnings, legacy.warnings,
+            "warnings mismatch on {table:?} ({backend:?})"
+        );
+        shadow_compare_migration_plan(table, schema, live, backend, opts)
+            .unwrap_or_else(|diff| panic!("shadow compare failed: {diff}"));
+        ir
+    }
+
+    fn assert_ir_legacy_parity(
+        table: &str,
+        schema: &serde_json::Value,
+        live: &[LiveColumn],
+        backend: SqlDialect,
+        opts: MigrateOptions,
+    ) {
+        plan_with_ir_legacy_parity(table, schema, live, backend, opts);
+    }
+
+    fn assert_ir_legacy_parity_err(
+        table: &str,
+        schema: &serde_json::Value,
+        live: &[LiveColumn],
+        backend: SqlDialect,
+        opts: MigrateOptions,
+        needle: &str,
+    ) {
+        let ir_err = plan_table_migration(table, schema, live, backend, opts)
+            .expect_err("IR planner should fail");
+        let legacy_err = plan_table_migration_legacy(table, schema, live, backend, opts)
+            .expect_err("legacy planner should fail");
+        assert!(
+            ir_err.to_string().contains(needle),
+            "IR error missing {needle:?}: {ir_err}"
+        );
+        assert!(
+            legacy_err.to_string().contains(needle),
+            "legacy error missing {needle:?}: {legacy_err}"
+        );
+    }
+
     #[test]
     fn adds_missing_nullable_column_on_both_backends() {
         let schema = invoice_schema();
@@ -1173,7 +1241,7 @@ mod tests {
                 },
             ];
             let plan =
-                plan_table_migration("invoice", &schema, &live_cols, backend, UPDATES).unwrap();
+                plan_with_ir_legacy_parity("invoice", &schema, &live_cols, backend, UPDATES);
             assert_eq!(
                 plan.statements.len(),
                 1,
@@ -1204,8 +1272,7 @@ mod tests {
             live("number", "varchar"),
         ];
         let plan =
-            plan_table_migration("invoice", &schema, &live_cols, SqlDialect::Sqlite, UPDATES)
-                .unwrap();
+            plan_with_ir_legacy_parity("invoice", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
         // db_type "date" renders date_text on SQLite — identical to CREATE TABLE.
         assert!(
             plan.statements[0].contains("date_text"),
@@ -1227,8 +1294,7 @@ mod tests {
             ..live("id", "integer")
         }];
 
-        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
-            .unwrap();
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
         assert_eq!(plan.statements.len(), 2, "{:?}", plan.statements);
         assert!(
             plan.statements[0].contains("NOT NULL"),
@@ -1247,7 +1313,7 @@ mod tests {
         );
 
         let plan =
-            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
         assert_eq!(
             plan.statements.len(),
             1,
@@ -1311,7 +1377,7 @@ mod tests {
         }];
 
         let plan =
-            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
         assert!(
             !plan.statements[0].to_uppercase().contains("UNIQUE"),
             "inline UNIQUE must be stripped on SQLite: {}",
@@ -1324,8 +1390,7 @@ mod tests {
         );
         assert_eq!(plan.warnings.len(), 1);
 
-        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
-            .unwrap();
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
         assert!(
             plan.statements[0].to_uppercase().contains("UNIQUE"),
             "Postgres keeps the inline UNIQUE: {}",
@@ -1347,7 +1412,7 @@ mod tests {
             ..live("id", "integer")
         }];
         let plan =
-            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
         assert_eq!(plan.statements.len(), 2, "{:?}", plan.statements);
         assert!(
             plan.statements[1].contains("\"idx_doc_status\""),
@@ -1372,14 +1437,13 @@ mod tests {
             ..live("id", "integer")
         }];
 
-        let plan = plan_table_migration(
+        let plan = plan_with_ir_legacy_parity(
             "invoice",
             &schema,
             &live_cols,
             SqlDialect::Postgres,
             UPDATES,
-        )
-        .unwrap();
+        );
         assert_eq!(plan.statements.len(), 2, "{:?}", plan.statements);
         assert_eq!(
             plan.statements[1],
@@ -1387,8 +1451,7 @@ mod tests {
         );
 
         let plan =
-            plan_table_migration("invoice", &schema, &live_cols, SqlDialect::Sqlite, UPDATES)
-                .unwrap();
+            plan_with_ir_legacy_parity("invoice", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
         assert_eq!(plan.statements.len(), 1, "{:?}", plan.statements);
         assert_eq!(plan.warnings.len(), 1);
         assert!(
@@ -1416,14 +1479,13 @@ mod tests {
                 ..live("total", "integer")
             },
         ];
-        let plan = plan_table_migration(
+        let plan = plan_with_ir_legacy_parity(
             "invoice",
             &schema,
             &live_cols,
             SqlDialect::Postgres,
             UPDATES,
-        )
-        .unwrap();
+        );
         assert_eq!(plan.statements.len(), 1, "{:?}", plan.statements);
         assert_eq!(
             plan.statements[0],
@@ -1454,8 +1516,7 @@ mod tests {
                 ..live("b", "character varying")
             },
         ];
-        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
-            .unwrap();
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
         assert!(
             plan.statements
                 .contains(&"ALTER TABLE \"doc\" ALTER COLUMN \"a\" SET NOT NULL".to_string()),
@@ -1489,8 +1550,7 @@ mod tests {
                 ..live("status", "USER-DEFINED")
             },
         ];
-        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
-            .unwrap();
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
         assert!(plan.statements.is_empty(), "{:?}", plan.statements);
     }
 
@@ -1510,7 +1570,7 @@ mod tests {
             ..live("id", "integer")
         }];
         let plan =
-            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
         let sql = &plan.statements[0];
         assert!(sql.contains("ADD COLUMN \"motto\""), "{sql}");
         assert!(
@@ -1543,8 +1603,7 @@ mod tests {
                 ..live("meta", "jsonb")
             },
         ];
-        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
-            .unwrap();
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
         assert!(
             !plan
                 .statements
@@ -1572,8 +1631,7 @@ mod tests {
             is_primary_key: true,
             ..live("id", "integer")
         }];
-        let plan = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES)
-            .unwrap();
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
         assert!(
             plan.statements.iter().any(|sql| {
                 sql.contains("ADD CONSTRAINT \"ck_doc_status\"")
@@ -1608,7 +1666,7 @@ mod tests {
             ..live("id", "integer")
         }];
         let plan =
-            plan_table_migration(table, &schema, &live_cols, SqlDialect::Postgres, UPDATES).unwrap();
+            plan_with_ir_legacy_parity(table, &schema, &live_cols, SqlDialect::Postgres, UPDATES);
         let check_sql = plan
             .statements
             .iter()
@@ -1640,7 +1698,7 @@ mod tests {
             live("count", "varchar"),
         ];
         let plan =
-            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
         assert!(plan.statements.is_empty(), "{:?}", plan.statements);
         assert_eq!(plan.warnings.len(), 1, "{:?}", plan.warnings);
         assert!(
@@ -1667,7 +1725,7 @@ mod tests {
             live("name", "varchar"),
         ];
         let plan =
-            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
         assert!(plan.statements.is_empty());
         assert_eq!(plan.warnings.len(), 1);
         assert!(
@@ -1695,13 +1753,12 @@ mod tests {
         ];
 
         let plan =
-            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, DESTRUCTIVE)
-                .unwrap();
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, DESTRUCTIVE);
         assert_eq!(plan.drop_columns, vec!["legacy_notes".to_string()]);
 
         // Without the destructive flag the extra column is untouched.
         let plan =
-            plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES).unwrap();
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
         assert!(plan.drop_columns.is_empty());
 
         // A live PK column missing from the model is a hard error.
@@ -1710,29 +1767,63 @@ mod tests {
                 "name": {"type": "string"},
             }
         });
-        let err = plan_table_migration(
+        for backend in [SqlDialect::Sqlite, SqlDialect::Postgres] {
+            assert_ir_legacy_parity_err(
+                "doc",
+                &schema_without_id,
+                &live_cols,
+                backend,
+                DESTRUCTIVE,
+                "primary key",
+            );
+        }
+    }
+
+    #[test]
+    fn sqlite_drift_warnings_use_normalized_live_db_type_tokens() {
+        let schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "count": {"type": "integer"},
+            }
+        });
+        let live_cols = vec![
+            LiveColumn {
+                is_primary_key: true,
+                declared_type: "INTEGER".to_string(),
+                ..live("id", "integer")
+            },
+            LiveColumn {
+                declared_type: "VARCHAR".to_string(),
+                ..live("count", "varchar")
+            },
+        ];
+        let plan = plan_with_ir_legacy_parity(
             "doc",
-            &schema_without_id,
+            &schema,
             &live_cols,
             SqlDialect::Sqlite,
-            DESTRUCTIVE,
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("primary key"), "{err}");
+            UPDATES,
+        );
+        assert_eq!(plan.warnings.len(), 1, "{:?}", plan.warnings);
+        assert!(
+            plan.warnings[0].contains("declared 'varchar' in the database"),
+            "{}",
+            plan.warnings[0]
+        );
     }
 
     #[test]
     fn no_updates_flag_produces_empty_plan() {
         let schema = invoice_schema();
         let live_cols = vec![live("number", "varchar")];
-        let plan = plan_table_migration(
+        let plan = plan_with_ir_legacy_parity(
             "invoice",
             &schema,
             &live_cols,
             SqlDialect::Sqlite,
             MigrateOptions::default(),
-        )
-        .unwrap();
+        );
         assert!(plan.is_empty());
         assert!(plan.warnings.is_empty());
     }
@@ -1791,5 +1882,166 @@ mod tests {
             vec!["ALTER TABLE \"doc\" DROP COLUMN \"stale\"".to_string()]
         );
         assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn ir_legacy_parity_matrix() {
+        let invoice = invoice_schema();
+        for (backend, varchar_spelling) in [
+            (SqlDialect::Sqlite, "varchar"),
+            (SqlDialect::Postgres, "character varying"),
+        ] {
+            let live_cols = vec![
+                LiveColumn {
+                    is_primary_key: true,
+                    ..live("id", "integer")
+                },
+                LiveColumn {
+                    is_nullable: false,
+                    ..live("number", varchar_spelling)
+                },
+            ];
+            assert_ir_legacy_parity("invoice", &invoice, &live_cols, backend, UPDATES);
+        }
+
+        let not_null_default = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "status": {"type": "string", "ferro_nullable": false, "default": "draft"},
+            }
+        });
+        let id_only = vec![LiveColumn {
+            is_primary_key: true,
+            ..live("id", "integer")
+        }];
+        assert_ir_legacy_parity(
+            "doc",
+            &not_null_default,
+            &id_only,
+            SqlDialect::Postgres,
+            UPDATES,
+        );
+        assert_ir_legacy_parity(
+            "doc",
+            &not_null_default,
+            &id_only,
+            SqlDialect::Sqlite,
+            UPDATES,
+        );
+
+        let not_null_no_default = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "created_at": {"type": "string", "format": "date-time", "ferro_nullable": false},
+            }
+        });
+        for backend in [SqlDialect::Sqlite, SqlDialect::Postgres] {
+            assert_ir_legacy_parity_err(
+                "doc",
+                &not_null_no_default,
+                &id_only,
+                backend,
+                UPDATES,
+                "Alembic",
+            );
+        }
+
+        let pk_guard = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "name": {"type": "string"},
+            }
+        });
+        assert_ir_legacy_parity_err(
+            "doc",
+            &pk_guard,
+            &[live("name", "varchar")],
+            SqlDialect::Sqlite,
+            UPDATES,
+            "primary key",
+        );
+
+        let destructive_pk_drop_schema = json!({
+            "properties": {
+                "name": {"type": "string"},
+            }
+        });
+        let destructive_pk_drop_live = vec![
+            LiveColumn {
+                is_primary_key: true,
+                ..live("id", "integer")
+            },
+            live("name", "varchar"),
+            live("legacy_notes", "text"),
+        ];
+        for backend in [SqlDialect::Sqlite, SqlDialect::Postgres] {
+            assert_ir_legacy_parity_err(
+                "doc",
+                &destructive_pk_drop_schema,
+                &destructive_pk_drop_live,
+                backend,
+                DESTRUCTIVE,
+                "primary key",
+            );
+        }
+
+        let destructive_schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "name": {"type": "string"},
+            }
+        });
+        let destructive_live = vec![
+            LiveColumn {
+                is_primary_key: true,
+                ..live("id", "integer")
+            },
+            live("name", "varchar"),
+            live("legacy_notes", "text"),
+        ];
+        assert_ir_legacy_parity(
+            "doc",
+            &destructive_schema,
+            &destructive_live,
+            SqlDialect::Sqlite,
+            DESTRUCTIVE,
+        );
+        assert_ir_legacy_parity(
+            "doc",
+            &destructive_schema,
+            &destructive_live,
+            SqlDialect::Postgres,
+            DESTRUCTIVE,
+        );
+
+        let no_updates_live = vec![live("number", "varchar")];
+        for backend in [SqlDialect::Sqlite, SqlDialect::Postgres] {
+            assert_ir_legacy_parity(
+                "invoice",
+                &invoice,
+                &no_updates_live,
+                backend,
+                MigrateOptions::default(),
+            );
+        }
+
+        let multi_col_schema = json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true},
+                "zebra": {"type": "string", "index": true},
+                "alpha": {"type": "string", "unique": true},
+            }
+        });
+        let multi_col_live = vec![LiveColumn {
+            is_primary_key: true,
+            ..live("id", "integer")
+        }];
+        assert_ir_legacy_parity(
+            "doc",
+            &multi_col_schema,
+            &multi_col_live,
+            SqlDialect::Sqlite,
+            UPDATES,
+        );
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -158,6 +158,33 @@ pub(crate) enum CanonicalType {
     Blob,
 }
 
+/// Map a resolved [`CanonicalType`] back to the canonical Ferro `db_type` token
+/// vocabulary used in SchemaIR and cross-emitter parity tests.
+pub(crate) fn canonical_to_db_type_token(canonical: CanonicalType, backend: SqlDialect) -> String {
+    match canonical {
+        CanonicalType::Integer => "int".to_string(),
+        CanonicalType::SmallInt => "smallint".to_string(),
+        CanonicalType::BigInt => "bigint".to_string(),
+        CanonicalType::Double => "double".to_string(),
+        CanonicalType::Decimal => "numeric".to_string(),
+        CanonicalType::Boolean => "boolean".to_string(),
+        CanonicalType::Json => "json".to_string(),
+        CanonicalType::Text => "text".to_string(),
+        CanonicalType::Varchar(None) => "varchar".to_string(),
+        CanonicalType::Varchar(Some(n)) => format!("varchar({n})"),
+        CanonicalType::Char(n) => match (backend, n) {
+            (SqlDialect::Sqlite, 32) => "uuid".to_string(),
+            _ => format!("char({n})"),
+        },
+        CanonicalType::Uuid => "uuid".to_string(),
+        CanonicalType::DateTime | CanonicalType::Timestamp => "timestamp".to_string(),
+        CanonicalType::TimestampTz => "timestamptz".to_string(),
+        CanonicalType::Date => "date".to_string(),
+        CanonicalType::Time => "time".to_string(),
+        CanonicalType::Blob => "bytea".to_string(),
+    }
+}
+
 pub(crate) fn apply_canonical_type(col_def: &mut ColumnDef, canonical: CanonicalType) {
     match canonical {
         CanonicalType::Integer => {
@@ -480,6 +507,7 @@ pub(crate) struct ColumnPlan {
     pub col_def: ColumnDef,
     pub canonical: CanonicalType,
     pub is_primary_key: bool,
+    pub autoincrement: bool,
     pub is_nullable: bool,
     pub is_unique: bool,
     /// Post-create SQL owned by this column, in emission order:
@@ -507,10 +535,14 @@ pub(crate) fn build_column_plan(
 
     let is_primary_key =
         column_bool_metadata(raw_col_info, col_info, "primary_key").unwrap_or(false);
-    let is_auto = column_bool_metadata(raw_col_info, col_info, "autoincrement").unwrap_or(true);
+    let autoincrement = if is_primary_key {
+        column_bool_metadata(raw_col_info, col_info, "autoincrement").unwrap_or(true)
+    } else {
+        column_bool_metadata(raw_col_info, col_info, "autoincrement").unwrap_or(false)
+    };
     if is_primary_key {
         col_def.primary_key();
-        if is_auto {
+        if autoincrement {
             col_def.auto_increment();
         }
     }
@@ -583,6 +615,7 @@ pub(crate) fn build_column_plan(
         col_def,
         canonical,
         is_primary_key,
+        autoincrement,
         is_nullable,
         is_unique,
         index_sqls,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -26,7 +26,9 @@ fn resolve_ref<'a>(
     col_info
 }
 
-fn property_json_type_and_format(col_info: &serde_json::Value) -> (Option<&str>, Option<&str>) {
+pub(crate) fn property_json_type_and_format(
+    col_info: &serde_json::Value,
+) -> (Option<&str>, Option<&str>) {
     let top_type = col_info.get("type").and_then(|t| t.as_str());
     let top_format = col_info.get("format").and_then(|f| f.as_str());
     if top_type.is_some() {

--- a/tests/fixtures/shadow_reports/postgres.json
+++ b/tests/fixtures/shadow_reports/postgres.json
@@ -43,5 +43,24 @@
         ]
       }
     }
+  },
+  "migration_compare": {
+    "ir": {
+      "drop_columns": [],
+      "statements": [
+        "ALTER TABLE \"shadowuser\" ADD COLUMN \"age\" integer",
+        "ALTER TABLE \"shadowuser\" ADD COLUMN \"name\" varchar"
+      ],
+      "warnings": []
+    },
+    "legacy": {
+      "drop_columns": [],
+      "statements": [
+        "ALTER TABLE \"shadowuser\" ADD COLUMN \"age\" integer",
+        "ALTER TABLE \"shadowuser\" ADD COLUMN \"name\" varchar"
+      ],
+      "warnings": []
+    },
+    "matches": true
   }
 }

--- a/tests/fixtures/shadow_reports/sqlite.json
+++ b/tests/fixtures/shadow_reports/sqlite.json
@@ -43,5 +43,24 @@
         ]
       }
     }
+  },
+  "migration_compare": {
+    "ir": {
+      "drop_columns": [],
+      "statements": [
+        "ALTER TABLE \"shadowuser\" ADD COLUMN \"age\" integer",
+        "ALTER TABLE \"shadowuser\" ADD COLUMN \"name\" varchar"
+      ],
+      "warnings": []
+    },
+    "legacy": {
+      "drop_columns": [],
+      "statements": [
+        "ALTER TABLE \"shadowuser\" ADD COLUMN \"age\" integer",
+        "ALTER TABLE \"shadowuser\" ADD COLUMN \"name\" varchar"
+      ],
+      "warnings": []
+    },
+    "matches": true
   }
 }

--- a/tests/test_shadow_reports.py
+++ b/tests/test_shadow_reports.py
@@ -8,6 +8,7 @@ from ferro import Model, connect
 from ferro._core import (
     _render_create_table_sql_for_test,
     _render_migration_sql_for_test,
+    _shadow_compare_migration_plan_for_test,
     _shadow_compare_query_plan_for_test,
 )
 from ferro.query.builder import _query_ir_payload_to_json
@@ -71,10 +72,30 @@ def _report_for_backend(dialect: str) -> dict:
         True,
         False,
     )
+    migration_compare = json.loads(
+        _shadow_compare_migration_plan_for_test(
+            "ShadowUser",
+            json.dumps(schema),
+            json.dumps(
+                [
+                    {
+                        "name": "id",
+                        "declared_type": "integer",
+                        "is_primary_key": True,
+                        "is_nullable": False,
+                    }
+                ]
+            ),
+            dialect,
+            True,
+            False,
+        )
+    )
     return {
         "query_compare": query_compare,
         "create_table": [create_table_sql, list(create_table_extras)],
         "migration": [list(migration_stmts), list(migration_warns)],
+        "migration_compare": migration_compare,
     }
 
 


### PR DESCRIPTION
## Description

Phase 8 (IR-first migration) cutover: runtime `auto_migrate` now plans and emits DDL through the typed SchemaIR → `ferro-migrate` pipeline instead of the legacy enriched-JSON diff walk. This PR completes the emission layer, wires the runtime hot path, and adds an enforced IR-vs-legacy parity gate so drift is caught before Phase 9 removes the legacy planner.

The legacy JSON planner is **deprecated but retained** as a shadow reference until `v0.14.0` ([#108](https://github.com/syn54x/ferro-orm/issues/108)).

## Changes

- Add `ferro-ddl-lowering` crate with I-1-safe canonical type tokens, constraint naming, and column-definition helpers shared across emitters
- Implement `emit_sql_with_ir` in `ferro-migrate`, returning `EmissionResult` with executable DDL for all `MigrationOp` variants on SQLite and Postgres (26 unit tests across the op × dialect matrix)
- Cut `plan_table_migration` over to `plan_from_ir` + `emit_sql_with_ir` as the sole hot-path planner; route `DropColumn` ops to `drop_columns` for SQLite index-aware execution
- Extract deprecated `plan_table_migration_legacy` for shadow comparison (not removed until Phase 9)
- Rewire `shadow_compare_migration_plan` to diff IR-primary vs legacy on `statements`, `drop_columns`, and `warnings` — replacing the prior JSON roundtrip self-compare
- Consolidate `schema_json_to_schema_ir` / `live_columns_to_schema_ir` onto `build_column_plan` / `canonical_to_db_type_token` so adapters don't duplicate inference logic
- Add `ir_legacy_parity_matrix` Rust tests, `_shadow_compare_migration_plan_for_test` pytest fixtures, and shadow report fixture updates
- Document runtime IR cutover in architecture guide and migration shadow gate in `docs/solutions/patterns/cross-emitter-ddl-parity.md`
- Defer hard removal of legacy planner to Phase 9 / `v0.14.0` per roadmap update

## Bridge and Schema Impact

- [ ] No Rust/Python bridge changes
- [x] Python model/schema changed
- [x] Rust core or SQL generation changed
- [x] `src/ferro/_core.pyi` updated (if needed)
- [x] Integration test added first for new behavior

Runtime migration planning and SQL emission now flow through SchemaIR. Public Python API is unchanged; `auto_migrate` behavior must remain observably identical for the supported capability matrix.

## Migration / Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes included (details below)

No user-facing API changes. `connect(auto_migrate=True)` and `ferro.migrate` semantics are preserved; the internal planner source changed from enriched-JSON diff to IR diff + typed emission.

## Documentation and Changelog

- [ ] No docs update needed
- [x] Docs updated (README/docs/inline docs)
- [ ] Changelog entry needed

Updated: `docs/pages/concepts/architecture.md`, `docs/solutions/patterns/cross-emitter-ddl-parity.md`, `docs/plans/ir-first-migration-guide.md`, Phase 8 roadmap deliverables. Changelog handled by release tooling (I-10).

## Related Issues

- Closes #118
- Closes #119
- Closes #120

Parent epic: #117

## Test plan

- [x] `cargo test -p ferro-ddl-lowering -p ferro-migrate -p ferro-schema-ir`
- [x] `cargo test --no-default-features --features testing migrate`
- [x] `cargo test migrate::tests::ir_legacy_parity_matrix`
- [x] `uv run pytest tests/test_migrate_plan.py tests/test_auto_migrate.py -q`
- [x] `uv run pytest tests/test_cross_emitter_parity.py tests/test_shadow_reports.py -q`
- [x] `cargo check -p ferro`

## Exit Steps

- [x] Related completed issues are linked above with Closes/Fixes/Resolves
- [x] Issue statuses are updated/auto-close on merge