### PR TITLE
feat(ir): drop db_type for non-explicit columns (#143)

### DIFF
--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -236,6 +236,10 @@ pub fn schema_columns_storage_drift(
         canonical_from_schema_column(new_col, dialect),
     ) {
         (Ok(old_c), Ok(new_c)) => old_c != new_c,
+        // Reached only when canonical resolution fails for both columns. At runtime
+        // both sides come from producers that always populate Some(...), so this
+        // Option comparison is behavior-equivalent to the old String comparison.
+        // (Will become load-bearing for None columns when #141 feeds the wire IR here.)
         _ => old_col.db_type != new_col.db_type,
     }
 }

--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -278,8 +278,8 @@ pub fn canonical_from_schema_column(
     col: &SchemaColumn,
     dialect: Dialect,
 ) -> Result<CanonicalType, String> {
-    canonical_from_parts(&col.logical_type, col.format.as_deref(), &col.db_type, dialect)
-        .map_err(|_| format!("unknown db_type '{}' on column '{}'", col.db_type, col.name))
+    canonical_from_parts(&col.logical_type, col.format.as_deref(), col.db_type.as_deref().unwrap_or(""), dialect)
+        .map_err(|_| format!("unknown db_type '{}' on column '{}'", col.db_type.as_deref().unwrap_or(""), col.name))
 }
 
 /// Single-column index name (`idx_<table>_<col>`).
@@ -511,7 +511,7 @@ mod tests {
         SchemaColumn {
             name: name.to_string(),
             logical_type: "unknown".to_string(),
-            db_type: db_type.to_string(),
+            db_type: Some(db_type.to_string()),
             db_type_explicit: None,
             nullable: true,
             primary_key: false,

--- a/crates/ferro-migrate/src/emit.rs
+++ b/crates/ferro-migrate/src/emit.rs
@@ -457,14 +457,14 @@ fn emit_alter_column_type(
                     ),
                 }
             })?;
-            if sqlite_type_storage_drift(&old_col.db_type, new_canonical) {
+            if sqlite_type_storage_drift(old_col.db_type.as_deref().unwrap_or(""), new_canonical) {
                 result.warnings.push(format!(
                     "Column '{}.{}' is declared '{}' in the database but the model expects \
                      '{}'. SQLite cannot change column types in place; use Alembic to \
                      migrate this column.",
                     table,
                     column,
-                    old_col.db_type,
+                    old_col.db_type.as_deref().unwrap_or(""),
                     sqlite_declared_type(new_canonical),
                 ));
             }

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -40,7 +40,7 @@ fn col(name: &str, db_type: &str, nullable: bool) -> SchemaColumn {
     SchemaColumn {
         name: name.to_string(),
         logical_type: "string".to_string(),
-        db_type: db_type.to_string(),
+        db_type: Some(db_type.to_string()),
         db_type_explicit: None,
         nullable,
         primary_key: false,
@@ -560,7 +560,7 @@ fn emit_sql_with_ir_add_table_missing_model_errors() {
 #[test]
 fn emit_sql_with_ir_alter_column_type_unknown_db_type_errors() {
     let bad_col = SchemaColumn {
-        db_type: "not_a_real_token".to_string(),
+        db_type: Some("not_a_real_token".to_string()),
         logical_type: "unknown".to_string(),
         ..col("name", "text", true)
     };

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -56,8 +56,10 @@ pub struct SchemaColumn {
     pub name: String,
     /// Pydantic JSON Schema type family (e.g. `"string"`, `"integer"`).
     pub logical_type: String,
-    /// Canonical storage token (`text`, `uuid`, `timestamptz`, …) after Ferro lowering.
-    pub db_type: String,
+    /// Canonical storage token. Present only for columns with an explicit `db_type=`;
+    /// `None` means "derive storage from `logical_type`/`format`".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub db_type: Option<String>,
     /// `true` when the user set an explicit `db_type=` on the field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub db_type_explicit: Option<bool>,

--- a/docs/brainstorms/2026-06-26-ir-p8.5-143-db-type-drop-requirements.md
+++ b/docs/brainstorms/2026-06-26-ir-p8.5-143-db-type-drop-requirements.md
@@ -54,9 +54,9 @@ already determine the canonical type for non-explicit columns, so a non-explicit
 2. **Python `src/ferro/ir/compiler.py`** — `_column_ir` emits `db_type` only when the
    field set one explicitly; **delete `_default_db_type`** (the source of the
    `bigint`/`text` defaults, now unused).
-3. **Rust producers** — `schema_json_to_schema_ir` (`src/migrate.rs`, model side)
-   emits `db_type` only when explicit (`Some`/`None`); `live_columns_to_schema_ir`
-   keeps the introspected value (`Some(...)`, the observed DB state).
+3. **Rust producers** — `live_columns_to_schema_ir` wraps the introspected value as
+   `Some(...)` (observed DB state). `schema_json_to_schema_ir` (model side)
+   **keeps resolving its `db_type` (`Some`) — unchanged** (see "Scope refinement").
 4. **Rust consumers** — `canonical_from_schema_column`, `canonical_from_parts`,
    `schema_columns_storage_drift`, and `emit.rs`'s drift checks adapt to `Option`
    via `col.db_type.as_deref().unwrap_or("")`; empty falls through to
@@ -66,14 +66,31 @@ already determine the canonical type for non-explicit columns, so a non-explicit
    IR **omits** `db_type` for a non-explicit column and **includes** it for an
    explicit one.
 
+## Scope refinement (verified during planning)
+
+The drop is applied to the **wire IR** (the Python compiler) only; the Rust migrate
+path's internal `db_type` resolution is left untouched. Verified concretely: a
+non-explicit `uuid` field on SQLite is declared `uuid_text`; the model side
+resolves `db_type="uuid"` → `Char(32)`, the live column introspects to the same →
+**no drift today (Ferro is silent)**. If `schema_json_to_schema_ir` dropped its
+resolved `db_type`, the model would *derive* `Uuid` (≠ live `Char(32)`) and emit a
+spurious *"column drifted, use Alembic"* warning on every auto-migrate — a
+user-visible false alarm. #143's goal (an honest wire IR before #141 makes it
+load-bearing) needs only the Python compiler change. The SQLite-uuid derivation
+reconciliation (making `canonical_from_parts` dialect-correct so `None` derives
+`Char(32)` on SQLite) belongs to **#141**, where Rust starts consuming the
+`None`-bearing wire IR.
+
 ## `ir_version`
 
-Making `db_type` optional is deserialize-compatible (old payloads that carry it
-still parse), so a bump is not strictly required. We **bump `ir_version` 1 → 2**
-anyway to mark the contract change honestly, and update the one enforcement point:
-`SUPPORTED_IR_VERSION` in `tests/test_ir_vectors_contract.py` (and the
-`ir_version` field in the regenerated fixtures). The Rust `IrEnvelope.ir_version`
-is a plain `u32` with no hard rejection, so no Rust gate changes.
+**Decision (revised during planning): keep `ir_version = 1`, no bump.** Making
+`db_type` optional is deserialize-compatible (old payloads that carry it still
+parse). And the version is enforced by a **single shared `SUPPORTED_IR_VERSION`**
+in `tests/test_ir_vectors_contract.py` that gates schema *and* query *and* codec
+fixtures, plus a hard `ir_version != 1` check on the **query** path in
+`src/operations.rs` — so bumping for a schema-only change would wrongly force
+unrelated query/codec fixtures (and a query-path constant) to move too. Since the
+change is backward-compatible, no bump is the clean choice.
 
 ## Behavior preservation & validation
 
@@ -90,6 +107,8 @@ Plus the new "non-explicit omits db_type / explicit keeps it" IR test.
 
 - Collapsing `db_type_explicit` into "`db_type` present ⟺ explicit" (separate cleanup).
 - Making `db_type` authoritative (the rejected alternative).
+- Changing the Rust migrate path's internal `db_type` resolution + the SQLite-uuid
+  derivation fix — deferred to #141 (see Scope refinement).
 - #141's FFI producer cutover (this de-risks it but does not do it).
 
 ## Migration impact

--- a/docs/brainstorms/2026-06-26-ir-p8.5-143-db-type-drop-requirements.md
+++ b/docs/brainstorms/2026-06-26-ir-p8.5-143-db-type-drop-requirements.md
@@ -1,0 +1,97 @@
+---
+title: "IR-P8.5 #143 — drop db_type for non-explicit columns"
+type: requirements
+status: draft
+date: 2026-06-26
+issue: https://github.com/syn54x/ferro-orm/issues/143
+epic: https://github.com/syn54x/ferro-orm/issues/139
+roadmap: docs/plans/2026-06-19-001-ir-first-roadmap.md (Phase 8.5)
+---
+
+# #143 — `db_type` is carried only when explicit
+
+## Goal
+
+Make the SchemaIR's `db_type` honest: it is present **only** for columns where the
+user explicitly set one. Non-explicit columns carry **no** `db_type`; their storage
+type is derived from `logical_type` (+`format`), which is already how they are
+typed by every emitter. Behavior-preserving — **zero change to emitted DDL**.
+
+## Why (the concrete problem)
+
+Today the Python compiler stamps a `db_type` on every column, and for non-explicit
+columns the value is wrong — and ignored:
+
+```
+model field        IR claims db_type   actual column (Rust)   actual column (Alembic)
+balance: int       "bigint"            INTEGER                INTEGER
+rate: float        "text"              double precision       FLOAT
+title: str         "text"             varchar                VARCHAR
+```
+
+Verified edge case — `max_length`: a non-explicit `str` with `Field(max_length=64)`
+still renders plain `varchar` (no length) today; `max_length` is ignored for column
+width. Only an explicit `db_type="varchar(N)"` carries a length, and explicit columns
+keep their `db_type` under this change. So dropping the non-explicit `db_type` loses
+no storage information.
+
+Both emitters ignore the IR's `db_type` for non-explicit columns and derive from
+`logical_type`, so it causes no bug **today**. But it is a loaded gun aimed at
+**#141**: once Rust consumes the Python SchemaIR over FFI, `canonical_from_schema_column`
+is `db_type`-**first**, so `"bigint"` → `BIGINT` for every plain int and `"text"` →
+`TEXT` for every float — silent column-type regressions and phantom/destructive
+auto-migrate diffs. #143 unloads the gun before #141 picks it up.
+
+`logical_type` + `format` are in the IR regardless (codec/hydration need them) and
+already determine the canonical type for non-explicit columns, so a non-explicit
+`db_type` is redundant. We drop the redundancy rather than correct-and-maintain it.
+
+## The change
+
+1. **IR type** — `ferro_schema_ir::SchemaColumn.db_type`: `String` → `Option<String>`
+   (serde: `skip_serializing_if = "Option::is_none"`, `default`). `logical_type`
+   stays required; `db_type_explicit` is **unchanged** (out of scope to collapse).
+2. **Python `src/ferro/ir/compiler.py`** — `_column_ir` emits `db_type` only when the
+   field set one explicitly; **delete `_default_db_type`** (the source of the
+   `bigint`/`text` defaults, now unused).
+3. **Rust producers** — `schema_json_to_schema_ir` (`src/migrate.rs`, model side)
+   emits `db_type` only when explicit (`Some`/`None`); `live_columns_to_schema_ir`
+   keeps the introspected value (`Some(...)`, the observed DB state).
+4. **Rust consumers** — `canonical_from_schema_column`, `canonical_from_parts`,
+   `schema_columns_storage_drift`, and `emit.rs`'s drift checks adapt to `Option`
+   via `col.db_type.as_deref().unwrap_or("")`; empty falls through to
+   `logical_type`/`format` exactly as today.
+5. **Fixtures + test** — regenerate `tests/fixtures/ir_vectors/schema_*.json` so
+   non-explicit columns no longer carry `db_type`; add a test asserting the compiled
+   IR **omits** `db_type` for a non-explicit column and **includes** it for an
+   explicit one.
+
+## `ir_version`
+
+Making `db_type` optional is deserialize-compatible (old payloads that carry it
+still parse), so a bump is not strictly required. We **bump `ir_version` 1 → 2**
+anyway to mark the contract change honestly, and update the one enforcement point:
+`SUPPORTED_IR_VERSION` in `tests/test_ir_vectors_contract.py` (and the
+`ir_version` field in the regenerated fixtures). The Rust `IrEnvelope.ir_version`
+is a plain `u32` with no hard rejection, so no Rust gate changes.
+
+## Behavior preservation & validation
+
+The emitted DDL must not change — non-explicit columns already derive from
+`logical_type`/`format`. Gate (must stay green on SQLite **and** Postgres, zero DDL
+diffs):
+- `cargo test --no-default-features --features testing` + `cargo test -p ferro-schema-ir -p ferro-migrate -p ferro-ddl-lowering`
+- `uv run pytest tests/test_db_type_cross_emitter_parity.py tests/test_cross_emitter_parity.py tests/test_ir_vectors_contract.py tests/test_alembic_autogenerate.py -q`
+- `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py -q`
+
+Plus the new "non-explicit omits db_type / explicit keeps it" IR test.
+
+## Non-goals
+
+- Collapsing `db_type_explicit` into "`db_type` present ⟺ explicit" (separate cleanup).
+- Making `db_type` authoritative (the rejected alternative).
+- #141's FFI producer cutover (this de-risks it but does not do it).
+
+## Migration impact
+
+`none` — internal IR contract; no user-facing API or emitted-DDL change.

--- a/docs/plans/2026-06-26-002-feat-ir-p8.5-143-db-type-drop-plan.md
+++ b/docs/plans/2026-06-26-002-feat-ir-p8.5-143-db-type-drop-plan.md
@@ -1,0 +1,229 @@
+# #143 — Drop `db_type` for Non-Explicit Columns — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The SchemaIR carries `db_type` only when the user set one explicitly; non-explicit columns omit it. The Python compiler stops emitting the wrong `bigint`/`text` defaults, so the wire IR is honest before #141 makes it load-bearing — with zero change to emitted DDL or runtime behavior.
+
+**Architecture:** Make `SchemaColumn.db_type` an `Option<String>` (serde-omitted when `None`); the Python compiler emits it only for explicit columns; all Rust *producers* keep emitting `Some(...)` (so runtime auto-migrate is untouched), and Rust *consumers* tolerate `None` via `as_deref()`. The compiler-snapshot fixture is regenerated.
+
+**Tech Stack:** Rust workspace (`ferro-schema-ir`, `ferro-ddl-lowering`, `ferro-migrate`, `_core`), PyO3, Python (`uv`/pytest), serde.
+
+## Global Constraints
+
+- **Behavior-preserving:** no change to emitted DDL or auto-migrate drift on SQLite or Postgres. Gate = existing parity/auto-migrate suites stay green.
+- **Scope is the WIRE IR only.** The Rust migrate model-side producer (`schema_json_to_schema_ir`) **keeps resolving** its `db_type` (`Some`) — do NOT make it `None`. (Dropping it causes a spurious uuid-on-SQLite drift warning; that reconciliation is #141.)
+- **`ir_version` stays `1`** — no bump. `SUPPORTED_IR_VERSION` is shared across schema/query/codec and `operations.rs` hard-checks the query version `!= 1`; the change is deserialize-compatible.
+- `db_type_explicit` is unchanged. Rust edition 2024, no new deps.
+
+---
+
+### Task 1: `SchemaColumn.db_type` → `Option<String>` + all Rust sites
+
+Atomic type change: making the field `Option` breaks every construction/read site until fixed. All Rust producers keep emitting `Some(...)`, so behavior is unchanged; the Rust suite must stay green.
+
+**Files:**
+- Modify: `crates/ferro-schema-ir/src/lib.rs:60`
+- Modify: `src/migrate.rs` (`schema_json_to_schema_ir`, `live_columns_to_schema_ir:227`, `schema_column_for_drift:724`)
+- Modify: `crates/ferro-ddl-lowering/src/lib.rs:281-282` (read), `:514` (test helper)
+- Modify: `crates/ferro-migrate/src/emit.rs:460,467` (reads)
+- Modify: `crates/ferro-migrate/src/tests.rs:43,563` (test helpers)
+
+**Interfaces:**
+- Produces: `SchemaColumn.db_type: Option<String>` (was `String`). `None` ⟺ no explicit override.
+
+- [ ] **Step 1: Change the field type** (`crates/ferro-schema-ir/src/lib.rs`, the `pub db_type: String,` at line 60):
+
+```rust
+    /// Canonical storage token. Present only for columns with an explicit `db_type=`;
+    /// `None` means "derive storage from `logical_type`/`format`".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub db_type: Option<String>,
+```
+
+- [ ] **Step 2: Wrap the Rust producer construction sites in `Some(...)`** (they keep resolving — behavior unchanged):
+  - `src/migrate.rs`, `schema_json_to_schema_ir`: the `SchemaColumn { … db_type, … }` shorthand → `db_type: Some(db_type),` (leave the `let db_type = … .unwrap_or_else(|| canonical_to_db_type_token(…))` exactly as is).
+  - `src/migrate.rs:227`, `live_columns_to_schema_ir`: `db_type: information_schema_to_db_type_token(&col.declared_type, col.char_max_len, dialect),` → wrap the call in `Some(...)`.
+  - `src/migrate.rs:724`, `schema_column_for_drift`: the `db_type,` field → `db_type: Some(db_type),`.
+
+- [ ] **Step 3: Fix the Rust read sites to tolerate `None`:**
+  - `crates/ferro-ddl-lowering/src/lib.rs:281`: `… col.format.as_deref(), &col.db_type, dialect)` → `… col.format.as_deref(), col.db_type.as_deref().unwrap_or(""), dialect)`.
+  - `crates/ferro-ddl-lowering/src/lib.rs:282`: in the `.map_err` format, `col.db_type` → `col.db_type.as_deref().unwrap_or("")`.
+  - `crates/ferro-migrate/src/emit.rs:460`: `sqlite_type_storage_drift(&old_col.db_type, new_canonical)` → `sqlite_type_storage_drift(old_col.db_type.as_deref().unwrap_or(""), new_canonical)`.
+  - `crates/ferro-migrate/src/emit.rs:467`: the `old_col.db_type` format arg → `old_col.db_type.as_deref().unwrap_or("")`.
+  - `crates/ferro-ddl-lowering/src/lib.rs:239` (`old_col.db_type != new_col.db_type`): leave as-is — `Option<String>` comparison compiles and is correct.
+
+- [ ] **Step 4: Fix the test-helper construction sites:**
+  - `crates/ferro-ddl-lowering/src/lib.rs:514` (`drift_col`): `db_type: db_type.to_string(),` → `db_type: Some(db_type.to_string()),`.
+  - `crates/ferro-migrate/src/tests.rs:43` (`col`): `db_type: db_type.to_string(),` → `db_type: Some(db_type.to_string()),`.
+  - `crates/ferro-migrate/src/tests.rs:563`: `db_type: "not_a_real_token".to_string(),` → `db_type: Some("not_a_real_token".to_string()),`.
+
+- [ ] **Step 5: Build + run the Rust suite**
+
+Run: `cargo build` then `cargo test --no-default-features --features testing` and `cargo test -p ferro-schema-ir -p ferro-migrate -p ferro-ddl-lowering`
+Expected: PASS, no warnings. (Fixtures still carry `db_type` at this point — they deserialize to `Some` and round-trip fine.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ferro-schema-ir/src/lib.rs crates/ferro-ddl-lowering/src/lib.rs crates/ferro-migrate/src/emit.rs crates/ferro-migrate/src/tests.rs src/migrate.rs
+git commit -m "refactor(schema-ir): make SchemaColumn.db_type optional; producers keep resolving (#143)"
+```
+
+---
+
+### Task 2: Python compiler drops the default; regenerate fixtures; new test
+
+**Files:**
+- Modify: `src/ferro/ir/compiler.py` (`_column_ir`; delete `_default_db_type`)
+- Modify: `tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json` (regenerate — compiler snapshot)
+- Modify: `tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json` (hand-edit — wire example)
+- Test: `tests/test_ir_vectors_contract.py` (add one test)
+
+**Interfaces:**
+- Consumes: `compile_schema_ir_payload(model_name, schema) -> dict` (unchanged signature; now omits `db_type` for non-explicit columns).
+
+- [ ] **Step 1: Write the failing test** in `tests/test_ir_vectors_contract.py` (near the other compiler tests):
+
+```python
+def test_compiler_omits_db_type_for_non_explicit_columns(clean_model_registry: None) -> None:
+    from ferro import Model, Field, clear_registry
+    from ferro.schema_metadata import build_model_schema
+    from ferro.ir.compiler import compile_schema_ir_payload
+
+    clear_registry()
+    M = type("Acct", (Model,), {
+        "__annotations__": {"id": int | None, "balance": int, "code": str},
+        "id": Field(default=None, primary_key=True),
+        "code": Field(db_type="varchar(32)"),
+    })
+    cols = {c["name"]: c for c in compile_schema_ir_payload("Acct", build_model_schema(M))["models"][0]["columns"]}
+    assert "db_type" not in cols["balance"], cols["balance"]   # non-explicit -> omitted
+    assert "db_type" not in cols["id"], cols["id"]             # non-explicit -> omitted
+    assert cols["code"]["db_type"] == "varchar(32)"            # explicit -> kept
+    assert cols["code"]["db_type_explicit"] is True
+```
+
+- [ ] **Step 2: Run it — expect FAIL**
+
+Run: `uv run pytest tests/test_ir_vectors_contract.py::test_compiler_omits_db_type_for_non_explicit_columns -q`
+Expected: FAIL (`db_type` still present on `balance`/`id`).
+
+- [ ] **Step 3: Change `_column_ir`** in `src/ferro/ir/compiler.py` — remove the unconditional `db_type`, add it only when explicit. Replace the `column_ir = { … }` dict literal's `"db_type": …` line (delete it) and the trailing explicit block:
+
+```python
+    column_ir = {
+        "name": col_name,
+        "logical_type": _logical_type(col_info),
+        "nullable": _is_nullable(col_name, col_info, required_fields),
+        "primary_key": bool(col_info.get("primary_key", False)),
+        "autoincrement": bool(col_info.get("autoincrement", False)),
+        "unique": bool(col_info.get("unique", False)),
+        "index": bool(col_info.get("index", False)),
+        "default": col_info.get("default"),
+        "format": col_info.get("format"),
+    }
+    enum_values = _enum_values(col_info)
+    if isinstance(enum_values, list):
+        column_ir["enum_values"] = list(enum_values)
+    if db_type_explicit:
+        column_ir["db_type"] = db_type_value
+        column_ir["db_type_explicit"] = True
+```
+
+- [ ] **Step 4: Delete the now-unused `_default_db_type`** function (`src/ferro/ir/compiler.py`, the whole `def _default_db_type(...)` block). Verify no other references:
+
+Run: `grep -rn "_default_db_type" src/`
+Expected: no matches.
+
+- [ ] **Step 5: Run the new test — expect PASS**
+
+Run: `uv run pytest tests/test_ir_vectors_contract.py::test_compiler_omits_db_type_for_non_explicit_columns -q`
+Expected: PASS.
+
+- [ ] **Step 6: Regenerate the compiler-snapshot fixture** (its `ir` + `fingerprint` must match the new output):
+
+Run:
+```bash
+uv run python - <<'PY'
+import json
+from ferro import clear_registry
+from ferro.ir import compile_registry_schema_ir, schema_ir_fingerprint
+from ferro.relations import resolve_relationships
+from tests.test_cross_emitter_parity import _build_fixture_models
+clear_registry(); _build_fixture_models(); resolve_relationships()
+compiled = compile_registry_schema_ir()
+p = "tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json"
+doc = json.load(open(p))
+doc["ir"] = compiled
+doc["fingerprint"] = schema_ir_fingerprint(compiled)
+with open(p, "w") as f: json.dump(doc, f, indent=2, ensure_ascii=True); f.write("\n")
+print("regenerated", p)
+PY
+```
+
+- [ ] **Step 7: Hand-edit the invoice wire example** (no fingerprint; drop `db_type` from its non-explicit columns for consistency):
+
+Run:
+```bash
+uv run python - <<'PY'
+import json
+p = "tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json"
+doc = json.load(open(p))
+for m in doc["ir"]["payload"]["models"]:
+    for c in m["columns"]:
+        if not c.get("db_type_explicit"):
+            c.pop("db_type", None)
+with open(p, "w") as f: json.dump(doc, f, indent=2, ensure_ascii=True); f.write("\n")
+print("edited", p)
+PY
+```
+
+- [ ] **Step 8: Run the IR contract + roundtrip suites**
+
+Run: `uv run pytest tests/test_ir_vectors_contract.py -q` and `cargo test -p ferro-schema-ir`
+Expected: PASS (snapshot matches; Rust round-trip encode==ir with the edited fixtures).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/ferro/ir/compiler.py tests/test_ir_vectors_contract.py tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json
+git commit -m "feat(ir): compiler omits db_type for non-explicit columns; regenerate fixtures (#143)"
+```
+
+---
+
+### Task 3: Behavior-preservation gate
+
+No code change — proves DDL and auto-migrate behavior are unchanged.
+
+- [ ] **Step 1: Cross-emitter + IR contract (SQLite path)**
+
+Run: `uv run pytest tests/test_db_type_cross_emitter_parity.py tests/test_cross_emitter_parity.py tests/test_ir_vectors_contract.py tests/test_alembic_autogenerate.py -q`
+Expected: PASS (Alembic already ignores non-explicit `db_type`, so its SQL is unchanged).
+
+- [ ] **Step 2: Auto-migrate + migrate-plan on the backend matrix**
+
+Run: `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py -q`
+Expected: PASS on both backends (Postgres requires the matrix harness; if unavailable locally, note it runs in CI — the Rust migrate path is untouched, so drift is byte-identical).
+
+- [ ] **Step 3: Full Rust suite**
+
+Run: `cargo test --no-default-features --features testing`
+Expected: PASS.
+
+- [ ] **Step 4: Open the PR** into the integration branch
+
+```bash
+git push -u origin feat/ir-p8.5-143-db-type-drop
+gh pr create --base feat/ir-p8.5-lowering-consolidation --title "feat(ir): drop db_type for non-explicit columns (#143)" --body "<closes #143 when 8.5 lands on main; behavior-preserving; CI runs the postgres matrix>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** field → `Option` (T1.S1); producers keep `Some` (T1.S2, the scope refinement); consumers tolerate `None` (T1.S3); Python drops the default (T2.S3–4); fixtures regenerated (T2.S6–7); new omits-test (T2.S1); `ir_version` unchanged (Global Constraints); validation (T3). ✅
+
+**Placeholder scan:** all steps carry real code/commands; the only `<...>` is the PR-body summary filled at PR time. ✅
+
+**Type consistency:** `db_type: Option<String>` is read everywhere via `.as_deref().unwrap_or("")` and constructed via `Some(...)`; `compile_schema_ir_payload(...)["models"][0]["columns"]` shape matches the new test and the regen script. ✅

--- a/src/ferro/ir/compiler.py
+++ b/src/ferro/ir/compiler.py
@@ -99,25 +99,6 @@ def _logical_type(col_info: dict[str, Any]) -> str:
     return "unknown"
 
 
-def _default_db_type(col_info: dict[str, Any]) -> str:
-    """Map schema metadata to the default canonical Ferro ``db_type`` token."""
-    field_type, field_format = _effective_type_and_format(col_info)
-    if field_type == "integer":
-        return "bigint"
-    if field_type == "number":
-        return "text"
-    if field_type == "string":
-        if field_format == "date-time":
-            return "timestamptz"
-        if field_format == "date":
-            return "date"
-        if field_format == "time":
-            return "time"
-        if field_format == "uuid":
-            return "uuid"
-        return "text"
-    return "text"
-
 
 def _effective_type_and_format(col_info: dict[str, Any]) -> tuple[Any, Any]:
     """Resolve concrete type/format from direct fields or ``anyOf`` unions."""
@@ -169,7 +150,6 @@ def _column_ir(
     column_ir = {
         "name": col_name,
         "logical_type": _logical_type(col_info),
-        "db_type": db_type_value if db_type_explicit else _default_db_type(col_info),
         "nullable": _is_nullable(col_name, col_info, required_fields),
         "primary_key": bool(col_info.get("primary_key", False)),
         "autoincrement": bool(col_info.get("autoincrement", False)),
@@ -182,6 +162,7 @@ def _column_ir(
     if isinstance(enum_values, list):
         column_ir["enum_values"] = list(enum_values)
     if db_type_explicit:
+        column_ir["db_type"] = db_type_value
         column_ir["db_type_explicit"] = True
     enum_type_name = col_info.get("enum_type_name")
     if isinstance(enum_type_name, str) and enum_type_name:

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -137,7 +137,7 @@ fn schema_json_to_schema_ir(
                     .0
                     .unwrap_or("unknown")
                     .to_string(),
-                db_type,
+                db_type: Some(db_type),
                 db_type_explicit: db_type_explicit.map(|_| true),
                 nullable: col_plan.is_nullable,
                 primary_key: col_plan.is_primary_key,
@@ -224,11 +224,11 @@ fn live_columns_to_schema_ir(
         .map(|col| SchemaColumn {
             name: col.name.clone(),
             logical_type: "unknown".to_string(),
-            db_type: information_schema_to_db_type_token(
+            db_type: Some(information_schema_to_db_type_token(
                 &col.declared_type,
                 col.char_max_len,
                 dialect,
-            ),
+            )),
             db_type_explicit: None,
             nullable: col.is_nullable,
             primary_key: col.is_primary_key,
@@ -728,7 +728,7 @@ fn schema_column_for_drift(
     SchemaColumn {
         name: name.to_string(),
         logical_type: "unknown".to_string(),
-        db_type,
+        db_type: Some(db_type),
         db_type_explicit: None,
         nullable,
         primary_key,

--- a/tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json
+++ b/tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json
@@ -15,7 +15,6 @@
             {
               "name": "id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": false,
               "primary_key": true,
               "autoincrement": true,
@@ -27,7 +26,6 @@
             {
               "name": "number",
               "logical_type": "string",
-              "db_type": "varchar(64)",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -39,7 +37,6 @@
             {
               "name": "customer_id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -51,7 +48,6 @@
             {
               "name": "created_at",
               "logical_type": "datetime",
-              "db_type": "timestamptz",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -73,19 +69,25 @@
           "indexes": [
             {
               "name": "idx_invoice_created_at",
-              "columns": ["created_at"],
+              "columns": [
+                "created_at"
+              ],
               "unique": false
             },
             {
               "name": "idx_invoice_customer_id",
-              "columns": ["customer_id"],
+              "columns": [
+                "customer_id"
+              ],
               "unique": false
             }
           ],
           "uniques": [
             {
               "name": "uq_invoice_number",
-              "columns": ["number"]
+              "columns": [
+                "number"
+              ]
             }
           ],
           "checks": [

--- a/tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json
+++ b/tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json
@@ -15,7 +15,6 @@
             {
               "name": "email",
               "logical_type": "string",
-              "db_type": "text",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -27,7 +26,6 @@
             {
               "name": "id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": true,
               "primary_key": true,
               "autoincrement": true,
@@ -39,7 +37,6 @@
             {
               "name": "org_id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -84,7 +81,6 @@
             {
               "name": "id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": true,
               "primary_key": true,
               "autoincrement": true,
@@ -96,7 +92,6 @@
             {
               "name": "name",
               "logical_type": "string",
-              "db_type": "text",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -108,7 +103,6 @@
             {
               "name": "slug",
               "logical_type": "string",
-              "db_type": "text",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -145,7 +139,6 @@
             {
               "name": "id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": true,
               "primary_key": true,
               "autoincrement": true,
@@ -157,7 +150,6 @@
             {
               "name": "name",
               "logical_type": "string",
-              "db_type": "text",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -169,7 +161,6 @@
             {
               "name": "org_id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -211,5 +202,5 @@
       ]
     }
   },
-  "fingerprint": "e32e8b0dbb67269dc456904d344dca7cecd506aabe1837a544fc9fba5efc3d3d"
+  "fingerprint": "aafcfe76d373bbce78092eb728456ddc7ff1d6a6f3ac647514e210bc84af143e"
 }

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -314,6 +314,24 @@ def test_schema_ir_compiler_emits_db_check_expression_for_closed_domain(
     ]
 
 
+def test_compiler_omits_db_type_for_non_explicit_columns(clean_model_registry: None) -> None:
+    from ferro import Model, Field, clear_registry
+    from ferro.schema_metadata import build_model_schema
+    from ferro.ir.compiler import compile_schema_ir_payload
+
+    clear_registry()
+    M = type("Acct", (Model,), {
+        "__annotations__": {"id": int | None, "balance": int, "code": str},
+        "id": Field(default=None, primary_key=True),
+        "code": Field(db_type="varchar(32)"),
+    })
+    cols = {c["name"]: c for c in compile_schema_ir_payload("Acct", build_model_schema(M))["models"][0]["columns"]}
+    assert "db_type" not in cols["balance"], cols["balance"]   # non-explicit -> omitted
+    assert "db_type" not in cols["id"], cols["id"]             # non-explicit -> omitted
+    assert cols["code"]["db_type"] == "varchar(32)"            # explicit -> kept
+    assert cols["code"]["db_type_explicit"] is True
+
+
 def test_schema_ir_compiler_includes_join_table_models(clean_model_registry: None) -> None:
     from ferro.ir import compile_registry_schema_ir
     from ferro.relations import resolve_relationships


### PR DESCRIPTION
Part of **Epic 8.5** (#139). Implements **#143**. Targets the Phase 8.5 integration branch (auto-closes #143 when that branch merges to `main`).

## What

The SchemaIR now carries `db_type` **only** when the user set one explicitly. Non-explicit columns omit it and derive their storage type from `logical_type`+`format` — which is already how they're typed. This removes the wrong defaults the Python compiler stamped on every column (a plain `int` was labeled `bigint`, a `float` was labeled `text`).

**Why it matters:** today those wrong values are ignored (Alembic re-derives from `logical_type`; the Rust create path uses its own canonical), but they're a loaded gun for **#141** — once Rust consumes the Python SchemaIR over FFI (db_type-first lowering), a plain `int` would emit `BIGINT` and a `float` would emit `TEXT`, with phantom/destructive auto-migrate diffs. #143 makes the wire IR honest first.

- `SchemaColumn.db_type`: `String` → `Option<String>` (serde-omitted when `None`).
- Python `_column_ir` emits `db_type` only when explicit; `_default_db_type` deleted.
- Compiler-snapshot fixture regenerated (ir + fingerprint); invoice wire-example edited; new omits-when-non-explicit test.

## Scope refinement (verified during planning)

The drop is applied to the **wire IR only**. The Rust migrate model-side producer **keeps resolving** its `db_type`, so runtime auto-migrate drift is byte-identical. Reason (verified): dropping it there would make a non-explicit `uuid` column derive `Uuid` while the live SQLite column introspects to `Char(32)` → a spurious "column drifted, use Alembic" warning on every startup. That SQLite-uuid derivation reconciliation belongs to **#141**, where Rust actually consumes the `None`-bearing IR. `ir_version` stays `1` (shared `SUPPORTED_IR_VERSION` gates query/codec too).

## Behavior-preserving

No emitted-DDL or auto-migrate change. Validated: cross-emitter + IR contract + Alembic autogenerate **49/49**, auto-migrate + migrate-plan **13/13** on SQLite, full Rust **126/126**.

⚠️ **CI must run the `--db-backends=...,postgres` matrix** — Postgres was CI-deferred (no local server; SQLite matrix passed, PG skipped cleanly).

Design spec: `docs/brainstorms/2026-06-26-ir-p8.5-143-db-type-drop-requirements.md`
Plan: `docs/plans/2026-06-26-002-feat-ir-p8.5-143-db-type-drop-plan.md`