### PR TITLE
feat(schema): single lowering library — route CREATE through ferro-ddl-lowering (#140)

### DIFF
--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -145,6 +145,33 @@ pub fn db_type_token_to_canonical(token: &str, dialect: Dialect) -> Option<Canon
     }
 }
 
+/// Map a resolved [`CanonicalType`] back to the canonical Ferro `db_type` token
+/// vocabulary used in SchemaIR and cross-emitter parity tests.
+pub fn canonical_to_db_type_token(canonical: CanonicalType, dialect: Dialect) -> String {
+    match canonical {
+        CanonicalType::Integer => "int".to_string(),
+        CanonicalType::SmallInt => "smallint".to_string(),
+        CanonicalType::BigInt => "bigint".to_string(),
+        CanonicalType::Double => "double".to_string(),
+        CanonicalType::Decimal => "numeric".to_string(),
+        CanonicalType::Boolean => "boolean".to_string(),
+        CanonicalType::Json => "json".to_string(),
+        CanonicalType::Text => "text".to_string(),
+        CanonicalType::Varchar(None) => "varchar".to_string(),
+        CanonicalType::Varchar(Some(n)) => format!("varchar({n})"),
+        CanonicalType::Char(n) => match (dialect, n) {
+            (Dialect::Sqlite, 32) => "uuid".to_string(),
+            _ => format!("char({n})"),
+        },
+        CanonicalType::Uuid => "uuid".to_string(),
+        CanonicalType::DateTime | CanonicalType::Timestamp => "timestamp".to_string(),
+        CanonicalType::TimestampTz => "timestamptz".to_string(),
+        CanonicalType::Date => "date".to_string(),
+        CanonicalType::Time => "time".to_string(),
+        CanonicalType::Blob => "bytea".to_string(),
+    }
+}
+
 /// Map `information_schema.columns` spellings to the canonical Ferro `db_type` token
 /// vocabulary (mirrors legacy `pg_type_matches` / sqlite storage classes).
 pub fn information_schema_to_db_type_token(
@@ -213,15 +240,19 @@ pub fn schema_columns_storage_drift(
     }
 }
 
-/// Resolve a [`SchemaColumn`] to its canonical storage type.
-pub fn canonical_from_schema_column(
-    col: &SchemaColumn,
+/// Resolve a model property's `(logical_type, format, db_type)` to a canonical
+/// type. A recognized `db_type` token wins; otherwise the logical-type + format
+/// cascade decides. An empty/unrecognized `db_type` falls through.
+pub fn canonical_from_parts(
+    logical_type: &str,
+    format: Option<&str>,
+    db_type: &str,
     dialect: Dialect,
 ) -> Result<CanonicalType, String> {
-    if let Some(canonical) = db_type_token_to_canonical(&col.db_type, dialect) {
+    if let Some(canonical) = db_type_token_to_canonical(db_type, dialect) {
         return Ok(canonical);
     }
-    match (col.logical_type.as_str(), col.format.as_deref()) {
+    match (logical_type, format) {
         ("string", Some("date-time")) => Ok(CanonicalType::TimestampTz),
         ("string", Some("date")) => Ok(CanonicalType::Date),
         ("string", Some("uuid")) => Ok(CanonicalType::Uuid),
@@ -235,11 +266,17 @@ pub fn canonical_from_schema_column(
             Dialect::Postgres => CanonicalType::Boolean,
         }),
         ("object" | "array", _) => Ok(CanonicalType::Json),
-        _ => Err(format!(
-            "unknown db_type '{}' on column '{}'",
-            col.db_type, col.name
-        )),
+        _ => Err(format!("unknown logical_type '{logical_type}'")),
     }
+}
+
+/// Resolve a [`SchemaColumn`] to its canonical storage type.
+pub fn canonical_from_schema_column(
+    col: &SchemaColumn,
+    dialect: Dialect,
+) -> Result<CanonicalType, String> {
+    canonical_from_parts(&col.logical_type, col.format.as_deref(), &col.db_type, dialect)
+        .map_err(|_| format!("unknown db_type '{}' on column '{}'", col.db_type, col.name))
 }
 
 /// Single-column index name (`idx_<table>_<col>`).
@@ -508,5 +545,24 @@ mod tests {
         let old = drift_col("created_at", "timestamp");
         let new = drift_col("created_at", "timestamptz");
         assert!(schema_columns_storage_drift(&old, &new, Dialect::Postgres));
+    }
+
+    #[test]
+    fn canonical_to_db_type_token_roundtrips_core_tokens() {
+        assert_eq!(canonical_to_db_type_token(CanonicalType::Integer, Dialect::Postgres), "int");
+        assert_eq!(canonical_to_db_type_token(CanonicalType::Char(32), Dialect::Sqlite), "uuid");
+        assert_eq!(canonical_to_db_type_token(CanonicalType::Char(10), Dialect::Sqlite), "char(10)");
+        assert_eq!(canonical_to_db_type_token(CanonicalType::TimestampTz, Dialect::Postgres), "timestamptz");
+    }
+
+    #[test]
+    fn canonical_from_parts_matches_schema_column_path() {
+        // db_type wins
+        assert_eq!(canonical_from_parts("string", None, "bigint", Dialect::Postgres), Ok(CanonicalType::BigInt));
+        // fallback to logical_type/format
+        assert_eq!(canonical_from_parts("string", Some("date-time"), "", Dialect::Postgres), Ok(CanonicalType::TimestampTz));
+        assert_eq!(canonical_from_parts("integer", None, "", Dialect::Sqlite), Ok(CanonicalType::Integer));
+        // unknown is an error (CREATE path maps this to Varchar at its call site)
+        assert!(canonical_from_parts("mystery", None, "", Dialect::Postgres).is_err());
     }
 }

--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -256,6 +256,9 @@ pub fn canonical_from_parts(
         ("string", Some("date-time")) => Ok(CanonicalType::TimestampTz),
         ("string", Some("date")) => Ok(CanonicalType::Date),
         ("string", Some("uuid")) => Ok(CanonicalType::Uuid),
+        // `format = "decimal"` is only ever emitted alongside a concrete logical
+        // type (see src/ferro/schema_metadata.py), so `(None, Some("decimal"))`
+        // never arises from a real model — this broad arm is safe.
         (_, Some("decimal")) => Ok(CanonicalType::Decimal),
         ("string", Some("binary")) => Ok(CanonicalType::Blob),
         ("integer", _) => Ok(CanonicalType::Integer),
@@ -553,6 +556,8 @@ mod tests {
         assert_eq!(canonical_to_db_type_token(CanonicalType::Char(32), Dialect::Sqlite), "uuid");
         assert_eq!(canonical_to_db_type_token(CanonicalType::Char(10), Dialect::Sqlite), "char(10)");
         assert_eq!(canonical_to_db_type_token(CanonicalType::TimestampTz, Dialect::Postgres), "timestamptz");
+        assert_eq!(canonical_to_db_type_token(CanonicalType::DateTime, Dialect::Postgres), "timestamp");
+        assert_eq!(canonical_to_db_type_token(CanonicalType::Char(32), Dialect::Postgres), "char(32)");
     }
 
     #[test]

--- a/docs/brainstorms/2026-06-26-ir-p8.5-140-shared-lowering-requirements.md
+++ b/docs/brainstorms/2026-06-26-ir-p8.5-140-shared-lowering-requirements.md
@@ -1,0 +1,111 @@
+---
+title: "IR-P8.5 #140 — ferro-ddl-lowering as the single lowering library"
+type: requirements
+status: draft
+date: 2026-06-26
+issue: https://github.com/syn54x/ferro-orm/issues/140
+epic: https://github.com/syn54x/ferro-orm/issues/139
+roadmap: docs/plans/2026-06-19-001-ir-first-roadmap.md (Phase 8.5)
+---
+
+# #140 — `ferro-ddl-lowering` as the single lowering library
+
+## Goal
+
+Make `ferro-ddl-lowering` the sole owner of canonical-type lowering and route the
+runtime CREATE path (`src/schema.rs`) through it, deleting `schema.rs`'s parallel
+`CanonicalType` and its mappers. This turns cross-emitter DDL parity (AGENTS.md
+I-1) from a *tested coincidence* into a *structural guarantee* for the type
+system.
+
+**This is a behavior-preserving refactor. It must emit byte-identical DDL on both
+backends.** The whole correctness argument is "the existing parity/auto-migrate
+suites stay green, plus one new characterization test for the single semantic
+seam."
+
+## Non-goals (explicitly out of scope)
+
+- Single SchemaIR *producer* over FFI — #141.
+- Removing the duplicated alter-helpers in `src/migrate.rs` — #142 / Phase 9.
+- `db_type` authority for non-explicit columns — #143.
+- Composite indexes/uniques in the runtime migrate IR — #144.
+- Unifying the three dialect enums — #146 (Phase 8.6).
+
+## Current state (the duplication, confirmed on `main`)
+
+`src/schema.rs` (CREATE path) imports **nothing** from `ferro-ddl-lowering` and
+carries its own:
+- `CanonicalType` (`:139`) — byte-identical variant set to the crate's.
+- `apply_canonical_type` (`:188`), `canonical_to_db_type_token` (`:163`),
+  `db_type_token_to_canonical` (`:350`).
+- `canonical_column_type` (`:383`) + `json_type_to_canonical` — the raw-JSON →
+  canonical mapper.
+
+`ferro-ddl-lowering` already owns: `CanonicalType`, `apply_canonical_type`,
+`db_type_token_to_canonical`, `canonical_from_schema_column` (the
+`SchemaColumn` → canonical mapper), and the naming/alter helpers. It is missing
+only `canonical_to_db_type_token` and a JSON → canonical entrypoint.
+
+> Note: `canonical_to_db_type_token` is currently consumed by **both** paths —
+> `src/migrate.rs` imports it via `crate::schema::canonical_to_db_type_token`. So
+> moving it into the crate cleans up the migrate side too.
+
+## The change (Approach 1: one mapper)
+
+1. **Move** `canonical_to_db_type_token` into `ferro-ddl-lowering`. Update the two
+   call sites (`schema.rs`, `migrate.rs`) to import it from the crate.
+2. **Delete** `schema.rs`'s `CanonicalType`, `apply_canonical_type`,
+   `db_type_token_to_canonical`, `json_type_to_canonical`; import the crate's
+   instead.
+3. **Replace** `schema.rs`'s `canonical_column_type` with a call to the crate's
+   `canonical_from_schema_column`. `build_column_plan` extracts
+   `(logical_type, format, db_type)` from the JSON, builds a minimal
+   `SchemaColumn`, and lowers through the crate. One JSON → canonical path, shared
+   by CREATE and migrate.
+4. **Dialect seam:** add a small `SqlDialect → ferro_ddl_lowering::Dialect`
+   conversion in `schema.rs` (mirroring the existing `backend_dialect` /
+   `lowering_dialect` helpers). Translate at the call boundary; do **not** unify
+   the dialect enums here (that is #146).
+
+## The semantic seams (where behavior could drift)
+
+These are the only places the two mappers differ; each must be preserved:
+
+1. **Unknown `logical_type`.** `canonical_from_schema_column` returns `Err`;
+   `canonical_column_type` defaults to `Varchar(None)`. To preserve CREATE
+   behavior, the call site maps `Err → Varchar(None)`. Covered by a new
+   characterization test.
+2. **Implicit `db_type`.** `canonical_column_type` only consults `db_type` when
+   the field sets it explicitly. The `SchemaColumn` we build must therefore carry
+   `db_type = <explicit value>` or `""` (empty), so
+   `db_type_token_to_canonical("")` returns `None` and the mapper falls through to
+   `(logical_type, format)` — matching today's precedence exactly.
+3. **`format = "decimal"`.** The crate matches `(_, Some("decimal")) => Decimal`
+   regardless of type; `schema.rs` requires a concrete type. Equivalent for all
+   real inputs; the parity suite guards it.
+
+## Testing / validation
+
+Existing safety net (must stay green, unchanged):
+- `tests/test_cross_emitter_parity.py`, `tests/test_db_type_cross_emitter_parity.py`
+- Rust unit tests in `ferro-ddl-lowering`, `ferro-migrate`, and `src/schema.rs`
+- IR-vs-legacy migrate parity + runtime shadow compare (`src/migrate.rs`)
+
+New:
+- A Rust characterization test for the unknown-`logical_type` → `Varchar(None)`
+  fallback (seam #1) so the `Err`-mapping is pinned.
+
+**Done =** `cargo test` (workspace) green + the full cross-emitter / auto-migrate
+pytest matrix green on **SQLite and Postgres**, with zero emitted-DDL diffs.
+
+## Risk
+
+The refactor is mechanical but touches the most-exercised DDL path. The risk is a
+subtle canonical/`db_type` mismatch on an edge type. Mitigation: the three seams
+above are explicitly preserved, the parity/auto-migrate matrix is the gate, and
+the change emits no new SQL spellings by construction (same crate functions the
+migrate path already uses).
+
+## Migration impact
+
+`none` — internal; no user-facing API or behavior change.

--- a/docs/plans/2026-06-26-001-feat-ir-p8.5-140-shared-lowering-plan.md
+++ b/docs/plans/2026-06-26-001-feat-ir-p8.5-140-shared-lowering-plan.md
@@ -1,0 +1,311 @@
+# #140 — `ferro-ddl-lowering` as the Single Lowering Library — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ferro-ddl-lowering` the sole owner of canonical-type lowering and route the runtime CREATE path (`src/schema.rs`) through it, deleting `schema.rs`'s parallel `CanonicalType` and mappers — with zero change to emitted DDL.
+
+**Architecture:** `ferro-ddl-lowering` gains the two pieces it lacks (`canonical_to_db_type_token`, a parts-based JSON→canonical mapper). `src/schema.rs` and `src/migrate.rs` import all canonical lowering from the crate; `schema.rs` deletes its copies and keeps only a thin JSON-adapter that delegates to the crate. Dialects are translated at the call seam (`SqlDialect → ferro_ddl_lowering::Dialect`).
+
+**Tech Stack:** Rust (workspace crates: `_core` main + `ferro-ddl-lowering`, `ferro-migrate`, `ferro-schema-ir`), PyO3, sea-query; Python test matrix via `uv run pytest`.
+
+## Global Constraints
+
+- **Behavior-preserving.** No emitted-DDL change on SQLite or Postgres. The gate is the existing parity/auto-migrate suites staying green (Task 4), plus one new characterization test.
+- **Rust edition 2024.** Match surrounding style; no new dependencies.
+- **The two `CanonicalType` enums are byte-identical** (verified) — variant names match, so the 78 `schema.rs` / 41 `migrate.rs` references resolve unchanged once the import flips.
+- **Four semantic seams** must be preserved (see Task 3): unknown `logical_type` → `Varchar(None)`; implicit `db_type` falls through (pass `""`); `format="decimal"`; and the crate's `db_type_token_to_canonical` being a *superset* of `schema.rs`'s (verified equivalent for validated combos by the per-token parity test in Task 4).
+- **Test commands:** Rust main-crate tests need `--no-default-features --features testing` (PyO3 auto-init). Crate tests run plain.
+
+---
+
+### Task 1: Extend `ferro-ddl-lowering` (additive)
+
+**Files:**
+- Modify: `crates/ferro-ddl-lowering/src/lib.rs` (add two `pub fn`; refactor `canonical_from_schema_column` at `:217`)
+- Test: `crates/ferro-ddl-lowering/src/lib.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces: `pub fn canonical_to_db_type_token(canonical: CanonicalType, dialect: Dialect) -> String`
+- Produces: `pub fn canonical_from_parts(logical_type: &str, format: Option<&str>, db_type: &str, dialect: Dialect) -> Result<CanonicalType, String>`
+- `canonical_from_schema_column` keeps its existing signature, now delegating.
+
+- [ ] **Step 1: Add `canonical_to_db_type_token`** (moved verbatim from `schema.rs:163`, `SqlDialect`→`Dialect`). Insert after `db_type_token_to_canonical` (`:146`):
+
+```rust
+/// Map a resolved [`CanonicalType`] back to the canonical Ferro `db_type` token
+/// vocabulary used in SchemaIR and cross-emitter parity tests.
+pub fn canonical_to_db_type_token(canonical: CanonicalType, dialect: Dialect) -> String {
+    match canonical {
+        CanonicalType::Integer => "int".to_string(),
+        CanonicalType::SmallInt => "smallint".to_string(),
+        CanonicalType::BigInt => "bigint".to_string(),
+        CanonicalType::Double => "double".to_string(),
+        CanonicalType::Decimal => "numeric".to_string(),
+        CanonicalType::Boolean => "boolean".to_string(),
+        CanonicalType::Json => "json".to_string(),
+        CanonicalType::Text => "text".to_string(),
+        CanonicalType::Varchar(None) => "varchar".to_string(),
+        CanonicalType::Varchar(Some(n)) => format!("varchar({n})"),
+        CanonicalType::Char(n) => match (dialect, n) {
+            (Dialect::Sqlite, 32) => "uuid".to_string(),
+            _ => format!("char({n})"),
+        },
+        CanonicalType::Uuid => "uuid".to_string(),
+        CanonicalType::DateTime | CanonicalType::Timestamp => "timestamp".to_string(),
+        CanonicalType::TimestampTz => "timestamptz".to_string(),
+        CanonicalType::Date => "date".to_string(),
+        CanonicalType::Time => "time".to_string(),
+        CanonicalType::Blob => "bytea".to_string(),
+    }
+}
+```
+
+- [ ] **Step 2: Add `canonical_from_parts` and delegate `canonical_from_schema_column` to it.** Replace the body of `canonical_from_schema_column` (`:217-243`) with:
+
+```rust
+/// Resolve a model property's `(logical_type, format, db_type)` to a canonical
+/// type. A recognized `db_type` token wins; otherwise the logical-type + format
+/// cascade decides. An empty/unrecognized `db_type` falls through.
+pub fn canonical_from_parts(
+    logical_type: &str,
+    format: Option<&str>,
+    db_type: &str,
+    dialect: Dialect,
+) -> Result<CanonicalType, String> {
+    if let Some(canonical) = db_type_token_to_canonical(db_type, dialect) {
+        return Ok(canonical);
+    }
+    match (logical_type, format) {
+        ("string", Some("date-time")) => Ok(CanonicalType::TimestampTz),
+        ("string", Some("date")) => Ok(CanonicalType::Date),
+        ("string", Some("uuid")) => Ok(CanonicalType::Uuid),
+        (_, Some("decimal")) => Ok(CanonicalType::Decimal),
+        ("string", Some("binary")) => Ok(CanonicalType::Blob),
+        ("integer", _) => Ok(CanonicalType::Integer),
+        ("string", _) => Ok(CanonicalType::Varchar(None)),
+        ("number", _) => Ok(CanonicalType::Double),
+        ("boolean", _) => Ok(match dialect {
+            Dialect::Sqlite => CanonicalType::Integer,
+            Dialect::Postgres => CanonicalType::Boolean,
+        }),
+        ("object" | "array", _) => Ok(CanonicalType::Json),
+        _ => Err(format!("unknown logical_type '{logical_type}'")),
+    }
+}
+
+/// Resolve a [`SchemaColumn`] to its canonical storage type.
+pub fn canonical_from_schema_column(
+    col: &SchemaColumn,
+    dialect: Dialect,
+) -> Result<CanonicalType, String> {
+    canonical_from_parts(&col.logical_type, col.format.as_deref(), &col.db_type, dialect)
+        .map_err(|_| format!("unknown db_type '{}' on column '{}'", col.db_type, col.name))
+}
+```
+
+- [ ] **Step 3: Add crate unit tests** in the existing `mod tests`:
+
+```rust
+#[test]
+fn canonical_to_db_type_token_roundtrips_core_tokens() {
+    assert_eq!(canonical_to_db_type_token(CanonicalType::Integer, Dialect::Postgres), "int");
+    assert_eq!(canonical_to_db_type_token(CanonicalType::Char(32), Dialect::Sqlite), "uuid");
+    assert_eq!(canonical_to_db_type_token(CanonicalType::Char(10), Dialect::Sqlite), "char(10)");
+    assert_eq!(canonical_to_db_type_token(CanonicalType::TimestampTz, Dialect::Postgres), "timestamptz");
+}
+
+#[test]
+fn canonical_from_parts_matches_schema_column_path() {
+    // db_type wins
+    assert_eq!(canonical_from_parts("string", None, "bigint", Dialect::Postgres), Ok(CanonicalType::BigInt));
+    // fallback to logical_type/format
+    assert_eq!(canonical_from_parts("string", Some("date-time"), "", Dialect::Postgres), Ok(CanonicalType::TimestampTz));
+    assert_eq!(canonical_from_parts("integer", None, "", Dialect::Sqlite), Ok(CanonicalType::Integer));
+    // unknown is an error (CREATE path maps this to Varchar at its call site)
+    assert!(canonical_from_parts("mystery", None, "", Dialect::Postgres).is_err());
+}
+```
+
+- [ ] **Step 4: Build + test the crate**
+
+Run: `cargo test -p ferro-ddl-lowering`
+Expected: PASS (all existing + 2 new tests). Crate compiles; no callers changed yet.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ferro-ddl-lowering/src/lib.rs
+git commit -m "feat(ddl-lowering): add canonical_to_db_type_token + canonical_from_parts (#140)"
+```
+
+---
+
+### Task 2: Pin the CREATE-path unknown-type behavior (characterization test)
+
+**Files:**
+- Test: `src/schema.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: `canonical_column_type(raw, resolved, backend) -> CanonicalType` (still the current `schema.rs` version at this point)
+
+This test passes on **current** code and must still pass after Task 3 — it locks the `Err → Varchar(None)` seam.
+
+- [ ] **Step 1: Add the characterization test** to `src/schema.rs` tests:
+
+```rust
+#[test]
+fn canonical_column_type_unknown_and_missing_type_fall_back_to_varchar() {
+    let unknown = serde_json::json!({ "type": "mystery" });
+    assert_eq!(
+        canonical_column_type(&unknown, &unknown, SqlDialect::Postgres),
+        CanonicalType::Varchar(None)
+    );
+    let no_type = serde_json::json!({});
+    assert_eq!(
+        canonical_column_type(&no_type, &no_type, SqlDialect::Sqlite),
+        CanonicalType::Varchar(None)
+    );
+}
+```
+
+- [ ] **Step 2: Run it against current code**
+
+Run: `cargo test --no-default-features --features testing canonical_column_type_unknown`
+Expected: PASS (pins existing behavior before the refactor).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/schema.rs
+git commit -m "test(schema): pin CREATE-path unknown-type -> varchar fallback (#140)"
+```
+
+---
+
+### Task 3: Flip `schema.rs` and `migrate.rs` onto the crate
+
+This is one atomic change: deleting `schema.rs`'s `CanonicalType` breaks `migrate.rs`'s import simultaneously, so both move together to keep `cargo build` green.
+
+**Files:**
+- Modify: `src/schema.rs` — delete `CanonicalType` (`:139-159`), `canonical_to_db_type_token` (`:163-186`), `apply_canonical_type` (`:188-246`), `json_type_to_canonical` (`:247-260`), `db_type_token_to_canonical` (`:350-376`); rewrite `canonical_column_type` (`:383-408`) as an adapter; add a dialect helper + imports.
+- Modify: `src/migrate.rs:29-33` — re-point three symbols to the crate.
+
+**Interfaces:**
+- Consumes (from Task 1): `ferro_ddl_lowering::{CanonicalType, apply_canonical_type, db_type_token_to_canonical, canonical_to_db_type_token, canonical_from_parts, Dialect}`
+- Produces: `canonical_column_type` keeps its `pub(crate)` signature (now an adapter); call sites at `schema.rs:531` and `:1144` are unchanged.
+
+- [ ] **Step 1: Update `src/schema.rs` imports.** Add to the `use` block (top of file, after `:7`):
+
+```rust
+use ferro_ddl_lowering::{
+    CanonicalType, Dialect, apply_canonical_type, canonical_from_parts,
+    canonical_to_db_type_token, db_type_token_to_canonical,
+};
+```
+
+- [ ] **Step 2: Delete the five duplicated definitions** from `src/schema.rs`: the `enum CanonicalType` (`:139-159`), `canonical_to_db_type_token` (`:163-186`), `apply_canonical_type` (`:188-246`), `json_type_to_canonical` (`:247-260`), and `db_type_token_to_canonical` (`:350-376`). (`parse_varchar_token` at `:336` is also now unused in this file — delete it too; the crate has its own.)
+
+- [ ] **Step 3: Add the dialect-seam helper** near the top of `src/schema.rs` (after the imports):
+
+```rust
+/// Translate the runtime backend tag to the lowering crate's dialect at the call seam.
+/// (Unifying these enums is tracked separately as #146 / Phase 8.6.)
+fn sql_dialect_to_lowering(backend: SqlDialect) -> Dialect {
+    match backend {
+        SqlDialect::Sqlite => Dialect::Sqlite,
+        SqlDialect::Postgres => Dialect::Postgres,
+    }
+}
+```
+
+- [ ] **Step 4: Rewrite `canonical_column_type`** as a thin adapter delegating to the crate (preserves all four seams):
+
+```rust
+/// Resolve a model property to its backend-specific [`CanonicalType`] via the
+/// shared lowering crate. `db_type` (when set) wins; otherwise the Pydantic
+/// JSON type/format cascade decides; unknown types fall back to `varchar`.
+pub(crate) fn canonical_column_type(
+    raw_col_info: &serde_json::Value,
+    resolved_col_info: &serde_json::Value,
+    backend: SqlDialect,
+) -> CanonicalType {
+    let db_type = raw_col_info
+        .get("db_type")
+        .or_else(|| resolved_col_info.get("db_type"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let (json_type, format) = property_json_type_and_format(resolved_col_info);
+    canonical_from_parts(json_type.unwrap_or(""), format, db_type, sql_dialect_to_lowering(backend))
+        .unwrap_or(CanonicalType::Varchar(None))
+}
+```
+
+- [ ] **Step 5: Re-point `src/migrate.rs` imports.** Change the `use crate::schema::{...}` block (`:29-33`) so `CanonicalType`, `apply_canonical_type`, and `canonical_to_db_type_token` come from the crate, leaving the rest:
+
+```rust
+use ferro_ddl_lowering::{
+    CanonicalType, Dialect, apply_canonical_type, canonical_to_db_type_token,
+    db_check_constraint_name, information_schema_to_db_type_token, schema_columns_storage_drift,
+};
+use crate::schema::{
+    ColumnPlan, build_column_plan, internal_create_tables,
+    order_schemas_for_creation, property_json_type_and_format,
+};
+```
+(Merge the new names into the existing `ferro_ddl_lowering` import already present at `:17`; do not duplicate the `use`.)
+
+- [ ] **Step 6: Build the workspace**
+
+Run: `cargo build`
+Expected: success, no warnings about unused imports. If `parse_varchar_token` or another helper is flagged unused, delete it.
+
+- [ ] **Step 7: Run the full Rust test suite**
+
+Run: `cargo test --no-default-features --features testing` then `cargo test -p ferro-ddl-lowering -p ferro-migrate -p ferro-schema-ir`
+Expected: PASS (including Task 2's characterization test and the migrate IR-vs-legacy parity tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/schema.rs src/migrate.rs
+git commit -m "refactor(schema): route CREATE lowering through ferro-ddl-lowering; delete duplicate CanonicalType (#140)"
+```
+
+---
+
+### Task 4: Behavior-preservation gate (Python parity + auto-migrate matrix)
+
+**Files:** none (verification). This is the proof the refactor changed no DDL.
+
+- [ ] **Step 1: Per-token + full-model cross-emitter parity (SQLite path)**
+
+Run: `uv run pytest tests/test_db_type_cross_emitter_parity.py tests/test_cross_emitter_parity.py tests/test_ir_vectors_contract.py -q`
+Expected: PASS. This walks every `(canonical_token, dialect)` pair — it is the check that the crate's superset `db_type_token_to_canonical` produces identical CREATE DDL to before.
+
+- [ ] **Step 2: Auto-migrate + migrate-plan on the backend matrix**
+
+Run: `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py tests/test_alembic_autogenerate.py -q`
+Expected: PASS on both backends. (Postgres requires the backend-matrix harness / a running Postgres; if unavailable locally, this runs in CI — note it in the PR.)
+
+- [ ] **Step 3: Full workspace test once more**
+
+Run: `cargo test --no-default-features --features testing`
+Expected: PASS.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin feat/ir-p8.5-140-shared-lowering
+gh pr create --base main --title "feat(schema): single lowering library — route CREATE through ferro-ddl-lowering (#140)" --body "<summary: closes #140; behavior-preserving; gate = cross-emitter + auto-migrate matrix green on SQLite+Postgres>"
+```
+(Body should note migration impact `none`, link the spec, and check the #140 deliverable.)
+
+---
+
+## Self-Review
+
+**Spec coverage:** every spec move maps to a task — `canonical_to_db_type_token` move (T1.S1), one JSON→canonical mapper (T1.S2 + T3.S4), delete duplicates (T3.S2), dialect seam (T3.S3), unknown-type seam test (T2), the parity gate (T4). The `db_type_token` superset seam is covered by T4.S1. ✅
+
+**Placeholder scan:** all steps carry real code/commands; the only `<...>` is the PR-body summary, which is content the author fills at PR time, not a logic gap. ✅
+
+**Type consistency:** `canonical_from_parts(logical_type: &str, format: Option<&str>, db_type: &str, dialect: Dialect) -> Result<CanonicalType, String>` and `canonical_to_db_type_token(CanonicalType, Dialect) -> String` are used identically in T1, T3, and the adapter. `sql_dialect_to_lowering(SqlDialect) -> Dialect` is defined once (T3.S3) and used in the adapter (T3.S4). ✅

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -15,8 +15,8 @@
 
 use crate::backend::EngineHandle;
 use ferro_ddl_lowering::{
-    Dialect, db_check_constraint_name, information_schema_to_db_type_token,
-    schema_columns_storage_drift,
+    CanonicalType, Dialect, apply_canonical_type, canonical_to_db_type_token,
+    db_check_constraint_name, information_schema_to_db_type_token, schema_columns_storage_drift,
 };
 use ferro_migrate::{BackendDialect, MigrationOp, emit_sql_with_ir, plan_from_ir};
 use ferro_schema_ir::{
@@ -27,9 +27,8 @@ use crate::introspect::{
     LiveColumn, live_table_columns, quote_ident, sqlite_indexes_covering_column,
 };
 use crate::schema::{
-    CanonicalType, ColumnPlan, apply_canonical_type, build_column_plan,
-    canonical_to_db_type_token, internal_create_tables,
-    order_schemas_for_creation, property_json_type_and_format,
+    ColumnPlan, build_column_plan, internal_create_tables,
+    order_schemas_for_creation, property_json_type_and_format, sql_dialect_to_lowering,
 };
 use crate::state::{IDENTITY_MAP, MODEL_REGISTRY, SqlDialect, engine_for_connection};
 use pyo3::prelude::*;
@@ -131,7 +130,7 @@ fn schema_json_to_schema_ir(
                 .and_then(|v| v.as_str());
             let db_type = db_type_explicit
                 .map(str::to_string)
-                .unwrap_or_else(|| canonical_to_db_type_token(col_plan.canonical, backend));
+                .unwrap_or_else(|| canonical_to_db_type_token(col_plan.canonical, sql_dialect_to_lowering(backend)));
             columns.push(SchemaColumn {
                 name: name.clone(),
                 logical_type: property_json_type_and_format(resolved)
@@ -772,7 +771,7 @@ fn plan_existing_column(
                 .or_else(|| resolved.get("db_type"))
                 .and_then(|v| v.as_str())
                 .map(str::to_string)
-                .unwrap_or_else(|| canonical_to_db_type_token(col_plan.canonical, backend));
+                .unwrap_or_else(|| canonical_to_db_type_token(col_plan.canonical, sql_dialect_to_lowering(backend)));
             let live_db_type = information_schema_to_db_type_token(
                 &live.declared_type,
                 live.char_max_len,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -5,6 +5,7 @@
 
 use crate::backend::EngineHandle;
 use crate::state::{MODEL_REGISTRY, SqlDialect, engine_for_connection};
+use ferro_ddl_lowering::{CanonicalType, Dialect, apply_canonical_type, canonical_from_parts};
 use pyo3::prelude::*;
 use sea_query::{
     Alias, ColumnDef, ForeignKey, ForeignKeyAction, Index, PostgresQueryBuilder,
@@ -130,134 +131,6 @@ pub(crate) fn order_schemas_for_creation(
     ordered
 }
 
-/// Canonical, backend-resolved column type shared by every Rust DDL path —
-/// CREATE TABLE, ALTER TABLE ADD COLUMN, and schema diffing. The pair
-/// `canonical_column_type` → `apply_canonical_type` is the single source of
-/// truth for "what SQL type does this model field get"; any path that needs a
-/// column type must go through it so emitters cannot drift. See AGENTS.md § I-1.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum CanonicalType {
-    Integer,
-    SmallInt,
-    BigInt,
-    Double,
-    Decimal,
-    Boolean,
-    Json,
-    Text,
-    /// `varchar` with optional length (`.string()` / `.string_len(n)`).
-    Varchar(Option<u32>),
-    Char(u32),
-    Uuid,
-    /// SQLite rendering of the `timestamp`/`timestamptz` tokens (`.date_time()`).
-    DateTime,
-    Timestamp,
-    TimestampTz,
-    Date,
-    Time,
-    Blob,
-}
-
-/// Map a resolved [`CanonicalType`] back to the canonical Ferro `db_type` token
-/// vocabulary used in SchemaIR and cross-emitter parity tests.
-pub(crate) fn canonical_to_db_type_token(canonical: CanonicalType, backend: SqlDialect) -> String {
-    match canonical {
-        CanonicalType::Integer => "int".to_string(),
-        CanonicalType::SmallInt => "smallint".to_string(),
-        CanonicalType::BigInt => "bigint".to_string(),
-        CanonicalType::Double => "double".to_string(),
-        CanonicalType::Decimal => "numeric".to_string(),
-        CanonicalType::Boolean => "boolean".to_string(),
-        CanonicalType::Json => "json".to_string(),
-        CanonicalType::Text => "text".to_string(),
-        CanonicalType::Varchar(None) => "varchar".to_string(),
-        CanonicalType::Varchar(Some(n)) => format!("varchar({n})"),
-        CanonicalType::Char(n) => match (backend, n) {
-            (SqlDialect::Sqlite, 32) => "uuid".to_string(),
-            _ => format!("char({n})"),
-        },
-        CanonicalType::Uuid => "uuid".to_string(),
-        CanonicalType::DateTime | CanonicalType::Timestamp => "timestamp".to_string(),
-        CanonicalType::TimestampTz => "timestamptz".to_string(),
-        CanonicalType::Date => "date".to_string(),
-        CanonicalType::Time => "time".to_string(),
-        CanonicalType::Blob => "bytea".to_string(),
-    }
-}
-
-pub(crate) fn apply_canonical_type(col_def: &mut ColumnDef, canonical: CanonicalType) {
-    match canonical {
-        CanonicalType::Integer => {
-            col_def.integer();
-        }
-        CanonicalType::SmallInt => {
-            col_def.small_integer();
-        }
-        CanonicalType::BigInt => {
-            col_def.big_integer();
-        }
-        CanonicalType::Double => {
-            col_def.double();
-        }
-        CanonicalType::Decimal => {
-            col_def.decimal();
-        }
-        CanonicalType::Boolean => {
-            col_def.boolean();
-        }
-        CanonicalType::Json => {
-            col_def.json();
-        }
-        CanonicalType::Text => {
-            col_def.text();
-        }
-        CanonicalType::Varchar(None) => {
-            col_def.string();
-        }
-        CanonicalType::Varchar(Some(n)) => {
-            col_def.string_len(n);
-        }
-        CanonicalType::Char(n) => {
-            col_def.char_len(n);
-        }
-        CanonicalType::Uuid => {
-            col_def.uuid();
-        }
-        CanonicalType::DateTime => {
-            col_def.date_time();
-        }
-        CanonicalType::Timestamp => {
-            col_def.timestamp();
-        }
-        CanonicalType::TimestampTz => {
-            col_def.timestamp_with_time_zone();
-        }
-        CanonicalType::Date => {
-            col_def.date();
-        }
-        CanonicalType::Time => {
-            col_def.time();
-        }
-        CanonicalType::Blob => {
-            col_def.blob();
-        }
-    }
-}
-
-fn json_type_to_canonical(json_type: &str, backend: SqlDialect) -> CanonicalType {
-    match json_type {
-        "integer" => CanonicalType::Integer,
-        "string" => CanonicalType::Varchar(None),
-        "number" => CanonicalType::Double,
-        "boolean" => match backend {
-            // SQLite stores booleans as integers.
-            SqlDialect::Sqlite => CanonicalType::Integer,
-            SqlDialect::Postgres => CanonicalType::Boolean,
-        },
-        "object" | "array" => CanonicalType::Json,
-        _ => CanonicalType::Varchar(None),
-    }
-}
 
 /// Unique index name for `ferro_composite_uniques`; matches Python Alembic `_build_sa_table`.
 fn composite_unique_index_name(table_lower: &str, col_names: &[&str]) -> String {
@@ -333,78 +206,31 @@ fn db_check_constraint_name(table_lower: &str, col_name: &str) -> String {
     raw
 }
 
-fn parse_varchar_token(token: &str) -> Option<u32> {
-    let body = token.strip_prefix("varchar(")?.strip_suffix(')')?;
-    let n: u32 = body.parse().ok()?;
-    if n == 0 { None } else { Some(n) }
-}
-
-/// Map a canonical `db_type` token to a [`CanonicalType`]. Returns `None` when
-/// the token is unrecognized (the caller falls back to the JSON-type cascade).
-/// Strict per-class-definition validation runs in
-/// `metaclass._validate_db_type_options`.
-///
-/// Duplicated on the Python side in `src/ferro/migrations/alembic.py
-/// ::_db_type_to_sa_type`. Add new tokens to both emitters in the same change
-/// and update the parity test. See AGENTS.md § I-1.
-fn db_type_token_to_canonical(token: &str, backend: SqlDialect) -> Option<CanonicalType> {
-    // Per-dialect resolution is chosen to byte-match SA's compilation in the
-    // Alembic bridge. SQLite emits the typed keyword (BIGINT, SMALLINT,
-    // CHAR(32), DATETIME) and lets SQLite type affinity normalize at
-    // runtime; the parity test (U5) pins both sides token-for-token.
-    match token {
-        "text" => Some(CanonicalType::Text),
-        "smallint" => Some(CanonicalType::SmallInt),
-        "int" => Some(CanonicalType::Integer),
-        "bigint" => Some(CanonicalType::BigInt),
-        "uuid" => Some(match backend {
-            SqlDialect::Sqlite => CanonicalType::Char(32),
-            SqlDialect::Postgres => CanonicalType::Uuid,
-        }),
-        "timestamp" => Some(match backend {
-            SqlDialect::Sqlite => CanonicalType::DateTime,
-            SqlDialect::Postgres => CanonicalType::Timestamp,
-        }),
-        "timestamptz" => Some(match backend {
-            SqlDialect::Sqlite => CanonicalType::DateTime,
-            SqlDialect::Postgres => CanonicalType::TimestampTz,
-        }),
-        "date" => Some(CanonicalType::Date),
-        "time" => Some(CanonicalType::Time),
-        other => parse_varchar_token(other).map(|n| CanonicalType::Varchar(Some(n))),
+/// Translate the runtime backend tag to the lowering crate's dialect at the call seam.
+/// (Unifying these enums is tracked separately as #146 / Phase 8.6.)
+pub(crate) fn sql_dialect_to_lowering(backend: SqlDialect) -> Dialect {
+    match backend {
+        SqlDialect::Sqlite => Dialect::Sqlite,
+        SqlDialect::Postgres => Dialect::Postgres,
     }
 }
 
-/// Resolve a model property to its backend-specific [`CanonicalType`].
-///
-/// `db_type` is the canonical user-facing storage knob: when present and
-/// recognized it overrides every other column-type branch. Otherwise the
-/// Pydantic JSON type/format cascade decides.
+/// Resolve a model property to its backend-specific [`CanonicalType`] via the
+/// shared lowering crate. `db_type` (when set) wins; otherwise the Pydantic
+/// JSON type/format cascade decides; unknown types fall back to `varchar`.
 pub(crate) fn canonical_column_type(
     raw_col_info: &serde_json::Value,
     resolved_col_info: &serde_json::Value,
     backend: SqlDialect,
 ) -> CanonicalType {
-    let db_type_token = raw_col_info
+    let db_type = raw_col_info
         .get("db_type")
         .or_else(|| resolved_col_info.get("db_type"))
-        .and_then(|v| v.as_str());
-    if let Some(token) = db_type_token
-        && let Some(canonical) = db_type_token_to_canonical(token, backend)
-    {
-        return canonical;
-    }
-
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
     let (json_type, format) = property_json_type_and_format(resolved_col_info);
-    match (json_type, format) {
-        (Some("string"), Some("date-time")) => CanonicalType::TimestampTz,
-        (Some("string"), Some("date")) => CanonicalType::Date,
-        (Some("string"), Some("uuid")) => CanonicalType::Uuid,
-        (Some(_), Some("decimal")) => CanonicalType::Decimal,
-        (Some("string"), Some("binary")) => CanonicalType::Blob,
-        (Some(t), _) => json_type_to_canonical(t, backend),
-        (None, _) => CanonicalType::Varchar(None),
-    }
+    canonical_from_parts(json_type.unwrap_or(""), format, db_type, sql_dialect_to_lowering(backend))
+        .unwrap_or(CanonicalType::Varchar(None))
 }
 
 fn render_check_values(col_info: &serde_json::Value) -> Option<String> {
@@ -1128,14 +954,6 @@ mod tests {
     }
 
     #[test]
-    fn test_db_type_unknown_token_maps_to_none() {
-        assert_eq!(
-            db_type_token_to_canonical("banana", SqlDialect::Postgres),
-            None
-        );
-    }
-
-    #[test]
     fn test_unknown_db_type_token_falls_back_to_json_cascade() {
         // An unrecognized token must not change behavior: the JSON-type
         // cascade decides, exactly as before the CanonicalType refactor.
@@ -1158,14 +976,6 @@ mod tests {
             canonical_column_type(&no_type, &no_type, SqlDialect::Sqlite),
             CanonicalType::Varchar(None)
         );
-    }
-
-    #[test]
-    fn test_parse_varchar_token_rejects_zero_and_garbage() {
-        assert_eq!(parse_varchar_token("varchar(0)"), None);
-        assert_eq!(parse_varchar_token("varchar(abc)"), None);
-        assert_eq!(parse_varchar_token("varchar()"), None);
-        assert_eq!(parse_varchar_token("varchar(10)"), Some(10));
     }
 
     #[test]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1147,6 +1147,20 @@ mod tests {
     }
 
     #[test]
+    fn canonical_column_type_unknown_and_missing_type_fall_back_to_varchar() {
+        let unknown = serde_json::json!({ "type": "mystery" });
+        assert_eq!(
+            canonical_column_type(&unknown, &unknown, SqlDialect::Postgres),
+            CanonicalType::Varchar(None)
+        );
+        let no_type = serde_json::json!({});
+        assert_eq!(
+            canonical_column_type(&no_type, &no_type, SqlDialect::Sqlite),
+            CanonicalType::Varchar(None)
+        );
+    }
+
+    #[test]
     fn test_parse_varchar_token_rejects_zero_and_garbage() {
         assert_eq!(parse_varchar_token("varchar(0)"), None);
         assert_eq!(parse_varchar_token("varchar(abc)"), None);


### PR DESCRIPTION
Part of **Epic 8.5** (#139). Implements **#140**. Targets the Phase 8.5 integration branch `feat/ir-p8.5-lowering-consolidation` (auto-closes #140 when that branch merges to `main`).

## What

Makes `ferro-ddl-lowering` the single lowering library for the runtime CREATE path. `src/schema.rs` no longer carries its own `CanonicalType` + mappers — it routes through the crate, so CREATE and migrate share one canonical type system. Turns cross-emitter DDL parity (AGENTS.md I-1) from a tested coincidence into a structural guarantee for the type layer.

- Adds `canonical_to_db_type_token` + `canonical_from_parts` to `ferro-ddl-lowering`; `canonical_from_schema_column` delegates to the latter.
- Deletes `schema.rs`'s parallel `CanonicalType`, `apply_canonical_type`, `canonical_to_db_type_token`, `db_type_token_to_canonical`, `json_type_to_canonical`; rewrites `canonical_column_type` as a thin adapter over the crate.
- Re-points `src/migrate.rs` onto the crate; one `SqlDialect → Dialect` seam helper.

## Behavior-preserving

No emitted-DDL change. Validated: Rust **126/126**, Python cross-emitter + IR contract **35/35**, auto-migrate/migrate-plan/alembic **43 passed** (1 pre-existing skip). A characterization test pins the unknown-type → `varchar` seam.

⚠️ **CI must run the `--db-backends=...,postgres` matrix** — the Postgres half of the parity gate was CI-deferred (no local PG server; SQLite variants passed, PG variants skipped cleanly).

## Scope

Deliberately excludes (tracked separately): single SchemaIR producer (#141), `migrate.rs` alter-helper duplication (#142), `db_type` authority (#143), composite indexes (#144), dialect-enum unification (#146 / Epic 8.6).

Design spec: `docs/brainstorms/2026-06-26-ir-p8.5-140-shared-lowering-requirements.md`
Plan: `docs/plans/2026-06-26-001-feat-ir-p8.5-140-shared-lowering-plan.md`