### PR TITLE
feat(migrate): reconcile indexes & uniques in auto-migrate (#144)

### DIFF
--- a/crates/ferro-migrate/src/emit.rs
+++ b/crates/ferro-migrate/src/emit.rs
@@ -121,6 +121,23 @@ fn single_column_unique_is_inline(model: &SchemaModel, unique_columns: &[String]
         .any(|col| col.name == *col_name && col.unique)
 }
 
+/// The standalone indexes/uniques the create path emits as separate
+/// `CREATE [UNIQUE] INDEX` statements: every `model.indexes`, plus `model.uniques`
+/// that are not inline single-column uniques. Returned as (name, columns, unique).
+pub(crate) fn standalone_indexes(model: &SchemaModel) -> Vec<(String, Vec<String>, bool)> {
+    let mut out = Vec::new();
+    for index in &model.indexes {
+        out.push((index.name.clone(), index.columns.clone(), index.unique));
+    }
+    for unique in &model.uniques {
+        if single_column_unique_is_inline(model, &unique.columns) {
+            continue;
+        }
+        out.push((unique.name.clone(), unique.columns.clone(), true));
+    }
+    out
+}
+
 fn post_create_artifacts(
     model: &SchemaModel,
     dialect: BackendDialect,
@@ -129,27 +146,8 @@ fn post_create_artifacts(
     let mut statements = Vec::new();
     let mut warnings = Vec::new();
 
-    for index in &model.indexes {
-        statements.push(render_index_sql(
-            table_lower,
-            &index.name,
-            &index.columns,
-            index.unique,
-            dialect,
-        ));
-    }
-
-    for unique in &model.uniques {
-        if single_column_unique_is_inline(model, &unique.columns) {
-            continue;
-        }
-        statements.push(render_index_sql(
-            table_lower,
-            &unique.name,
-            &unique.columns,
-            true,
-            dialect,
-        ));
+    for (name, columns, unique) in standalone_indexes(model) {
+        statements.push(render_index_sql(table_lower, &name, &columns, unique, dialect));
     }
 
     for check in &model.checks {
@@ -601,6 +599,12 @@ pub fn emit_sql_with_ir(
                     emit_alter_column_nullability(table, column, old_col, new_col, dialect);
                 result.statements.extend(partial.statements);
                 result.warnings.extend(partial.warnings);
+            }
+            MigrationOp::AddIndex { table, name, columns, unique } => {
+                result.statements.push(render_index_sql(table, name, columns, *unique, dialect));
+            }
+            MigrationOp::DropIndex { table: _, name } => {
+                result.statements.push(format!("DROP INDEX IF EXISTS \"{}\"", name));
             }
         }
     }

--- a/crates/ferro-migrate/src/emit.rs
+++ b/crates/ferro-migrate/src/emit.rs
@@ -603,6 +603,8 @@ pub fn emit_sql_with_ir(
             MigrationOp::AddIndex { table, name, columns, unique } => {
                 result.statements.push(render_index_sql(table, name, columns, *unique, dialect));
             }
+            // `table` is intentionally unused: DROP INDEX is schema-scoped (not
+            // table-qualified) on both SQLite and Postgres, so only the index name is needed.
             MigrationOp::DropIndex { table: _, name } => {
                 result.statements.push(format!("DROP INDEX IF EXISTS \"{}\"", name));
             }

--- a/crates/ferro-migrate/src/lib.rs
+++ b/crates/ferro-migrate/src/lib.rs
@@ -290,6 +290,11 @@ fn diff_model_indexes(
     new_model: &SchemaModel,
     plan: &mut MigrationPlan,
 ) {
+    // Columns present in the old model — indexes that cover only NEW columns are
+    // emitted by emit_add_column during AddColumn processing, so we must not emit
+    // a redundant standalone AddIndex for them.
+    let old_col_names: BTreeSet<&str> = old_model.columns.iter().map(|c| c.name.as_str()).collect();
+
     let old_by_name: BTreeMap<String, (Vec<String>, bool)> = old_model
         .indexes
         .iter()
@@ -300,6 +305,12 @@ fn diff_model_indexes(
 
     for (name, columns, unique) in &new_set {
         if !old_by_name.contains_key(name) {
+            // Skip AddIndex when all indexed columns are being added in this plan;
+            // emit_add_column already handles the CREATE INDEX for column-add indexes.
+            let all_columns_are_new = columns.iter().all(|c| !old_col_names.contains(c.as_str()));
+            if all_columns_are_new {
+                continue;
+            }
             plan.operations.push(MigrationOp::AddIndex {
                 table: table.to_string(),
                 name: name.clone(),

--- a/crates/ferro-migrate/src/lib.rs
+++ b/crates/ferro-migrate/src/lib.rs
@@ -85,6 +85,24 @@ pub enum MigrationOp {
         /// Column whose nullability drifted.
         column: String,
     },
+    /// A standalone Ferro-named index/unique present in the model but not live.
+    AddIndex {
+        /// Owning table.
+        table: String,
+        /// Index name.
+        name: String,
+        /// Indexed columns.
+        columns: Vec<String>,
+        /// Whether this is a unique index.
+        unique: bool,
+    },
+    /// A standalone Ferro-named index present live but gone from the model.
+    DropIndex {
+        /// Owning table.
+        table: String,
+        /// Index name.
+        name: String,
+    },
 }
 
 /// Ordered migration operations plus non-fatal warnings collected during planning.
@@ -149,6 +167,12 @@ pub fn emit_sql(plan: &MigrationPlan, dialect: BackendDialect) -> Vec<String> {
                     table, column
                 )),
             },
+            MigrationOp::AddIndex { name, .. } => {
+                sql.push(format!("-- index '{}' handled by emit_sql_with_ir", name));
+            }
+            MigrationOp::DropIndex { name, .. } => {
+                sql.push(format!("-- index '{}' handled by emit_sql_with_ir", name));
+            }
         }
     }
     sql
@@ -190,6 +214,7 @@ pub fn plan_from_ir(
             continue;
         };
         diff_model_columns(*table, old_model, new_model, ddl_dialect, &mut plan);
+        diff_model_indexes(*table, old_model, new_model, &mut plan);
     }
 
     plan
@@ -254,6 +279,40 @@ fn diff_model_columns(
             plan.operations.push(MigrationOp::AlterColumnNullability {
                 table: table.to_string(),
                 column: (*col).to_string(),
+            });
+        }
+    }
+}
+
+fn diff_model_indexes(
+    table: &str,
+    old_model: &SchemaModel,
+    new_model: &SchemaModel,
+    plan: &mut MigrationPlan,
+) {
+    let old_by_name: BTreeMap<String, (Vec<String>, bool)> = old_model
+        .indexes
+        .iter()
+        .map(|i| (i.name.clone(), (i.columns.clone(), i.unique)))
+        .collect();
+    let new_set = emit::standalone_indexes(new_model);
+    let new_names: BTreeSet<&str> = new_set.iter().map(|(n, _, _)| n.as_str()).collect();
+
+    for (name, columns, unique) in &new_set {
+        if !old_by_name.contains_key(name) {
+            plan.operations.push(MigrationOp::AddIndex {
+                table: table.to_string(),
+                name: name.clone(),
+                columns: columns.clone(),
+                unique: *unique,
+            });
+        }
+    }
+    for name in old_by_name.keys() {
+        if !new_names.contains(name.as_str()) {
+            plan.operations.push(MigrationOp::DropIndex {
+                table: table.to_string(),
+                name: name.clone(),
             });
         }
     }

--- a/crates/ferro-migrate/src/lib.rs
+++ b/crates/ferro-migrate/src/lib.rs
@@ -305,10 +305,11 @@ fn diff_model_indexes(
 
     for (name, columns, unique) in &new_set {
         if !old_by_name.contains_key(name) {
-            // Skip AddIndex when all indexed columns are being added in this plan;
-            // emit_add_column already handles the CREATE INDEX for column-add indexes.
-            let all_columns_are_new = columns.iter().all(|c| !old_col_names.contains(c.as_str()));
-            if all_columns_are_new {
+            // Skip AddIndex only when it is a single-column index whose sole column is
+            // newly added — emit_add_column already emits that CREATE INDEX.
+            // Composite indexes are never emitted by emit_add_column and must NOT be
+            // skipped here, even when every indexed column is new (AGENTS.md I-1).
+            if columns.len() == 1 && !old_col_names.contains(columns[0].as_str()) {
                 continue;
             }
             plan.operations.push(MigrationOp::AddIndex {

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -711,3 +711,59 @@ fn emit_sql_no_comment_placeholders_on_full_plan() {
         assert_no_comment_placeholders(&result.statements);
     }
 }
+
+// Regression: composite index whose columns are all newly added must NOT be skipped.
+// Before the fix, `all_columns_are_new` caused this AddIndex to be silently dropped.
+#[test]
+fn plan_from_ir_composite_all_new_columns_emits_add_index() {
+    let old = envelope(vec![schema_model("doc", vec![col("id", "int", false)])]);
+    let mut nm = schema_model(
+        "doc",
+        vec![col("id", "int", false), col("a", "text", true), col("b", "text", true)],
+    );
+    nm.indexes = vec![SchemaIndex {
+        name: "idx_doc_a_b".to_string(),
+        columns: vec!["a".to_string(), "b".to_string()],
+        unique: false,
+    }];
+    let new = envelope(vec![nm]);
+    let plan = plan_from_ir(&old, &new, BackendDialect::Sqlite);
+    assert!(
+        plan.operations.contains(&MigrationOp::AddIndex {
+            table: "doc".to_string(),
+            name: "idx_doc_a_b".to_string(),
+            columns: vec!["a".to_string(), "b".to_string()],
+            unique: false,
+        }),
+        "composite index over all-new columns must appear in plan; got: {:?}",
+        plan.operations
+    );
+}
+
+// Regression: single-column index on a newly added column IS correctly skipped
+// because emit_add_column emits the CREATE INDEX for that case.
+#[test]
+fn plan_from_ir_single_column_new_index_is_skipped() {
+    let old = envelope(vec![schema_model("doc", vec![col("id", "int", false)])]);
+    let mut nm = schema_model(
+        "doc",
+        vec![col("id", "int", false), col_with_flags("c", "text", true, false, true, None)],
+    );
+    nm.indexes = vec![SchemaIndex {
+        name: "idx_doc_c".to_string(),
+        columns: vec!["c".to_string()],
+        unique: false,
+    }];
+    let new = envelope(vec![nm]);
+    let plan = plan_from_ir(&old, &new, BackendDialect::Sqlite);
+    assert!(
+        !plan.operations.contains(&MigrationOp::AddIndex {
+            table: "doc".to_string(),
+            name: "idx_doc_c".to_string(),
+            columns: vec!["c".to_string()],
+            unique: false,
+        }),
+        "single-column index on a new column must NOT appear in plan (emit_add_column handles it); got: {:?}",
+        plan.operations
+    );
+}

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -655,6 +655,44 @@ fn emit_sql_multi_op_ordering() {
 }
 
 #[test]
+fn plan_from_ir_adds_missing_index() {
+    let old = envelope(vec![schema_model("doc", vec![col("a", "text", true), col("b", "text", true)])]);
+    let mut nm = schema_model("doc", vec![col("a", "text", true), col("b", "text", true)]);
+    nm.indexes = vec![SchemaIndex { name: "idx_doc_a_b".into(), columns: vec!["a".into(), "b".into()], unique: false }];
+    let new = envelope(vec![nm]);
+    let plan = plan_from_ir(&old, &new, BackendDialect::Sqlite);
+    assert!(plan.operations.contains(&MigrationOp::AddIndex {
+        table: "doc".into(), name: "idx_doc_a_b".into(), columns: vec!["a".into(), "b".into()], unique: false
+    }));
+}
+
+#[test]
+fn plan_from_ir_drops_orphaned_index() {
+    let mut om = schema_model("doc", vec![col("a", "text", true)]);
+    om.indexes = vec![SchemaIndex { name: "idx_doc_a".into(), columns: vec!["a".into()], unique: false }];
+    let old = envelope(vec![om]);
+    let new = envelope(vec![schema_model("doc", vec![col("a", "text", true)])]); // no index
+    let plan = plan_from_ir(&old, &new, BackendDialect::Sqlite);
+    assert!(plan.operations.contains(&MigrationOp::DropIndex { table: "doc".into(), name: "idx_doc_a".into() }));
+}
+
+#[test]
+fn emit_add_index_matches_create_path() {
+    let plan = MigrationPlan { operations: vec![MigrationOp::AddIndex {
+        table: "doc".into(), name: "idx_doc_a_b".into(), columns: vec!["a".into(), "b".into()], unique: false
+    }], warnings: vec![] };
+    let r = emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Sqlite).unwrap();
+    assert_eq!(r.statements, vec!["CREATE INDEX IF NOT EXISTS \"idx_doc_a_b\" ON \"doc\" (\"a\", \"b\")".to_string()]);
+}
+
+#[test]
+fn emit_drop_index_renders_drop() {
+    let plan = MigrationPlan { operations: vec![MigrationOp::DropIndex { table: "doc".into(), name: "idx_doc_a".into() }], warnings: vec![] };
+    let r = emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Postgres).unwrap();
+    assert_eq!(r.statements, vec!["DROP INDEX IF EXISTS \"idx_doc_a\"".to_string()]);
+}
+
+#[test]
 fn emit_sql_no_comment_placeholders_on_full_plan() {
     let old_ir = envelope(vec![schema_model(
         "doc",

--- a/docs/brainstorms/2026-06-26-ir-p8.5-144-reconcile-indexes-requirements.md
+++ b/docs/brainstorms/2026-06-26-ir-p8.5-144-reconcile-indexes-requirements.md
@@ -83,6 +83,23 @@ autoindexes, or anything not matching its naming convention.
 - Postgres unique: emitted as a unique **index** (`CREATE UNIQUE INDEX uq_…`),
   matching what `post_create_artifacts` emits for composite uniques today.
 
+## Parity gate (#120) — scoped to column-ops
+
+This is the point where the IR planner **legitimately surpasses** the legacy
+planner: `plan_table_migration_legacy` reconciles only columns (it emits an index
+only when *adding a column*, never standalone/composite on existing tables), so
+the #120 byte-parity assertion (`shadow_compare_migration_plan`:
+`ir.statements == legacy.statements`) can no longer hold once the IR planner emits
+`AddIndex`/`DropIndex`.
+
+Resolution (approved): scope the IR↔legacy parity to the **legacy planner's
+domain**. Exclude `AddIndex`/`DropIndex` statements from the IR side before
+comparing to legacy in `shadow_compare_migration_plan` and the
+`assert_ir_legacy_parity` test helpers. Column add/drop/alter parity stays
+enforced (until Phase 9 removes legacy); index reconciliation is verified by the
+new tests below. We do **not** teach the legacy planner index reconciliation —
+it's deleted in Phase 9 (no stop-gap).
+
 ## Validation
 
 New auto-migrate tests on **both backends** (`tests/test_auto_migrate.py` /

--- a/docs/brainstorms/2026-06-26-ir-p8.5-144-reconcile-indexes-requirements.md
+++ b/docs/brainstorms/2026-06-26-ir-p8.5-144-reconcile-indexes-requirements.md
@@ -1,0 +1,113 @@
+---
+title: "IR-P8.5 #144 — reconcile indexes & uniques in auto-migrate"
+type: requirements
+status: draft
+date: 2026-06-26
+issue: https://github.com/syn54x/ferro-orm/issues/144
+epic: https://github.com/syn54x/ferro-orm/issues/139
+roadmap: docs/plans/2026-06-19-001-ir-first-roadmap.md (Phase 8.5)
+---
+
+# #144 — Reconcile indexes & uniques in auto-migrate
+
+## Goal
+
+Auto-migrate reconciles **standalone, Ferro-named** indexes & uniques (single +
+composite) on existing tables — symmetric with how it already reconciles columns.
+Today this is a **silent no-op**: a user who adds an index to their model and
+restarts with `auto_migrate` gets no index and no warning (verified — the create
+path emits `CREATE INDEX "idx_t_a_b"`, the migrate path emits nothing).
+
+## The parity principle (gives us AGENTS.md I-1 for free)
+
+The migrate path reconciles **exactly the set of standalone `CREATE INDEX`
+statements the create path's `post_create_artifacts` already emits** — i.e.
+`model.indexes` + `model.uniques`, minus inline single-column uniques (those the
+create path renders inline in the column definition, never as a `uq_` index).
+By reusing the same naming helpers (`ferro-ddl-lowering::*_index_name` /
+`*_unique_index_name`) and the same `render_index_sql`, an auto-migrated table is
+byte-identical to a freshly created one.
+
+## Behavior
+
+Matched **by Ferro's canonical names only** — `idx_<table>_<cols>` and
+`uq_<table>_<cols>`. Ferro never touches user-created indexes, PK/constraint
+autoindexes, or anything not matching its naming convention.
+
+- **ADD (always):** a model index/unique whose canonical name is absent from the
+  live table → `CREATE INDEX` / `CREATE UNIQUE INDEX`.
+- **DROP (only `migrate_destructive`):** a Ferro-named index present live but gone
+  from the model → `DROP INDEX`. Mirrors `DropColumn` (filtered out when not
+  destructive).
+- **Out of scope:** inline single-column `UNIQUE` on existing columns. The create
+  path renders these inline (not as a `uq_` index), so there is no standalone
+  index to reconcile; adding/removing an inline constraint on an existing column
+  remains an Alembic concern (and `emit_add_column` already handles the
+  new-unique-column case).
+
+## Components
+
+1. **Live introspection (the one genuinely new piece).**
+   `live_table_indexes(engine, table) -> Vec<LiveIndex>` in `src/introspect.rs`,
+   dispatching by backend like `live_table_columns`:
+   - SQLite: `PRAGMA index_list(table)` + `PRAGMA index_info(name)`.
+   - Postgres: `pg_indexes` / `pg_catalog` (index name, columns, `is_unique`).
+   Returns only **Ferro-named standalone** indexes (`idx_`/`uq_` prefix); each
+   `LiveIndex` carries `name`, `columns` (ordered), `unique`. (PK/constraint
+   autoindexes and user indexes are filtered out by the name prefix.)
+
+2. **Populate the model IR.** `schema_json_to_schema_ir` (`src/migrate.rs`) fills
+   `indexes`/`uniques` from the JSON schema — single-column `index=`/`unique=` and
+   `ferro_composite_indexes`/`ferro_composite_uniques` — using the shared naming
+   helpers, mirroring the Python `compile_schema_ir_payload`.
+   `live_columns_to_schema_ir` is replaced/augmented so the live model carries the
+   introspected index set.
+
+3. **Diff + ops.** New `MigrationOp::AddIndex { table, name }` and
+   `DropIndex { table, name }` in `ferro-migrate`. `plan_from_ir` compares the
+   model's standalone-index set vs the live set by name (ADD missing; DROP
+   orphaned). `plan_table_migration` filters `DropIndex` out unless
+   `opts.destructive`, exactly as it does for `DropColumn`.
+
+4. **Emit.** `AddIndex` → look up the `SchemaIndex`/`SchemaUnique` by name in the
+   new IR and render via `render_index_sql` (reused). `DropIndex` →
+   `DROP INDEX [IF EXISTS] "<name>"` (SQLite/Postgres spelling).
+
+## Execution / ordering notes
+
+- `AddIndex` runs after column adds (a new composite index may reference a
+  just-added column). `DropIndex` runs before column drops where a SQLite drop
+  needs the index gone first — note the existing `execute_drop_column` already
+  drops covering indexes for SQLite, so avoid double-dropping (a `DROP INDEX IF
+  EXISTS` is idempotent, which keeps this safe).
+- Postgres unique: emitted as a unique **index** (`CREATE UNIQUE INDEX uq_…`),
+  matching what `post_create_artifacts` emits for composite uniques today.
+
+## Validation
+
+New auto-migrate tests on **both backends** (`tests/test_auto_migrate.py` /
+`tests/test_migrate_plan.py`):
+- composite index added to an existing table;
+- single-column `index=` added to an existing column;
+- destructive drop of an orphaned Ferro-named index;
+- a Ferro-named index already present → **no-op** (no spurious re-create — the
+  false-alarm guard);
+- a non-explicit / user-created index is left untouched.
+
+Plus a cross-emitter assertion that a migrate-added index's SQL equals the
+create-emitted one, and the full existing parity/auto-migrate matrix stays green
+on SQLite **and** Postgres.
+
+## Migration impact
+
+`minor` — new auto-migrate behavior (indexes/uniques are now reconciled; under
+`migrate_destructive`, orphaned Ferro-named indexes are dropped). The migration
+guide (`docs/plans/ir-first-migration-guide.md`) and the migrations how-to
+capability matrix must be updated before the issue is Done (roadmap doc policy).
+
+## Non-goals
+
+- Inline single-column `UNIQUE` reconciliation on existing columns (above).
+- Index option changes (partial/where, expression, opclass, collation) — only
+  presence/absence by canonical name is reconciled.
+- Reconciling check constraints (`ck_`) — separate concern.

--- a/docs/pages/guide/migrations.md
+++ b/docs/pages/guide/migrations.md
@@ -40,10 +40,13 @@ What it covers is capability-relative per backend:
 | :--- | :--- | :--- |
 | Add missing column | ✅ `ADD COLUMN` | ✅ `ADD COLUMN` |
 | Add the column's index (`index=True`) | ✅ `CREATE INDEX` | ✅ `CREATE INDEX` |
+| Add composite index (`__ferro_composite_indexes__`) to existing columns | ✅ `CREATE INDEX` | ✅ `CREATE INDEX` |
 | Add unique column (`unique=True`) | ✅ via explicit unique index + warning | ✅ inline `UNIQUE` |
 | Add foreign-key column | ✅ column only, no FK constraint + warning | ✅ column + FK constraint |
 | Change column type | ⚠️ `UserWarning`, no DDL (SQLite type affinity makes drift mostly cosmetic) | ✅ `ALTER COLUMN ... TYPE ... USING` cast |
 | Change nullability | ⚠️ `UserWarning`, no DDL | ✅ `SET NOT NULL` / `DROP NOT NULL` |
+| Drop orphaned Ferro-named index (`idx_*` / `uq_*`) | ✅ with `migrate_destructive=True` | ✅ with `migrate_destructive=True` |
+| Inline single-column `UNIQUE` on existing column, index option changes | ❌ never — Alembic territory | ❌ never |
 | Rename column/table, change primary key, drop table | ❌ never — Alembic territory | ❌ never |
 
 Rules worth knowing:

--- a/docs/plans/2026-06-26-003-feat-ir-p8.5-144-reconcile-indexes-plan.md
+++ b/docs/plans/2026-06-26-003-feat-ir-p8.5-144-reconcile-indexes-plan.md
@@ -1,0 +1,503 @@
+# #144 — Reconcile Indexes & Uniques in Auto-Migrate — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-migrate reconciles standalone Ferro-named indexes & uniques (single + composite) on existing tables — ADD missing always, DROP orphaned under `migrate_destructive` — byte-identical to what the create path emits, on SQLite and Postgres.
+
+**Architecture:** A new live-index introspection layer (`live_table_indexes`) mirrors `live_table_columns`. The `ferro-migrate` planner gains `AddIndex`/`DropIndex` ops and diffs the model's "standalone index set" (the exact set the create path renders) against the live set by canonical name. The Rust producer populates the model IR's `indexes`/`uniques`; the runtime wires introspection → diff → execute. The legacy planner is untouched; IR↔legacy parity is scoped to column-ops.
+
+**Tech Stack:** Rust workspace (`ferro-schema-ir`, `ferro-ddl-lowering`, `ferro-migrate`, `_core`), PyO3, sqlx, sea-query; Python (`uv`/pytest).
+
+## Global Constraints
+
+- **Match by canonical name only:** `idx_<table>_<cols>` / `uq_<table>_<cols>` (helper `is_ferro_index_name`: prefix `idx_` or `uq_`). Never touch user-created indexes, PK/constraint autoindexes, or `sqlite_autoindex_*`.
+- **Parity with the create path (AGENTS.md I-1):** the migrate path reconciles exactly the standalone set `post_create_artifacts` renders — `model.indexes` (all) + `model.uniques` (minus inline single-column uniques). Reuse `render_index_sql` and the shared naming helpers; do not hand-write index SQL.
+- **ADD always; DROP only under `opts.destructive`** (mirror `DropColumn`).
+- **Inline single-column `UNIQUE` on existing columns is out of scope.**
+- **IR↔legacy parity scoped to column-ops:** exclude `AddIndex`/`DropIndex` from the IR side before comparing to legacy (`shadow_compare_migration_plan` + `assert_ir_legacy_parity`). Do NOT teach the legacy planner index reconciliation.
+- **Migration impact `minor`:** update `docs/plans/ir-first-migration-guide.md` + `docs/pages/guide/migrations.md` capability matrix before Done.
+- Rust edition 2024; no new deps. Rust tests: `--no-default-features --features testing`.
+
+---
+
+### Task 1: Live index introspection (`live_table_indexes`)
+
+**Files:**
+- Modify: `src/introspect.rs` (add `LiveIndex`, `is_ferro_index_name`, `live_table_indexes`, `sqlite_table_indexes`, `postgres_table_indexes`)
+
+**Interfaces:**
+- Produces: `pub struct LiveIndex { pub name: String, pub columns: Vec<String>, pub unique: bool }` (derives `Clone, Debug, serde::Deserialize`)
+- Produces: `pub async fn live_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>>` (Ferro-named standalone indexes only)
+- Produces: `pub(crate) fn is_ferro_index_name(name: &str) -> bool`
+
+- [ ] **Step 1: Add the struct + name filter + a failing unit test.** In `src/introspect.rs`:
+
+```rust
+/// One live standalone index that Ferro owns (its name follows the `idx_`/`uq_`
+/// convention). Deserialize exists for `_render_migration_sql_for_test`.
+#[derive(Clone, Debug, serde::Deserialize)]
+pub struct LiveIndex {
+    pub name: String,
+    #[serde(default)]
+    pub columns: Vec<String>,
+    #[serde(default)]
+    pub unique: bool,
+}
+
+/// Ferro emits standalone indexes as `idx_<table>_<cols>` and uniques as
+/// `uq_<table>_<cols>`. Reconciliation only ever touches names it owns.
+pub(crate) fn is_ferro_index_name(name: &str) -> bool {
+    name.starts_with("idx_") || name.starts_with("uq_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_ferro_index_name;
+    #[test]
+    fn ferro_index_names_are_recognized() {
+        assert!(is_ferro_index_name("idx_user_email"));
+        assert!(is_ferro_index_name("uq_user_email"));
+        assert!(!is_ferro_index_name("sqlite_autoindex_user_1"));
+        assert!(!is_ferro_index_name("user_email_key"));
+        assert!(!is_ferro_index_name("my_custom_index"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test — expect PASS** (pure helper).
+
+Run: `cargo test -p _core --no-default-features --features testing is_ferro || cargo test --no-default-features --features testing ferro_index_names_are_recognized`
+Expected: PASS.
+
+- [ ] **Step 3: Add `live_table_indexes` + the two backend impls.** Mirror `live_table_columns` (the query API is `engine.fetch_all_sql_unprepared(&sql)` for SQLite PRAGMA, and `engine.fetch_all_sql_unprepared_with_binds(sql, &[EngineBindValue::String(...)])` for Postgres; row access via `row_string`/`row_bool`/`row_opt_i64`). Add to `src/introspect.rs`:
+
+```rust
+/// Live standalone indexes Ferro owns on `table`, normalized across backends.
+pub async fn live_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>> {
+    match engine.backend() {
+        SqlDialect::Sqlite => sqlite_table_indexes(engine, table).await,
+        SqlDialect::Postgres => postgres_table_indexes(engine, table).await,
+    }
+}
+
+async fn sqlite_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>> {
+    let list_sql = format!("PRAGMA index_list({})", quote_ident(table));
+    let index_rows = engine
+        .fetch_all_sql_unprepared(&list_sql)
+        .await
+        .map_err(|e| introspection_error("PRAGMA index_list", table, e))?;
+
+    let mut out = Vec::new();
+    for index_row in &index_rows {
+        let Some(name) = row_string(index_row, "name") else { continue };
+        if !is_ferro_index_name(&name) {
+            continue;
+        }
+        let unique = row_bool(index_row, "unique");
+        let info_sql = format!("PRAGMA index_info({})", quote_ident(&name));
+        let col_rows = engine
+            .fetch_all_sql_unprepared(&info_sql)
+            .await
+            .map_err(|e| introspection_error("PRAGMA index_info", table, e))?;
+        // PRAGMA index_info returns rows in `seqno` order already.
+        let columns: Vec<String> = col_rows.iter().filter_map(|r| row_string(r, "name")).collect();
+        out.push(LiveIndex { name, columns, unique });
+    }
+    Ok(out)
+}
+
+async fn postgres_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>> {
+    // One row per (index, column); `pos` orders columns within the index.
+    let sql = r#"
+        SELECT cl.relname::text AS index_name,
+               i.indisunique     AS is_unique,
+               a.attname::text   AS column_name,
+               array_position(i.indkey, a.attnum) AS pos
+        FROM pg_index i
+        JOIN pg_class cl ON cl.oid = i.indexrelid
+        JOIN pg_class t  ON t.oid  = i.indrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(i.indkey)
+        WHERE n.nspname = current_schema()
+          AND t.relname = $1
+          AND NOT i.indisprimary
+        ORDER BY cl.relname, pos
+        "#;
+    let rows = engine
+        .fetch_all_sql_unprepared_with_binds(sql, &[EngineBindValue::String(table.to_string())])
+        .await
+        .map_err(|e| introspection_error("pg_index", table, e))?;
+
+    // Group ordered rows into indexes (rows are already ordered by name, pos).
+    let mut out: Vec<LiveIndex> = Vec::new();
+    for row in &rows {
+        let Some(name) = row_string(row, "index_name") else { continue };
+        if !is_ferro_index_name(&name) {
+            continue;
+        }
+        let unique = row_bool(row, "is_unique");
+        let column = row_string(row, "column_name").unwrap_or_default();
+        match out.last_mut() {
+            Some(last) if last.name == name => last.columns.push(column),
+            _ => out.push(LiveIndex { name, columns: vec![column], unique }),
+        }
+    }
+    Ok(out)
+}
+```
+
+- [ ] **Step 4: Build** — `cargo build` (Rust compile; the PyO3 link step may warn — fine). Confirm no unused-import warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/introspect.rs
+git commit -m "feat(introspect): add live_table_indexes for SQLite + Postgres (#144)"
+```
+(The introspection is exercised end-to-end by the Task 4 integration tests; this task lands the code + the name-filter unit test.)
+
+---
+
+### Task 2: `ferro-migrate` IR layer — ops, diff, emit
+
+**Files:**
+- Modify: `crates/ferro-migrate/src/lib.rs` (`MigrationOp` enum; `plan_from_ir`; the `emit_sql` stub match)
+- Modify: `crates/ferro-migrate/src/emit.rs` (`standalone_indexes` helper extracted from `post_create_artifacts`; `emit_sql_with_ir` match arms)
+- Test: `crates/ferro-migrate/src/tests.rs`
+
+**Interfaces:**
+- Produces: `MigrationOp::AddIndex { table: String, name: String, columns: Vec<String>, unique: bool }` and `MigrationOp::DropIndex { table: String, name: String }`
+- Produces: `pub(crate) fn standalone_indexes(model: &SchemaModel) -> Vec<(String, Vec<String>, bool)>` in `emit.rs` (name, columns, unique) — the create path's standalone set.
+
+- [ ] **Step 1: Add the two `MigrationOp` variants** to `crates/ferro-migrate/src/lib.rs` (after `AlterColumnNullability`):
+
+```rust
+    /// A standalone Ferro-named index/unique present in the model but not live.
+    AddIndex {
+        table: String,
+        name: String,
+        columns: Vec<String>,
+        unique: bool,
+    },
+    /// A standalone Ferro-named index present live but gone from the model.
+    DropIndex {
+        table: String,
+        name: String,
+    },
+```
+
+- [ ] **Step 2: Extract `standalone_indexes` in `emit.rs`** (the exact set `post_create_artifacts` renders) and have `post_create_artifacts` use it. Add to `crates/ferro-migrate/src/emit.rs`:
+
+```rust
+/// The standalone indexes/uniques the create path emits as separate
+/// `CREATE [UNIQUE] INDEX` statements: every `model.indexes`, plus `model.uniques`
+/// that are not inline single-column uniques. Returned as (name, columns, unique).
+pub(crate) fn standalone_indexes(model: &SchemaModel) -> Vec<(String, Vec<String>, bool)> {
+    let mut out = Vec::new();
+    for index in &model.indexes {
+        out.push((index.name.clone(), index.columns.clone(), index.unique));
+    }
+    for unique in &model.uniques {
+        if single_column_unique_is_inline(model, &unique.columns) {
+            continue;
+        }
+        out.push((unique.name.clone(), unique.columns.clone(), true));
+    }
+    out
+}
+```
+
+Then rewrite the two loops in `post_create_artifacts` (the `for index in &model.indexes` and `for unique in &model.uniques` blocks) to iterate `standalone_indexes(model)`:
+
+```rust
+    for (name, columns, unique) in standalone_indexes(model) {
+        statements.push(render_index_sql(table_lower, &name, &columns, unique, dialect));
+    }
+```
+
+- [ ] **Step 3: Diff indexes in `plan_from_ir`** (`crates/ferro-migrate/src/lib.rs`). After the existing `diff_model_columns(...)` call inside the `for table in new_tables.intersection(&old_tables)` loop, add an index diff. Add a helper near `diff_model_columns`:
+
+```rust
+fn diff_model_indexes(
+    table: &str,
+    old_model: &SchemaModel,
+    new_model: &SchemaModel,
+    plan: &mut MigrationPlan,
+) {
+    use std::collections::BTreeMap;
+    // Live side: introspected standalone indexes live in old_model.indexes.
+    let old: BTreeMap<&str, &crate::ferro_schema_ir_index> = BTreeMap::new(); // placeholder type, see note
+    let _ = old;
+    let old_by_name: BTreeMap<String, (Vec<String>, bool)> = old_model
+        .indexes
+        .iter()
+        .map(|i| (i.name.clone(), (i.columns.clone(), i.unique)))
+        .collect();
+    let new_set = emit::standalone_indexes(new_model);
+    let new_names: std::collections::BTreeSet<&str> = new_set.iter().map(|(n, _, _)| n.as_str()).collect();
+
+    for (name, columns, unique) in &new_set {
+        if !old_by_name.contains_key(name) {
+            plan.operations.push(MigrationOp::AddIndex {
+                table: table.to_string(),
+                name: name.clone(),
+                columns: columns.clone(),
+                unique: *unique,
+            });
+        }
+    }
+    for name in old_by_name.keys() {
+        if !new_names.contains(name.as_str()) {
+            plan.operations.push(MigrationOp::DropIndex {
+                table: table.to_string(),
+                name: name.clone(),
+            });
+        }
+    }
+}
+```
+
+> Implementer note: drop the `placeholder type` line above — it is illustrative. Use `old_model.indexes` directly (type `&[SchemaIndex]`). Make `mod emit`'s `standalone_indexes` reachable from `lib.rs` via `emit::standalone_indexes` (it is `pub(crate)`).
+
+Call it in `plan_from_ir`:
+
+```rust
+        diff_model_columns(*table, old_model, new_model, ddl_dialect, &mut plan);
+        diff_model_indexes(*table, old_model, new_model, &mut plan);
+```
+
+- [ ] **Step 4: Emit the new ops** in `emit_sql_with_ir` (`crates/ferro-migrate/src/emit.rs`) — add arms to the `for operation in &plan.operations` match:
+
+```rust
+            MigrationOp::AddIndex { table, name, columns, unique } => {
+                result.statements.push(render_index_sql(table, name, columns, *unique, dialect));
+            }
+            MigrationOp::DropIndex { table, name } => {
+                result.statements.push(format!("DROP INDEX IF EXISTS \"{}\"", name));
+            }
+```
+
+(SQLite and Postgres both accept `DROP INDEX IF EXISTS "<name>"`; on Postgres an index name is schema-scoped — `current_schema` is correct here.) Also add matching arms to the legacy `emit_sql` stub in `lib.rs` (it must stay exhaustive — emit a comment for `AddIndex`/`DropIndex`, e.g. `format!("-- index '{}' handled by emit_sql_with_ir", name)`).
+
+- [ ] **Step 5: Write crate unit tests** in `crates/ferro-migrate/src/tests.rs`:
+
+```rust
+#[test]
+fn plan_from_ir_adds_missing_index() {
+    let old = envelope(vec![schema_model("doc", vec![col("a", "text", true), col("b", "text", true)])]);
+    let mut nm = schema_model("doc", vec![col("a", "text", true), col("b", "text", true)]);
+    nm.indexes = vec![SchemaIndex { name: "idx_doc_a_b".into(), columns: vec!["a".into(), "b".into()], unique: false }];
+    let new = envelope(vec![nm]);
+    let plan = plan_from_ir(&old, &new, BackendDialect::Sqlite);
+    assert!(plan.operations.contains(&MigrationOp::AddIndex {
+        table: "doc".into(), name: "idx_doc_a_b".into(), columns: vec!["a".into(), "b".into()], unique: false
+    }));
+}
+
+#[test]
+fn plan_from_ir_drops_orphaned_index() {
+    let mut om = schema_model("doc", vec![col("a", "text", true)]);
+    om.indexes = vec![SchemaIndex { name: "idx_doc_a".into(), columns: vec!["a".into()], unique: false }];
+    let old = envelope(vec![om]);
+    let new = envelope(vec![schema_model("doc", vec![col("a", "text", true)])]); // no index
+    let plan = plan_from_ir(&old, &new, BackendDialect::Sqlite);
+    assert!(plan.operations.contains(&MigrationOp::DropIndex { table: "doc".into(), name: "idx_doc_a".into() }));
+}
+
+#[test]
+fn emit_add_index_matches_create_path() {
+    let plan = MigrationPlan { operations: vec![MigrationOp::AddIndex {
+        table: "doc".into(), name: "idx_doc_a_b".into(), columns: vec!["a".into(), "b".into()], unique: false
+    }], warnings: vec![] };
+    let r = emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Sqlite).unwrap();
+    assert_eq!(r.statements, vec!["CREATE INDEX IF NOT EXISTS \"idx_doc_a_b\" ON \"doc\" (\"a\", \"b\")".to_string()]);
+}
+
+#[test]
+fn emit_drop_index_renders_drop() {
+    let plan = MigrationPlan { operations: vec![MigrationOp::DropIndex { table: "doc".into(), name: "idx_doc_a".into() }], warnings: vec![] };
+    let r = emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Postgres).unwrap();
+    assert_eq!(r.statements, vec!["DROP INDEX IF EXISTS \"idx_doc_a\"".to_string()]);
+}
+```
+
+> The `SchemaIndex` import already exists in `tests.rs` via `ferro_schema_ir`. Confirm the exact `CREATE INDEX` spelling against `render_index_sql`/`SqliteQueryBuilder` output and adjust the expected string if sea-query differs; the test is the source of truth for the spelling.
+
+- [ ] **Step 6: Run crate tests** — `cargo test -p ferro-migrate` → PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ferro-migrate/src/lib.rs crates/ferro-migrate/src/emit.rs crates/ferro-migrate/src/tests.rs
+git commit -m "feat(ferro-migrate): AddIndex/DropIndex ops + index diff/emit (#144)"
+```
+
+---
+
+### Task 3: Rust producer, runtime wiring, and parity scoping
+
+**Files:**
+- Modify: `src/migrate.rs` (`schema_json_to_schema_ir` index/unique population; `live_columns_to_schema_ir` → take live indexes; `plan_table_migration` + `plan_table_migration_legacy` signatures gain `live_indexes`; filter `DropIndex` by destructive; `internal_migrate` introspects + passes; `_render_migration_sql_for_test` + `_shadow_compare_migration_plan_for_test` gain a live-indexes arg; `shadow_compare_migration_plan` + the test parity helpers scoped to column-ops)
+
+**Interfaces:**
+- Consumes (Task 1): `introspect::{LiveIndex, live_table_indexes}`
+- Consumes (Task 2): `MigrationOp::{AddIndex, DropIndex}`
+
+- [ ] **Step 1: Populate the model IR's `indexes`/`uniques`** in `schema_json_to_schema_ir` (replace the two `Vec::<SchemaIndex>::new()` / `Vec::<SchemaUnique>::new()` placeholders). Mirror the Python `compile_schema_ir_payload`: per-column `index=`/`unique=`, then `ferro_composite_indexes`/`ferro_composite_uniques`, using `ferro_ddl_lowering::{single_index_name, single_unique_index_name, composite_index_name, composite_unique_index_name}`. Build `Vec<SchemaIndex>` / `Vec<SchemaUnique>`, sort each by `name`, and pass them into the `SchemaModel`:
+
+```rust
+    // single-column index=/unique= (collected in the column loop)
+    if migrate_column_bool(raw_col, resolved, "index").unwrap_or(false) {
+        indexes.push(SchemaIndex {
+            name: single_index_name(table_lower, name),
+            columns: vec![name.clone()],
+            unique: false,
+        });
+    }
+    if col_plan.is_unique {
+        uniques.push(SchemaUnique {
+            name: single_unique_index_name(table_lower, name),
+            columns: vec![name.clone()],
+        });
+    }
+    // ... after the column loop, composite groups from the schema:
+    for group in schema.get("ferro_composite_indexes").and_then(|g| g.as_array()).into_iter().flatten() {
+        let cols: Vec<String> = group.as_array().map(|a| a.iter().filter_map(|c| c.as_str().map(String::from)).collect()).unwrap_or_default();
+        if cols.len() >= 2 {
+            let refs: Vec<&str> = cols.iter().map(String::as_str).collect();
+            indexes.push(SchemaIndex { name: composite_index_name(table_lower, &refs), columns: cols, unique: false });
+        }
+    }
+    for group in schema.get("ferro_composite_uniques").and_then(|g| g.as_array()).into_iter().flatten() {
+        let cols: Vec<String> = group.as_array().map(|a| a.iter().filter_map(|c| c.as_str().map(String::from)).collect()).unwrap_or_default();
+        if cols.len() >= 2 {
+            let refs: Vec<&str> = cols.iter().map(String::as_str).collect();
+            uniques.push(SchemaUnique { name: composite_unique_index_name(table_lower, &refs), columns: cols });
+        }
+    }
+    indexes.sort_by(|a, b| a.name.cmp(&b.name));
+    uniques.sort_by(|a, b| a.name.cmp(&b.name));
+```
+
+Import the four naming helpers from `ferro_ddl_lowering` at the top of `migrate.rs`.
+
+- [ ] **Step 2: Feed live indexes into the live IR.** Change `live_columns_to_schema_ir(table, live, backend)` to `live_to_schema_ir(table, live, live_indexes, backend)` (or add a param) and populate `indexes` from `&[LiveIndex]`:
+
+```rust
+            indexes: live_indexes.iter().map(|i| SchemaIndex {
+                name: i.name.clone(), columns: i.columns.clone(), unique: i.unique,
+            }).collect(),
+            uniques: Vec::<SchemaUnique>::new(),
+```
+
+- [ ] **Step 3: Thread `live_indexes` through `plan_table_migration`** (and `plan_table_migration_legacy`, which ignores it — keeps call sites uniform). Signature: add `live_indexes: &[LiveIndex]`. In `plan_table_migration`, build `old_ir` with `live_to_schema_ir(table_lower, live, live_indexes, backend)`. Add `DropIndex` to the non-destructive filter (alongside the existing `DropColumn` retain):
+
+```rust
+    if !opts.destructive {
+        typed_plan.operations.retain(|op| !matches!(op, MigrationOp::DropColumn { .. } | MigrationOp::DropIndex { .. }));
+    }
+```
+
+(AddIndex flows through `exec_ops` → `emit_sql_with_ir` → `plan.statements`, executed like any other statement. `DropIndex` under destructive also flows through `plan.statements` as `DROP INDEX IF EXISTS`.)
+
+- [ ] **Step 4: Wire introspection into `internal_migrate`.** Where it calls `live_table_columns(&engine, &table_lower)`, also call `live_table_indexes`, and pass both to `plan_table_migration`:
+
+```rust
+        let live_indexes = live_table_indexes(&engine, &table_lower).await?;
+        let mut plan = plan_table_migration(&table_lower, &schema, &live, &live_indexes, backend, opts)?;
+```
+
+Import `live_table_indexes` from `crate::introspect`.
+
+- [ ] **Step 5: Scope the parity comparison to column-ops.** In `shadow_compare_migration_plan` and the test helper `_shadow_compare_migration_plan_for_test` (and `plan_with_ir_legacy_parity` in the `#[cfg(test)] mod tests`), compare the IR plan with index statements removed against legacy. Add a filter helper and use it:
+
+```rust
+fn without_index_statements(statements: &[String]) -> Vec<String> {
+    statements.iter().filter(|s| {
+        let t = s.trim_start();
+        !(t.starts_with("DROP INDEX") )  // index drops are IR-only
+    }).cloned().collect()
+}
+```
+
+> The only IR-only index statements that legacy never produces are the **standalone** `CREATE [UNIQUE] INDEX` from `AddIndex` and the `DROP INDEX` from `DropIndex`. Column-add indexes (legacy produces these too) must NOT be filtered. Since both come out as `CREATE INDEX`, filtering by string is ambiguous — instead, scope at the typed-op level: have `plan_table_migration` expose (test-only) the column-domain statements, OR compare `legacy.statements` against the IR plan re-emitted from `typed_plan.operations` **with `AddIndex`/`DropIndex` filtered out**. Implement the latter: in `shadow_compare_migration_plan`, after building `typed_plan`, build `column_ops = typed_plan.operations without AddIndex/DropIndex`, emit them via `emit_sql_with_ir`, and compare those statements + drop_columns + warnings to `legacy`. This is exact and unambiguous.
+
+Replace the body of `shadow_compare_migration_plan` so the IR side is the column-domain emission (filter `AddIndex`/`DropIndex` from the typed ops before `emit_sql_with_ir`), and compare to `legacy`. Apply the same column-domain projection in the `plan_with_ir_legacy_parity` test helper.
+
+- [ ] **Step 6: Add the live-indexes arg to the test FFI helpers.** `_render_migration_sql_for_test` and `_shadow_compare_migration_plan_for_test`: add a `live_indexes_json: String` parameter (parsed as `Vec<LiveIndex>`, default `"[]"`), and pass it through. Update the `#[pyo3(signature = …)]` lines and `src/ferro/_core.pyi`.
+
+- [ ] **Step 7: Build + run the full Rust suite**
+
+Run: `cargo build` then `cargo test --no-default-features --features testing` and `cargo test -p ferro-migrate -p ferro-ddl-lowering -p ferro-schema-ir`
+Expected: PASS — including the existing IR-vs-legacy parity tests (now column-scoped) and the migrate IR-legacy parity matrix.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/migrate.rs src/ferro/_core.pyi
+git commit -m "feat(migrate): wire index reconciliation into auto-migrate; scope parity to column-ops (#144)"
+```
+
+---
+
+### Task 4: Integration tests (both backends) + docs
+
+**Files:**
+- Test: `tests/test_auto_migrate.py` (new index-reconciliation tests)
+- Modify: `docs/plans/ir-first-migration-guide.md`, `docs/pages/guide/migrations.md` (capability matrix)
+
+- [ ] **Step 1: Add auto-migrate integration tests** to `tests/test_auto_migrate.py`, parametrized over the backend matrix (follow the file's existing `@pytest.mark.backend_matrix` / `db_url` fixture pattern). Cover:
+  - **add composite index:** create a model+table, then redefine the model with a `ferro_composite_indexes` on two existing columns, run auto-migrate, assert the live table now has `idx_<t>_<a>_<b>` (introspect via the engine).
+  - **add single-column index to an existing column:** add `index=True` to an existing field → `idx_<t>_<col>` appears.
+  - **no-op when present:** run auto-migrate again → no statements, index unchanged (the false-alarm guard).
+  - **destructive drop:** remove the composite index from the model, run with `migrate_destructive=True` → `idx_<t>_<a>_<b>` is dropped; without destructive → it remains.
+  - **leaves a user index untouched:** a hand-created `CREATE INDEX my_custom_idx` survives auto-migrate (non-destructive and destructive).
+
+Use the same harness the existing auto-migrate tests use (connect with `auto_migrate=True`, then re-introspect). Write real assertions against the live index set (e.g. `PRAGMA index_list` / `pg_indexes` via a raw query, or a small helper).
+
+- [ ] **Step 2: Run the new tests on SQLite**
+
+Run: `uv run pytest tests/test_auto_migrate.py -q -k "index"`
+Expected: PASS.
+
+- [ ] **Step 3: Update docs.** In `docs/pages/guide/migrations.md` capability matrix, add a row: auto-migrate now **adds** missing indexes/uniques on existing tables and **drops** orphaned Ferro-named ones under `migrate_destructive`; inline single-column UNIQUE on existing columns and index option changes remain Alembic's domain. Add a matching `minor`-impact entry to `docs/plans/ir-first-migration-guide.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_auto_migrate.py docs/pages/guide/migrations.md docs/plans/ir-first-migration-guide.md
+git commit -m "test(migrate): index-reconciliation auto-migrate tests; docs (#144)"
+```
+
+---
+
+### Task 5: Behavior-preservation + new-behavior gate
+
+- [ ] **Step 1: Cross-emitter + IR contract + Alembic**
+
+Run: `uv run pytest tests/test_db_type_cross_emitter_parity.py tests/test_cross_emitter_parity.py tests/test_ir_vectors_contract.py tests/test_alembic_autogenerate.py -q`
+Expected: PASS (create-path index emission unchanged; the new `standalone_indexes` extraction is behavior-preserving for create).
+
+- [ ] **Step 2: Auto-migrate + migrate-plan on the backend matrix**
+
+Run: `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py -q`
+Expected: PASS on SQLite; Postgres via CI if no local server (the new index tests must run on Postgres in CI — note it in the PR).
+
+- [ ] **Step 3: Full Rust suite** — `cargo test --no-default-features --features testing` → PASS.
+
+- [ ] **Step 4: Open the PR** into the integration branch
+
+```bash
+git push -u origin feat/ir-p8.5-144-reconcile-indexes
+gh pr create --base feat/ir-p8.5-lowering-consolidation --title "feat(migrate): reconcile indexes & uniques in auto-migrate (#144)" --body "<closes #144 when 8.5 lands on main; new live_table_indexes; ADD always / DROP destructive; parity scoped to column-ops; CI must run the postgres matrix>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** introspection both backends (T1); ops + diff + emit + create-path parity via shared `standalone_indexes` (T2); producer population, runtime wiring, destructive filter, parity-gate scoping, test FFI args (T3); both-backend integration tests incl. no-op/user-index guards + docs (T4); validation gate (T5). ✅
+
+**Placeholder scan:** the `diff_model_indexes` snippet carries an explicit "drop the placeholder line" implementer note and the parity-scoping step spells out the exact typed-op projection; no `TODO`/`TBD`. The `<...>` in the PR body is author-filled at PR time. ✅
+
+**Type consistency:** `LiveIndex { name, columns, unique }` (T1) flows into `live_to_schema_ir` → `old_model.indexes` (`SchemaIndex`); `standalone_indexes -> Vec<(String, Vec<String>, bool)>` (T2) is consumed by `diff_model_indexes` and `post_create_artifacts`; `AddIndex { table, name, columns, unique }` / `DropIndex { table, name }` are constructed in T2's diff and matched in T2's emit. ✅

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -141,6 +141,7 @@ Runtime migration IR cutover (target: `v0.13.0`).
 | [#118](https://github.com/syn54x/ferro-orm/issues/118) | Complete executable SQL emission from `MigrationPlan` for all ops (SQLite + Postgres) | none | No action | Continues #90 scaffold |
 | [#119](https://github.com/syn54x/ferro-orm/issues/119) | Wire `auto_migrate` / `plan_table_migration` to execute ferro-migrate IR plans | none | No action — behavior must remain observably identical | IR planner becomes primary; legacy path deprecated |
 | [#120](https://github.com/syn54x/ferro-orm/issues/120) | Parity gate + shadow comparison (IR vs legacy, `create_tables`, Alembic) | none | No action | Legacy planner retained deprecated; removal in Phase 9 |
+| [#144](https://github.com/syn54x/ferro-orm/issues/144) | `migrate_updates` now reconciles standalone indexes on existing tables: adds missing Ferro-named indexes (`idx_*` / `uq_*`) and, under `migrate_destructive`, drops orphaned ones | minor | No action required — index reconciliation is automatic under existing flags; hand-created user indexes (names not starting with `idx_`/`uq_`) are never touched | Covered by integration tests in `tests/test_auto_migrate.py` |
 
 - **Migration impact:** `none` for public APIs — `connect(auto_migrate=...)` and `ferro.migrate` signatures unchanged.
 - **Internal change:** `auto_migrate` executes `ferro-migrate` `SchemaIR(old,new)` plans as the primary path. The legacy enriched-JSON diff walk in `src/migrate.rs` is **deprecated** and kept for shadow comparison until Phase 9 removal.

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -46,12 +46,15 @@ def _render_migration_sql_for_test(
     dialect: str,
     updates: bool = True,
     destructive: bool = False,
+    live_indexes_json: str = "",
 ) -> tuple[list[str], list[str]]:
     """Test-only: render the auto-migrate diff for one table without a database.
 
     ``live_columns_json`` is a JSON array of objects with the LiveColumn shape
     (``name``, ``declared_type``, ``is_nullable``, ``is_primary_key``,
-    ``char_max_len``, ``is_enum_udt``). Returns ``(statements, warnings)``.
+    ``char_max_len``, ``is_enum_udt``). ``live_indexes_json`` is a JSON array
+    of objects with the LiveIndex shape (``name``, ``columns``, ``unique``).
+    Returns ``(statements, warnings)``.
     """
     ...
 
@@ -62,8 +65,9 @@ def _shadow_compare_migration_plan_for_test(
     dialect: str,
     updates: bool = True,
     destructive: bool = False,
+    live_indexes_json: str = "",
 ) -> str:
-    """Test-only: compare IR-primary vs legacy migration planners."""
+    """Test-only: compare IR-primary vs legacy migration planners (column-domain scoped)."""
     ...
 
 def _shadow_compare_query_plan_for_test(

--- a/src/introspect.rs
+++ b/src/introspect.rs
@@ -287,7 +287,7 @@ async fn postgres_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<
         SELECT cl.relname::text AS index_name,
                i.indisunique     AS is_unique,
                a.attname::text   AS column_name,
-               array_position(i.indkey, a.attnum) AS pos
+               array_position(i.indkey::smallint[], a.attnum) AS pos
         FROM pg_index i
         JOIN pg_class cl ON cl.oid = i.indexrelid
         JOIN pg_class t  ON t.oid  = i.indrelid
@@ -311,7 +311,7 @@ async fn postgres_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<
             continue;
         }
         let unique = row_bool(row, "is_unique");
-        let column = row_string(row, "column_name").unwrap_or_default();
+        let Some(column) = row_string(row, "column_name") else { continue };
         match out.last_mut() {
             Some(last) if last.name == name => last.columns.push(column),
             _ => out.push(LiveIndex { name, columns: vec![column], unique }),

--- a/src/introspect.rs
+++ b/src/introspect.rs
@@ -40,6 +40,23 @@ pub struct LiveColumn {
     pub is_enum_udt: bool,
 }
 
+/// One live standalone index that Ferro owns (its name follows the `idx_`/`uq_`
+/// convention). Deserialize exists for `_render_migration_sql_for_test`.
+#[derive(Clone, Debug, serde::Deserialize)]
+pub struct LiveIndex {
+    pub name: String,
+    #[serde(default)]
+    pub columns: Vec<String>,
+    #[serde(default)]
+    pub unique: bool,
+}
+
+/// Ferro emits standalone indexes as `idx_<table>_<cols>` and uniques as
+/// `uq_<table>_<cols>`. Reconciliation only ever touches names it owns.
+pub(crate) fn is_ferro_index_name(name: &str) -> bool {
+    name.starts_with("idx_") || name.starts_with("uq_")
+}
+
 /// One live SQLite index covering some column, with enough context to decide
 /// whether it can be dropped ahead of `ALTER TABLE ... DROP COLUMN`.
 #[derive(Clone, Debug)]
@@ -230,6 +247,79 @@ pub async fn sqlite_indexes_covering_column(
     Ok(covering)
 }
 
+/// Live standalone indexes Ferro owns on `table`, normalized across backends.
+pub async fn live_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>> {
+    match engine.backend() {
+        SqlDialect::Sqlite => sqlite_table_indexes(engine, table).await,
+        SqlDialect::Postgres => postgres_table_indexes(engine, table).await,
+    }
+}
+
+async fn sqlite_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>> {
+    let list_sql = format!("PRAGMA index_list({})", quote_ident(table));
+    let index_rows = engine
+        .fetch_all_sql_unprepared(&list_sql)
+        .await
+        .map_err(|e| introspection_error("PRAGMA index_list", table, e))?;
+
+    let mut out = Vec::new();
+    for index_row in &index_rows {
+        let Some(name) = row_string(index_row, "name") else { continue };
+        if !is_ferro_index_name(&name) {
+            continue;
+        }
+        let unique = row_bool(index_row, "unique");
+        let info_sql = format!("PRAGMA index_info({})", quote_ident(&name));
+        let col_rows = engine
+            .fetch_all_sql_unprepared(&info_sql)
+            .await
+            .map_err(|e| introspection_error("PRAGMA index_info", table, e))?;
+        // PRAGMA index_info returns rows in `seqno` order already.
+        let columns: Vec<String> = col_rows.iter().filter_map(|r| row_string(r, "name")).collect();
+        out.push(LiveIndex { name, columns, unique });
+    }
+    Ok(out)
+}
+
+async fn postgres_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>> {
+    // One row per (index, column); `pos` orders columns within the index.
+    let sql = r#"
+        SELECT cl.relname::text AS index_name,
+               i.indisunique     AS is_unique,
+               a.attname::text   AS column_name,
+               array_position(i.indkey, a.attnum) AS pos
+        FROM pg_index i
+        JOIN pg_class cl ON cl.oid = i.indexrelid
+        JOIN pg_class t  ON t.oid  = i.indrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(i.indkey)
+        WHERE n.nspname = current_schema()
+          AND t.relname = $1
+          AND NOT i.indisprimary
+        ORDER BY cl.relname, pos
+        "#;
+    let rows = engine
+        .fetch_all_sql_unprepared_with_binds(sql, &[EngineBindValue::String(table.to_string())])
+        .await
+        .map_err(|e| introspection_error("pg_index", table, e))?;
+
+    // Group ordered rows into indexes (rows are already ordered by name, pos).
+    let mut out: Vec<LiveIndex> = Vec::new();
+    for row in &rows {
+        let Some(name) = row_string(row, "index_name") else { continue };
+        if !is_ferro_index_name(&name) {
+            continue;
+        }
+        let unique = row_bool(row, "is_unique");
+        let column = row_string(row, "column_name").unwrap_or_default();
+        match out.last_mut() {
+            Some(last) if last.name == name => last.columns.push(column),
+            _ => out.push(LiveIndex { name, columns: vec![column], unique }),
+        }
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,6 +335,15 @@ mod tests {
         })
         .await
         .unwrap()
+    }
+
+    #[test]
+    fn ferro_index_names_are_recognized() {
+        assert!(is_ferro_index_name("idx_user_email"));
+        assert!(is_ferro_index_name("uq_user_email"));
+        assert!(!is_ferro_index_name("sqlite_autoindex_user_1"));
+        assert!(!is_ferro_index_name("user_email_key"));
+        assert!(!is_ferro_index_name("my_custom_index"));
     }
 
     #[tokio::test]

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -16,7 +16,9 @@
 use crate::backend::EngineHandle;
 use ferro_ddl_lowering::{
     CanonicalType, Dialect, apply_canonical_type, canonical_to_db_type_token,
-    db_check_constraint_name, information_schema_to_db_type_token, schema_columns_storage_drift,
+    composite_index_name, composite_unique_index_name, db_check_constraint_name,
+    information_schema_to_db_type_token, schema_columns_storage_drift,
+    single_index_name, single_unique_index_name as ddl_single_unique_index_name,
 };
 use ferro_migrate::{BackendDialect, MigrationOp, emit_sql_with_ir, plan_from_ir};
 use ferro_schema_ir::{
@@ -24,7 +26,8 @@ use ferro_schema_ir::{
     SchemaModel, SchemaUnique,
 };
 use crate::introspect::{
-    LiveColumn, live_table_columns, quote_ident, sqlite_indexes_covering_column,
+    LiveColumn, LiveIndex, live_table_columns, live_table_indexes, quote_ident,
+    sqlite_indexes_covering_column,
 };
 use crate::schema::{
     ColumnPlan, build_column_plan, internal_create_tables,
@@ -120,6 +123,8 @@ fn schema_json_to_schema_ir(
     let mut columns = Vec::new();
     let mut foreign_keys = Vec::new();
     let mut checks = Vec::new();
+    let mut indexes: Vec<SchemaIndex> = Vec::new();
+    let mut uniques: Vec<SchemaUnique> = Vec::new();
     if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
         for (name, raw_col) in properties {
             let resolved = resolve_col_schema(schema, raw_col);
@@ -157,6 +162,20 @@ fn schema_json_to_schema_ir(
                 postgres_native_enum: false,
             });
 
+            if migrate_column_bool(raw_col, resolved, "index").unwrap_or(false) {
+                indexes.push(SchemaIndex {
+                    name: single_index_name(table_lower, name),
+                    columns: vec![name.clone()],
+                    unique: false,
+                });
+            }
+            if col_plan.is_unique {
+                uniques.push(SchemaUnique {
+                    name: ddl_single_unique_index_name(table_lower, name),
+                    columns: vec![name.clone()],
+                });
+            }
+
             if let Some(fk_info) = migrate_column_object(raw_col, resolved, "foreign_key") {
                 let to_table = fk_info
                     .get("to_table")
@@ -190,6 +209,22 @@ fn schema_json_to_schema_ir(
             }
         }
     }
+    for group in schema.get("ferro_composite_indexes").and_then(|g| g.as_array()).into_iter().flatten() {
+        let cols: Vec<String> = group.as_array().map(|a| a.iter().filter_map(|c| c.as_str().map(String::from)).collect()).unwrap_or_default();
+        if cols.len() >= 2 {
+            let refs: Vec<&str> = cols.iter().map(String::as_str).collect();
+            indexes.push(SchemaIndex { name: composite_index_name(table_lower, &refs), columns: cols, unique: false });
+        }
+    }
+    for group in schema.get("ferro_composite_uniques").and_then(|g| g.as_array()).into_iter().flatten() {
+        let cols: Vec<String> = group.as_array().map(|a| a.iter().filter_map(|c| c.as_str().map(String::from)).collect()).unwrap_or_default();
+        if cols.len() >= 2 {
+            let refs: Vec<&str> = cols.iter().map(String::as_str).collect();
+            uniques.push(SchemaUnique { name: composite_unique_index_name(table_lower, &refs), columns: cols });
+        }
+    }
+    indexes.sort_by(|a, b| a.name.cmp(&b.name));
+    uniques.sort_by(|a, b| a.name.cmp(&b.name));
     columns.sort_by(|a, b| a.name.cmp(&b.name));
 
     IrEnvelope {
@@ -202,8 +237,8 @@ fn schema_json_to_schema_ir(
                 table_name: table_lower.to_string(),
                 columns,
                 foreign_keys,
-                indexes: Vec::<SchemaIndex>::new(),
-                uniques: Vec::<SchemaUnique>::new(),
+                indexes,
+                uniques,
                 checks,
             }],
         },
@@ -213,6 +248,7 @@ fn schema_json_to_schema_ir(
 fn live_columns_to_schema_ir(
     table_lower: &str,
     live: &[LiveColumn],
+    live_indexes: &[LiveIndex],
     backend: SqlDialect,
 ) -> IrEnvelope<SchemaIrPayload> {
     let dialect = match backend {
@@ -253,7 +289,9 @@ fn live_columns_to_schema_ir(
                 table_name: table_lower.to_string(),
                 columns,
                 foreign_keys: Vec::<SchemaForeignKey>::new(),
-                indexes: Vec::<SchemaIndex>::new(),
+                indexes: live_indexes.iter().map(|i| SchemaIndex {
+                    name: i.name.clone(), columns: i.columns.clone(), unique: i.unique,
+                }).collect(),
                 uniques: Vec::<SchemaUnique>::new(),
                 checks: Vec::<SchemaCheck>::new(),
             }],
@@ -451,6 +489,7 @@ pub fn plan_table_migration(
     table_lower: &str,
     schema: &serde_json::Value,
     live: &[LiveColumn],
+    live_indexes: &[LiveIndex],
     backend: SqlDialect,
     opts: MigrateOptions,
 ) -> PyResult<MigrationPlan> {
@@ -458,14 +497,14 @@ pub fn plan_table_migration(
         return Ok(MigrationPlan::new());
     }
 
-    let old_ir = live_columns_to_schema_ir(table_lower, live, backend);
+    let old_ir = live_columns_to_schema_ir(table_lower, live, live_indexes, backend);
     let new_ir = schema_json_to_schema_ir(table_lower, schema, backend);
     let mut typed_plan = plan_from_ir(&old_ir, &new_ir, backend_dialect(backend));
 
     if !opts.destructive {
         typed_plan
             .operations
-            .retain(|op| !matches!(op, MigrationOp::DropColumn { .. }));
+            .retain(|op| !matches!(op, MigrationOp::DropColumn { .. } | MigrationOp::DropIndex { .. }));
     }
 
     let mut plan = MigrationPlan::new();
@@ -510,6 +549,7 @@ fn plan_table_migration_legacy(
     table_lower: &str,
     schema: &serde_json::Value,
     live: &[LiveColumn],
+    _live_indexes: &[LiveIndex],
     backend: SqlDialect,
     opts: MigrateOptions,
 ) -> PyResult<MigrationPlan> {
@@ -576,23 +616,59 @@ fn shadow_compare_migration_plan(
     table_lower: &str,
     schema: &serde_json::Value,
     live: &[LiveColumn],
+    live_indexes: &[LiveIndex],
     backend: SqlDialect,
     opts: MigrateOptions,
 ) -> Result<(), String> {
-    let ir = plan_table_migration(table_lower, schema, live, backend, opts)
+    if !opts.updates {
+        return Ok(());
+    }
+    // Build the old and new IRs for the column-domain emission.
+    let old_ir = live_columns_to_schema_ir(table_lower, live, live_indexes, backend);
+    let new_ir = schema_json_to_schema_ir(table_lower, schema, backend);
+
+    let mut typed_plan = plan_from_ir(&old_ir, &new_ir, backend_dialect(backend));
+
+    if !opts.destructive {
+        typed_plan
+            .operations
+            .retain(|op| !matches!(op, MigrationOp::DropColumn { .. } | MigrationOp::DropIndex { .. }));
+    }
+
+    // Separate out DropColumn and standalone index ops; only column-domain ops
+    // are compared to legacy (which never produces standalone index statements).
+    let mut drop_columns: Vec<String> = Vec::new();
+    let mut column_ops: Vec<MigrationOp> = Vec::new();
+    for op in typed_plan.operations {
+        match &op {
+            MigrationOp::DropColumn { column, .. } => drop_columns.push(column.clone()),
+            MigrationOp::AddIndex { .. } | MigrationOp::DropIndex { .. } => {
+                // filtered out — legacy never produces standalone index ops
+            }
+            _ => column_ops.push(op),
+        }
+    }
+
+    let column_plan = ferro_migrate::MigrationPlan {
+        operations: column_ops,
+        warnings: typed_plan.warnings,
+    };
+    let emission = emit_sql_with_ir(&column_plan, &old_ir, &new_ir, backend_dialect(backend))
+        .map_err(|e| e.message)?;
+
+    let legacy = plan_table_migration_legacy(table_lower, schema, live, live_indexes, backend, opts)
         .map_err(|e| e.to_string())?;
-    let legacy = plan_table_migration_legacy(table_lower, schema, live, backend, opts)
-        .map_err(|e| e.to_string())?;
-    if ir.statements == legacy.statements
-        && ir.drop_columns == legacy.drop_columns
-        && ir.warnings == legacy.warnings
+
+    if emission.statements == legacy.statements
+        && drop_columns == legacy.drop_columns
+        && emission.warnings == legacy.warnings
     {
         return Ok(());
     }
     Err(format!(
         "shadow migration-plan mismatch for '{}': ir={} legacy={}",
         table_lower,
-        serde_json::to_string(&ir.statements).unwrap_or_else(|_| "<ir>".to_string()),
+        serde_json::to_string(&emission.statements).unwrap_or_else(|_| "<ir>".to_string()),
         serde_json::to_string(&legacy.statements).unwrap_or_else(|_| "<legacy>".to_string())
     ))
 }
@@ -931,11 +1007,12 @@ pub async fn internal_migrate(engine: Arc<EngineHandle>, opts: MigrateOptions) -
             // Freshly created (or otherwise absent) tables have nothing to diff.
             continue;
         };
+        let live_indexes = live_table_indexes(&engine, &table_lower).await?;
 
-        let mut plan = plan_table_migration(&table_lower, &schema, &live, backend, opts)?;
+        let mut plan = plan_table_migration(&table_lower, &schema, &live, &live_indexes, backend, opts)?;
         if engine.is_shadow_runtime_enabled()
             && let Err(diff) =
-                shadow_compare_migration_plan(&table_lower, &schema, &live, backend, opts)
+                shadow_compare_migration_plan(&table_lower, &schema, &live, &live_indexes, backend, opts)
         {
             crate::log_debug(format!("⚠️ Ferro shadow runtime mismatch: {diff}"));
             if std::env::var("FERRO_SHADOW_RUNTIME_STRICT")
@@ -1030,7 +1107,7 @@ pub fn migrate(
 /// unrecognized, or the diff contains an unsafe change.
 #[pyfunction]
 #[pyo3(name = "_render_migration_sql_for_test")]
-#[pyo3(signature = (name, schema_json, live_columns_json, dialect, updates=true, destructive=false))]
+#[pyo3(signature = (name, schema_json, live_columns_json, dialect, updates=true, destructive=false, live_indexes_json=String::new()))]
 pub fn _render_migration_sql_for_test(
     name: String,
     schema_json: String,
@@ -1038,6 +1115,7 @@ pub fn _render_migration_sql_for_test(
     dialect: String,
     updates: bool,
     destructive: bool,
+    live_indexes_json: String,
 ) -> PyResult<(Vec<String>, Vec<String>)> {
     let backend = match dialect.as_str() {
         "postgres" => SqlDialect::Postgres,
@@ -1055,10 +1133,17 @@ pub fn _render_migration_sql_for_test(
     let live: Vec<LiveColumn> = serde_json::from_str(&live_columns_json).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("Invalid live-columns JSON: {}", e))
     })?;
+    let live_indexes: Vec<LiveIndex> = if live_indexes_json.is_empty() {
+        Vec::new()
+    } else {
+        serde_json::from_str(&live_indexes_json).map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("Invalid live-indexes JSON: {}", e))
+        })?
+    };
 
     let table_lower = name.to_lowercase();
     let opts = MigrateOptions::laddered(updates, destructive);
-    let plan = plan_table_migration(&table_lower, &schema, &live, backend, opts)?;
+    let plan = plan_table_migration(&table_lower, &schema, &live, &live_indexes, backend, opts)?;
 
     let mut statements = plan.statements;
     for col_name in &plan.drop_columns {
@@ -1084,7 +1169,7 @@ fn migration_plan_snapshot(plan: &MigrationPlan) -> serde_json::Value {
 /// Returns JSON with `matches`, `ir`, and `legacy` plan snapshots.
 #[pyfunction]
 #[pyo3(name = "_shadow_compare_migration_plan_for_test")]
-#[pyo3(signature = (name, schema_json, live_columns_json, dialect, updates=true, destructive=false))]
+#[pyo3(signature = (name, schema_json, live_columns_json, dialect, updates=true, destructive=false, live_indexes_json=String::new()))]
 pub fn _shadow_compare_migration_plan_for_test(
     name: String,
     schema_json: String,
@@ -1092,6 +1177,7 @@ pub fn _shadow_compare_migration_plan_for_test(
     dialect: String,
     updates: bool,
     destructive: bool,
+    live_indexes_json: String,
 ) -> PyResult<String> {
     let backend = match dialect.as_str() {
         "postgres" => SqlDialect::Postgres,
@@ -1109,17 +1195,55 @@ pub fn _shadow_compare_migration_plan_for_test(
     let live: Vec<LiveColumn> = serde_json::from_str(&live_columns_json).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("Invalid live-columns JSON: {}", e))
     })?;
+    let live_indexes: Vec<LiveIndex> = if live_indexes_json.is_empty() {
+        Vec::new()
+    } else {
+        serde_json::from_str(&live_indexes_json).map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("Invalid live-indexes JSON: {}", e))
+        })?
+    };
 
     let table_lower = name.to_lowercase();
     let opts = MigrateOptions::laddered(updates, destructive);
-    let ir = plan_table_migration(&table_lower, &schema, &live, backend, opts)?;
-    let legacy = plan_table_migration_legacy(&table_lower, &schema, &live, backend, opts)?;
-    let matches = ir.statements == legacy.statements
-        && ir.drop_columns == legacy.drop_columns
-        && ir.warnings == legacy.warnings;
+
+    // Build column-domain IR plan (filter AddIndex/DropIndex) for parity comparison.
+    let old_ir = live_columns_to_schema_ir(&table_lower, &live, &live_indexes, backend);
+    let new_ir = schema_json_to_schema_ir(&table_lower, &schema, backend);
+    let mut typed_plan = plan_from_ir(&old_ir, &new_ir, backend_dialect(backend));
+    if !opts.destructive {
+        typed_plan
+            .operations
+            .retain(|op| !matches!(op, MigrationOp::DropColumn { .. } | MigrationOp::DropIndex { .. }));
+    }
+    let mut drop_columns: Vec<String> = Vec::new();
+    let mut column_ops: Vec<MigrationOp> = Vec::new();
+    for op in typed_plan.operations {
+        match &op {
+            MigrationOp::DropColumn { column, .. } => drop_columns.push(column.clone()),
+            MigrationOp::AddIndex { .. } | MigrationOp::DropIndex { .. } => {}
+            _ => column_ops.push(op),
+        }
+    }
+    let column_plan = ferro_migrate::MigrationPlan {
+        operations: column_ops,
+        warnings: typed_plan.warnings,
+    };
+    let emission = emit_sql_with_ir(&column_plan, &old_ir, &new_ir, backend_dialect(backend))
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.message))?;
+
+    let legacy = plan_table_migration_legacy(&table_lower, &schema, &live, &live_indexes, backend, opts)?;
+
+    let matches = emission.statements == legacy.statements
+        && drop_columns == legacy.drop_columns
+        && emission.warnings == legacy.warnings;
+    let ir_snapshot = serde_json::json!({
+        "statements": emission.statements,
+        "drop_columns": drop_columns,
+        "warnings": emission.warnings,
+    });
     let payload = serde_json::json!({
         "matches": matches,
-        "ir": migration_plan_snapshot(&ir),
+        "ir": ir_snapshot,
         "legacy": migration_plan_snapshot(&legacy),
     });
     serde_json::to_string(&payload).map_err(|e| {
@@ -1166,26 +1290,64 @@ mod tests {
         table: &str,
         schema: &serde_json::Value,
         live: &[LiveColumn],
+        live_indexes: &[LiveIndex],
         backend: SqlDialect,
         opts: MigrateOptions,
     ) -> MigrationPlan {
-        let ir = plan_table_migration(table, schema, live, backend, opts)
+        let ir = plan_table_migration(table, schema, live, live_indexes, backend, opts)
             .unwrap_or_else(|e| panic!("IR planner failed for '{table}': {e}"));
-        let legacy = plan_table_migration_legacy(table, schema, live, backend, opts)
+        let legacy = plan_table_migration_legacy(table, schema, live, live_indexes, backend, opts)
             .unwrap_or_else(|e| panic!("legacy planner failed for '{table}': {e}"));
+
+        if !opts.updates {
+            // Both planners return empty when updates is off; skip column-domain diffing.
+            assert_eq!(ir.statements, legacy.statements, "statements mismatch on {table:?} ({backend:?})");
+            assert_eq!(ir.drop_columns, legacy.drop_columns, "drop_columns mismatch on {table:?} ({backend:?})");
+            assert_eq!(ir.warnings, legacy.warnings, "warnings mismatch on {table:?} ({backend:?})");
+            shadow_compare_migration_plan(table, schema, live, live_indexes, backend, opts)
+                .unwrap_or_else(|diff| panic!("shadow compare failed: {diff}"));
+            return ir;
+        }
+
+        // Build column-domain IR emission for parity comparison.
+        // AddIndex/DropIndex are filtered out because legacy never produces standalone index ops.
+        let old_ir = live_columns_to_schema_ir(table, live, live_indexes, backend);
+        let new_ir = schema_json_to_schema_ir(table, schema, backend);
+        let mut typed_plan = plan_from_ir(&old_ir, &new_ir, backend_dialect(backend));
+        if !opts.destructive {
+            typed_plan
+                .operations
+                .retain(|op| !matches!(op, MigrationOp::DropColumn { .. } | MigrationOp::DropIndex { .. }));
+        }
+        let mut drop_columns_col: Vec<String> = Vec::new();
+        let mut column_ops: Vec<MigrationOp> = Vec::new();
+        for op in typed_plan.operations {
+            match &op {
+                MigrationOp::DropColumn { column, .. } => drop_columns_col.push(column.clone()),
+                MigrationOp::AddIndex { .. } | MigrationOp::DropIndex { .. } => {}
+                _ => column_ops.push(op),
+            }
+        }
+        let column_plan_ops = ferro_migrate::MigrationPlan {
+            operations: column_ops,
+            warnings: typed_plan.warnings,
+        };
+        let emission = emit_sql_with_ir(&column_plan_ops, &old_ir, &new_ir, backend_dialect(backend))
+            .unwrap_or_else(|e| panic!("IR column-domain emission failed for '{table}': {e:?}"));
+
         assert_eq!(
-            ir.statements, legacy.statements,
+            emission.statements, legacy.statements,
             "statements mismatch on {table:?} ({backend:?})"
         );
         assert_eq!(
-            ir.drop_columns, legacy.drop_columns,
+            drop_columns_col, legacy.drop_columns,
             "drop_columns mismatch on {table:?} ({backend:?})"
         );
         assert_eq!(
-            ir.warnings, legacy.warnings,
+            emission.warnings, legacy.warnings,
             "warnings mismatch on {table:?} ({backend:?})"
         );
-        shadow_compare_migration_plan(table, schema, live, backend, opts)
+        shadow_compare_migration_plan(table, schema, live, live_indexes, backend, opts)
             .unwrap_or_else(|diff| panic!("shadow compare failed: {diff}"));
         ir
     }
@@ -1194,23 +1356,25 @@ mod tests {
         table: &str,
         schema: &serde_json::Value,
         live: &[LiveColumn],
+        live_indexes: &[LiveIndex],
         backend: SqlDialect,
         opts: MigrateOptions,
     ) {
-        plan_with_ir_legacy_parity(table, schema, live, backend, opts);
+        plan_with_ir_legacy_parity(table, schema, live, live_indexes, backend, opts);
     }
 
     fn assert_ir_legacy_parity_err(
         table: &str,
         schema: &serde_json::Value,
         live: &[LiveColumn],
+        live_indexes: &[LiveIndex],
         backend: SqlDialect,
         opts: MigrateOptions,
         needle: &str,
     ) {
-        let ir_err = plan_table_migration(table, schema, live, backend, opts)
+        let ir_err = plan_table_migration(table, schema, live, live_indexes, backend, opts)
             .expect_err("IR planner should fail");
-        let legacy_err = plan_table_migration_legacy(table, schema, live, backend, opts)
+        let legacy_err = plan_table_migration_legacy(table, schema, live, live_indexes, backend, opts)
             .expect_err("legacy planner should fail");
         assert!(
             ir_err.to_string().contains(needle),
@@ -1240,7 +1404,7 @@ mod tests {
                 },
             ];
             let plan =
-                plan_with_ir_legacy_parity("invoice", &schema, &live_cols, backend, UPDATES);
+                plan_with_ir_legacy_parity("invoice", &schema, &live_cols, &[], backend, UPDATES);
             assert_eq!(
                 plan.statements.len(),
                 1,
@@ -1271,7 +1435,7 @@ mod tests {
             live("number", "varchar"),
         ];
         let plan =
-            plan_with_ir_legacy_parity("invoice", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("invoice", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         // db_type "date" renders date_text on SQLite — identical to CREATE TABLE.
         assert!(
             plan.statements[0].contains("date_text"),
@@ -1293,7 +1457,7 @@ mod tests {
             ..live("id", "integer")
         }];
 
-        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         assert_eq!(plan.statements.len(), 2, "{:?}", plan.statements);
         assert!(
             plan.statements[0].contains("NOT NULL"),
@@ -1312,7 +1476,7 @@ mod tests {
         );
 
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert_eq!(
             plan.statements.len(),
             1,
@@ -1341,7 +1505,7 @@ mod tests {
 
         for backend in [SqlDialect::Sqlite, SqlDialect::Postgres] {
             let err =
-                plan_table_migration("doc", &schema, &live_cols, backend, UPDATES).unwrap_err();
+                plan_table_migration("doc", &schema, &live_cols, &[], backend, UPDATES).unwrap_err();
             let message = err.to_string();
             assert!(message.contains("doc.created_at"), "{message}");
             assert!(message.contains("Alembic"), "{message}");
@@ -1357,7 +1521,7 @@ mod tests {
             }
         });
         let live_cols = vec![live("name", "varchar")];
-        let err = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES)
+        let err = plan_table_migration("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES)
             .unwrap_err();
         assert!(err.to_string().contains("primary key"), "{err}");
     }
@@ -1376,7 +1540,7 @@ mod tests {
         }];
 
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert!(
             !plan.statements[0].to_uppercase().contains("UNIQUE"),
             "inline UNIQUE must be stripped on SQLite: {}",
@@ -1389,7 +1553,7 @@ mod tests {
         );
         assert_eq!(plan.warnings.len(), 1);
 
-        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         assert!(
             plan.statements[0].to_uppercase().contains("UNIQUE"),
             "Postgres keeps the inline UNIQUE: {}",
@@ -1411,7 +1575,7 @@ mod tests {
             ..live("id", "integer")
         }];
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert_eq!(plan.statements.len(), 2, "{:?}", plan.statements);
         assert!(
             plan.statements[1].contains("\"idx_doc_status\""),
@@ -1440,6 +1604,7 @@ mod tests {
             "invoice",
             &schema,
             &live_cols,
+            &[],
             SqlDialect::Postgres,
             UPDATES,
         );
@@ -1450,7 +1615,7 @@ mod tests {
         );
 
         let plan =
-            plan_with_ir_legacy_parity("invoice", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("invoice", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert_eq!(plan.statements.len(), 1, "{:?}", plan.statements);
         assert_eq!(plan.warnings.len(), 1);
         assert!(
@@ -1482,6 +1647,7 @@ mod tests {
             "invoice",
             &schema,
             &live_cols,
+            &[],
             SqlDialect::Postgres,
             UPDATES,
         );
@@ -1515,7 +1681,7 @@ mod tests {
                 ..live("b", "character varying")
             },
         ];
-        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         assert!(
             plan.statements
                 .contains(&"ALTER TABLE \"doc\" ALTER COLUMN \"a\" SET NOT NULL".to_string()),
@@ -1549,7 +1715,7 @@ mod tests {
                 ..live("status", "USER-DEFINED")
             },
         ];
-        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         assert!(plan.statements.is_empty(), "{:?}", plan.statements);
     }
 
@@ -1569,7 +1735,7 @@ mod tests {
             ..live("id", "integer")
         }];
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         let sql = &plan.statements[0];
         assert!(sql.contains("ADD COLUMN \"motto\""), "{sql}");
         assert!(
@@ -1602,7 +1768,7 @@ mod tests {
                 ..live("meta", "jsonb")
             },
         ];
-        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         assert!(
             !plan
                 .statements
@@ -1630,7 +1796,7 @@ mod tests {
             is_primary_key: true,
             ..live("id", "integer")
         }];
-        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         assert!(
             plan.statements.iter().any(|sql| {
                 sql.contains("ADD CONSTRAINT \"ck_doc_status\"")
@@ -1665,7 +1831,7 @@ mod tests {
             ..live("id", "integer")
         }];
         let plan =
-            plan_with_ir_legacy_parity(table, &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+            plan_with_ir_legacy_parity(table, &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         let check_sql = plan
             .statements
             .iter()
@@ -1697,7 +1863,7 @@ mod tests {
             live("count", "varchar"),
         ];
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert!(plan.statements.is_empty(), "{:?}", plan.statements);
         assert_eq!(plan.warnings.len(), 1, "{:?}", plan.warnings);
         assert!(
@@ -1724,7 +1890,7 @@ mod tests {
             live("name", "varchar"),
         ];
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert!(plan.statements.is_empty());
         assert_eq!(plan.warnings.len(), 1);
         assert!(
@@ -1752,12 +1918,12 @@ mod tests {
         ];
 
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, DESTRUCTIVE);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, DESTRUCTIVE);
         assert_eq!(plan.drop_columns, vec!["legacy_notes".to_string()]);
 
         // Without the destructive flag the extra column is untouched.
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert!(plan.drop_columns.is_empty());
 
         // A live PK column missing from the model is a hard error.
@@ -1771,6 +1937,7 @@ mod tests {
                 "doc",
                 &schema_without_id,
                 &live_cols,
+                &[],
                 backend,
                 DESTRUCTIVE,
                 "primary key",
@@ -1801,6 +1968,7 @@ mod tests {
             "doc",
             &schema,
             &live_cols,
+            &[],
             SqlDialect::Sqlite,
             UPDATES,
         );
@@ -1820,6 +1988,7 @@ mod tests {
             "invoice",
             &schema,
             &live_cols,
+            &[],
             SqlDialect::Sqlite,
             MigrateOptions::default(),
         );
@@ -1874,6 +2043,7 @@ mod tests {
             "sqlite".to_string(),
             true,
             true,
+            String::new(),
         )
         .unwrap();
         assert_eq!(
@@ -1900,7 +2070,7 @@ mod tests {
                     ..live("number", varchar_spelling)
                 },
             ];
-            assert_ir_legacy_parity("invoice", &invoice, &live_cols, backend, UPDATES);
+            assert_ir_legacy_parity("invoice", &invoice, &live_cols, &[], backend, UPDATES);
         }
 
         let not_null_default = json!({
@@ -1917,6 +2087,7 @@ mod tests {
             "doc",
             &not_null_default,
             &id_only,
+            &[],
             SqlDialect::Postgres,
             UPDATES,
         );
@@ -1924,6 +2095,7 @@ mod tests {
             "doc",
             &not_null_default,
             &id_only,
+            &[],
             SqlDialect::Sqlite,
             UPDATES,
         );
@@ -1939,6 +2111,7 @@ mod tests {
                 "doc",
                 &not_null_no_default,
                 &id_only,
+                &[],
                 backend,
                 UPDATES,
                 "Alembic",
@@ -1955,6 +2128,7 @@ mod tests {
             "doc",
             &pk_guard,
             &[live("name", "varchar")],
+            &[],
             SqlDialect::Sqlite,
             UPDATES,
             "primary key",
@@ -1978,6 +2152,7 @@ mod tests {
                 "doc",
                 &destructive_pk_drop_schema,
                 &destructive_pk_drop_live,
+                &[],
                 backend,
                 DESTRUCTIVE,
                 "primary key",
@@ -2002,6 +2177,7 @@ mod tests {
             "doc",
             &destructive_schema,
             &destructive_live,
+            &[],
             SqlDialect::Sqlite,
             DESTRUCTIVE,
         );
@@ -2009,6 +2185,7 @@ mod tests {
             "doc",
             &destructive_schema,
             &destructive_live,
+            &[],
             SqlDialect::Postgres,
             DESTRUCTIVE,
         );
@@ -2019,6 +2196,7 @@ mod tests {
                 "invoice",
                 &invoice,
                 &no_updates_live,
+                &[],
                 backend,
                 MigrateOptions::default(),
             );
@@ -2039,6 +2217,7 @@ mod tests {
             "doc",
             &multi_col_schema,
             &multi_col_live,
+            &[],
             SqlDialect::Sqlite,
             UPDATES,
         );

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -580,3 +580,271 @@ async def test_postgres_type_and_nullability_reconciliation(db_url, clean_regist
     assert (
         data[0]["status"] == "draft"
     ), "existing rows backfilled with the literal default"
+
+
+# ---------------------------------------------------------------------------
+# Index reconciliation (issue #144)
+# ---------------------------------------------------------------------------
+
+
+def _live_index_names(db_url: str, db_backend: str, table: str) -> set[str]:
+    """Return the set of index names on *table* in the live DB.
+
+    For SQLite we use PRAGMA index_list (synchronous raw driver).
+    For Postgres we query pg_indexes via the same synchronous psycopg path used
+    elsewhere in this file.  The postgres_base_url / db_schema_name fixtures are
+    not available here so we parse the search_path from db_url directly.
+    """
+    if db_backend == "sqlite":
+        return _sqlite_index_names(db_url, table)
+
+    # Postgres: extract connection params from the async URL.
+    # URL form: postgres://user:pass@host:port/dbname?options=-c search_path=<schema>
+    import re
+    import psycopg
+
+    m = re.search(r"search_path=([^&]+)", db_url)
+    schema = m.group(1) if m else "public"
+    # Build a synchronous libpq-style DSN by replacing the async scheme.
+    sync_url = db_url.replace("postgres://", "postgresql://", 1)
+    # Strip the options query param for psycopg (it handles search_path separately).
+    base_url = sync_url.split("?")[0]
+
+    with psycopg.connect(base_url, options=f"-c search_path={schema}") as conn:
+        rows = conn.execute(
+            "SELECT indexname FROM pg_indexes WHERE schemaname = %s AND tablename = %s",
+            (schema, table),
+        ).fetchall()
+    return {r[0] for r in rows}
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_index_reconcile_adds_composite_index_to_existing_table(
+    db_url, db_backend, clean_registry
+):
+    """migrate_updates adds a composite Ferro-named index to a pre-existing
+    table that was created without it."""
+    from typing import ClassVar
+
+    class IdxCompModel(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        col_a: int
+        col_b: int
+
+    # Create the table without any indexes.
+    await ferro.connect(db_url)
+    if db_backend == "sqlite":
+        await execute(
+            'CREATE TABLE "idxcompmodel" '
+            '("id" integer PRIMARY KEY AUTOINCREMENT, '
+            '"col_a" integer NOT NULL, "col_b" integer NOT NULL)'
+        )
+    else:
+        await execute(
+            'CREATE TABLE "idxcompmodel" '
+            '("id" serial PRIMARY KEY, '
+            '"col_a" integer NOT NULL, "col_b" integer NOT NULL)'
+        )
+    ferro.reset_engine()
+
+    # Re-register a NEW model class with the composite index annotation.
+    from ferro import clear_registry
+    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+
+    class IdxCompModel(Model):  # noqa: F811 — intentional redefinition
+        __ferro_composite_indexes__: ClassVar[tuple[tuple[str, ...], ...]] = (
+            ("col_a", "col_b"),
+        )
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        col_a: int
+        col_b: int
+
+    await ferro.connect(db_url, migrate_updates=True)
+
+    names = _live_index_names(db_url, db_backend, "idxcompmodel")
+    assert "idx_idxcompmodel_col_a_col_b" in names, (
+        f"expected composite index idx_idxcompmodel_col_a_col_b, got: {names}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_index_reconcile_adds_single_column_index_to_existing_column(
+    db_url, db_backend, clean_registry
+):
+    """migrate_updates creates idx_<table>_<col> when index=True is added to an
+    existing column that was originally created without an index."""
+
+    class IdxSingleModel(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        status: str
+
+    # Create table with 'status' but no index on it.
+    await ferro.connect(db_url)
+    if db_backend == "sqlite":
+        await execute(
+            'CREATE TABLE "idxsinglemodel" '
+            '("id" integer PRIMARY KEY AUTOINCREMENT, "status" varchar NOT NULL)'
+        )
+    else:
+        await execute(
+            'CREATE TABLE "idxsinglemodel" '
+            '("id" serial PRIMARY KEY, "status" varchar NOT NULL)'
+        )
+    ferro.reset_engine()
+
+    # Re-register with index=True on the existing column.
+    from ferro import clear_registry
+    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+
+    class IdxSingleModel(Model):  # noqa: F811
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        status: Annotated[str, FerroField(index=True)]
+
+    await ferro.connect(db_url, migrate_updates=True)
+
+    names = _live_index_names(db_url, db_backend, "idxsinglemodel")
+    assert "idx_idxsinglemodel_status" in names, (
+        f"expected idx_idxsinglemodel_status, got: {names}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_index_reconcile_noop_when_index_already_present(
+    db_url, db_backend, clean_registry
+):
+    """Running migrate_updates a second time when the index already exists must
+    be a no-op: the index remains and auto-migrate does not fail (false-alarm guard)."""
+    from typing import ClassVar
+
+    class IdxNoopModel(Model):
+        __ferro_composite_indexes__: ClassVar[tuple[tuple[str, ...], ...]] = (
+            ("x", "y"),
+        )
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        x: int
+        y: int
+
+    # First connect creates the table + index.
+    await ferro.connect(db_url, auto_migrate=True)
+    names_after_first = _live_index_names(db_url, db_backend, "idxnoopmodel")
+    assert "idx_idxnoopmodel_x_y" in names_after_first
+    ferro.reset_engine()
+
+    # Second connect — same model, same index already present.
+    await ferro.connect(db_url, migrate_updates=True)
+
+    names_after_second = _live_index_names(db_url, db_backend, "idxnoopmodel")
+    assert "idx_idxnoopmodel_x_y" in names_after_second, (
+        "index must survive second migrate_updates pass (no-op guard)"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_index_reconcile_destructive_drops_removed_composite_index(
+    db_url, db_backend, clean_registry
+):
+    """When a composite index is removed from the model:
+    - migrate_destructive=True drops it.
+    - migrate_updates=True (non-destructive) leaves it intact."""
+    from typing import ClassVar
+
+    class IdxDropModel(Model):
+        __ferro_composite_indexes__: ClassVar[tuple[tuple[str, ...], ...]] = (
+            ("p", "q"),
+        )
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        p: int
+        q: int
+
+    # Bootstrap with the index present.
+    await ferro.connect(db_url, auto_migrate=True)
+    names = _live_index_names(db_url, db_backend, "idxdropmodel")
+    assert "idx_idxdropmodel_p_q" in names
+    ferro.reset_engine()
+
+    # Re-register model WITHOUT the composite index.
+    from ferro import clear_registry
+    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+
+    class IdxDropModel(Model):  # noqa: F811
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        p: int
+        q: int
+
+    # Non-destructive: index must remain.
+    await ferro.connect(db_url, migrate_updates=True)
+    names_after_updates = _live_index_names(db_url, db_backend, "idxdropmodel")
+    assert "idx_idxdropmodel_p_q" in names_after_updates, (
+        "non-destructive pass must leave orphaned ferro index intact"
+    )
+    ferro.reset_engine()
+
+    # Destructive: index must be dropped.
+    await ferro.connect(db_url, migrate_destructive=True)
+    names_after_destructive = _live_index_names(db_url, db_backend, "idxdropmodel")
+    assert "idx_idxdropmodel_p_q" not in names_after_destructive, (
+        "migrate_destructive must drop the orphaned ferro index"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_index_reconcile_user_index_survives_auto_migrate(
+    db_url, db_backend, clean_registry
+):
+    """A hand-created user index (name does NOT start with idx_/uq_) must
+    survive both non-destructive and destructive auto-migrate passes unchanged."""
+    from typing import ClassVar
+
+    class IdxUserModel(Model):
+        __ferro_composite_indexes__: ClassVar[tuple[tuple[str, ...], ...]] = (
+            ("m", "n"),
+        )
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        m: int
+        n: int
+
+    # Create table with a Ferro composite index AND a custom user index.
+    await ferro.connect(db_url, auto_migrate=True)
+    await execute('CREATE INDEX "my_custom_idx" ON "idxusermodel" ("m")')
+
+    names_initial = _live_index_names(db_url, db_backend, "idxusermodel")
+    assert "idx_idxusermodel_m_n" in names_initial
+    assert "my_custom_idx" in names_initial
+    ferro.reset_engine()
+
+    # Non-destructive pass: both indexes must survive.
+    await ferro.connect(db_url, migrate_updates=True)
+    names_after_updates = _live_index_names(db_url, db_backend, "idxusermodel")
+    assert "idx_idxusermodel_m_n" in names_after_updates
+    assert "my_custom_idx" in names_after_updates, (
+        "user index must survive non-destructive auto-migrate"
+    )
+    ferro.reset_engine()
+
+    # Destructive pass: Ferro index still present (model still has it), user index still present.
+    await ferro.connect(db_url, migrate_destructive=True)
+    names_after_destructive = _live_index_names(db_url, db_backend, "idxusermodel")
+    assert "idx_idxusermodel_m_n" in names_after_destructive
+    assert "my_custom_idx" in names_after_destructive, (
+        "user index must survive destructive auto-migrate"
+    )

--- a/tests/test_migrate_plan.py
+++ b/tests/test_migrate_plan.py
@@ -223,3 +223,57 @@ def test_updates_false_produces_no_plan():
 def test_unknown_dialect_is_rejected():
     with pytest.raises(ValueError, match="Unknown dialect"):
         render(schema_with({}), PK_ONLY_LIVE, "mysql")
+
+
+# ---------------------------------------------------------------------------
+# Index no-op guard (issue #144) — unit-level assertion
+# ---------------------------------------------------------------------------
+
+# Live-column list for IdxNoopModel: id (PK) + x + y
+_NOOP_LIVE_COLUMNS = [
+    {
+        "name": "id",
+        "declared_type": "integer",
+        "is_primary_key": True,
+        "is_nullable": False,
+    },
+    {"name": "x", "declared_type": "integer", "is_nullable": False},
+    {"name": "y", "declared_type": "integer", "is_nullable": False},
+]
+
+# Schema with a composite index over (x, y).
+_NOOP_SCHEMA = {
+    "properties": {
+        "id": {"type": "integer", "primary_key": True},
+        "x": {"type": "integer", "ferro_nullable": False},
+        "y": {"type": "integer", "ferro_nullable": False},
+    },
+    "ferro_composite_indexes": [["x", "y"]],
+}
+
+# Canonical index name the planner would have created.
+_NOOP_LIVE_INDEXES = [
+    {"name": "idx_idxnoopmodel_x_y", "columns": ["x", "y"], "unique": False}
+]
+
+
+@pytest.mark.parametrize("dialect", ["sqlite", "postgres"])
+def test_index_noop_emits_zero_ddl_when_index_already_present(dialect):
+    """Planner must produce an empty statement list when the composite index
+    already exists in the live schema — no DROP INDEX + CREATE INDEX churn
+    (false-alarm class of bug, issue #144)."""
+    stmts, warns = _render_migration_sql_for_test(
+        "idxnoopmodel",
+        json.dumps(_NOOP_SCHEMA),
+        json.dumps(_NOOP_LIVE_COLUMNS),
+        dialect,
+        True,   # updates
+        False,  # destructive
+        json.dumps(_NOOP_LIVE_INDEXES),
+    )
+    assert stmts == [], (
+        f"[{dialect}] expected no DDL when index already present, got: {stmts}"
+    )
+    assert warns == [], (
+        f"[{dialect}] expected no warnings when index already present, got: {warns}"
+    )


### PR DESCRIPTION
Part of **Epic 8.5** (#139). Implements **#144**. Targets the Phase 8.5 integration branch (auto-closes #144 when that branch merges to `main`).

## ⚠️ CI MUST run the Postgres backend matrix before merge

The new live-index introspection query (`postgres_table_indexes`) is **only exercisable against a real Postgres** — there's no local PG server here, so its tests are CI-deferred. The final review caught (and this PR fixes) an `array_position(int2vector, …)` type error that would have broken auto-migrate on Postgres entirely; that class of bug is invisible to the SQLite-only local run. **Do not merge until `--db-backends=...,postgres tests/test_auto_migrate.py -k index` is green in CI.**

## What

Auto-migrate now reconciles **standalone Ferro-named** indexes & uniques (single + composite) on existing tables — previously a silent no-op. Symmetric with column reconciliation:
- **ADD** missing always; **DROP** orphaned Ferro-named ones (`idx_`/`uq_`) under `migrate_destructive`.
- Never touches user-created, PK, or constraint indexes.
- A migrate-added index is **byte-identical to the create path** (AGENTS.md I-1) — guaranteed by reconciling exactly `standalone_indexes(model)` (the single source shared with `post_create_artifacts`) and reusing `render_index_sql`.

## How

- New `live_table_indexes` introspection (SQLite `PRAGMA index_list/index_info`; Postgres `pg_index`), Ferro-name-filtered.
- `ferro-migrate`: `MigrationOp::AddIndex`/`DropIndex` + diff + emit.
- Producer populates the model IR's `indexes`/`uniques`; runtime wires introspection → diff → execute; `DropIndex` gated on destructive.
- **IR↔legacy parity scoped to column-ops** at the typed-op level (the IR planner now legitimately surpasses the frozen legacy planner; legacy is NOT taught index reconciliation — it's deleted in Phase 9).

## Validated

Cross-emitter + IR + Alembic 49/49; auto-migrate + migrate-plan 18/18 on SQLite incl. 5 new index tests (composite add, single-col add, no-op-empty-plan guard, destructive drop, user-index survival); Rust 127/127 incl. `ir_legacy_parity_matrix`.

Two correctness issues were caught in review and fixed in-branch: a composite-index-over-all-new-columns skip (would've dropped the index → I-1 break) and the Postgres `array_position` type error above.

Migration impact: `minor` (capability matrix + migration guide updated).
Spec: `docs/brainstorms/2026-06-26-ir-p8.5-144-reconcile-indexes-requirements.md` · Plan: `docs/plans/2026-06-26-003-feat-ir-p8.5-144-reconcile-indexes-plan.md`