### PR TITLE
docs(ir-first): lowering-consolidation audit + Phase 8.5

### DIFF
--- a/docs/pages/concepts/architecture.md
+++ b/docs/pages/concepts/architecture.md
@@ -36,9 +36,18 @@ graph LR
     Builder --> Compiler
     Compiler --> SchemaIR
     SchemaIR --> Alembic
-    SchemaIR --> Migrate
     EnrichedJSON --> Registry
+    EnrichedJSON --> Migrate
 ```
+
+> **Implementation status (2026-06-26):** only `SchemaIR --> Alembic` is a fully
+> realized SchemaIR consumer. The runtime DDL / `ferro-migrate` path currently
+> re-derives its own SchemaIR in Rust from the enriched JSON (it does not consume
+> the Python-compiled SchemaIR envelope), and the runtime CREATE emitter
+> (`src/schema.rs`) uses its own canonical type system rather than the shared
+> `ferro-ddl-lowering` crate. Collapsing these onto one SchemaIR producer and one
+> lowering library is tracked as **Phase 8.5** — see the
+> [IR-first lowering consolidation audit](../../solutions/architecture-patterns/ir-first-lowering-consolidation-audit.md).
 
 ### Runtime path (per operation)
 
@@ -102,7 +111,7 @@ Ferro models are real Pydantic V2 `BaseModel` subclasses. The Python layer owns:
 
 The FFI boundary is built on [PyO3](https://pyo3.rs) with `pyo3-async-runtimes` bridging Python's asyncio event loop to Rust's tokio runtime. Versioned IR envelopes cross the boundary:
 
-- **SchemaIR** (`ir_kind: "schema"`) — compiled at class-creation time from the enriched model schema. Cached in Python (`ferro.state`) and consumed by Alembic `get_metadata()`, migration planning, and parity tests. The Rust registry still receives enriched JSON schema for runtime query/bind metadata.
+- **SchemaIR** (`ir_kind: "schema"`) — compiled at class-creation time from the enriched model schema. Cached in Python (`ferro.state`) and consumed by Alembic `get_metadata()` and parity tests. The Rust registry receives enriched JSON schema for runtime query/bind metadata, and the runtime migration planner currently re-derives its own SchemaIR in Rust from that JSON rather than consuming this envelope (consolidation tracked in [Phase 8.5](../../plans/2026-06-19-001-ir-first-roadmap.md)).
 - **QueryIR** (`ir_kind: "query"`) — emitted per operation from the query builder as `{ir_kind, ir_version, payload}`. Rust deserializes the envelope, plans SQL, and binds parameters through the shared codec registry.
 - **Rows** travel back as typed values that Rust hydrates into Python objects via the hydration ABI (direct `__dict__` population with required Pydantic slots initialized).
 
@@ -199,7 +208,7 @@ await connect("sqlite::memory:", auto_migrate=True)
 
 The legacy enriched-JSON migration planner remains in the codebase as a deprecated shadow reference until `v0.14.0` (Phase 9); parity against the IR path is gated in Phase 8 ([#120](https://github.com/syn54x/ferro-orm/issues/120)).
 
-For renames, primary-key changes, and complex transforms, use the [Alembic bridge](../guide/migrations.md). **SchemaIR** is the canonical contract for cross-emitter DDL parity — Alembic `get_metadata()` derives SQLAlchemy metadata from compiled SchemaIR so autogenerate agrees with Ferro's naming and type conventions. The enriched JSON schema in the Rust registry remains the runtime source for query bind typing and hydration metadata.
+For renames, primary-key changes, and complex transforms, use the [Alembic bridge](../guide/migrations.md). **SchemaIR** is the intended canonical contract for cross-emitter DDL parity — Alembic `get_metadata()` derives SQLAlchemy metadata from compiled SchemaIR so autogenerate agrees with Ferro's naming and type conventions. The runtime CREATE and migrate emitters do not yet consume SchemaIR directly, so today that parity is enforced by tests (`test_cross_emitter_parity.py`, `test_db_type_cross_emitter_parity.py`) rather than by shared lowering code; making it structural is tracked in [Phase 8.5](../../plans/2026-06-19-001-ir-first-roadmap.md). The enriched JSON schema in the Rust registry remains the runtime source for query bind typing and hydration metadata.
 
 ## Async Architecture
 

--- a/docs/pages/howto/migrating-to-v0-12-0.md
+++ b/docs/pages/howto/migrating-to-v0-12-0.md
@@ -10,7 +10,9 @@ several independent code paths.
 A single source of truth removes whole classes of drift bugs:
 
 - **Predictable schema diffs.** Runtime DDL and the Alembic autogenerate bridge
-  derive from the same IR, so migrations stop proposing phantom changes.
+  are held to the same schema contract — Alembic derives its metadata from the
+  compiled SchemaIR, and cross-emitter parity tests pin the runtime emitter to
+  it — so migrations stop proposing phantom changes.
 - **Typed query execution.** Queries compile through typed IR rather than ad-hoc
   JSON, so bind and null semantics behave the same on SQLite and PostgreSQL.
 - **Explicit runtime state.** Connection and transaction routing are scoped to a

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -87,25 +87,52 @@ Definition of done addition:
 
 ## Program status
 
-- Overall status: `In progress` (Phases 0–7 merged; Phase 8 ferro-migrate cutover pending; Phase 9 shim removal pending)
+- Overall status: `In progress` (Phases 0–7 merged; Phase 8 ferro-migrate cutover landing; Phase 8.5 lowering consolidation pending; Phase 9 shim removal pending)
 - Current phase: `Phase 8`
-- Last updated: `2026-06-23`
+- Last updated: `2026-06-26`
 - Roadmap owner: `@syn54x`
+
+> **Architecture audit (2026-06-26):** a code-grounded audit
+> ([`ir-first-lowering-consolidation-audit.md`](../solutions/architecture-patterns/ir-first-lowering-consolidation-audit.md))
+> found that the program's success criterion *"Runtime DDL, Alembic adapter, and
+> migration planner consume the same IR artifacts"* and the principle *"One source
+> of truth: no parallel emitters"* are **not yet met for the schema domain**: the
+> runtime CREATE path (`src/schema.rs`) keeps its own `CanonicalType` and consumes
+> no IR; SchemaIR is compiled by two independent producers (Python
+> `compile_schema_ir_payload` + Rust `schema_json_to_schema_ir`); and the type
+> system is encoded in ~5 parallel places. Phase 9 removes the legacy *planner*
+> but does not close this gap. **Phase 8.5 (below) is added to close it and gates
+> Phase 9.**
 
 ## Branching and release policy
 
-IR program integration branch:
+> **Policy correction (2026-06-26):** the original model below — *stage all work
+> on `feat/ir-first`, promote to `main` only at program end* — was abandoned early
+> in the program. In practice the IR work ships to `main` incrementally via
+> `0.12.x` releases, and each phase integrates on its own short-lived branch.
+> `feat/ir-first` is **retired** (diverged from `main`, no open PRs); do not branch
+> from it or target it. The current (actual) flow is recorded below; the original
+> text is kept struck-through for history.
 
-- `feat/ir-first` is the staging branch for all roadmap work.
-- Starting work on any phase issue requires creating a new branch from `feat/ir-first`.
-- Phase PRs must target `feat/ir-first` (not `main`).
-- Completed phase work merges back into `feat/ir-first`.
+Current (actual) flow:
 
-Promotion to release:
+- `main` is the trunk. Completed phase work lands on `main` and ships in a
+  `0.1x.y` release. Partial IR work on `main` is acceptable because deprecated
+  paths stay behind the compatibility window until the `v0.14.0` cutover.
+- Each phase uses a short-lived integration branch (e.g.
+  `feat/ir-p8-migrate-cutover` for Phase 8). Sub-issue branches stack onto it and
+  merge via PR; the phase branch then promotes to `main`.
+- Start a new phase/sub-issue branch from `main`, or from the active phase
+  integration branch when stacking within a phase.
+- Release notes and migration-guide updates are required at each promotion to
+  `main`, not only at program end.
 
-- `main` must not receive partial IR migration work.
-- Merge `feat/ir-first` into `main` only when the IR program is complete and release-ready.
-- Release notes and migration guide updates are required at promotion time.
+Original (superseded) policy:
+
+- ~~`feat/ir-first` is the staging branch for all roadmap work.~~
+- ~~Starting work on any phase issue requires creating a new branch from `feat/ir-first`.~~
+- ~~Phase PRs must target `feat/ir-first` (not `main`).~~
+- ~~Completed phase work merges back into `feat/ir-first`; merge into `main` only when the IR program is complete.~~
 
 ## Traceability rule (roadmap <-> GitHub issues)
 
@@ -441,7 +468,7 @@ Issue references:
 - [x] `plan_table_migration` executes the IR plan as the primary runtime path; legacy enriched-JSON diff walk **deprecated** but retained for shadow comparison (removal deferred to Phase 9).
 - [x] Shadow/parity gate: IR migration path matches legacy planner, `create_tables`, and Alembic for the `auto_migrate` capability matrix.
 - [x] `shadow_compare_migration_plan` compares IR vs legacy output (not legacy roundtrip); `FERRO_SHADOW_RUNTIME` / `FERRO_SHADOW_RUNTIME_STRICT` enforce drift in CI.
-- [x] Duplicate `schema_json_to_schema_ir` / `live_columns_to_schema_ir` lowering consolidated or single-sourced where feasible.
+- [~] Duplicate `schema_json_to_schema_ir` / `live_columns_to_schema_ir` lowering consolidated or single-sourced where feasible. **Correction (2026-06-26 audit):** consolidation was scoped to the migrate path only. The runtime CREATE emitter (`src/schema.rs`) still uses its own `CanonicalType` (not `ferro-ddl-lowering`), and SchemaIR is still produced by two independent compilers (Python + Rust). Full single-sourcing moved to **Phase 8.5**.
 
 **Exit gate**
 - [ ] `cargo test -p ferro-migrate` green with full op coverage.
@@ -456,9 +483,66 @@ Issue references:
 
 ---
 
+### Phase 8.5 - Lowering consolidation & single-source-of-truth closeout (gates Phase 9)
+
+Status: `Not started`
+
+Issue references:
+
+- `Epic:` _to be filed_
+- `Sub-issues:` _to be filed_
+
+> Inserted as `8.5` (not renumbered) so existing Phase 9 issue references
+> (#107–#110) stay valid per the traceability/sync rules. Source:
+> [`ir-first-lowering-consolidation-audit.md`](../solutions/architecture-patterns/ir-first-lowering-consolidation-audit.md).
+
+**Objective**
+- Make the schema/DDL domain actually single-sourced — the property the program
+  set as a success criterion but has not yet met. Until this lands, cross-emitter
+  parity (AGENTS.md I-1) is test-enforced rather than structural, and the legacy
+  planner cannot be safely removed.
+
+**Deliverables**
+- [ ] `src/schema.rs` (runtime CREATE) consumes `ferro-ddl-lowering`; its private
+      `CanonicalType` / `canonical_to_db_type_token` are deleted. One canonical
+      type system across CREATE and migrate.
+- [ ] Single SchemaIR producer: Rust consumes the Python-compiled SchemaIR over
+      FFI (as the Query path does) instead of rebuilding it via
+      `schema_json_to_schema_ir` / `live_columns_to_schema_ir`.
+- [ ] Duplicated helpers in `src/migrate.rs` (`pg_alter_type_target`,
+      `sqlite_declared_type`, `sqlite_type_class`, `single_unique_index_name`,
+      `fk_action_sql`, `literal_default_value`) removed in favor of the
+      `ferro-ddl-lowering` originals.
+- [ ] IR `db_type` is authoritative, or it is dropped for non-explicit columns
+      (emitters must not silently re-derive a value that disagrees with the IR).
+- [ ] Runtime migrate IR populates composite indexes/uniques, or the scope cut is
+      documented with a tracked follow-up.
+
+**Exit gate**
+- [ ] Exactly one `CanonicalType` and one SchemaIR producer remain in the tree
+      (grep-verified; no parallel encoders).
+- [ ] Cross-emitter parity is backed by shared code, not only by
+      `test_cross_emitter_parity.py` / `test_db_type_cross_emitter_parity.py`
+      (those become regression sentinels over shared lowering, not the primary
+      guarantee).
+- [ ] Backend matrix green on SQLite + Postgres.
+
+**Verification commands**
+- `cargo test -p ferro-schema-ir -p ferro-migrate`
+- `cargo test --no-default-features --features testing`
+- `uv run pytest tests/test_cross_emitter_parity.py tests/test_db_type_cross_emitter_parity.py tests/test_ir_vectors_contract.py -q`
+- `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py -q`
+
+---
+
 ### Phase 9 - Compatibility cutover and shim removal (`v0.14.0`)
 
 Status: `Not started`
+
+> **Dependency (2026-06-26 audit):** removal of the deprecated enriched-JSON
+> migration planner in `src/migrate.rs` must not land until **Phase 8.5** has
+> single-sourced the IR path. Deleting the legacy planner while SchemaIR still has
+> two producers and the CREATE path still diverges would leave parity unguarded.
 
 Issue references:
 
@@ -600,6 +684,12 @@ Use this roadmap as the source for issues and project fields.
   - Mitigation: golden vector suite plus backend matrix at every phase gate.
 - Risk: compatibility shim drag extends timeline.
   - Mitigation: define shim sunset at creation time with a hard owning phase.
+- Risk: "single source of truth" is asserted by phase gates but not realized in
+  code — parallel type-lowering encoders and a dual SchemaIR producer persist,
+  so cross-emitter parity is test-enforced rather than structural (2026-06-26
+  audit).
+  - Mitigation: Phase 8.5 collapses the encoders and producers; it gates Phase 9
+    so the legacy planner is not removed while parity is unguarded.
 
 ## Progress log
 
@@ -621,6 +711,8 @@ Append updates as concise entries.
 - `2026-06-22` - Phase 5 working-branch implementation landed: added unified codec registry module (`src/codec.rs`) across insert/update/filter/m2m/fetch paths, extracted single hydration ABI helper (`src/hydration.rs`) with required Pydantic slot initialization, and expanded codec conformance vectors/tests for null/uuid/decimal/temporal/enum semantics.
 - `2026-06-22` - Phase 6 working-branch implementation landed: introduced sessionized runtime API (`engines.session` / `Session`) and ambient session routing, moved transaction/identity-map hot-path state to session scope in Rust with compatibility fallback + deprecation warnings, added session lifecycle tests, and synchronized migration/guide/API/invariant docs.
 - `2026-06-22` - Phase 7 working-branch implementation landed: completed version-centric public migration guidance (`Migrating to v0.12.0`), added release checklist + changelog entries, centralized `v0.14.0` deprecation-target messaging across compatibility paths, added deprecated-path inventory tests, and validated full Rust/Python/docs/release verification matrix.
+- `2026-06-26` - Code-grounded architecture audit recorded at `docs/solutions/architecture-patterns/ir-first-lowering-consolidation-audit.md`. Finding: the schema/DDL domain is not yet single-sourced — runtime CREATE (`src/schema.rs`) keeps a private `CanonicalType` and consumes no IR; SchemaIR has two independent producers (Python `compile_schema_ir_payload` + Rust `schema_json_to_schema_ir`); the type system is encoded in ~5 parallel places. Corrected the overclaimed Phase 8 consolidation deliverable (`[x]` → `[~]`).
+- `2026-06-26` - Inserted **Phase 8.5** (lowering consolidation & single-source-of-truth closeout); gates Phase 9 shim removal. Numbered `8.5` (no renumbering) to preserve existing Phase 9 issue references (#107–#110). Phase 8.5 issues to be filed.
 
 ## Immediate next actions
 

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -144,6 +144,33 @@ Original (superseded) policy:
 - Any roadmap change that affects scope, acceptance criteria, ownership, status, risk, sequencing, or exit gates must be reflected in all already-created linked issues in the same work session (or same PR when applicable).
 - Any issue change that affects those same dimensions must be reflected in the roadmap in the same work session (or same PR when applicable).
 
+### Project board and native sub-issues (required)
+
+Filing an issue is not enough. Every epic and sub-issue must be enrolled on the
+GitHub Project and wired into the native issue hierarchy **at filing time** —
+text references and markdown checklists do not satisfy this.
+
+1. **Add to the board.** Every issue goes on **Project #7** (org `syn54x`,
+   <https://github.com/orgs/syn54x/projects/7>):
+   `gh project item-add 7 --owner syn54x --url <issue-url>`. Set `Status` (new
+   work → `Todo`).
+2. **Use GitHub native sub-issues.** Link each sub-issue to its epic with the
+   **native sub-issue** relationship — the issue UI ("Create sub-issue" / "Add
+   existing issue") or the GraphQL mutation (note the feature header):
+   ```
+   gh api graphql -H "GraphQL-Features: sub_issues" -f query='
+     mutation { addSubIssue(input:{ issueId:"<EPIC_NODE_ID>", subIssueId:"<SUB_NODE_ID>" }) { subIssue { number } } }'
+   ```
+   A markdown checklist in the epic body is optional context, **not** a
+   substitute for the native link.
+3. **Group by milestone, not the `Phase` field.** Assign the phase milestone
+   `IR-P<phase>` (e.g. `IR-P8.5`): `gh issue edit <n> --milestone IR-P<phase>`
+   (create it first if absent: `gh api repos/syn54x/ferro-orm/milestones -f title=...`).
+   The board's `Phase` single-select is stale (options stop at `7`) and unused —
+   do not rely on it.
+4. **Verify before claiming done:** the epic reports N native sub-issues and
+   every issue appears on Project #7 with a `Status`.
+
 ### Reference format
 
 Use issue references inline under each phase:
@@ -645,12 +672,22 @@ async with engines.session("app"):
 - Attempting convenience model calls outside a session raises a deterministic error.
 - Multi-DB behavior is deterministic under concurrent coroutine workloads.
 
-## GitHub Project mapping (ready to instantiate)
+## GitHub Project mapping
 
-Use this roadmap as the source for issues and project fields.
+**Live project:** org `syn54x`, **Project #7** — <https://github.com/orgs/syn54x/projects/7>.
+Enrollment, native sub-issues, and milestone assignment are **mandatory** for
+every issue; see *Traceability rule → Project board and native sub-issues
+(required)* above for the exact steps.
 
-**Recommended project fields**
-- `Phase`: 0, 1, 2, 3, 4, 5, 6, 7, 8
+> **Field note (2026-06-26):** in practice the board is driven by the **`Status`**
+> field (`Todo` / `In Progress` / `Done`) plus the **`IR-P<phase>` milestone**,
+> with phase/workstream carried in the issue title prefix (`[IR-P<phase>][WSx]`).
+> The custom `Phase` single-select is stale (options stop at `7`) and unused —
+> **group by milestone**. The field list below is the original design intent, not
+> the live schema.
+
+**Project fields (original design intent)**
+- `Phase`: 0, 1, 2, ... — *stale; use the `IR-P<phase>` milestone instead*
 - `Workstream`: WS1..WS6
 - `Type`: RFC, Infra, Runtime, Migration, Test, Docs, Release
 - `Status`: Backlog, Ready, In Progress, Blocked, In Review, Done
@@ -670,7 +707,8 @@ Use this roadmap as the source for issues and project fields.
 
 ## Milestone cadence
 
-- Milestone per phase (`IR-P0`, `IR-P1`, ...).
+- Milestone per phase (`IR-P0`, `IR-P1`, ...); inserted sub-phases use a `.5`
+  suffix milestone (e.g. `IR-P8.5`).
 - Weekly roadmap review:
   - phase status changes
   - new blockers and risk level updates

--- a/docs/plans/2026-06-19-001-ir-first-roadmap.md
+++ b/docs/plans/2026-06-19-001-ir-first-roadmap.md
@@ -489,8 +489,8 @@ Status: `Not started`
 
 Issue references:
 
-- `Epic:` _to be filed_
-- `Sub-issues:` _to be filed_
+- `Epic:` [#139](https://github.com/syn54x/ferro-orm/issues/139)
+- `Sub-issues:` [#140](https://github.com/syn54x/ferro-orm/issues/140), [#141](https://github.com/syn54x/ferro-orm/issues/141), [#142](https://github.com/syn54x/ferro-orm/issues/142), [#143](https://github.com/syn54x/ferro-orm/issues/143), [#144](https://github.com/syn54x/ferro-orm/issues/144)
 
 > Inserted as `8.5` (not renumbered) so existing Phase 9 issue references
 > (#107–#110) stay valid per the traceability/sync rules. Source:
@@ -712,7 +712,8 @@ Append updates as concise entries.
 - `2026-06-22` - Phase 6 working-branch implementation landed: introduced sessionized runtime API (`engines.session` / `Session`) and ambient session routing, moved transaction/identity-map hot-path state to session scope in Rust with compatibility fallback + deprecation warnings, added session lifecycle tests, and synchronized migration/guide/API/invariant docs.
 - `2026-06-22` - Phase 7 working-branch implementation landed: completed version-centric public migration guidance (`Migrating to v0.12.0`), added release checklist + changelog entries, centralized `v0.14.0` deprecation-target messaging across compatibility paths, added deprecated-path inventory tests, and validated full Rust/Python/docs/release verification matrix.
 - `2026-06-26` - Code-grounded architecture audit recorded at `docs/solutions/architecture-patterns/ir-first-lowering-consolidation-audit.md`. Finding: the schema/DDL domain is not yet single-sourced — runtime CREATE (`src/schema.rs`) keeps a private `CanonicalType` and consumes no IR; SchemaIR has two independent producers (Python `compile_schema_ir_payload` + Rust `schema_json_to_schema_ir`); the type system is encoded in ~5 parallel places. Corrected the overclaimed Phase 8 consolidation deliverable (`[x]` → `[~]`).
-- `2026-06-26` - Inserted **Phase 8.5** (lowering consolidation & single-source-of-truth closeout); gates Phase 9 shim removal. Numbered `8.5` (no renumbering) to preserve existing Phase 9 issue references (#107–#110). Phase 8.5 issues to be filed.
+- `2026-06-26` - Inserted **Phase 8.5** (lowering consolidation & single-source-of-truth closeout); gates Phase 9 shim removal. Numbered `8.5` (no renumbering) to preserve existing Phase 9 issue references (#107–#110).
+- `2026-06-26` - Phase 8.5 issues filed and linked: epic [#139](https://github.com/syn54x/ferro-orm/issues/139) with sub-issues [#140](https://github.com/syn54x/ferro-orm/issues/140), [#141](https://github.com/syn54x/ferro-orm/issues/141), [#142](https://github.com/syn54x/ferro-orm/issues/142), [#143](https://github.com/syn54x/ferro-orm/issues/143), [#144](https://github.com/syn54x/ferro-orm/issues/144). Audit captured in PR [#138](https://github.com/syn54x/ferro-orm/pull/138).
 
 ## Immediate next actions
 

--- a/docs/solutions/architecture-patterns/ir-first-lowering-consolidation-audit.md
+++ b/docs/solutions/architecture-patterns/ir-first-lowering-consolidation-audit.md
@@ -1,0 +1,246 @@
+---
+title: IR-first lowering consolidation audit
+date: 2026-06-26
+category: architecture-patterns
+module: ir-first
+problem_type: architecture_pattern
+component: schema_migration
+severity: high
+status: active
+applies_when:
+  - "Deciding whether the IR-first program is paying off before Phase 9 shim removal"
+  - "A phase gate claims 'one source of truth' but multiple code paths derive schema semantics independently"
+  - "Adding a schema feature and discovering it must be edited in several type-lowering encoders"
+  - "Reasoning about why cross-emitter parity is currently test-enforced rather than structural"
+resolution_type: roadmap_correction
+tags:
+  - ir-first
+  - schema-ir
+  - ddl-lowering
+  - cross-emitter-parity
+  - single-source-of-truth
+  - migration
+related_components:
+  - documentation
+  - testing_framework
+---
+
+# IR-first lowering consolidation audit
+
+## Context
+
+This is a **code-grounded audit** of the IR-first program as it stands on
+branch `feat/ir-p8-120-parity-gate` (Phase 8 parity gate landed; runtime
+`auto_migrate` now runs the IR planner as primary with the legacy planner
+shadow-compared). It was produced by reading the IR stack end-to-end —
+`ferro-schema-ir`, `ferro-ddl-lowering`, `ferro-migrate`, the runtime
+create/migrate paths in `src/schema.rs` and `src/migrate.rs`, the Python
+`src/ferro/ir/compiler.py` and `src/ferro/migrations/alembic.py`, the query
+plumbing, and the parity tests — **without relying on prose docs**, then
+reconciling against the [IR-first roadmap](../../plans/2026-06-19-001-ir-first-roadmap.md)
+and the [merge-readiness review](./ir-first-merge-readiness-review.md).
+
+It complements the merge-readiness review (point-in-time defect list) by
+auditing a deeper, structural question the phase gates have not yet closed:
+**is the IR actually the single source of truth it is meant to be?** Today, for
+the schema/DDL domain, it is not.
+
+## Verdict
+
+The IR-first direction is **correct in principle and correctly motivated** for a
+Python ORM with a Rust core that has many consumers of the same schema knowledge
+(runtime CREATE, runtime ALTER, Alembic autogenerate, query planning, codec). A
+versioned, serializable IR is the right contract to decouple *what the schema/query
+is* from *how each backend renders it*. The **Query IR** slice proves the idea
+works end-to-end.
+
+But the program is currently at the most expensive point of the transition, and
+the **schema/DDL slice has not realized the "single source of truth" property**.
+The refactor has, at this moment, *increased* the number of places that encode
+the type system rather than reducing them. The payoff is real **iff the
+consolidation is finished**; if the current dual-path / multi-encoder state
+ossifies, it is net-negative versus the legacy path it replaced.
+
+This finding is not "IR-first is wrong." It is: **the roadmap's own
+program-level success criterion ("Runtime DDL, Alembic adapter, and migration
+planner consume the same IR artifacts") and decision principle ("One source of
+truth: no parallel emitters that independently derive schema semantics") are not
+yet met for the schema domain, and no existing phase explicitly closes that
+gap.** Phase 9 removes the legacy *planner*; it does not, as written, unify the
+type-lowering encoders or collapse the dual SchemaIR producers.
+
+## Findings (with evidence)
+
+### 1. The type system is encoded in ~5 parallel places
+
+The whole value of an IR + a shared lowering crate is *one* place that maps a
+Ferro type to a `db_type`/SQL spelling. There are currently at least five:
+
+1. `src/schema.rs:139` — its own `CanonicalType` enum + `canonical_column_type` +
+   `canonical_to_db_type_token` (`:163`). This is the **runtime CREATE path**.
+2. `crates/ferro-ddl-lowering/src/lib.rs:20` — a *second* `CanonicalType` enum +
+   token mapping. This is the **runtime ALTER (migrate) path**.
+3. `src/migrate.rs` legacy — verbatim re-implementations of helpers that already
+   live in `ferro-ddl-lowering`: `pg_alter_type_target` (`:312`),
+   `sqlite_declared_type` (`:336`), `sqlite_type_class` (`:373`),
+   `single_unique_index_name` (`:405`), `fk_action_sql` (`:413`),
+   `literal_default_value` (`:425`).
+4. Python `src/ferro/ir/compiler.py:102` — `_default_db_type` / `_logical_type`.
+5. Python `src/ferro/migrations/alembic.py:438` — `_db_type_to_sa_type`; the
+   comment at `:435` literally says *"Duplicated on the Rust side."*
+
+`src/schema.rs` imports nothing from `ferro-ddl-lowering` (verified). The crate
+that was created to be "shared across Ferro emitters" is used by only one of the
+two Rust emitters.
+
+### 2. SchemaIR has two independent producers (split brain)
+
+- Python `compile_schema_ir_payload` (`src/ferro/ir/compiler.py:253`) builds a
+  SchemaIR, persists it to `ferro.state`, and fingerprints it. Its only consumer
+  is the **Alembic** bridge (`get_metadata()`).
+- The **runtime auto-migrate** path does **not** consume that artifact. It
+  rebuilds its own SchemaIR in Rust from the enriched JSON schema via
+  `schema_json_to_schema_ir` (`src/migrate.rs:116`) and
+  `live_columns_to_schema_ir` (`:214`).
+
+So "the canonical SchemaIR" is compiled twice, by two different
+implementations, and kept in agreement only by behavioral tests — the opposite
+of a single source of truth. Contrast the Query path, where Python is the sole
+IR producer and Rust consumes it.
+
+### 3. The runtime CREATE emitter consumes no IR at all
+
+The invariant "an auto-migrated database matches a freshly created one"
+(AGENTS.md I-1) is currently a **tested coincidence, not a structural
+guarantee**. CREATE (`src/schema.rs`) and ALTER (`ferro-migrate` via
+`ferro-ddl-lowering`) use two different `CanonicalType` systems; they agree only
+because `tests/test_cross_emitter_parity.py` and
+`tests/test_db_type_cross_emitter_parity.py` assert it, and those tests must be
+*manually* extended for every new feature (the suite says so in its own
+docstring). Shared code would make whole categories of drift impossible instead
+of merely detectable.
+
+### 4. The IR's `db_type` field is not authoritative
+
+`ir/compiler.py:102` sets a bare integer's `db_type` to `"bigint"`, but the only
+consumer (`alembic.py:_sa_type_from_ir_column`, `:196`) ignores `db_type` for
+non-explicit columns and re-derives from `logical_type` → `sa.Integer()`.
+Meanwhile the Rust create path maps integer → `int`. The IR therefore carries a
+field value that disagrees with what every emitter actually does. It is masked
+today (Alembic ignores it), but it means the IR is something emitters *re-derive
+around* rather than obey.
+
+### 5. The runtime migrate IR under-populates what the IR can express
+
+`schema_json_to_schema_ir` hardcodes `indexes: []` and `uniques: []`
+(`src/migrate.rs:206-207`) and only emits single-column checks, even though
+`SchemaIrPayload` models composite indexes/uniques/checks and the Python
+compiler fills them in. There is a capability gap between what the contract can
+express and what the runtime consumer populates — composite-constraint changes
+are not planned by the runtime migrate path.
+
+### 6. Codec IR (the wire contract) is unwired
+
+`CodecIrPayload` / `CodecBindRule` / `CodecFetchRule` / `HydrationAbi` exist as
+types plus one conformance fixture
+(`tests/fixtures/ir_vectors/codec_registry_core_v1.json`) with **zero runtime
+consumers** on either side. (This is distinct from the Phase 5 runtime codec
+*registry* in `src/codec.rs`, which is genuinely unified — the *behavior* is
+centralized; the *IR envelope* for codec is fixture-only.) Fine as a roadmap
+stub, but it widens the versioned contract surface for no current behavior.
+
+### 7. The parity gate is a maintenance tax, justified only if short-lived
+
+Keeping `plan_table_migration` (`src/migrate.rs:451`) and
+`plan_table_migration_legacy` (`:510`) byte-identical across `statements`,
+`drop_columns`, and `warnings` (`shadow_compare_migration_plan`, `:576`) means
+every change lands in two planners and must be proven equal. This is exactly the
+"best-effort / transitional scaffolding" that AGENTS.md I-6 ("No stop-gap
+solutions") warns against. It is a sound *cutover* instrument; it is a liability
+as a steady state.
+
+## What is genuinely working (keep these)
+
+- **Query IR is real and clean.** `src/ferro/query/builder.py` emits a versioned
+  envelope (`ir_kind:"query"`); `src/operations.rs:209` deserializes
+  `IrEnvelope<QueryIrPayload>`; `src/query.rs` lowers it. An honest Python→Rust
+  contract — the proof the architecture works.
+- **Versioned envelopes** (`ir_kind`/`ir_version`) + **fingerprints** + **golden
+  vectors** (`tests/fixtures/ir_vectors/`) give real wire-stability and
+  cross-language testability.
+- **`ferro-ddl-lowering` is a good unit** — pure functions, minimal deps
+  (serde + sea-query), canonical tokens + naming helpers + drift detection,
+  well unit-tested. It is the right home for "the rules" — it just needs to be
+  *the* home.
+- **Cutover discipline is good** — shadow comparison, env-gated strict mode
+  (`FERRO_SHADOW_RUNTIME_STRICT`), IR-native unit tests in `ferro-migrate`, and
+  a behavioral parity test that bootstraps a real DB via Rust and asserts an
+  empty Alembic autogenerate diff.
+
+## Remediation plan (the "collapse")
+
+In priority order. These are the deliverables proposed as **Phase 8.5** in the
+roadmap (gating Phase 9 shim removal).
+
+1. **Make `ferro-ddl-lowering` the one lowering library; have `src/schema.rs`
+   consume it.** Delete schema.rs's private `CanonicalType` and route the CREATE
+   path through the shared crate. This is the keystone — it turns I-1 from a
+   tested coincidence into a structural guarantee and finally justifies the
+   crate's existence. (Removes encoder #1's overlap with #2.)
+2. **Produce SchemaIR in exactly one place.** Prefer the Query model: Python
+   compiles the canonical SchemaIR once (it already does), passes it over FFI,
+   and Rust consumes it for *both* migrate and create — instead of Rust
+   re-deriving via `schema_json_to_schema_ir`. (Collapses producers in finding #2.)
+3. **Delete the duplicated helpers in `src/migrate.rs`** (finding #1, item 3)
+   once the legacy planner is gone, and put a hard removal date on the legacy
+   planner + parity gate. A parity gate is a cutover tool, not an architecture.
+4. **Make `db_type` authoritative or drop it for non-explicit columns**
+   (finding #4). Carrying a value no emitter honors invites the drift the IR
+   exists to prevent.
+5. **Populate composite indexes/uniques in the runtime migrate IR, or document
+   the deliberate scope cut** (finding #5).
+6. **Defer Codec IR wiring until it has a consumer** (finding #6) — do not carry
+   a versioned contract domain with no runtime behavior.
+
+## What is missing (capabilities the IR could unlock but doesn't yet)
+
+- **Shared lowering in the CREATE path** — the single highest-value gap.
+- **A single SchemaIR producer** — currently two.
+- **A structural (not test-only) emitter-agreement guarantee.**
+- **A migration artifact / history.** This is a live-diff auto-migrator
+  (introspect → diff → execute immediately, statement by statement; a mid-run
+  failure leaves partial DDL, with only a pool refresh + identity-map clear at
+  the end). The IR is perfectly positioned to enable a serialized, replayable,
+  transactional `MigrationPlan` artifact — the obvious capability it unlocks and
+  is not yet cashing in.
+- **Native-enum reconciliation** is deferred to Alembic (`postgres_native_enum`
+  short-circuit) — a known gap.
+
+## Why this matters
+
+- A second roadmap or a parallel "source of truth" would reproduce the exact
+  failure mode this audit criticizes. The fix is **fewer** encoders, not more
+  documents — and the same logic applies to docs: this audit amends the existing
+  roadmap rather than competing with it.
+- "Worth it" is conditional. Stopping at the current state leaves five type
+  encoders kept in sync by manually-maintained tests — more fragile than the
+  single legacy path it replaced. Finishing the collapse delivers the
+  drift-proof architecture the program promised.
+
+## When to apply
+
+- **Before Phase 9 shim removal** — do not delete the legacy planner while the IR
+  path still has a split-brain producer and the CREATE path still diverges.
+- **When adding any schema feature** — if the change must be made in more than one
+  type-lowering encoder, that is finding #1 biting; route through
+  `ferro-ddl-lowering` instead.
+- **When a phase gate claims "unify X across paths"** — grep for parallel
+  derivations and verify the agreement is structural, not just asserted by tests.
+
+## Related
+
+- [`2026-06-19-001-ir-first-roadmap.md`](../../plans/2026-06-19-001-ir-first-roadmap.md) — amended with **Phase 8.5** for this work
+- [`ir-first-merge-readiness-review.md`](./ir-first-merge-readiness-review.md) — prior point-in-time review (this audit is the structural follow-up)
+- [`ir-invariants.md`](../patterns/ir-invariants.md) — Invariant I (cross-emitter parity) this audit shows is test-enforced, not yet structural
+- [`cross-emitter-ddl-parity.md`](../patterns/cross-emitter-ddl-parity.md) — the parity recipes that currently substitute for shared code
+- [`docs/pages/concepts/architecture.md`](../../pages/concepts/architecture.md) — two-pipeline model; carries a status note pointing here

--- a/docs/solutions/architecture-patterns/ir-first-merge-readiness-review.md
+++ b/docs/solutions/architecture-patterns/ir-first-merge-readiness-review.md
@@ -225,6 +225,7 @@ FFI per `await` as QueryIR inside an active `engines.session()`.
 
 ## Related
 
+- [`ir-first-lowering-consolidation-audit.md`](./ir-first-lowering-consolidation-audit.md) — **structural follow-up (2026-06-26):** this point-in-time review noted runtime `auto_migrate` legacy execution as accepted residual risk; the audit shows the deeper unmet "single source of truth" gap (parallel type encoders, dual SchemaIR producers, CREATE path not on shared lowering) and tracks the fix as roadmap Phase 8.5
 - [`ir-invariants.md`](../patterns/ir-invariants.md) — invariant contract the review validates
 - [`cross-emitter-ddl-parity.md`](../patterns/cross-emitter-ddl-parity.md) — concrete parity symptoms/recipes
 - [`typed-null-binds.md`](../patterns/typed-null-binds.md) — CodecIR/bind enforcement


### PR DESCRIPTION
## What

Docs-only. Captures a code-grounded architecture audit of the IR-first program and turns its findings into tracked roadmap work, plus corrects doc-vs-reality drift surfaced along the way.

## Why

An end-to-end read of the IR stack found that the schema/DDL domain is **not yet single-sourced** — the property the roadmap sets as a success criterion:

- The runtime CREATE emitter (`src/schema.rs`) keeps its own `CanonicalType` and consumes **no** IR; it shares no code with `ferro-ddl-lowering`.
- SchemaIR is compiled by **two** independent producers: Python `compile_schema_ir_payload` (feeds Alembic) and Rust `schema_json_to_schema_ir` (feeds runtime migrate).
- The type system is encoded in **~5 parallel places**, so cross-emitter parity (AGENTS.md I-1) is currently **test-enforced, not structural**.

The IR direction is right (the Query IR slice proves it end-to-end), but it pays off only if the consolidation is finished. Phase 9 removes the legacy *planner*; it does not close this gap — hence **Phase 8.5**.

## Changes

- **New:** `docs/solutions/architecture-patterns/ir-first-lowering-consolidation-audit.md` — the audit (verdict, findings with `file:line` evidence, remediation/collapse plan, what's missing).
- **Roadmap:** correct the overclaimed Phase 8 consolidation deliverable (`[x]` → `[~]`); insert **Phase 8.5** (lowering consolidation & single-source-of-truth closeout, gating Phase 9); risk-register + progress-log entries; correct the stale branching policy (`feat/ir-first` retired, `main` is the trunk).
- **`architecture.md`:** fix the `SchemaIR --> Migrate` edge and the "canonical contract" / "migration planning consumes SchemaIR" claims to reflect that runtime emitters currently re-derive their own lowering.
- **`migrating-to-v0-12-0.md`:** soften the "derive from the same IR" mechanism claim (parity is held by tests) while keeping the true user-facing outcome (no phantom diffs).
- **`merge-readiness-review.md`:** forward-link to the audit as its structural follow-up.

## Follow-up

Phase 8.5 epic + sub-issues to be filed and back-linked into the roadmap's "Issue references" (currently `to be filed`).

No code changes; no behavior change.