### PR TITLE
refactor: Lowering consolidation & single-source-of-truth closeout (#139)

### DIFF
--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -145,6 +145,33 @@ pub fn db_type_token_to_canonical(token: &str, dialect: Dialect) -> Option<Canon
     }
 }
 
+/// Map a resolved [`CanonicalType`] back to the canonical Ferro `db_type` token
+/// vocabulary used in SchemaIR and cross-emitter parity tests.
+pub fn canonical_to_db_type_token(canonical: CanonicalType, dialect: Dialect) -> String {
+    match canonical {
+        CanonicalType::Integer => "int".to_string(),
+        CanonicalType::SmallInt => "smallint".to_string(),
+        CanonicalType::BigInt => "bigint".to_string(),
+        CanonicalType::Double => "double".to_string(),
+        CanonicalType::Decimal => "numeric".to_string(),
+        CanonicalType::Boolean => "boolean".to_string(),
+        CanonicalType::Json => "json".to_string(),
+        CanonicalType::Text => "text".to_string(),
+        CanonicalType::Varchar(None) => "varchar".to_string(),
+        CanonicalType::Varchar(Some(n)) => format!("varchar({n})"),
+        CanonicalType::Char(n) => match (dialect, n) {
+            (Dialect::Sqlite, 32) => "uuid".to_string(),
+            _ => format!("char({n})"),
+        },
+        CanonicalType::Uuid => "uuid".to_string(),
+        CanonicalType::DateTime | CanonicalType::Timestamp => "timestamp".to_string(),
+        CanonicalType::TimestampTz => "timestamptz".to_string(),
+        CanonicalType::Date => "date".to_string(),
+        CanonicalType::Time => "time".to_string(),
+        CanonicalType::Blob => "bytea".to_string(),
+    }
+}
+
 /// Map `information_schema.columns` spellings to the canonical Ferro `db_type` token
 /// vocabulary (mirrors legacy `pg_type_matches` / sqlite storage classes).
 pub fn information_schema_to_db_type_token(
@@ -213,18 +240,25 @@ pub fn schema_columns_storage_drift(
     }
 }
 
-/// Resolve a [`SchemaColumn`] to its canonical storage type.
-pub fn canonical_from_schema_column(
-    col: &SchemaColumn,
+/// Resolve a model property's `(logical_type, format, db_type)` to a canonical
+/// type. A recognized `db_type` token wins; otherwise the logical-type + format
+/// cascade decides. An empty/unrecognized `db_type` falls through.
+pub fn canonical_from_parts(
+    logical_type: &str,
+    format: Option<&str>,
+    db_type: &str,
     dialect: Dialect,
 ) -> Result<CanonicalType, String> {
-    if let Some(canonical) = db_type_token_to_canonical(&col.db_type, dialect) {
+    if let Some(canonical) = db_type_token_to_canonical(db_type, dialect) {
         return Ok(canonical);
     }
-    match (col.logical_type.as_str(), col.format.as_deref()) {
+    match (logical_type, format) {
         ("string", Some("date-time")) => Ok(CanonicalType::TimestampTz),
         ("string", Some("date")) => Ok(CanonicalType::Date),
         ("string", Some("uuid")) => Ok(CanonicalType::Uuid),
+        // `format = "decimal"` is only ever emitted alongside a concrete logical
+        // type (see src/ferro/schema_metadata.py), so `(None, Some("decimal"))`
+        // never arises from a real model — this broad arm is safe.
         (_, Some("decimal")) => Ok(CanonicalType::Decimal),
         ("string", Some("binary")) => Ok(CanonicalType::Blob),
         ("integer", _) => Ok(CanonicalType::Integer),
@@ -235,11 +269,17 @@ pub fn canonical_from_schema_column(
             Dialect::Postgres => CanonicalType::Boolean,
         }),
         ("object" | "array", _) => Ok(CanonicalType::Json),
-        _ => Err(format!(
-            "unknown db_type '{}' on column '{}'",
-            col.db_type, col.name
-        )),
+        _ => Err(format!("unknown logical_type '{logical_type}'")),
     }
+}
+
+/// Resolve a [`SchemaColumn`] to its canonical storage type.
+pub fn canonical_from_schema_column(
+    col: &SchemaColumn,
+    dialect: Dialect,
+) -> Result<CanonicalType, String> {
+    canonical_from_parts(&col.logical_type, col.format.as_deref(), &col.db_type, dialect)
+        .map_err(|_| format!("unknown db_type '{}' on column '{}'", col.db_type, col.name))
 }
 
 /// Single-column index name (`idx_<table>_<col>`).
@@ -508,5 +548,26 @@ mod tests {
         let old = drift_col("created_at", "timestamp");
         let new = drift_col("created_at", "timestamptz");
         assert!(schema_columns_storage_drift(&old, &new, Dialect::Postgres));
+    }
+
+    #[test]
+    fn canonical_to_db_type_token_roundtrips_core_tokens() {
+        assert_eq!(canonical_to_db_type_token(CanonicalType::Integer, Dialect::Postgres), "int");
+        assert_eq!(canonical_to_db_type_token(CanonicalType::Char(32), Dialect::Sqlite), "uuid");
+        assert_eq!(canonical_to_db_type_token(CanonicalType::Char(10), Dialect::Sqlite), "char(10)");
+        assert_eq!(canonical_to_db_type_token(CanonicalType::TimestampTz, Dialect::Postgres), "timestamptz");
+        assert_eq!(canonical_to_db_type_token(CanonicalType::DateTime, Dialect::Postgres), "timestamp");
+        assert_eq!(canonical_to_db_type_token(CanonicalType::Char(32), Dialect::Postgres), "char(32)");
+    }
+
+    #[test]
+    fn canonical_from_parts_matches_schema_column_path() {
+        // db_type wins
+        assert_eq!(canonical_from_parts("string", None, "bigint", Dialect::Postgres), Ok(CanonicalType::BigInt));
+        // fallback to logical_type/format
+        assert_eq!(canonical_from_parts("string", Some("date-time"), "", Dialect::Postgres), Ok(CanonicalType::TimestampTz));
+        assert_eq!(canonical_from_parts("integer", None, "", Dialect::Sqlite), Ok(CanonicalType::Integer));
+        // unknown is an error (CREATE path maps this to Varchar at its call site)
+        assert!(canonical_from_parts("mystery", None, "", Dialect::Postgres).is_err());
     }
 }

--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -235,11 +235,17 @@ pub fn schema_columns_storage_drift(
         canonical_from_schema_column(old_col, dialect),
         canonical_from_schema_column(new_col, dialect),
     ) {
-        (Ok(old_c), Ok(new_c)) => old_c != new_c,
+        (Ok(old_c), Ok(new_c)) => {
+            // Compare by storage token, not raw canonical: on SQLite both `Uuid`
+            // and `Char(32)` map to "uuid" (and `DateTime`/`Timestamp` to
+            // "timestamp"), so a derived model column does not read as drifted
+            // against the token-round-tripped live column. Real changes
+            // (int → bigint) still differ. (See #141.)
+            canonical_to_db_type_token(old_c, dialect) != canonical_to_db_type_token(new_c, dialect)
+        }
         // Reached only when canonical resolution fails for both columns. At runtime
         // both sides come from producers that always populate Some(...), so this
         // Option comparison is behavior-equivalent to the old String comparison.
-        // (Will become load-bearing for None columns when #141 feeds the wire IR here.)
         _ => old_col.db_type != new_col.db_type,
     }
 }
@@ -247,6 +253,11 @@ pub fn schema_columns_storage_drift(
 /// Resolve a model property's `(logical_type, format, db_type)` to a canonical
 /// type. A recognized `db_type` token wins; otherwise the logical-type + format
 /// cascade decides. An empty/unrecognized `db_type` falls through.
+///
+/// Accepts both raw JSON Schema type values (`"string"` + format) **and** the
+/// domain-specific `logical_type` tokens emitted by the Python SchemaIR compiler
+/// (`"datetime"`, `"date"`, `"time"`, `"uuid"`, `"json"`, `"decimal"`), so that
+/// compiled IR envelopes can be consumed directly by the migration planner.
 pub fn canonical_from_parts(
     logical_type: &str,
     format: Option<&str>,
@@ -257,6 +268,14 @@ pub fn canonical_from_parts(
         return Ok(canonical);
     }
     match (logical_type, format) {
+        // DEPRECATED (legacy JSON-Schema vocabulary): the Python SchemaIR compiler
+        // now emits domain `logical_type` tokens ("datetime"/"date"/"uuid") instead
+        // of "string"+format for these. Retained because the CREATE TABLE path still
+        // resolves columns via "string"+format. Remove once the create path consumes
+        // the Python SchemaIR logical_type vocabulary (create-path unification; #141 non-goal).
+        // Note: "time" does NOT appear here because the CREATE TABLE path has no
+        // ("string", "time") arm; it falls through to Varchar(None). See below.
+        // Raw JSON Schema types with format — produced by schema_json_to_schema_ir.
         ("string", Some("date-time")) => Ok(CanonicalType::TimestampTz),
         ("string", Some("date")) => Ok(CanonicalType::Date),
         ("string", Some("uuid")) => Ok(CanonicalType::Uuid),
@@ -265,6 +284,22 @@ pub fn canonical_from_parts(
         // never arises from a real model — this broad arm is safe.
         (_, Some("decimal")) => Ok(CanonicalType::Decimal),
         ("string", Some("binary")) => Ok(CanonicalType::Blob),
+        // Domain-specific logical_type tokens emitted by the Python SchemaIR
+        // compiler (compiler.py `_logical_type`). These are accepted alongside
+        // the raw JSON Schema types so compiled IR envelopes can be consumed.
+        // "datetime", "date", "uuid" have symmetric create-path counterparts.
+        ("datetime", _) => Ok(CanonicalType::TimestampTz),
+        ("date", _) => Ok(CanonicalType::Date),
+        // "time" is the ASYMMETRIC case: schema.rs canonical_column_type has no
+        // ("string", "time") arm, so datetime.time fields are created as varchar
+        // on both SQLite and Postgres. Resolve to Varchar(None) here so the
+        // consume side agrees with the live column token ("varchar") and no
+        // spurious AlterColumnType / "use Alembic" warning fires. (#141 review.)
+        ("time", _) => Ok(CanonicalType::Varchar(None)),
+        ("uuid", _) => Ok(CanonicalType::Uuid),
+        ("json", _) => Ok(CanonicalType::Json),
+        ("decimal", _) => Ok(CanonicalType::Decimal),
+        // Raw JSON Schema primitive types.
         ("integer", _) => Ok(CanonicalType::Integer),
         ("string", _) => Ok(CanonicalType::Varchar(None)),
         ("number", _) => Ok(CanonicalType::Double),
@@ -528,6 +563,90 @@ mod tests {
             enum_type_name: None,
             postgres_native_enum: false,
         }
+    }
+
+    /// Build a SchemaColumn for drift tests with explicit logical_type, format and db_type.
+    fn col_with_db_type(
+        name: &str,
+        logical_type: &str,
+        format: Option<&str>,
+        db_type: Option<&str>,
+    ) -> SchemaColumn {
+        SchemaColumn {
+            name: name.to_string(),
+            logical_type: logical_type.to_string(),
+            db_type: db_type.map(str::to_string),
+            db_type_explicit: None,
+            nullable: true,
+            primary_key: false,
+            autoincrement: false,
+            unique: false,
+            index: false,
+            default: None,
+            format: format.map(str::to_string),
+            enum_values: None,
+            enum_type_name: None,
+            postgres_native_enum: false,
+        }
+    }
+
+    #[test]
+    fn uuid_model_does_not_drift_against_char32_live_on_sqlite() {
+        // Live introspected `uuid_text` → db_type "uuid" → Char(32).
+        let live = col_with_db_type("id", "string", Some("uuid"), Some("uuid"));
+        // Model derived (post-#141 wire IR): db_type None, format "uuid" → Uuid.
+        let model = col_with_db_type("id", "string", Some("uuid"), None);
+        assert!(!schema_columns_storage_drift(&live, &model, Dialect::Sqlite));
+    }
+
+    /// Regression guard for the `"time"` phantom-drift false alarm (#141 review).
+    ///
+    /// The CREATE TABLE path (schema.rs `canonical_column_type`) has no
+    /// `("string", "time")` arm: it falls through to `json_type_to_canonical("string")`
+    /// → `Varchar(None)` → live column token `"varchar"`. The consume side must
+    /// resolve `logical_type = "time"` to the same canonical so no spurious
+    /// AlterColumnType fires on every startup for a `datetime.time` field.
+    #[test]
+    fn time_derived_does_not_drift_against_varchar_live_on_sqlite() {
+        // Live column: created as varchar (what the CREATE path emits for time).
+        let live = col_with_db_type("start_time", "string", None, Some("varchar"));
+        // Model column: Python SchemaIR compiler emits logical_type="time", db_type=None.
+        let model = col_with_db_type("start_time", "time", None, None);
+        assert!(
+            !schema_columns_storage_drift(&live, &model, Dialect::Sqlite),
+            "time logical_type must resolve to Varchar(None) to match the live varchar column"
+        );
+    }
+
+    #[test]
+    fn time_derived_does_not_drift_against_varchar_live_on_postgres() {
+        // Same parity check on Postgres: CREATE path also falls to Varchar(None)
+        // for a time field (no ("string", "time") arm in schema.rs).
+        let live = col_with_db_type("start_time", "string", None, Some("varchar"));
+        let model = col_with_db_type("start_time", "time", None, None);
+        assert!(
+            !schema_columns_storage_drift(&live, &model, Dialect::Postgres),
+            "time logical_type must resolve to Varchar(None) on Postgres as well"
+        );
+    }
+
+    #[test]
+    fn datetime_and_timestamp_are_storage_equivalent_on_sqlite() {
+        // On SQLite, "timestamp" token → DateTime and "timestamptz" token → DateTime;
+        // canonical_to_db_type_token maps DateTime → "timestamp" in both cases, so
+        // the token comparison merges them. (On Postgres these give distinct canonicals.)
+        let a = col_with_db_type("ts", "string", None, Some("timestamp"));
+        let b = col_with_db_type("ts", "string", None, Some("timestamptz"));
+        assert!(!schema_columns_storage_drift(&a, &b, Dialect::Sqlite));
+        // Cross-check: same tokens DO differ on Postgres (Timestamp vs TimestampTz).
+        assert!(schema_columns_storage_drift(&a, &b, Dialect::Postgres));
+    }
+
+    #[test]
+    fn int_to_bigint_still_drifts() {
+        let small = col_with_db_type("n", "integer", None, Some("int"));
+        let big = col_with_db_type("n", "integer", None, Some("bigint"));
+        assert!(schema_columns_storage_drift(&small, &big, Dialect::Sqlite));
     }
 
     #[test]

--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -236,6 +236,10 @@ pub fn schema_columns_storage_drift(
         canonical_from_schema_column(new_col, dialect),
     ) {
         (Ok(old_c), Ok(new_c)) => old_c != new_c,
+        // Reached only when canonical resolution fails for both columns. At runtime
+        // both sides come from producers that always populate Some(...), so this
+        // Option comparison is behavior-equivalent to the old String comparison.
+        // (Will become load-bearing for None columns when #141 feeds the wire IR here.)
         _ => old_col.db_type != new_col.db_type,
     }
 }
@@ -278,8 +282,8 @@ pub fn canonical_from_schema_column(
     col: &SchemaColumn,
     dialect: Dialect,
 ) -> Result<CanonicalType, String> {
-    canonical_from_parts(&col.logical_type, col.format.as_deref(), &col.db_type, dialect)
-        .map_err(|_| format!("unknown db_type '{}' on column '{}'", col.db_type, col.name))
+    canonical_from_parts(&col.logical_type, col.format.as_deref(), col.db_type.as_deref().unwrap_or(""), dialect)
+        .map_err(|_| format!("unknown db_type '{}' on column '{}'", col.db_type.as_deref().unwrap_or(""), col.name))
 }
 
 /// Single-column index name (`idx_<table>_<col>`).
@@ -511,7 +515,7 @@ mod tests {
         SchemaColumn {
             name: name.to_string(),
             logical_type: "unknown".to_string(),
-            db_type: db_type.to_string(),
+            db_type: Some(db_type.to_string()),
             db_type_explicit: None,
             nullable: true,
             primary_key: false,

--- a/crates/ferro-migrate/src/emit.rs
+++ b/crates/ferro-migrate/src/emit.rs
@@ -457,14 +457,14 @@ fn emit_alter_column_type(
                     ),
                 }
             })?;
-            if sqlite_type_storage_drift(&old_col.db_type, new_canonical) {
+            if sqlite_type_storage_drift(old_col.db_type.as_deref().unwrap_or(""), new_canonical) {
                 result.warnings.push(format!(
                     "Column '{}.{}' is declared '{}' in the database but the model expects \
                      '{}'. SQLite cannot change column types in place; use Alembic to \
                      migrate this column.",
                     table,
                     column,
-                    old_col.db_type,
+                    old_col.db_type.as_deref().unwrap_or(""),
                     sqlite_declared_type(new_canonical),
                 ));
             }

--- a/crates/ferro-migrate/src/emit.rs
+++ b/crates/ferro-migrate/src/emit.rs
@@ -121,6 +121,23 @@ fn single_column_unique_is_inline(model: &SchemaModel, unique_columns: &[String]
         .any(|col| col.name == *col_name && col.unique)
 }
 
+/// The standalone indexes/uniques the create path emits as separate
+/// `CREATE [UNIQUE] INDEX` statements: every `model.indexes`, plus `model.uniques`
+/// that are not inline single-column uniques. Returned as (name, columns, unique).
+pub(crate) fn standalone_indexes(model: &SchemaModel) -> Vec<(String, Vec<String>, bool)> {
+    let mut out = Vec::new();
+    for index in &model.indexes {
+        out.push((index.name.clone(), index.columns.clone(), index.unique));
+    }
+    for unique in &model.uniques {
+        if single_column_unique_is_inline(model, &unique.columns) {
+            continue;
+        }
+        out.push((unique.name.clone(), unique.columns.clone(), true));
+    }
+    out
+}
+
 fn post_create_artifacts(
     model: &SchemaModel,
     dialect: BackendDialect,
@@ -129,27 +146,8 @@ fn post_create_artifacts(
     let mut statements = Vec::new();
     let mut warnings = Vec::new();
 
-    for index in &model.indexes {
-        statements.push(render_index_sql(
-            table_lower,
-            &index.name,
-            &index.columns,
-            index.unique,
-            dialect,
-        ));
-    }
-
-    for unique in &model.uniques {
-        if single_column_unique_is_inline(model, &unique.columns) {
-            continue;
-        }
-        statements.push(render_index_sql(
-            table_lower,
-            &unique.name,
-            &unique.columns,
-            true,
-            dialect,
-        ));
+    for (name, columns, unique) in standalone_indexes(model) {
+        statements.push(render_index_sql(table_lower, &name, &columns, unique, dialect));
     }
 
     for check in &model.checks {
@@ -601,6 +599,14 @@ pub fn emit_sql_with_ir(
                     emit_alter_column_nullability(table, column, old_col, new_col, dialect);
                 result.statements.extend(partial.statements);
                 result.warnings.extend(partial.warnings);
+            }
+            MigrationOp::AddIndex { table, name, columns, unique } => {
+                result.statements.push(render_index_sql(table, name, columns, *unique, dialect));
+            }
+            // `table` is intentionally unused: DROP INDEX is schema-scoped (not
+            // table-qualified) on both SQLite and Postgres, so only the index name is needed.
+            MigrationOp::DropIndex { table: _, name } => {
+                result.statements.push(format!("DROP INDEX IF EXISTS \"{}\"", name));
             }
         }
     }

--- a/crates/ferro-migrate/src/lib.rs
+++ b/crates/ferro-migrate/src/lib.rs
@@ -85,6 +85,24 @@ pub enum MigrationOp {
         /// Column whose nullability drifted.
         column: String,
     },
+    /// A standalone Ferro-named index/unique present in the model but not live.
+    AddIndex {
+        /// Owning table.
+        table: String,
+        /// Index name.
+        name: String,
+        /// Indexed columns.
+        columns: Vec<String>,
+        /// Whether this is a unique index.
+        unique: bool,
+    },
+    /// A standalone Ferro-named index present live but gone from the model.
+    DropIndex {
+        /// Owning table.
+        table: String,
+        /// Index name.
+        name: String,
+    },
 }
 
 /// Ordered migration operations plus non-fatal warnings collected during planning.
@@ -149,6 +167,12 @@ pub fn emit_sql(plan: &MigrationPlan, dialect: BackendDialect) -> Vec<String> {
                     table, column
                 )),
             },
+            MigrationOp::AddIndex { name, .. } => {
+                sql.push(format!("-- index '{}' handled by emit_sql_with_ir", name));
+            }
+            MigrationOp::DropIndex { name, .. } => {
+                sql.push(format!("-- index '{}' handled by emit_sql_with_ir", name));
+            }
         }
     }
     sql
@@ -190,6 +214,7 @@ pub fn plan_from_ir(
             continue;
         };
         diff_model_columns(*table, old_model, new_model, ddl_dialect, &mut plan);
+        diff_model_indexes(*table, old_model, new_model, &mut plan);
     }
 
     plan
@@ -254,6 +279,52 @@ fn diff_model_columns(
             plan.operations.push(MigrationOp::AlterColumnNullability {
                 table: table.to_string(),
                 column: (*col).to_string(),
+            });
+        }
+    }
+}
+
+fn diff_model_indexes(
+    table: &str,
+    old_model: &SchemaModel,
+    new_model: &SchemaModel,
+    plan: &mut MigrationPlan,
+) {
+    // Columns present in the old model — indexes that cover only NEW columns are
+    // emitted by emit_add_column during AddColumn processing, so we must not emit
+    // a redundant standalone AddIndex for them.
+    let old_col_names: BTreeSet<&str> = old_model.columns.iter().map(|c| c.name.as_str()).collect();
+
+    let old_by_name: BTreeMap<String, (Vec<String>, bool)> = old_model
+        .indexes
+        .iter()
+        .map(|i| (i.name.clone(), (i.columns.clone(), i.unique)))
+        .collect();
+    let new_set = emit::standalone_indexes(new_model);
+    let new_names: BTreeSet<&str> = new_set.iter().map(|(n, _, _)| n.as_str()).collect();
+
+    for (name, columns, unique) in &new_set {
+        if !old_by_name.contains_key(name) {
+            // Skip AddIndex only when it is a single-column index whose sole column is
+            // newly added — emit_add_column already emits that CREATE INDEX.
+            // Composite indexes are never emitted by emit_add_column and must NOT be
+            // skipped here, even when every indexed column is new (AGENTS.md I-1).
+            if columns.len() == 1 && !old_col_names.contains(columns[0].as_str()) {
+                continue;
+            }
+            plan.operations.push(MigrationOp::AddIndex {
+                table: table.to_string(),
+                name: name.clone(),
+                columns: columns.clone(),
+                unique: *unique,
+            });
+        }
+    }
+    for name in old_by_name.keys() {
+        if !new_names.contains(name.as_str()) {
+            plan.operations.push(MigrationOp::DropIndex {
+                table: table.to_string(),
+                name: name.clone(),
             });
         }
     }

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -40,7 +40,7 @@ fn col(name: &str, db_type: &str, nullable: bool) -> SchemaColumn {
     SchemaColumn {
         name: name.to_string(),
         logical_type: "string".to_string(),
-        db_type: db_type.to_string(),
+        db_type: Some(db_type.to_string()),
         db_type_explicit: None,
         nullable,
         primary_key: false,
@@ -560,7 +560,7 @@ fn emit_sql_with_ir_add_table_missing_model_errors() {
 #[test]
 fn emit_sql_with_ir_alter_column_type_unknown_db_type_errors() {
     let bad_col = SchemaColumn {
-        db_type: "not_a_real_token".to_string(),
+        db_type: Some("not_a_real_token".to_string()),
         logical_type: "unknown".to_string(),
         ..col("name", "text", true)
     };

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -655,6 +655,44 @@ fn emit_sql_multi_op_ordering() {
 }
 
 #[test]
+fn plan_from_ir_adds_missing_index() {
+    let old = envelope(vec![schema_model("doc", vec![col("a", "text", true), col("b", "text", true)])]);
+    let mut nm = schema_model("doc", vec![col("a", "text", true), col("b", "text", true)]);
+    nm.indexes = vec![SchemaIndex { name: "idx_doc_a_b".into(), columns: vec!["a".into(), "b".into()], unique: false }];
+    let new = envelope(vec![nm]);
+    let plan = plan_from_ir(&old, &new, BackendDialect::Sqlite);
+    assert!(plan.operations.contains(&MigrationOp::AddIndex {
+        table: "doc".into(), name: "idx_doc_a_b".into(), columns: vec!["a".into(), "b".into()], unique: false
+    }));
+}
+
+#[test]
+fn plan_from_ir_drops_orphaned_index() {
+    let mut om = schema_model("doc", vec![col("a", "text", true)]);
+    om.indexes = vec![SchemaIndex { name: "idx_doc_a".into(), columns: vec!["a".into()], unique: false }];
+    let old = envelope(vec![om]);
+    let new = envelope(vec![schema_model("doc", vec![col("a", "text", true)])]); // no index
+    let plan = plan_from_ir(&old, &new, BackendDialect::Sqlite);
+    assert!(plan.operations.contains(&MigrationOp::DropIndex { table: "doc".into(), name: "idx_doc_a".into() }));
+}
+
+#[test]
+fn emit_add_index_matches_create_path() {
+    let plan = MigrationPlan { operations: vec![MigrationOp::AddIndex {
+        table: "doc".into(), name: "idx_doc_a_b".into(), columns: vec!["a".into(), "b".into()], unique: false
+    }], warnings: vec![] };
+    let r = emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Sqlite).unwrap();
+    assert_eq!(r.statements, vec!["CREATE INDEX IF NOT EXISTS \"idx_doc_a_b\" ON \"doc\" (\"a\", \"b\")".to_string()]);
+}
+
+#[test]
+fn emit_drop_index_renders_drop() {
+    let plan = MigrationPlan { operations: vec![MigrationOp::DropIndex { table: "doc".into(), name: "idx_doc_a".into() }], warnings: vec![] };
+    let r = emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Postgres).unwrap();
+    assert_eq!(r.statements, vec!["DROP INDEX IF EXISTS \"idx_doc_a\"".to_string()]);
+}
+
+#[test]
 fn emit_sql_no_comment_placeholders_on_full_plan() {
     let old_ir = envelope(vec![schema_model(
         "doc",
@@ -672,4 +710,60 @@ fn emit_sql_no_comment_placeholders_on_full_plan() {
         let result = emit_sql_with_ir(&plan, &old_ir, &new_ir, dialect).unwrap();
         assert_no_comment_placeholders(&result.statements);
     }
+}
+
+// Regression: composite index whose columns are all newly added must NOT be skipped.
+// Before the fix, `all_columns_are_new` caused this AddIndex to be silently dropped.
+#[test]
+fn plan_from_ir_composite_all_new_columns_emits_add_index() {
+    let old = envelope(vec![schema_model("doc", vec![col("id", "int", false)])]);
+    let mut nm = schema_model(
+        "doc",
+        vec![col("id", "int", false), col("a", "text", true), col("b", "text", true)],
+    );
+    nm.indexes = vec![SchemaIndex {
+        name: "idx_doc_a_b".to_string(),
+        columns: vec!["a".to_string(), "b".to_string()],
+        unique: false,
+    }];
+    let new = envelope(vec![nm]);
+    let plan = plan_from_ir(&old, &new, BackendDialect::Sqlite);
+    assert!(
+        plan.operations.contains(&MigrationOp::AddIndex {
+            table: "doc".to_string(),
+            name: "idx_doc_a_b".to_string(),
+            columns: vec!["a".to_string(), "b".to_string()],
+            unique: false,
+        }),
+        "composite index over all-new columns must appear in plan; got: {:?}",
+        plan.operations
+    );
+}
+
+// Regression: single-column index on a newly added column IS correctly skipped
+// because emit_add_column emits the CREATE INDEX for that case.
+#[test]
+fn plan_from_ir_single_column_new_index_is_skipped() {
+    let old = envelope(vec![schema_model("doc", vec![col("id", "int", false)])]);
+    let mut nm = schema_model(
+        "doc",
+        vec![col("id", "int", false), col_with_flags("c", "text", true, false, true, None)],
+    );
+    nm.indexes = vec![SchemaIndex {
+        name: "idx_doc_c".to_string(),
+        columns: vec!["c".to_string()],
+        unique: false,
+    }];
+    let new = envelope(vec![nm]);
+    let plan = plan_from_ir(&old, &new, BackendDialect::Sqlite);
+    assert!(
+        !plan.operations.contains(&MigrationOp::AddIndex {
+            table: "doc".to_string(),
+            name: "idx_doc_c".to_string(),
+            columns: vec!["c".to_string()],
+            unique: false,
+        }),
+        "single-column index on a new column must NOT appear in plan (emit_add_column handles it); got: {:?}",
+        plan.operations
+    );
 }

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -56,8 +56,10 @@ pub struct SchemaColumn {
     pub name: String,
     /// Pydantic JSON Schema type family (e.g. `"string"`, `"integer"`).
     pub logical_type: String,
-    /// Canonical storage token (`text`, `uuid`, `timestamptz`, …) after Ferro lowering.
-    pub db_type: String,
+    /// Canonical storage token. Present only for columns with an explicit `db_type=`;
+    /// `None` means "derive storage from `logical_type`/`format`".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub db_type: Option<String>,
     /// `true` when the user set an explicit `db_type=` on the field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub db_type_explicit: Option<bool>,

--- a/docs/brainstorms/2026-06-26-ir-p8.5-140-shared-lowering-requirements.md
+++ b/docs/brainstorms/2026-06-26-ir-p8.5-140-shared-lowering-requirements.md
@@ -1,0 +1,111 @@
+---
+title: "IR-P8.5 #140 — ferro-ddl-lowering as the single lowering library"
+type: requirements
+status: draft
+date: 2026-06-26
+issue: https://github.com/syn54x/ferro-orm/issues/140
+epic: https://github.com/syn54x/ferro-orm/issues/139
+roadmap: docs/plans/2026-06-19-001-ir-first-roadmap.md (Phase 8.5)
+---
+
+# #140 — `ferro-ddl-lowering` as the single lowering library
+
+## Goal
+
+Make `ferro-ddl-lowering` the sole owner of canonical-type lowering and route the
+runtime CREATE path (`src/schema.rs`) through it, deleting `schema.rs`'s parallel
+`CanonicalType` and its mappers. This turns cross-emitter DDL parity (AGENTS.md
+I-1) from a *tested coincidence* into a *structural guarantee* for the type
+system.
+
+**This is a behavior-preserving refactor. It must emit byte-identical DDL on both
+backends.** The whole correctness argument is "the existing parity/auto-migrate
+suites stay green, plus one new characterization test for the single semantic
+seam."
+
+## Non-goals (explicitly out of scope)
+
+- Single SchemaIR *producer* over FFI — #141.
+- Removing the duplicated alter-helpers in `src/migrate.rs` — #142 / Phase 9.
+- `db_type` authority for non-explicit columns — #143.
+- Composite indexes/uniques in the runtime migrate IR — #144.
+- Unifying the three dialect enums — #146 (Phase 8.6).
+
+## Current state (the duplication, confirmed on `main`)
+
+`src/schema.rs` (CREATE path) imports **nothing** from `ferro-ddl-lowering` and
+carries its own:
+- `CanonicalType` (`:139`) — byte-identical variant set to the crate's.
+- `apply_canonical_type` (`:188`), `canonical_to_db_type_token` (`:163`),
+  `db_type_token_to_canonical` (`:350`).
+- `canonical_column_type` (`:383`) + `json_type_to_canonical` — the raw-JSON →
+  canonical mapper.
+
+`ferro-ddl-lowering` already owns: `CanonicalType`, `apply_canonical_type`,
+`db_type_token_to_canonical`, `canonical_from_schema_column` (the
+`SchemaColumn` → canonical mapper), and the naming/alter helpers. It is missing
+only `canonical_to_db_type_token` and a JSON → canonical entrypoint.
+
+> Note: `canonical_to_db_type_token` is currently consumed by **both** paths —
+> `src/migrate.rs` imports it via `crate::schema::canonical_to_db_type_token`. So
+> moving it into the crate cleans up the migrate side too.
+
+## The change (Approach 1: one mapper)
+
+1. **Move** `canonical_to_db_type_token` into `ferro-ddl-lowering`. Update the two
+   call sites (`schema.rs`, `migrate.rs`) to import it from the crate.
+2. **Delete** `schema.rs`'s `CanonicalType`, `apply_canonical_type`,
+   `db_type_token_to_canonical`, `json_type_to_canonical`; import the crate's
+   instead.
+3. **Replace** `schema.rs`'s `canonical_column_type` with a call to the crate's
+   `canonical_from_schema_column`. `build_column_plan` extracts
+   `(logical_type, format, db_type)` from the JSON, builds a minimal
+   `SchemaColumn`, and lowers through the crate. One JSON → canonical path, shared
+   by CREATE and migrate.
+4. **Dialect seam:** add a small `SqlDialect → ferro_ddl_lowering::Dialect`
+   conversion in `schema.rs` (mirroring the existing `backend_dialect` /
+   `lowering_dialect` helpers). Translate at the call boundary; do **not** unify
+   the dialect enums here (that is #146).
+
+## The semantic seams (where behavior could drift)
+
+These are the only places the two mappers differ; each must be preserved:
+
+1. **Unknown `logical_type`.** `canonical_from_schema_column` returns `Err`;
+   `canonical_column_type` defaults to `Varchar(None)`. To preserve CREATE
+   behavior, the call site maps `Err → Varchar(None)`. Covered by a new
+   characterization test.
+2. **Implicit `db_type`.** `canonical_column_type` only consults `db_type` when
+   the field sets it explicitly. The `SchemaColumn` we build must therefore carry
+   `db_type = <explicit value>` or `""` (empty), so
+   `db_type_token_to_canonical("")` returns `None` and the mapper falls through to
+   `(logical_type, format)` — matching today's precedence exactly.
+3. **`format = "decimal"`.** The crate matches `(_, Some("decimal")) => Decimal`
+   regardless of type; `schema.rs` requires a concrete type. Equivalent for all
+   real inputs; the parity suite guards it.
+
+## Testing / validation
+
+Existing safety net (must stay green, unchanged):
+- `tests/test_cross_emitter_parity.py`, `tests/test_db_type_cross_emitter_parity.py`
+- Rust unit tests in `ferro-ddl-lowering`, `ferro-migrate`, and `src/schema.rs`
+- IR-vs-legacy migrate parity + runtime shadow compare (`src/migrate.rs`)
+
+New:
+- A Rust characterization test for the unknown-`logical_type` → `Varchar(None)`
+  fallback (seam #1) so the `Err`-mapping is pinned.
+
+**Done =** `cargo test` (workspace) green + the full cross-emitter / auto-migrate
+pytest matrix green on **SQLite and Postgres**, with zero emitted-DDL diffs.
+
+## Risk
+
+The refactor is mechanical but touches the most-exercised DDL path. The risk is a
+subtle canonical/`db_type` mismatch on an edge type. Mitigation: the three seams
+above are explicitly preserved, the parity/auto-migrate matrix is the gate, and
+the change emits no new SQL spellings by construction (same crate functions the
+migrate path already uses).
+
+## Migration impact
+
+`none` — internal; no user-facing API or behavior change.

--- a/docs/brainstorms/2026-06-26-ir-p8.5-143-db-type-drop-requirements.md
+++ b/docs/brainstorms/2026-06-26-ir-p8.5-143-db-type-drop-requirements.md
@@ -1,0 +1,116 @@
+---
+title: "IR-P8.5 #143 — drop db_type for non-explicit columns"
+type: requirements
+status: draft
+date: 2026-06-26
+issue: https://github.com/syn54x/ferro-orm/issues/143
+epic: https://github.com/syn54x/ferro-orm/issues/139
+roadmap: docs/plans/2026-06-19-001-ir-first-roadmap.md (Phase 8.5)
+---
+
+# #143 — `db_type` is carried only when explicit
+
+## Goal
+
+Make the SchemaIR's `db_type` honest: it is present **only** for columns where the
+user explicitly set one. Non-explicit columns carry **no** `db_type`; their storage
+type is derived from `logical_type` (+`format`), which is already how they are
+typed by every emitter. Behavior-preserving — **zero change to emitted DDL**.
+
+## Why (the concrete problem)
+
+Today the Python compiler stamps a `db_type` on every column, and for non-explicit
+columns the value is wrong — and ignored:
+
+```
+model field        IR claims db_type   actual column (Rust)   actual column (Alembic)
+balance: int       "bigint"            INTEGER                INTEGER
+rate: float        "text"              double precision       FLOAT
+title: str         "text"             varchar                VARCHAR
+```
+
+Verified edge case — `max_length`: a non-explicit `str` with `Field(max_length=64)`
+still renders plain `varchar` (no length) today; `max_length` is ignored for column
+width. Only an explicit `db_type="varchar(N)"` carries a length, and explicit columns
+keep their `db_type` under this change. So dropping the non-explicit `db_type` loses
+no storage information.
+
+Both emitters ignore the IR's `db_type` for non-explicit columns and derive from
+`logical_type`, so it causes no bug **today**. But it is a loaded gun aimed at
+**#141**: once Rust consumes the Python SchemaIR over FFI, `canonical_from_schema_column`
+is `db_type`-**first**, so `"bigint"` → `BIGINT` for every plain int and `"text"` →
+`TEXT` for every float — silent column-type regressions and phantom/destructive
+auto-migrate diffs. #143 unloads the gun before #141 picks it up.
+
+`logical_type` + `format` are in the IR regardless (codec/hydration need them) and
+already determine the canonical type for non-explicit columns, so a non-explicit
+`db_type` is redundant. We drop the redundancy rather than correct-and-maintain it.
+
+## The change
+
+1. **IR type** — `ferro_schema_ir::SchemaColumn.db_type`: `String` → `Option<String>`
+   (serde: `skip_serializing_if = "Option::is_none"`, `default`). `logical_type`
+   stays required; `db_type_explicit` is **unchanged** (out of scope to collapse).
+2. **Python `src/ferro/ir/compiler.py`** — `_column_ir` emits `db_type` only when the
+   field set one explicitly; **delete `_default_db_type`** (the source of the
+   `bigint`/`text` defaults, now unused).
+3. **Rust producers** — `live_columns_to_schema_ir` wraps the introspected value as
+   `Some(...)` (observed DB state). `schema_json_to_schema_ir` (model side)
+   **keeps resolving its `db_type` (`Some`) — unchanged** (see "Scope refinement").
+4. **Rust consumers** — `canonical_from_schema_column`, `canonical_from_parts`,
+   `schema_columns_storage_drift`, and `emit.rs`'s drift checks adapt to `Option`
+   via `col.db_type.as_deref().unwrap_or("")`; empty falls through to
+   `logical_type`/`format` exactly as today.
+5. **Fixtures + test** — regenerate `tests/fixtures/ir_vectors/schema_*.json` so
+   non-explicit columns no longer carry `db_type`; add a test asserting the compiled
+   IR **omits** `db_type` for a non-explicit column and **includes** it for an
+   explicit one.
+
+## Scope refinement (verified during planning)
+
+The drop is applied to the **wire IR** (the Python compiler) only; the Rust migrate
+path's internal `db_type` resolution is left untouched. Verified concretely: a
+non-explicit `uuid` field on SQLite is declared `uuid_text`; the model side
+resolves `db_type="uuid"` → `Char(32)`, the live column introspects to the same →
+**no drift today (Ferro is silent)**. If `schema_json_to_schema_ir` dropped its
+resolved `db_type`, the model would *derive* `Uuid` (≠ live `Char(32)`) and emit a
+spurious *"column drifted, use Alembic"* warning on every auto-migrate — a
+user-visible false alarm. #143's goal (an honest wire IR before #141 makes it
+load-bearing) needs only the Python compiler change. The SQLite-uuid derivation
+reconciliation (making `canonical_from_parts` dialect-correct so `None` derives
+`Char(32)` on SQLite) belongs to **#141**, where Rust starts consuming the
+`None`-bearing wire IR.
+
+## `ir_version`
+
+**Decision (revised during planning): keep `ir_version = 1`, no bump.** Making
+`db_type` optional is deserialize-compatible (old payloads that carry it still
+parse). And the version is enforced by a **single shared `SUPPORTED_IR_VERSION`**
+in `tests/test_ir_vectors_contract.py` that gates schema *and* query *and* codec
+fixtures, plus a hard `ir_version != 1` check on the **query** path in
+`src/operations.rs` — so bumping for a schema-only change would wrongly force
+unrelated query/codec fixtures (and a query-path constant) to move too. Since the
+change is backward-compatible, no bump is the clean choice.
+
+## Behavior preservation & validation
+
+The emitted DDL must not change — non-explicit columns already derive from
+`logical_type`/`format`. Gate (must stay green on SQLite **and** Postgres, zero DDL
+diffs):
+- `cargo test --no-default-features --features testing` + `cargo test -p ferro-schema-ir -p ferro-migrate -p ferro-ddl-lowering`
+- `uv run pytest tests/test_db_type_cross_emitter_parity.py tests/test_cross_emitter_parity.py tests/test_ir_vectors_contract.py tests/test_alembic_autogenerate.py -q`
+- `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py -q`
+
+Plus the new "non-explicit omits db_type / explicit keeps it" IR test.
+
+## Non-goals
+
+- Collapsing `db_type_explicit` into "`db_type` present ⟺ explicit" (separate cleanup).
+- Making `db_type` authoritative (the rejected alternative).
+- Changing the Rust migrate path's internal `db_type` resolution + the SQLite-uuid
+  derivation fix — deferred to #141 (see Scope refinement).
+- #141's FFI producer cutover (this de-risks it but does not do it).
+
+## Migration impact
+
+`none` — internal IR contract; no user-facing API or emitted-DDL change.

--- a/docs/brainstorms/2026-06-26-ir-p8.5-144-reconcile-indexes-requirements.md
+++ b/docs/brainstorms/2026-06-26-ir-p8.5-144-reconcile-indexes-requirements.md
@@ -1,0 +1,130 @@
+---
+title: "IR-P8.5 #144 — reconcile indexes & uniques in auto-migrate"
+type: requirements
+status: draft
+date: 2026-06-26
+issue: https://github.com/syn54x/ferro-orm/issues/144
+epic: https://github.com/syn54x/ferro-orm/issues/139
+roadmap: docs/plans/2026-06-19-001-ir-first-roadmap.md (Phase 8.5)
+---
+
+# #144 — Reconcile indexes & uniques in auto-migrate
+
+## Goal
+
+Auto-migrate reconciles **standalone, Ferro-named** indexes & uniques (single +
+composite) on existing tables — symmetric with how it already reconciles columns.
+Today this is a **silent no-op**: a user who adds an index to their model and
+restarts with `auto_migrate` gets no index and no warning (verified — the create
+path emits `CREATE INDEX "idx_t_a_b"`, the migrate path emits nothing).
+
+## The parity principle (gives us AGENTS.md I-1 for free)
+
+The migrate path reconciles **exactly the set of standalone `CREATE INDEX`
+statements the create path's `post_create_artifacts` already emits** — i.e.
+`model.indexes` + `model.uniques`, minus inline single-column uniques (those the
+create path renders inline in the column definition, never as a `uq_` index).
+By reusing the same naming helpers (`ferro-ddl-lowering::*_index_name` /
+`*_unique_index_name`) and the same `render_index_sql`, an auto-migrated table is
+byte-identical to a freshly created one.
+
+## Behavior
+
+Matched **by Ferro's canonical names only** — `idx_<table>_<cols>` and
+`uq_<table>_<cols>`. Ferro never touches user-created indexes, PK/constraint
+autoindexes, or anything not matching its naming convention.
+
+- **ADD (always):** a model index/unique whose canonical name is absent from the
+  live table → `CREATE INDEX` / `CREATE UNIQUE INDEX`.
+- **DROP (only `migrate_destructive`):** a Ferro-named index present live but gone
+  from the model → `DROP INDEX`. Mirrors `DropColumn` (filtered out when not
+  destructive).
+- **Out of scope:** inline single-column `UNIQUE` on existing columns. The create
+  path renders these inline (not as a `uq_` index), so there is no standalone
+  index to reconcile; adding/removing an inline constraint on an existing column
+  remains an Alembic concern (and `emit_add_column` already handles the
+  new-unique-column case).
+
+## Components
+
+1. **Live introspection (the one genuinely new piece).**
+   `live_table_indexes(engine, table) -> Vec<LiveIndex>` in `src/introspect.rs`,
+   dispatching by backend like `live_table_columns`:
+   - SQLite: `PRAGMA index_list(table)` + `PRAGMA index_info(name)`.
+   - Postgres: `pg_indexes` / `pg_catalog` (index name, columns, `is_unique`).
+   Returns only **Ferro-named standalone** indexes (`idx_`/`uq_` prefix); each
+   `LiveIndex` carries `name`, `columns` (ordered), `unique`. (PK/constraint
+   autoindexes and user indexes are filtered out by the name prefix.)
+
+2. **Populate the model IR.** `schema_json_to_schema_ir` (`src/migrate.rs`) fills
+   `indexes`/`uniques` from the JSON schema — single-column `index=`/`unique=` and
+   `ferro_composite_indexes`/`ferro_composite_uniques` — using the shared naming
+   helpers, mirroring the Python `compile_schema_ir_payload`.
+   `live_columns_to_schema_ir` is replaced/augmented so the live model carries the
+   introspected index set.
+
+3. **Diff + ops.** New `MigrationOp::AddIndex { table, name }` and
+   `DropIndex { table, name }` in `ferro-migrate`. `plan_from_ir` compares the
+   model's standalone-index set vs the live set by name (ADD missing; DROP
+   orphaned). `plan_table_migration` filters `DropIndex` out unless
+   `opts.destructive`, exactly as it does for `DropColumn`.
+
+4. **Emit.** `AddIndex` → look up the `SchemaIndex`/`SchemaUnique` by name in the
+   new IR and render via `render_index_sql` (reused). `DropIndex` →
+   `DROP INDEX [IF EXISTS] "<name>"` (SQLite/Postgres spelling).
+
+## Execution / ordering notes
+
+- `AddIndex` runs after column adds (a new composite index may reference a
+  just-added column). `DropIndex` runs before column drops where a SQLite drop
+  needs the index gone first — note the existing `execute_drop_column` already
+  drops covering indexes for SQLite, so avoid double-dropping (a `DROP INDEX IF
+  EXISTS` is idempotent, which keeps this safe).
+- Postgres unique: emitted as a unique **index** (`CREATE UNIQUE INDEX uq_…`),
+  matching what `post_create_artifacts` emits for composite uniques today.
+
+## Parity gate (#120) — scoped to column-ops
+
+This is the point where the IR planner **legitimately surpasses** the legacy
+planner: `plan_table_migration_legacy` reconciles only columns (it emits an index
+only when *adding a column*, never standalone/composite on existing tables), so
+the #120 byte-parity assertion (`shadow_compare_migration_plan`:
+`ir.statements == legacy.statements`) can no longer hold once the IR planner emits
+`AddIndex`/`DropIndex`.
+
+Resolution (approved): scope the IR↔legacy parity to the **legacy planner's
+domain**. Exclude `AddIndex`/`DropIndex` statements from the IR side before
+comparing to legacy in `shadow_compare_migration_plan` and the
+`assert_ir_legacy_parity` test helpers. Column add/drop/alter parity stays
+enforced (until Phase 9 removes legacy); index reconciliation is verified by the
+new tests below. We do **not** teach the legacy planner index reconciliation —
+it's deleted in Phase 9 (no stop-gap).
+
+## Validation
+
+New auto-migrate tests on **both backends** (`tests/test_auto_migrate.py` /
+`tests/test_migrate_plan.py`):
+- composite index added to an existing table;
+- single-column `index=` added to an existing column;
+- destructive drop of an orphaned Ferro-named index;
+- a Ferro-named index already present → **no-op** (no spurious re-create — the
+  false-alarm guard);
+- a non-explicit / user-created index is left untouched.
+
+Plus a cross-emitter assertion that a migrate-added index's SQL equals the
+create-emitted one, and the full existing parity/auto-migrate matrix stays green
+on SQLite **and** Postgres.
+
+## Migration impact
+
+`minor` — new auto-migrate behavior (indexes/uniques are now reconciled; under
+`migrate_destructive`, orphaned Ferro-named indexes are dropped). The migration
+guide (`docs/plans/ir-first-migration-guide.md`) and the migrations how-to
+capability matrix must be updated before the issue is Done (roadmap doc policy).
+
+## Non-goals
+
+- Inline single-column `UNIQUE` reconciliation on existing columns (above).
+- Index option changes (partial/where, expression, opclass, collation) — only
+  presence/absence by canonical name is reconciled.
+- Reconciling check constraints (`ck_`) — separate concern.

--- a/docs/brainstorms/2026-06-28-ir-p8.5-141-single-schema-ir-producer-requirements.md
+++ b/docs/brainstorms/2026-06-28-ir-p8.5-141-single-schema-ir-producer-requirements.md
@@ -1,0 +1,166 @@
+---
+title: "IR-P8.5 #141 — single SchemaIR producer (Python over FFI)"
+type: requirements
+status: draft
+date: 2026-06-28
+issue: https://github.com/syn54x/ferro-orm/issues/141
+epic: https://github.com/syn54x/ferro-orm/issues/139
+roadmap: docs/plans/2026-06-19-001-ir-first-roadmap.md (Phase 8.5)
+---
+
+# #141 — Single SchemaIR producer
+
+## Goal
+
+The **declared** schema (what your models say) is compiled to SchemaIR in **one
+place — Python** (`compile_registry_schema_ir`, already cached in
+`_SCHEMA_IR_MODELSET`). Runtime auto-migrate consumes that same IR over FFI,
+exactly as the Query IR path already does, and the parallel Rust producer
+(`schema_json_to_schema_ir`) is **deleted**. This is the audit's headline
+"single source of truth" goal, realized for the migrate path.
+
+A migration is always `diff(declared, observed)`. #141 unifies only the
+**declared** side. The **observed** side stays Rust introspection
+(`live_table_columns` + `live_table_indexes`) — that is not a second producer,
+it reads the real database; there is nothing to unify there.
+
+```
+   Python SchemaIR   ──┐
+   (declared, the      ├──►  diff  ──►  ADD / DROP / ALTER
+    single producer)   │
+   Rust introspection ─┘
+   (observed: the real DB)
+```
+
+## Why
+
+Today the declared SchemaIR is compiled **twice**: Python `compile_registry_schema_ir`
+(drives `alembic revision --autogenerate`) and Rust `schema_json_to_schema_ir`
+(drives `connect(auto_migrate=True)`). Two engines deriving "what your model
+means" can silently disagree — a user reasonably expects Alembic and auto-migrate
+to see the same schema. #141 removes that class of divergence by construction:
+both read the one Python-compiled IR.
+
+#143 already de-risked this by making the wire IR honest (`db_type` present only
+when explicit). #141 is where Rust starts **consuming** that `None`-bearing IR —
+which springs the trap #143 deferred here (below).
+
+## The deferred uuid-on-SQLite fix (the load-bearing detail)
+
+`canonical_from_schema_column` is `db_type`-first. Once Rust reads the Python IR,
+a derived `uuid` column arrives with `db_type: None`, so Rust derives its canonical
+from `logical_type`/`format`:
+
+- model (derived): `canonical_from_parts("string", "uuid", …)` → **`Uuid`**
+- live (introspected `uuid_text`): `"uuid"` token → **`Char(32)`** on SQLite
+
+`Char(32) != Uuid` → a phantom `AlterColumnType` → and because
+`sqlite_type_storage_drift("uuid", Uuid)` is **true** (`"uuid"` → Numeric class,
+`"uuid_text"` → Text class — verified), the user gets this on **every** SQLite
+startup, for a column nobody touched:
+
+```
+Column 'user.id' is declared 'uuid' in the database but the model expects
+'uuid_text'. SQLite cannot change column types in place; use Alembic to
+migrate this column.
+```
+
+(Postgres is unaffected — `uuid` ↔ `Uuid` on both sides.)
+
+We **cannot** fix this by making `canonical_from_parts` return `Char(32)` for uuid
+on SQLite: that function is also the **create** path, so it would change emitted
+DDL (`uuid_text` → `char(32)`) and break cross-emitter parity.
+
+**The fix lives at the diff boundary.** `schema_columns_storage_drift` compares
+storage **tokens** instead of raw canonicals: `canonical_to_db_type_token(old, dialect)`
+vs `canonical_to_db_type_token(new, dialect)`. On SQLite both `Uuid` and `Char(32)`
+map to `"uuid"` → equal → no drift. The same normalization correctly merges other
+storage-equivalent pairs (`DateTime`≡`Timestamp` → `"timestamp"`) while still
+catching real changes (`int` → `bigint`). **Zero change to emitted DDL** — only the
+phantom diff disappears.
+
+## User-facing behavior
+
+- **uuid PK / any derived uuid column on SQLite:** silent before and after #141.
+  Without the fix, #141 would print the false-alarm warning above on every boot.
+- **Alembic vs auto-migrate consistency:** `alembic revision --autogenerate` and
+  `connect(auto_migrate=True)` now consult the identical compiled SchemaIR; they
+  can no longer disagree about a type or an index name from two derivations.
+- **#144 index reconciliation:** keeps working unchanged — the Python compiler
+  already populates `indexes`/`uniques`, so the single producer carries them.
+
+## The change
+
+1. **Python — single producer + FFI handoff.** The auto-migrate entrypoint passes
+   the compiled **modelset** SchemaIR (`compile_registry_schema_ir()` envelope,
+   already cached) to the Rust migrate path as JSON, mirroring the Query IR
+   pattern: an `{ ir_kind: "schema", ir_version, payload }` envelope. Passed
+   **once** per migrate run (not per model); Rust indexes it by table.
+
+2. **Rust — consume + delete the duplicate producer.** Rust deserializes
+   `IrEnvelope<SchemaIrPayload>` (the type already exists — `schema_json_to_schema_ir`
+   builds one today) and validates `ir_kind == "schema"` and `ir_version` as the
+   query path validates its envelope (a hard version check, matching the
+   `tests/test_ir_vectors_contract.py::SUPPORTED_IR_VERSION` contract). The migrate
+   diff then uses each model's `SchemaModel` directly as the **declared** side.
+   **Delete
+   `schema_json_to_schema_ir`** and convert its call sites to take the declared
+   `SchemaModel`:
+   - `plan_table_migration` (the new/declared IR),
+   - the existing-column drift path,
+   - `_render_migration_sql_for_test` and `_shadow_compare_migration_plan_for_test`
+     — these gain a `schema_ir_json` parameter (the compiled SchemaIR for the
+     model) replacing the raw enriched-`schema_json` they pass today.
+
+3. **The uuid fix** — `schema_columns_storage_drift` compares via
+   `canonical_to_db_type_token` (above). Verify the downstream emit-level
+   `sqlite_type_storage_drift` check is consistent (it is no longer reached for
+   uuid once the diff stops generating the op, but must not contradict).
+
+4. **Live side unchanged** — `live_table_columns` + `live_table_indexes` still
+   produce the observed IR in Rust.
+
+## Parity gate
+
+Parity stays **column-scoped** (established in #144: `AddIndex`/`DropIndex` are
+projected out before comparing IR to legacy). #141 changes how the IR's **column**
+ops are derived (Python IR instead of the Rust producer), so the IR-vs-legacy
+parity matrix is the guard that the Python-derived column ops still match the
+legacy planner (which derives from the enriched JSON). The uuid fix is part of
+keeping them aligned. The legacy planner is **not** modified — it is removed in
+Phase 9.
+
+## Validation
+
+Must stay green on SQLite **and** Postgres, zero DDL diffs:
+
+- `cargo test --no-default-features --features testing` + the workspace crates.
+- `uv run pytest tests/test_db_type_cross_emitter_parity.py tests/test_cross_emitter_parity.py tests/test_ir_vectors_contract.py tests/test_alembic_autogenerate.py -q`
+- `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py -q`
+- The IR-vs-legacy parity matrix (column ops) stays green.
+
+**New tests:**
+- **The Example-1 regression:** a derived `uuid` column on SQLite, with Rust
+  consuming the Python IR (`db_type: None`), produces **no** drift / no
+  `AlterColumnType` / no "use Alembic" warning — on first run and on re-run.
+- A `DateTime`/`Timestamp` storage-equivalence assertion (no spurious drift) and a
+  real `int`→`bigint` assertion (drift still detected) to pin the token
+  normalization.
+- The dual producer is gone: `schema_json_to_schema_ir` no longer exists; the
+  migrate path drives entirely off the consumed Python SchemaIR.
+
+## Migration impact
+
+`none` — internal IR-producer unification. No emitted-DDL change and no
+user-facing API change. The uuid fix strictly **prevents** a false-alarm warning
+that #141 would otherwise introduce; net user-visible change is zero.
+
+## Non-goals
+
+- **`CREATE TABLE` (create path) unification** — it builds DDL straight from the
+  schema, not via SchemaIR; untouched by #141.
+- **Removing the legacy planner / the parity scaffolding** — Phase 9.
+- **Collapsing `db_type_explicit`** into "`db_type` present ⟺ explicit" — separate
+  cleanup (noted in #143).
+- **Per-model FFI handoff** — rejected in favor of passing the modelset once.
+- **Making `db_type` authoritative** — rejected in #143.

--- a/docs/pages/guide/migrations.md
+++ b/docs/pages/guide/migrations.md
@@ -40,10 +40,13 @@ What it covers is capability-relative per backend:
 | :--- | :--- | :--- |
 | Add missing column | ✅ `ADD COLUMN` | ✅ `ADD COLUMN` |
 | Add the column's index (`index=True`) | ✅ `CREATE INDEX` | ✅ `CREATE INDEX` |
+| Add composite index (`__ferro_composite_indexes__`) to existing columns | ✅ `CREATE INDEX` | ✅ `CREATE INDEX` |
 | Add unique column (`unique=True`) | ✅ via explicit unique index + warning | ✅ inline `UNIQUE` |
 | Add foreign-key column | ✅ column only, no FK constraint + warning | ✅ column + FK constraint |
 | Change column type | ⚠️ `UserWarning`, no DDL (SQLite type affinity makes drift mostly cosmetic) | ✅ `ALTER COLUMN ... TYPE ... USING` cast |
 | Change nullability | ⚠️ `UserWarning`, no DDL | ✅ `SET NOT NULL` / `DROP NOT NULL` |
+| Drop orphaned Ferro-named index (`idx_*` / `uq_*`) | ✅ with `migrate_destructive=True` | ✅ with `migrate_destructive=True` |
+| Inline single-column `UNIQUE` on existing column, index option changes | ❌ never — Alembic territory | ❌ never |
 | Rename column/table, change primary key, drop table | ❌ never — Alembic territory | ❌ never |
 
 Rules worth knowing:

--- a/docs/plans/2026-06-26-001-feat-ir-p8.5-140-shared-lowering-plan.md
+++ b/docs/plans/2026-06-26-001-feat-ir-p8.5-140-shared-lowering-plan.md
@@ -1,0 +1,311 @@
+# #140 — `ferro-ddl-lowering` as the Single Lowering Library — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ferro-ddl-lowering` the sole owner of canonical-type lowering and route the runtime CREATE path (`src/schema.rs`) through it, deleting `schema.rs`'s parallel `CanonicalType` and mappers — with zero change to emitted DDL.
+
+**Architecture:** `ferro-ddl-lowering` gains the two pieces it lacks (`canonical_to_db_type_token`, a parts-based JSON→canonical mapper). `src/schema.rs` and `src/migrate.rs` import all canonical lowering from the crate; `schema.rs` deletes its copies and keeps only a thin JSON-adapter that delegates to the crate. Dialects are translated at the call seam (`SqlDialect → ferro_ddl_lowering::Dialect`).
+
+**Tech Stack:** Rust (workspace crates: `_core` main + `ferro-ddl-lowering`, `ferro-migrate`, `ferro-schema-ir`), PyO3, sea-query; Python test matrix via `uv run pytest`.
+
+## Global Constraints
+
+- **Behavior-preserving.** No emitted-DDL change on SQLite or Postgres. The gate is the existing parity/auto-migrate suites staying green (Task 4), plus one new characterization test.
+- **Rust edition 2024.** Match surrounding style; no new dependencies.
+- **The two `CanonicalType` enums are byte-identical** (verified) — variant names match, so the 78 `schema.rs` / 41 `migrate.rs` references resolve unchanged once the import flips.
+- **Four semantic seams** must be preserved (see Task 3): unknown `logical_type` → `Varchar(None)`; implicit `db_type` falls through (pass `""`); `format="decimal"`; and the crate's `db_type_token_to_canonical` being a *superset* of `schema.rs`'s (verified equivalent for validated combos by the per-token parity test in Task 4).
+- **Test commands:** Rust main-crate tests need `--no-default-features --features testing` (PyO3 auto-init). Crate tests run plain.
+
+---
+
+### Task 1: Extend `ferro-ddl-lowering` (additive)
+
+**Files:**
+- Modify: `crates/ferro-ddl-lowering/src/lib.rs` (add two `pub fn`; refactor `canonical_from_schema_column` at `:217`)
+- Test: `crates/ferro-ddl-lowering/src/lib.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces: `pub fn canonical_to_db_type_token(canonical: CanonicalType, dialect: Dialect) -> String`
+- Produces: `pub fn canonical_from_parts(logical_type: &str, format: Option<&str>, db_type: &str, dialect: Dialect) -> Result<CanonicalType, String>`
+- `canonical_from_schema_column` keeps its existing signature, now delegating.
+
+- [ ] **Step 1: Add `canonical_to_db_type_token`** (moved verbatim from `schema.rs:163`, `SqlDialect`→`Dialect`). Insert after `db_type_token_to_canonical` (`:146`):
+
+```rust
+/// Map a resolved [`CanonicalType`] back to the canonical Ferro `db_type` token
+/// vocabulary used in SchemaIR and cross-emitter parity tests.
+pub fn canonical_to_db_type_token(canonical: CanonicalType, dialect: Dialect) -> String {
+    match canonical {
+        CanonicalType::Integer => "int".to_string(),
+        CanonicalType::SmallInt => "smallint".to_string(),
+        CanonicalType::BigInt => "bigint".to_string(),
+        CanonicalType::Double => "double".to_string(),
+        CanonicalType::Decimal => "numeric".to_string(),
+        CanonicalType::Boolean => "boolean".to_string(),
+        CanonicalType::Json => "json".to_string(),
+        CanonicalType::Text => "text".to_string(),
+        CanonicalType::Varchar(None) => "varchar".to_string(),
+        CanonicalType::Varchar(Some(n)) => format!("varchar({n})"),
+        CanonicalType::Char(n) => match (dialect, n) {
+            (Dialect::Sqlite, 32) => "uuid".to_string(),
+            _ => format!("char({n})"),
+        },
+        CanonicalType::Uuid => "uuid".to_string(),
+        CanonicalType::DateTime | CanonicalType::Timestamp => "timestamp".to_string(),
+        CanonicalType::TimestampTz => "timestamptz".to_string(),
+        CanonicalType::Date => "date".to_string(),
+        CanonicalType::Time => "time".to_string(),
+        CanonicalType::Blob => "bytea".to_string(),
+    }
+}
+```
+
+- [ ] **Step 2: Add `canonical_from_parts` and delegate `canonical_from_schema_column` to it.** Replace the body of `canonical_from_schema_column` (`:217-243`) with:
+
+```rust
+/// Resolve a model property's `(logical_type, format, db_type)` to a canonical
+/// type. A recognized `db_type` token wins; otherwise the logical-type + format
+/// cascade decides. An empty/unrecognized `db_type` falls through.
+pub fn canonical_from_parts(
+    logical_type: &str,
+    format: Option<&str>,
+    db_type: &str,
+    dialect: Dialect,
+) -> Result<CanonicalType, String> {
+    if let Some(canonical) = db_type_token_to_canonical(db_type, dialect) {
+        return Ok(canonical);
+    }
+    match (logical_type, format) {
+        ("string", Some("date-time")) => Ok(CanonicalType::TimestampTz),
+        ("string", Some("date")) => Ok(CanonicalType::Date),
+        ("string", Some("uuid")) => Ok(CanonicalType::Uuid),
+        (_, Some("decimal")) => Ok(CanonicalType::Decimal),
+        ("string", Some("binary")) => Ok(CanonicalType::Blob),
+        ("integer", _) => Ok(CanonicalType::Integer),
+        ("string", _) => Ok(CanonicalType::Varchar(None)),
+        ("number", _) => Ok(CanonicalType::Double),
+        ("boolean", _) => Ok(match dialect {
+            Dialect::Sqlite => CanonicalType::Integer,
+            Dialect::Postgres => CanonicalType::Boolean,
+        }),
+        ("object" | "array", _) => Ok(CanonicalType::Json),
+        _ => Err(format!("unknown logical_type '{logical_type}'")),
+    }
+}
+
+/// Resolve a [`SchemaColumn`] to its canonical storage type.
+pub fn canonical_from_schema_column(
+    col: &SchemaColumn,
+    dialect: Dialect,
+) -> Result<CanonicalType, String> {
+    canonical_from_parts(&col.logical_type, col.format.as_deref(), &col.db_type, dialect)
+        .map_err(|_| format!("unknown db_type '{}' on column '{}'", col.db_type, col.name))
+}
+```
+
+- [ ] **Step 3: Add crate unit tests** in the existing `mod tests`:
+
+```rust
+#[test]
+fn canonical_to_db_type_token_roundtrips_core_tokens() {
+    assert_eq!(canonical_to_db_type_token(CanonicalType::Integer, Dialect::Postgres), "int");
+    assert_eq!(canonical_to_db_type_token(CanonicalType::Char(32), Dialect::Sqlite), "uuid");
+    assert_eq!(canonical_to_db_type_token(CanonicalType::Char(10), Dialect::Sqlite), "char(10)");
+    assert_eq!(canonical_to_db_type_token(CanonicalType::TimestampTz, Dialect::Postgres), "timestamptz");
+}
+
+#[test]
+fn canonical_from_parts_matches_schema_column_path() {
+    // db_type wins
+    assert_eq!(canonical_from_parts("string", None, "bigint", Dialect::Postgres), Ok(CanonicalType::BigInt));
+    // fallback to logical_type/format
+    assert_eq!(canonical_from_parts("string", Some("date-time"), "", Dialect::Postgres), Ok(CanonicalType::TimestampTz));
+    assert_eq!(canonical_from_parts("integer", None, "", Dialect::Sqlite), Ok(CanonicalType::Integer));
+    // unknown is an error (CREATE path maps this to Varchar at its call site)
+    assert!(canonical_from_parts("mystery", None, "", Dialect::Postgres).is_err());
+}
+```
+
+- [ ] **Step 4: Build + test the crate**
+
+Run: `cargo test -p ferro-ddl-lowering`
+Expected: PASS (all existing + 2 new tests). Crate compiles; no callers changed yet.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ferro-ddl-lowering/src/lib.rs
+git commit -m "feat(ddl-lowering): add canonical_to_db_type_token + canonical_from_parts (#140)"
+```
+
+---
+
+### Task 2: Pin the CREATE-path unknown-type behavior (characterization test)
+
+**Files:**
+- Test: `src/schema.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: `canonical_column_type(raw, resolved, backend) -> CanonicalType` (still the current `schema.rs` version at this point)
+
+This test passes on **current** code and must still pass after Task 3 — it locks the `Err → Varchar(None)` seam.
+
+- [ ] **Step 1: Add the characterization test** to `src/schema.rs` tests:
+
+```rust
+#[test]
+fn canonical_column_type_unknown_and_missing_type_fall_back_to_varchar() {
+    let unknown = serde_json::json!({ "type": "mystery" });
+    assert_eq!(
+        canonical_column_type(&unknown, &unknown, SqlDialect::Postgres),
+        CanonicalType::Varchar(None)
+    );
+    let no_type = serde_json::json!({});
+    assert_eq!(
+        canonical_column_type(&no_type, &no_type, SqlDialect::Sqlite),
+        CanonicalType::Varchar(None)
+    );
+}
+```
+
+- [ ] **Step 2: Run it against current code**
+
+Run: `cargo test --no-default-features --features testing canonical_column_type_unknown`
+Expected: PASS (pins existing behavior before the refactor).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/schema.rs
+git commit -m "test(schema): pin CREATE-path unknown-type -> varchar fallback (#140)"
+```
+
+---
+
+### Task 3: Flip `schema.rs` and `migrate.rs` onto the crate
+
+This is one atomic change: deleting `schema.rs`'s `CanonicalType` breaks `migrate.rs`'s import simultaneously, so both move together to keep `cargo build` green.
+
+**Files:**
+- Modify: `src/schema.rs` — delete `CanonicalType` (`:139-159`), `canonical_to_db_type_token` (`:163-186`), `apply_canonical_type` (`:188-246`), `json_type_to_canonical` (`:247-260`), `db_type_token_to_canonical` (`:350-376`); rewrite `canonical_column_type` (`:383-408`) as an adapter; add a dialect helper + imports.
+- Modify: `src/migrate.rs:29-33` — re-point three symbols to the crate.
+
+**Interfaces:**
+- Consumes (from Task 1): `ferro_ddl_lowering::{CanonicalType, apply_canonical_type, db_type_token_to_canonical, canonical_to_db_type_token, canonical_from_parts, Dialect}`
+- Produces: `canonical_column_type` keeps its `pub(crate)` signature (now an adapter); call sites at `schema.rs:531` and `:1144` are unchanged.
+
+- [ ] **Step 1: Update `src/schema.rs` imports.** Add to the `use` block (top of file, after `:7`):
+
+```rust
+use ferro_ddl_lowering::{
+    CanonicalType, Dialect, apply_canonical_type, canonical_from_parts,
+    canonical_to_db_type_token, db_type_token_to_canonical,
+};
+```
+
+- [ ] **Step 2: Delete the five duplicated definitions** from `src/schema.rs`: the `enum CanonicalType` (`:139-159`), `canonical_to_db_type_token` (`:163-186`), `apply_canonical_type` (`:188-246`), `json_type_to_canonical` (`:247-260`), and `db_type_token_to_canonical` (`:350-376`). (`parse_varchar_token` at `:336` is also now unused in this file — delete it too; the crate has its own.)
+
+- [ ] **Step 3: Add the dialect-seam helper** near the top of `src/schema.rs` (after the imports):
+
+```rust
+/// Translate the runtime backend tag to the lowering crate's dialect at the call seam.
+/// (Unifying these enums is tracked separately as #146 / Phase 8.6.)
+fn sql_dialect_to_lowering(backend: SqlDialect) -> Dialect {
+    match backend {
+        SqlDialect::Sqlite => Dialect::Sqlite,
+        SqlDialect::Postgres => Dialect::Postgres,
+    }
+}
+```
+
+- [ ] **Step 4: Rewrite `canonical_column_type`** as a thin adapter delegating to the crate (preserves all four seams):
+
+```rust
+/// Resolve a model property to its backend-specific [`CanonicalType`] via the
+/// shared lowering crate. `db_type` (when set) wins; otherwise the Pydantic
+/// JSON type/format cascade decides; unknown types fall back to `varchar`.
+pub(crate) fn canonical_column_type(
+    raw_col_info: &serde_json::Value,
+    resolved_col_info: &serde_json::Value,
+    backend: SqlDialect,
+) -> CanonicalType {
+    let db_type = raw_col_info
+        .get("db_type")
+        .or_else(|| resolved_col_info.get("db_type"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let (json_type, format) = property_json_type_and_format(resolved_col_info);
+    canonical_from_parts(json_type.unwrap_or(""), format, db_type, sql_dialect_to_lowering(backend))
+        .unwrap_or(CanonicalType::Varchar(None))
+}
+```
+
+- [ ] **Step 5: Re-point `src/migrate.rs` imports.** Change the `use crate::schema::{...}` block (`:29-33`) so `CanonicalType`, `apply_canonical_type`, and `canonical_to_db_type_token` come from the crate, leaving the rest:
+
+```rust
+use ferro_ddl_lowering::{
+    CanonicalType, Dialect, apply_canonical_type, canonical_to_db_type_token,
+    db_check_constraint_name, information_schema_to_db_type_token, schema_columns_storage_drift,
+};
+use crate::schema::{
+    ColumnPlan, build_column_plan, internal_create_tables,
+    order_schemas_for_creation, property_json_type_and_format,
+};
+```
+(Merge the new names into the existing `ferro_ddl_lowering` import already present at `:17`; do not duplicate the `use`.)
+
+- [ ] **Step 6: Build the workspace**
+
+Run: `cargo build`
+Expected: success, no warnings about unused imports. If `parse_varchar_token` or another helper is flagged unused, delete it.
+
+- [ ] **Step 7: Run the full Rust test suite**
+
+Run: `cargo test --no-default-features --features testing` then `cargo test -p ferro-ddl-lowering -p ferro-migrate -p ferro-schema-ir`
+Expected: PASS (including Task 2's characterization test and the migrate IR-vs-legacy parity tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/schema.rs src/migrate.rs
+git commit -m "refactor(schema): route CREATE lowering through ferro-ddl-lowering; delete duplicate CanonicalType (#140)"
+```
+
+---
+
+### Task 4: Behavior-preservation gate (Python parity + auto-migrate matrix)
+
+**Files:** none (verification). This is the proof the refactor changed no DDL.
+
+- [ ] **Step 1: Per-token + full-model cross-emitter parity (SQLite path)**
+
+Run: `uv run pytest tests/test_db_type_cross_emitter_parity.py tests/test_cross_emitter_parity.py tests/test_ir_vectors_contract.py -q`
+Expected: PASS. This walks every `(canonical_token, dialect)` pair — it is the check that the crate's superset `db_type_token_to_canonical` produces identical CREATE DDL to before.
+
+- [ ] **Step 2: Auto-migrate + migrate-plan on the backend matrix**
+
+Run: `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py tests/test_alembic_autogenerate.py -q`
+Expected: PASS on both backends. (Postgres requires the backend-matrix harness / a running Postgres; if unavailable locally, this runs in CI — note it in the PR.)
+
+- [ ] **Step 3: Full workspace test once more**
+
+Run: `cargo test --no-default-features --features testing`
+Expected: PASS.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin feat/ir-p8.5-140-shared-lowering
+gh pr create --base main --title "feat(schema): single lowering library — route CREATE through ferro-ddl-lowering (#140)" --body "<summary: closes #140; behavior-preserving; gate = cross-emitter + auto-migrate matrix green on SQLite+Postgres>"
+```
+(Body should note migration impact `none`, link the spec, and check the #140 deliverable.)
+
+---
+
+## Self-Review
+
+**Spec coverage:** every spec move maps to a task — `canonical_to_db_type_token` move (T1.S1), one JSON→canonical mapper (T1.S2 + T3.S4), delete duplicates (T3.S2), dialect seam (T3.S3), unknown-type seam test (T2), the parity gate (T4). The `db_type_token` superset seam is covered by T4.S1. ✅
+
+**Placeholder scan:** all steps carry real code/commands; the only `<...>` is the PR-body summary, which is content the author fills at PR time, not a logic gap. ✅
+
+**Type consistency:** `canonical_from_parts(logical_type: &str, format: Option<&str>, db_type: &str, dialect: Dialect) -> Result<CanonicalType, String>` and `canonical_to_db_type_token(CanonicalType, Dialect) -> String` are used identically in T1, T3, and the adapter. `sql_dialect_to_lowering(SqlDialect) -> Dialect` is defined once (T3.S3) and used in the adapter (T3.S4). ✅

--- a/docs/plans/2026-06-26-002-feat-ir-p8.5-143-db-type-drop-plan.md
+++ b/docs/plans/2026-06-26-002-feat-ir-p8.5-143-db-type-drop-plan.md
@@ -1,0 +1,229 @@
+# #143 — Drop `db_type` for Non-Explicit Columns — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The SchemaIR carries `db_type` only when the user set one explicitly; non-explicit columns omit it. The Python compiler stops emitting the wrong `bigint`/`text` defaults, so the wire IR is honest before #141 makes it load-bearing — with zero change to emitted DDL or runtime behavior.
+
+**Architecture:** Make `SchemaColumn.db_type` an `Option<String>` (serde-omitted when `None`); the Python compiler emits it only for explicit columns; all Rust *producers* keep emitting `Some(...)` (so runtime auto-migrate is untouched), and Rust *consumers* tolerate `None` via `as_deref()`. The compiler-snapshot fixture is regenerated.
+
+**Tech Stack:** Rust workspace (`ferro-schema-ir`, `ferro-ddl-lowering`, `ferro-migrate`, `_core`), PyO3, Python (`uv`/pytest), serde.
+
+## Global Constraints
+
+- **Behavior-preserving:** no change to emitted DDL or auto-migrate drift on SQLite or Postgres. Gate = existing parity/auto-migrate suites stay green.
+- **Scope is the WIRE IR only.** The Rust migrate model-side producer (`schema_json_to_schema_ir`) **keeps resolving** its `db_type` (`Some`) — do NOT make it `None`. (Dropping it causes a spurious uuid-on-SQLite drift warning; that reconciliation is #141.)
+- **`ir_version` stays `1`** — no bump. `SUPPORTED_IR_VERSION` is shared across schema/query/codec and `operations.rs` hard-checks the query version `!= 1`; the change is deserialize-compatible.
+- `db_type_explicit` is unchanged. Rust edition 2024, no new deps.
+
+---
+
+### Task 1: `SchemaColumn.db_type` → `Option<String>` + all Rust sites
+
+Atomic type change: making the field `Option` breaks every construction/read site until fixed. All Rust producers keep emitting `Some(...)`, so behavior is unchanged; the Rust suite must stay green.
+
+**Files:**
+- Modify: `crates/ferro-schema-ir/src/lib.rs:60`
+- Modify: `src/migrate.rs` (`schema_json_to_schema_ir`, `live_columns_to_schema_ir:227`, `schema_column_for_drift:724`)
+- Modify: `crates/ferro-ddl-lowering/src/lib.rs:281-282` (read), `:514` (test helper)
+- Modify: `crates/ferro-migrate/src/emit.rs:460,467` (reads)
+- Modify: `crates/ferro-migrate/src/tests.rs:43,563` (test helpers)
+
+**Interfaces:**
+- Produces: `SchemaColumn.db_type: Option<String>` (was `String`). `None` ⟺ no explicit override.
+
+- [ ] **Step 1: Change the field type** (`crates/ferro-schema-ir/src/lib.rs`, the `pub db_type: String,` at line 60):
+
+```rust
+    /// Canonical storage token. Present only for columns with an explicit `db_type=`;
+    /// `None` means "derive storage from `logical_type`/`format`".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub db_type: Option<String>,
+```
+
+- [ ] **Step 2: Wrap the Rust producer construction sites in `Some(...)`** (they keep resolving — behavior unchanged):
+  - `src/migrate.rs`, `schema_json_to_schema_ir`: the `SchemaColumn { … db_type, … }` shorthand → `db_type: Some(db_type),` (leave the `let db_type = … .unwrap_or_else(|| canonical_to_db_type_token(…))` exactly as is).
+  - `src/migrate.rs:227`, `live_columns_to_schema_ir`: `db_type: information_schema_to_db_type_token(&col.declared_type, col.char_max_len, dialect),` → wrap the call in `Some(...)`.
+  - `src/migrate.rs:724`, `schema_column_for_drift`: the `db_type,` field → `db_type: Some(db_type),`.
+
+- [ ] **Step 3: Fix the Rust read sites to tolerate `None`:**
+  - `crates/ferro-ddl-lowering/src/lib.rs:281`: `… col.format.as_deref(), &col.db_type, dialect)` → `… col.format.as_deref(), col.db_type.as_deref().unwrap_or(""), dialect)`.
+  - `crates/ferro-ddl-lowering/src/lib.rs:282`: in the `.map_err` format, `col.db_type` → `col.db_type.as_deref().unwrap_or("")`.
+  - `crates/ferro-migrate/src/emit.rs:460`: `sqlite_type_storage_drift(&old_col.db_type, new_canonical)` → `sqlite_type_storage_drift(old_col.db_type.as_deref().unwrap_or(""), new_canonical)`.
+  - `crates/ferro-migrate/src/emit.rs:467`: the `old_col.db_type` format arg → `old_col.db_type.as_deref().unwrap_or("")`.
+  - `crates/ferro-ddl-lowering/src/lib.rs:239` (`old_col.db_type != new_col.db_type`): leave as-is — `Option<String>` comparison compiles and is correct.
+
+- [ ] **Step 4: Fix the test-helper construction sites:**
+  - `crates/ferro-ddl-lowering/src/lib.rs:514` (`drift_col`): `db_type: db_type.to_string(),` → `db_type: Some(db_type.to_string()),`.
+  - `crates/ferro-migrate/src/tests.rs:43` (`col`): `db_type: db_type.to_string(),` → `db_type: Some(db_type.to_string()),`.
+  - `crates/ferro-migrate/src/tests.rs:563`: `db_type: "not_a_real_token".to_string(),` → `db_type: Some("not_a_real_token".to_string()),`.
+
+- [ ] **Step 5: Build + run the Rust suite**
+
+Run: `cargo build` then `cargo test --no-default-features --features testing` and `cargo test -p ferro-schema-ir -p ferro-migrate -p ferro-ddl-lowering`
+Expected: PASS, no warnings. (Fixtures still carry `db_type` at this point — they deserialize to `Some` and round-trip fine.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ferro-schema-ir/src/lib.rs crates/ferro-ddl-lowering/src/lib.rs crates/ferro-migrate/src/emit.rs crates/ferro-migrate/src/tests.rs src/migrate.rs
+git commit -m "refactor(schema-ir): make SchemaColumn.db_type optional; producers keep resolving (#143)"
+```
+
+---
+
+### Task 2: Python compiler drops the default; regenerate fixtures; new test
+
+**Files:**
+- Modify: `src/ferro/ir/compiler.py` (`_column_ir`; delete `_default_db_type`)
+- Modify: `tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json` (regenerate — compiler snapshot)
+- Modify: `tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json` (hand-edit — wire example)
+- Test: `tests/test_ir_vectors_contract.py` (add one test)
+
+**Interfaces:**
+- Consumes: `compile_schema_ir_payload(model_name, schema) -> dict` (unchanged signature; now omits `db_type` for non-explicit columns).
+
+- [ ] **Step 1: Write the failing test** in `tests/test_ir_vectors_contract.py` (near the other compiler tests):
+
+```python
+def test_compiler_omits_db_type_for_non_explicit_columns(clean_model_registry: None) -> None:
+    from ferro import Model, Field, clear_registry
+    from ferro.schema_metadata import build_model_schema
+    from ferro.ir.compiler import compile_schema_ir_payload
+
+    clear_registry()
+    M = type("Acct", (Model,), {
+        "__annotations__": {"id": int | None, "balance": int, "code": str},
+        "id": Field(default=None, primary_key=True),
+        "code": Field(db_type="varchar(32)"),
+    })
+    cols = {c["name"]: c for c in compile_schema_ir_payload("Acct", build_model_schema(M))["models"][0]["columns"]}
+    assert "db_type" not in cols["balance"], cols["balance"]   # non-explicit -> omitted
+    assert "db_type" not in cols["id"], cols["id"]             # non-explicit -> omitted
+    assert cols["code"]["db_type"] == "varchar(32)"            # explicit -> kept
+    assert cols["code"]["db_type_explicit"] is True
+```
+
+- [ ] **Step 2: Run it — expect FAIL**
+
+Run: `uv run pytest tests/test_ir_vectors_contract.py::test_compiler_omits_db_type_for_non_explicit_columns -q`
+Expected: FAIL (`db_type` still present on `balance`/`id`).
+
+- [ ] **Step 3: Change `_column_ir`** in `src/ferro/ir/compiler.py` — remove the unconditional `db_type`, add it only when explicit. Replace the `column_ir = { … }` dict literal's `"db_type": …` line (delete it) and the trailing explicit block:
+
+```python
+    column_ir = {
+        "name": col_name,
+        "logical_type": _logical_type(col_info),
+        "nullable": _is_nullable(col_name, col_info, required_fields),
+        "primary_key": bool(col_info.get("primary_key", False)),
+        "autoincrement": bool(col_info.get("autoincrement", False)),
+        "unique": bool(col_info.get("unique", False)),
+        "index": bool(col_info.get("index", False)),
+        "default": col_info.get("default"),
+        "format": col_info.get("format"),
+    }
+    enum_values = _enum_values(col_info)
+    if isinstance(enum_values, list):
+        column_ir["enum_values"] = list(enum_values)
+    if db_type_explicit:
+        column_ir["db_type"] = db_type_value
+        column_ir["db_type_explicit"] = True
+```
+
+- [ ] **Step 4: Delete the now-unused `_default_db_type`** function (`src/ferro/ir/compiler.py`, the whole `def _default_db_type(...)` block). Verify no other references:
+
+Run: `grep -rn "_default_db_type" src/`
+Expected: no matches.
+
+- [ ] **Step 5: Run the new test — expect PASS**
+
+Run: `uv run pytest tests/test_ir_vectors_contract.py::test_compiler_omits_db_type_for_non_explicit_columns -q`
+Expected: PASS.
+
+- [ ] **Step 6: Regenerate the compiler-snapshot fixture** (its `ir` + `fingerprint` must match the new output):
+
+Run:
+```bash
+uv run python - <<'PY'
+import json
+from ferro import clear_registry
+from ferro.ir import compile_registry_schema_ir, schema_ir_fingerprint
+from ferro.relations import resolve_relationships
+from tests.test_cross_emitter_parity import _build_fixture_models
+clear_registry(); _build_fixture_models(); resolve_relationships()
+compiled = compile_registry_schema_ir()
+p = "tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json"
+doc = json.load(open(p))
+doc["ir"] = compiled
+doc["fingerprint"] = schema_ir_fingerprint(compiled)
+with open(p, "w") as f: json.dump(doc, f, indent=2, ensure_ascii=True); f.write("\n")
+print("regenerated", p)
+PY
+```
+
+- [ ] **Step 7: Hand-edit the invoice wire example** (no fingerprint; drop `db_type` from its non-explicit columns for consistency):
+
+Run:
+```bash
+uv run python - <<'PY'
+import json
+p = "tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json"
+doc = json.load(open(p))
+for m in doc["ir"]["payload"]["models"]:
+    for c in m["columns"]:
+        if not c.get("db_type_explicit"):
+            c.pop("db_type", None)
+with open(p, "w") as f: json.dump(doc, f, indent=2, ensure_ascii=True); f.write("\n")
+print("edited", p)
+PY
+```
+
+- [ ] **Step 8: Run the IR contract + roundtrip suites**
+
+Run: `uv run pytest tests/test_ir_vectors_contract.py -q` and `cargo test -p ferro-schema-ir`
+Expected: PASS (snapshot matches; Rust round-trip encode==ir with the edited fixtures).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/ferro/ir/compiler.py tests/test_ir_vectors_contract.py tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json
+git commit -m "feat(ir): compiler omits db_type for non-explicit columns; regenerate fixtures (#143)"
+```
+
+---
+
+### Task 3: Behavior-preservation gate
+
+No code change — proves DDL and auto-migrate behavior are unchanged.
+
+- [ ] **Step 1: Cross-emitter + IR contract (SQLite path)**
+
+Run: `uv run pytest tests/test_db_type_cross_emitter_parity.py tests/test_cross_emitter_parity.py tests/test_ir_vectors_contract.py tests/test_alembic_autogenerate.py -q`
+Expected: PASS (Alembic already ignores non-explicit `db_type`, so its SQL is unchanged).
+
+- [ ] **Step 2: Auto-migrate + migrate-plan on the backend matrix**
+
+Run: `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py -q`
+Expected: PASS on both backends (Postgres requires the matrix harness; if unavailable locally, note it runs in CI — the Rust migrate path is untouched, so drift is byte-identical).
+
+- [ ] **Step 3: Full Rust suite**
+
+Run: `cargo test --no-default-features --features testing`
+Expected: PASS.
+
+- [ ] **Step 4: Open the PR** into the integration branch
+
+```bash
+git push -u origin feat/ir-p8.5-143-db-type-drop
+gh pr create --base feat/ir-p8.5-lowering-consolidation --title "feat(ir): drop db_type for non-explicit columns (#143)" --body "<closes #143 when 8.5 lands on main; behavior-preserving; CI runs the postgres matrix>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** field → `Option` (T1.S1); producers keep `Some` (T1.S2, the scope refinement); consumers tolerate `None` (T1.S3); Python drops the default (T2.S3–4); fixtures regenerated (T2.S6–7); new omits-test (T2.S1); `ir_version` unchanged (Global Constraints); validation (T3). ✅
+
+**Placeholder scan:** all steps carry real code/commands; the only `<...>` is the PR-body summary filled at PR time. ✅
+
+**Type consistency:** `db_type: Option<String>` is read everywhere via `.as_deref().unwrap_or("")` and constructed via `Some(...)`; `compile_schema_ir_payload(...)["models"][0]["columns"]` shape matches the new test and the regen script. ✅

--- a/docs/plans/2026-06-26-003-feat-ir-p8.5-144-reconcile-indexes-plan.md
+++ b/docs/plans/2026-06-26-003-feat-ir-p8.5-144-reconcile-indexes-plan.md
@@ -1,0 +1,503 @@
+# #144 — Reconcile Indexes & Uniques in Auto-Migrate — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-migrate reconciles standalone Ferro-named indexes & uniques (single + composite) on existing tables — ADD missing always, DROP orphaned under `migrate_destructive` — byte-identical to what the create path emits, on SQLite and Postgres.
+
+**Architecture:** A new live-index introspection layer (`live_table_indexes`) mirrors `live_table_columns`. The `ferro-migrate` planner gains `AddIndex`/`DropIndex` ops and diffs the model's "standalone index set" (the exact set the create path renders) against the live set by canonical name. The Rust producer populates the model IR's `indexes`/`uniques`; the runtime wires introspection → diff → execute. The legacy planner is untouched; IR↔legacy parity is scoped to column-ops.
+
+**Tech Stack:** Rust workspace (`ferro-schema-ir`, `ferro-ddl-lowering`, `ferro-migrate`, `_core`), PyO3, sqlx, sea-query; Python (`uv`/pytest).
+
+## Global Constraints
+
+- **Match by canonical name only:** `idx_<table>_<cols>` / `uq_<table>_<cols>` (helper `is_ferro_index_name`: prefix `idx_` or `uq_`). Never touch user-created indexes, PK/constraint autoindexes, or `sqlite_autoindex_*`.
+- **Parity with the create path (AGENTS.md I-1):** the migrate path reconciles exactly the standalone set `post_create_artifacts` renders — `model.indexes` (all) + `model.uniques` (minus inline single-column uniques). Reuse `render_index_sql` and the shared naming helpers; do not hand-write index SQL.
+- **ADD always; DROP only under `opts.destructive`** (mirror `DropColumn`).
+- **Inline single-column `UNIQUE` on existing columns is out of scope.**
+- **IR↔legacy parity scoped to column-ops:** exclude `AddIndex`/`DropIndex` from the IR side before comparing to legacy (`shadow_compare_migration_plan` + `assert_ir_legacy_parity`). Do NOT teach the legacy planner index reconciliation.
+- **Migration impact `minor`:** update `docs/plans/ir-first-migration-guide.md` + `docs/pages/guide/migrations.md` capability matrix before Done.
+- Rust edition 2024; no new deps. Rust tests: `--no-default-features --features testing`.
+
+---
+
+### Task 1: Live index introspection (`live_table_indexes`)
+
+**Files:**
+- Modify: `src/introspect.rs` (add `LiveIndex`, `is_ferro_index_name`, `live_table_indexes`, `sqlite_table_indexes`, `postgres_table_indexes`)
+
+**Interfaces:**
+- Produces: `pub struct LiveIndex { pub name: String, pub columns: Vec<String>, pub unique: bool }` (derives `Clone, Debug, serde::Deserialize`)
+- Produces: `pub async fn live_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>>` (Ferro-named standalone indexes only)
+- Produces: `pub(crate) fn is_ferro_index_name(name: &str) -> bool`
+
+- [ ] **Step 1: Add the struct + name filter + a failing unit test.** In `src/introspect.rs`:
+
+```rust
+/// One live standalone index that Ferro owns (its name follows the `idx_`/`uq_`
+/// convention). Deserialize exists for `_render_migration_sql_for_test`.
+#[derive(Clone, Debug, serde::Deserialize)]
+pub struct LiveIndex {
+    pub name: String,
+    #[serde(default)]
+    pub columns: Vec<String>,
+    #[serde(default)]
+    pub unique: bool,
+}
+
+/// Ferro emits standalone indexes as `idx_<table>_<cols>` and uniques as
+/// `uq_<table>_<cols>`. Reconciliation only ever touches names it owns.
+pub(crate) fn is_ferro_index_name(name: &str) -> bool {
+    name.starts_with("idx_") || name.starts_with("uq_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_ferro_index_name;
+    #[test]
+    fn ferro_index_names_are_recognized() {
+        assert!(is_ferro_index_name("idx_user_email"));
+        assert!(is_ferro_index_name("uq_user_email"));
+        assert!(!is_ferro_index_name("sqlite_autoindex_user_1"));
+        assert!(!is_ferro_index_name("user_email_key"));
+        assert!(!is_ferro_index_name("my_custom_index"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test — expect PASS** (pure helper).
+
+Run: `cargo test -p _core --no-default-features --features testing is_ferro || cargo test --no-default-features --features testing ferro_index_names_are_recognized`
+Expected: PASS.
+
+- [ ] **Step 3: Add `live_table_indexes` + the two backend impls.** Mirror `live_table_columns` (the query API is `engine.fetch_all_sql_unprepared(&sql)` for SQLite PRAGMA, and `engine.fetch_all_sql_unprepared_with_binds(sql, &[EngineBindValue::String(...)])` for Postgres; row access via `row_string`/`row_bool`/`row_opt_i64`). Add to `src/introspect.rs`:
+
+```rust
+/// Live standalone indexes Ferro owns on `table`, normalized across backends.
+pub async fn live_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>> {
+    match engine.backend() {
+        SqlDialect::Sqlite => sqlite_table_indexes(engine, table).await,
+        SqlDialect::Postgres => postgres_table_indexes(engine, table).await,
+    }
+}
+
+async fn sqlite_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>> {
+    let list_sql = format!("PRAGMA index_list({})", quote_ident(table));
+    let index_rows = engine
+        .fetch_all_sql_unprepared(&list_sql)
+        .await
+        .map_err(|e| introspection_error("PRAGMA index_list", table, e))?;
+
+    let mut out = Vec::new();
+    for index_row in &index_rows {
+        let Some(name) = row_string(index_row, "name") else { continue };
+        if !is_ferro_index_name(&name) {
+            continue;
+        }
+        let unique = row_bool(index_row, "unique");
+        let info_sql = format!("PRAGMA index_info({})", quote_ident(&name));
+        let col_rows = engine
+            .fetch_all_sql_unprepared(&info_sql)
+            .await
+            .map_err(|e| introspection_error("PRAGMA index_info", table, e))?;
+        // PRAGMA index_info returns rows in `seqno` order already.
+        let columns: Vec<String> = col_rows.iter().filter_map(|r| row_string(r, "name")).collect();
+        out.push(LiveIndex { name, columns, unique });
+    }
+    Ok(out)
+}
+
+async fn postgres_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>> {
+    // One row per (index, column); `pos` orders columns within the index.
+    let sql = r#"
+        SELECT cl.relname::text AS index_name,
+               i.indisunique     AS is_unique,
+               a.attname::text   AS column_name,
+               array_position(i.indkey, a.attnum) AS pos
+        FROM pg_index i
+        JOIN pg_class cl ON cl.oid = i.indexrelid
+        JOIN pg_class t  ON t.oid  = i.indrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(i.indkey)
+        WHERE n.nspname = current_schema()
+          AND t.relname = $1
+          AND NOT i.indisprimary
+        ORDER BY cl.relname, pos
+        "#;
+    let rows = engine
+        .fetch_all_sql_unprepared_with_binds(sql, &[EngineBindValue::String(table.to_string())])
+        .await
+        .map_err(|e| introspection_error("pg_index", table, e))?;
+
+    // Group ordered rows into indexes (rows are already ordered by name, pos).
+    let mut out: Vec<LiveIndex> = Vec::new();
+    for row in &rows {
+        let Some(name) = row_string(row, "index_name") else { continue };
+        if !is_ferro_index_name(&name) {
+            continue;
+        }
+        let unique = row_bool(row, "is_unique");
+        let column = row_string(row, "column_name").unwrap_or_default();
+        match out.last_mut() {
+            Some(last) if last.name == name => last.columns.push(column),
+            _ => out.push(LiveIndex { name, columns: vec![column], unique }),
+        }
+    }
+    Ok(out)
+}
+```
+
+- [ ] **Step 4: Build** — `cargo build` (Rust compile; the PyO3 link step may warn — fine). Confirm no unused-import warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/introspect.rs
+git commit -m "feat(introspect): add live_table_indexes for SQLite + Postgres (#144)"
+```
+(The introspection is exercised end-to-end by the Task 4 integration tests; this task lands the code + the name-filter unit test.)
+
+---
+
+### Task 2: `ferro-migrate` IR layer — ops, diff, emit
+
+**Files:**
+- Modify: `crates/ferro-migrate/src/lib.rs` (`MigrationOp` enum; `plan_from_ir`; the `emit_sql` stub match)
+- Modify: `crates/ferro-migrate/src/emit.rs` (`standalone_indexes` helper extracted from `post_create_artifacts`; `emit_sql_with_ir` match arms)
+- Test: `crates/ferro-migrate/src/tests.rs`
+
+**Interfaces:**
+- Produces: `MigrationOp::AddIndex { table: String, name: String, columns: Vec<String>, unique: bool }` and `MigrationOp::DropIndex { table: String, name: String }`
+- Produces: `pub(crate) fn standalone_indexes(model: &SchemaModel) -> Vec<(String, Vec<String>, bool)>` in `emit.rs` (name, columns, unique) — the create path's standalone set.
+
+- [ ] **Step 1: Add the two `MigrationOp` variants** to `crates/ferro-migrate/src/lib.rs` (after `AlterColumnNullability`):
+
+```rust
+    /// A standalone Ferro-named index/unique present in the model but not live.
+    AddIndex {
+        table: String,
+        name: String,
+        columns: Vec<String>,
+        unique: bool,
+    },
+    /// A standalone Ferro-named index present live but gone from the model.
+    DropIndex {
+        table: String,
+        name: String,
+    },
+```
+
+- [ ] **Step 2: Extract `standalone_indexes` in `emit.rs`** (the exact set `post_create_artifacts` renders) and have `post_create_artifacts` use it. Add to `crates/ferro-migrate/src/emit.rs`:
+
+```rust
+/// The standalone indexes/uniques the create path emits as separate
+/// `CREATE [UNIQUE] INDEX` statements: every `model.indexes`, plus `model.uniques`
+/// that are not inline single-column uniques. Returned as (name, columns, unique).
+pub(crate) fn standalone_indexes(model: &SchemaModel) -> Vec<(String, Vec<String>, bool)> {
+    let mut out = Vec::new();
+    for index in &model.indexes {
+        out.push((index.name.clone(), index.columns.clone(), index.unique));
+    }
+    for unique in &model.uniques {
+        if single_column_unique_is_inline(model, &unique.columns) {
+            continue;
+        }
+        out.push((unique.name.clone(), unique.columns.clone(), true));
+    }
+    out
+}
+```
+
+Then rewrite the two loops in `post_create_artifacts` (the `for index in &model.indexes` and `for unique in &model.uniques` blocks) to iterate `standalone_indexes(model)`:
+
+```rust
+    for (name, columns, unique) in standalone_indexes(model) {
+        statements.push(render_index_sql(table_lower, &name, &columns, unique, dialect));
+    }
+```
+
+- [ ] **Step 3: Diff indexes in `plan_from_ir`** (`crates/ferro-migrate/src/lib.rs`). After the existing `diff_model_columns(...)` call inside the `for table in new_tables.intersection(&old_tables)` loop, add an index diff. Add a helper near `diff_model_columns`:
+
+```rust
+fn diff_model_indexes(
+    table: &str,
+    old_model: &SchemaModel,
+    new_model: &SchemaModel,
+    plan: &mut MigrationPlan,
+) {
+    use std::collections::BTreeMap;
+    // Live side: introspected standalone indexes live in old_model.indexes.
+    let old: BTreeMap<&str, &crate::ferro_schema_ir_index> = BTreeMap::new(); // placeholder type, see note
+    let _ = old;
+    let old_by_name: BTreeMap<String, (Vec<String>, bool)> = old_model
+        .indexes
+        .iter()
+        .map(|i| (i.name.clone(), (i.columns.clone(), i.unique)))
+        .collect();
+    let new_set = emit::standalone_indexes(new_model);
+    let new_names: std::collections::BTreeSet<&str> = new_set.iter().map(|(n, _, _)| n.as_str()).collect();
+
+    for (name, columns, unique) in &new_set {
+        if !old_by_name.contains_key(name) {
+            plan.operations.push(MigrationOp::AddIndex {
+                table: table.to_string(),
+                name: name.clone(),
+                columns: columns.clone(),
+                unique: *unique,
+            });
+        }
+    }
+    for name in old_by_name.keys() {
+        if !new_names.contains(name.as_str()) {
+            plan.operations.push(MigrationOp::DropIndex {
+                table: table.to_string(),
+                name: name.clone(),
+            });
+        }
+    }
+}
+```
+
+> Implementer note: drop the `placeholder type` line above — it is illustrative. Use `old_model.indexes` directly (type `&[SchemaIndex]`). Make `mod emit`'s `standalone_indexes` reachable from `lib.rs` via `emit::standalone_indexes` (it is `pub(crate)`).
+
+Call it in `plan_from_ir`:
+
+```rust
+        diff_model_columns(*table, old_model, new_model, ddl_dialect, &mut plan);
+        diff_model_indexes(*table, old_model, new_model, &mut plan);
+```
+
+- [ ] **Step 4: Emit the new ops** in `emit_sql_with_ir` (`crates/ferro-migrate/src/emit.rs`) — add arms to the `for operation in &plan.operations` match:
+
+```rust
+            MigrationOp::AddIndex { table, name, columns, unique } => {
+                result.statements.push(render_index_sql(table, name, columns, *unique, dialect));
+            }
+            MigrationOp::DropIndex { table, name } => {
+                result.statements.push(format!("DROP INDEX IF EXISTS \"{}\"", name));
+            }
+```
+
+(SQLite and Postgres both accept `DROP INDEX IF EXISTS "<name>"`; on Postgres an index name is schema-scoped — `current_schema` is correct here.) Also add matching arms to the legacy `emit_sql` stub in `lib.rs` (it must stay exhaustive — emit a comment for `AddIndex`/`DropIndex`, e.g. `format!("-- index '{}' handled by emit_sql_with_ir", name)`).
+
+- [ ] **Step 5: Write crate unit tests** in `crates/ferro-migrate/src/tests.rs`:
+
+```rust
+#[test]
+fn plan_from_ir_adds_missing_index() {
+    let old = envelope(vec![schema_model("doc", vec![col("a", "text", true), col("b", "text", true)])]);
+    let mut nm = schema_model("doc", vec![col("a", "text", true), col("b", "text", true)]);
+    nm.indexes = vec![SchemaIndex { name: "idx_doc_a_b".into(), columns: vec!["a".into(), "b".into()], unique: false }];
+    let new = envelope(vec![nm]);
+    let plan = plan_from_ir(&old, &new, BackendDialect::Sqlite);
+    assert!(plan.operations.contains(&MigrationOp::AddIndex {
+        table: "doc".into(), name: "idx_doc_a_b".into(), columns: vec!["a".into(), "b".into()], unique: false
+    }));
+}
+
+#[test]
+fn plan_from_ir_drops_orphaned_index() {
+    let mut om = schema_model("doc", vec![col("a", "text", true)]);
+    om.indexes = vec![SchemaIndex { name: "idx_doc_a".into(), columns: vec!["a".into()], unique: false }];
+    let old = envelope(vec![om]);
+    let new = envelope(vec![schema_model("doc", vec![col("a", "text", true)])]); // no index
+    let plan = plan_from_ir(&old, &new, BackendDialect::Sqlite);
+    assert!(plan.operations.contains(&MigrationOp::DropIndex { table: "doc".into(), name: "idx_doc_a".into() }));
+}
+
+#[test]
+fn emit_add_index_matches_create_path() {
+    let plan = MigrationPlan { operations: vec![MigrationOp::AddIndex {
+        table: "doc".into(), name: "idx_doc_a_b".into(), columns: vec!["a".into(), "b".into()], unique: false
+    }], warnings: vec![] };
+    let r = emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Sqlite).unwrap();
+    assert_eq!(r.statements, vec!["CREATE INDEX IF NOT EXISTS \"idx_doc_a_b\" ON \"doc\" (\"a\", \"b\")".to_string()]);
+}
+
+#[test]
+fn emit_drop_index_renders_drop() {
+    let plan = MigrationPlan { operations: vec![MigrationOp::DropIndex { table: "doc".into(), name: "idx_doc_a".into() }], warnings: vec![] };
+    let r = emit_sql_with_ir(&plan, &empty_envelope(), &empty_envelope(), BackendDialect::Postgres).unwrap();
+    assert_eq!(r.statements, vec!["DROP INDEX IF EXISTS \"idx_doc_a\"".to_string()]);
+}
+```
+
+> The `SchemaIndex` import already exists in `tests.rs` via `ferro_schema_ir`. Confirm the exact `CREATE INDEX` spelling against `render_index_sql`/`SqliteQueryBuilder` output and adjust the expected string if sea-query differs; the test is the source of truth for the spelling.
+
+- [ ] **Step 6: Run crate tests** — `cargo test -p ferro-migrate` → PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ferro-migrate/src/lib.rs crates/ferro-migrate/src/emit.rs crates/ferro-migrate/src/tests.rs
+git commit -m "feat(ferro-migrate): AddIndex/DropIndex ops + index diff/emit (#144)"
+```
+
+---
+
+### Task 3: Rust producer, runtime wiring, and parity scoping
+
+**Files:**
+- Modify: `src/migrate.rs` (`schema_json_to_schema_ir` index/unique population; `live_columns_to_schema_ir` → take live indexes; `plan_table_migration` + `plan_table_migration_legacy` signatures gain `live_indexes`; filter `DropIndex` by destructive; `internal_migrate` introspects + passes; `_render_migration_sql_for_test` + `_shadow_compare_migration_plan_for_test` gain a live-indexes arg; `shadow_compare_migration_plan` + the test parity helpers scoped to column-ops)
+
+**Interfaces:**
+- Consumes (Task 1): `introspect::{LiveIndex, live_table_indexes}`
+- Consumes (Task 2): `MigrationOp::{AddIndex, DropIndex}`
+
+- [ ] **Step 1: Populate the model IR's `indexes`/`uniques`** in `schema_json_to_schema_ir` (replace the two `Vec::<SchemaIndex>::new()` / `Vec::<SchemaUnique>::new()` placeholders). Mirror the Python `compile_schema_ir_payload`: per-column `index=`/`unique=`, then `ferro_composite_indexes`/`ferro_composite_uniques`, using `ferro_ddl_lowering::{single_index_name, single_unique_index_name, composite_index_name, composite_unique_index_name}`. Build `Vec<SchemaIndex>` / `Vec<SchemaUnique>`, sort each by `name`, and pass them into the `SchemaModel`:
+
+```rust
+    // single-column index=/unique= (collected in the column loop)
+    if migrate_column_bool(raw_col, resolved, "index").unwrap_or(false) {
+        indexes.push(SchemaIndex {
+            name: single_index_name(table_lower, name),
+            columns: vec![name.clone()],
+            unique: false,
+        });
+    }
+    if col_plan.is_unique {
+        uniques.push(SchemaUnique {
+            name: single_unique_index_name(table_lower, name),
+            columns: vec![name.clone()],
+        });
+    }
+    // ... after the column loop, composite groups from the schema:
+    for group in schema.get("ferro_composite_indexes").and_then(|g| g.as_array()).into_iter().flatten() {
+        let cols: Vec<String> = group.as_array().map(|a| a.iter().filter_map(|c| c.as_str().map(String::from)).collect()).unwrap_or_default();
+        if cols.len() >= 2 {
+            let refs: Vec<&str> = cols.iter().map(String::as_str).collect();
+            indexes.push(SchemaIndex { name: composite_index_name(table_lower, &refs), columns: cols, unique: false });
+        }
+    }
+    for group in schema.get("ferro_composite_uniques").and_then(|g| g.as_array()).into_iter().flatten() {
+        let cols: Vec<String> = group.as_array().map(|a| a.iter().filter_map(|c| c.as_str().map(String::from)).collect()).unwrap_or_default();
+        if cols.len() >= 2 {
+            let refs: Vec<&str> = cols.iter().map(String::as_str).collect();
+            uniques.push(SchemaUnique { name: composite_unique_index_name(table_lower, &refs), columns: cols });
+        }
+    }
+    indexes.sort_by(|a, b| a.name.cmp(&b.name));
+    uniques.sort_by(|a, b| a.name.cmp(&b.name));
+```
+
+Import the four naming helpers from `ferro_ddl_lowering` at the top of `migrate.rs`.
+
+- [ ] **Step 2: Feed live indexes into the live IR.** Change `live_columns_to_schema_ir(table, live, backend)` to `live_to_schema_ir(table, live, live_indexes, backend)` (or add a param) and populate `indexes` from `&[LiveIndex]`:
+
+```rust
+            indexes: live_indexes.iter().map(|i| SchemaIndex {
+                name: i.name.clone(), columns: i.columns.clone(), unique: i.unique,
+            }).collect(),
+            uniques: Vec::<SchemaUnique>::new(),
+```
+
+- [ ] **Step 3: Thread `live_indexes` through `plan_table_migration`** (and `plan_table_migration_legacy`, which ignores it — keeps call sites uniform). Signature: add `live_indexes: &[LiveIndex]`. In `plan_table_migration`, build `old_ir` with `live_to_schema_ir(table_lower, live, live_indexes, backend)`. Add `DropIndex` to the non-destructive filter (alongside the existing `DropColumn` retain):
+
+```rust
+    if !opts.destructive {
+        typed_plan.operations.retain(|op| !matches!(op, MigrationOp::DropColumn { .. } | MigrationOp::DropIndex { .. }));
+    }
+```
+
+(AddIndex flows through `exec_ops` → `emit_sql_with_ir` → `plan.statements`, executed like any other statement. `DropIndex` under destructive also flows through `plan.statements` as `DROP INDEX IF EXISTS`.)
+
+- [ ] **Step 4: Wire introspection into `internal_migrate`.** Where it calls `live_table_columns(&engine, &table_lower)`, also call `live_table_indexes`, and pass both to `plan_table_migration`:
+
+```rust
+        let live_indexes = live_table_indexes(&engine, &table_lower).await?;
+        let mut plan = plan_table_migration(&table_lower, &schema, &live, &live_indexes, backend, opts)?;
+```
+
+Import `live_table_indexes` from `crate::introspect`.
+
+- [ ] **Step 5: Scope the parity comparison to column-ops.** In `shadow_compare_migration_plan` and the test helper `_shadow_compare_migration_plan_for_test` (and `plan_with_ir_legacy_parity` in the `#[cfg(test)] mod tests`), compare the IR plan with index statements removed against legacy. Add a filter helper and use it:
+
+```rust
+fn without_index_statements(statements: &[String]) -> Vec<String> {
+    statements.iter().filter(|s| {
+        let t = s.trim_start();
+        !(t.starts_with("DROP INDEX") )  // index drops are IR-only
+    }).cloned().collect()
+}
+```
+
+> The only IR-only index statements that legacy never produces are the **standalone** `CREATE [UNIQUE] INDEX` from `AddIndex` and the `DROP INDEX` from `DropIndex`. Column-add indexes (legacy produces these too) must NOT be filtered. Since both come out as `CREATE INDEX`, filtering by string is ambiguous — instead, scope at the typed-op level: have `plan_table_migration` expose (test-only) the column-domain statements, OR compare `legacy.statements` against the IR plan re-emitted from `typed_plan.operations` **with `AddIndex`/`DropIndex` filtered out**. Implement the latter: in `shadow_compare_migration_plan`, after building `typed_plan`, build `column_ops = typed_plan.operations without AddIndex/DropIndex`, emit them via `emit_sql_with_ir`, and compare those statements + drop_columns + warnings to `legacy`. This is exact and unambiguous.
+
+Replace the body of `shadow_compare_migration_plan` so the IR side is the column-domain emission (filter `AddIndex`/`DropIndex` from the typed ops before `emit_sql_with_ir`), and compare to `legacy`. Apply the same column-domain projection in the `plan_with_ir_legacy_parity` test helper.
+
+- [ ] **Step 6: Add the live-indexes arg to the test FFI helpers.** `_render_migration_sql_for_test` and `_shadow_compare_migration_plan_for_test`: add a `live_indexes_json: String` parameter (parsed as `Vec<LiveIndex>`, default `"[]"`), and pass it through. Update the `#[pyo3(signature = …)]` lines and `src/ferro/_core.pyi`.
+
+- [ ] **Step 7: Build + run the full Rust suite**
+
+Run: `cargo build` then `cargo test --no-default-features --features testing` and `cargo test -p ferro-migrate -p ferro-ddl-lowering -p ferro-schema-ir`
+Expected: PASS — including the existing IR-vs-legacy parity tests (now column-scoped) and the migrate IR-legacy parity matrix.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/migrate.rs src/ferro/_core.pyi
+git commit -m "feat(migrate): wire index reconciliation into auto-migrate; scope parity to column-ops (#144)"
+```
+
+---
+
+### Task 4: Integration tests (both backends) + docs
+
+**Files:**
+- Test: `tests/test_auto_migrate.py` (new index-reconciliation tests)
+- Modify: `docs/plans/ir-first-migration-guide.md`, `docs/pages/guide/migrations.md` (capability matrix)
+
+- [ ] **Step 1: Add auto-migrate integration tests** to `tests/test_auto_migrate.py`, parametrized over the backend matrix (follow the file's existing `@pytest.mark.backend_matrix` / `db_url` fixture pattern). Cover:
+  - **add composite index:** create a model+table, then redefine the model with a `ferro_composite_indexes` on two existing columns, run auto-migrate, assert the live table now has `idx_<t>_<a>_<b>` (introspect via the engine).
+  - **add single-column index to an existing column:** add `index=True` to an existing field → `idx_<t>_<col>` appears.
+  - **no-op when present:** run auto-migrate again → no statements, index unchanged (the false-alarm guard).
+  - **destructive drop:** remove the composite index from the model, run with `migrate_destructive=True` → `idx_<t>_<a>_<b>` is dropped; without destructive → it remains.
+  - **leaves a user index untouched:** a hand-created `CREATE INDEX my_custom_idx` survives auto-migrate (non-destructive and destructive).
+
+Use the same harness the existing auto-migrate tests use (connect with `auto_migrate=True`, then re-introspect). Write real assertions against the live index set (e.g. `PRAGMA index_list` / `pg_indexes` via a raw query, or a small helper).
+
+- [ ] **Step 2: Run the new tests on SQLite**
+
+Run: `uv run pytest tests/test_auto_migrate.py -q -k "index"`
+Expected: PASS.
+
+- [ ] **Step 3: Update docs.** In `docs/pages/guide/migrations.md` capability matrix, add a row: auto-migrate now **adds** missing indexes/uniques on existing tables and **drops** orphaned Ferro-named ones under `migrate_destructive`; inline single-column UNIQUE on existing columns and index option changes remain Alembic's domain. Add a matching `minor`-impact entry to `docs/plans/ir-first-migration-guide.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_auto_migrate.py docs/pages/guide/migrations.md docs/plans/ir-first-migration-guide.md
+git commit -m "test(migrate): index-reconciliation auto-migrate tests; docs (#144)"
+```
+
+---
+
+### Task 5: Behavior-preservation + new-behavior gate
+
+- [ ] **Step 1: Cross-emitter + IR contract + Alembic**
+
+Run: `uv run pytest tests/test_db_type_cross_emitter_parity.py tests/test_cross_emitter_parity.py tests/test_ir_vectors_contract.py tests/test_alembic_autogenerate.py -q`
+Expected: PASS (create-path index emission unchanged; the new `standalone_indexes` extraction is behavior-preserving for create).
+
+- [ ] **Step 2: Auto-migrate + migrate-plan on the backend matrix**
+
+Run: `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py -q`
+Expected: PASS on SQLite; Postgres via CI if no local server (the new index tests must run on Postgres in CI — note it in the PR).
+
+- [ ] **Step 3: Full Rust suite** — `cargo test --no-default-features --features testing` → PASS.
+
+- [ ] **Step 4: Open the PR** into the integration branch
+
+```bash
+git push -u origin feat/ir-p8.5-144-reconcile-indexes
+gh pr create --base feat/ir-p8.5-lowering-consolidation --title "feat(migrate): reconcile indexes & uniques in auto-migrate (#144)" --body "<closes #144 when 8.5 lands on main; new live_table_indexes; ADD always / DROP destructive; parity scoped to column-ops; CI must run the postgres matrix>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** introspection both backends (T1); ops + diff + emit + create-path parity via shared `standalone_indexes` (T2); producer population, runtime wiring, destructive filter, parity-gate scoping, test FFI args (T3); both-backend integration tests incl. no-op/user-index guards + docs (T4); validation gate (T5). ✅
+
+**Placeholder scan:** the `diff_model_indexes` snippet carries an explicit "drop the placeholder line" implementer note and the parity-scoping step spells out the exact typed-op projection; no `TODO`/`TBD`. The `<...>` in the PR body is author-filled at PR time. ✅
+
+**Type consistency:** `LiveIndex { name, columns, unique }` (T1) flows into `live_to_schema_ir` → `old_model.indexes` (`SchemaIndex`); `standalone_indexes -> Vec<(String, Vec<String>, bool)>` (T2) is consumed by `diff_model_indexes` and `post_create_artifacts`; `AddIndex { table, name, columns, unique }` / `DropIndex { table, name }` are constructed in T2's diff and matched in T2's emit. ✅

--- a/docs/plans/2026-06-28-001-feat-ir-p8.5-141-single-schema-ir-producer-plan.md
+++ b/docs/plans/2026-06-28-001-feat-ir-p8.5-141-single-schema-ir-producer-plan.md
@@ -1,0 +1,394 @@
+# #141 — Single SchemaIR Producer (Python over FFI) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Runtime auto-migrate consumes the **Python-compiled** SchemaIR over FFI for the declared/model side; the parallel Rust producer `schema_json_to_schema_ir` is deleted. The SQLite-uuid false-alarm this exposes is fixed at the diff boundary.
+
+**Architecture:** A migration is `diff(declared, observed)`. The **declared** side becomes single-sourced in Python (`compile_registry_schema_ir`, already cached), pushed to a Rust `SCHEMA_IR_MODELSET` store (mirroring `MODEL_REGISTRY`) and consumed by `internal_migrate`. The **observed** side stays Rust introspection. Drift is compared by storage **token** so `Uuid`≡`Char(32)` on SQLite no longer reads as a phantom change.
+
+**Tech Stack:** Rust workspace (`ferro-schema-ir`, `ferro-ddl-lowering`, `ferro-migrate`, `_core`), PyO3, sqlx; Python (`uv`/pytest).
+
+## Global Constraints
+
+- **Zero change to emitted DDL.** The create path is untouched; the migrate path must produce identical SQL for every case that exists today.
+- **The uuid fix is at the diff boundary only** (`schema_columns_storage_drift`), comparing `canonical_to_db_type_token(old, dialect)` vs `canonical_to_db_type_token(new, dialect)`. Do **not** change `canonical_from_parts` (that is also the create path).
+- **The declared side is Python's compiled SchemaIR** (`IrEnvelope<SchemaIrPayload>`, `ir_kind == "schema"`). The observed side stays `live_table_columns` + `live_table_indexes`.
+- **`schema_json_to_schema_ir` is deleted** by the end (its last caller goes away in Task 4).
+- **Parity stays column-scoped** (from #144): the IR-vs-legacy parity matrix must stay green — the legacy planner (JSON-derived) is **not** modified.
+- Rust edition 2024; no new deps. Rust tests: `--no-default-features --features testing`. Validate on SQLite **and** Postgres (Postgres via CI if no local server).
+
+---
+
+### Task 1: uuid drift fix — compare storage tokens
+
+**Files:**
+- Modify: `crates/ferro-ddl-lowering/src/lib.rs` (`schema_columns_storage_drift`)
+- Test: `crates/ferro-ddl-lowering/src/lib.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `canonical_to_db_type_token(CanonicalType, Dialect) -> String` (exists), `canonical_from_schema_column(&SchemaColumn, Dialect) -> Result<CanonicalType, _>` (exists)
+- Produces: `schema_columns_storage_drift(&SchemaColumn, &SchemaColumn, Dialect) -> bool` (same signature; storage-token comparison)
+
+- [ ] **Step 1: Write failing tests.** Add to the `#[cfg(test)]` module in `crates/ferro-ddl-lowering/src/lib.rs`. Use the existing test helpers for building a `SchemaColumn` (search the test module for how columns are constructed; mirror it). The cases:
+
+```rust
+#[test]
+fn uuid_model_does_not_drift_against_char32_live_on_sqlite() {
+    // Live introspected `uuid_text` → db_type "uuid" → Char(32).
+    let live = col_with_db_type("id", "string", Some("uuid"), Some("uuid"));
+    // Model derived (post-#141 wire IR): db_type None, format "uuid" → Uuid.
+    let model = col_with_db_type("id", "string", Some("uuid"), None);
+    assert!(!schema_columns_storage_drift(&live, &model, Dialect::Sqlite));
+}
+
+#[test]
+fn datetime_and_timestamp_are_storage_equivalent_on_sqlite() {
+    let a = col_with_db_type("ts", "string", Some("date-time"), Some("timestamp"));
+    let b = col_with_db_type("ts", "string", Some("date-time"), Some("datetime"));
+    assert!(!schema_columns_storage_drift(&a, &b, Dialect::Sqlite));
+}
+
+#[test]
+fn int_to_bigint_still_drifts() {
+    let small = col_with_db_type("n", "integer", None, Some("int"));
+    let big = col_with_db_type("n", "integer", None, Some("bigint"));
+    assert!(schema_columns_storage_drift(&small, &big, Dialect::Sqlite));
+}
+```
+
+> Implementer: adapt `col_with_db_type(name, logical_type, format, db_type)` to the actual `SchemaColumn` constructor in the test module (field order may differ; `db_type: Option<String>`, `format: Option<String>`). If a helper already exists, use it; otherwise add a small one in the test module.
+
+- [ ] **Step 2: Run — expect FAIL** on `uuid_model_does_not_drift…` (today `Char(32) != Uuid` is `true`).
+
+Run: `cargo test -p ferro-ddl-lowering storage_drift`
+Expected: the uuid test FAILS (drift reported), the int test PASSES.
+
+- [ ] **Step 3: Apply the fix.** In `schema_columns_storage_drift`, change the `(Ok, Ok)` arm to compare storage tokens:
+
+```rust
+        (Ok(old_c), Ok(new_c)) => {
+            // Compare by storage token, not raw canonical: on SQLite both `Uuid`
+            // and `Char(32)` map to "uuid" (and `DateTime`/`Timestamp` to
+            // "timestamp"), so a derived model column does not read as drifted
+            // against the token-round-tripped live column. Real changes
+            // (int → bigint) still differ. (See #141.)
+            canonical_to_db_type_token(old_c, dialect) != canonical_to_db_type_token(new_c, dialect)
+        }
+```
+
+Leave the `_ =>` fallback arm unchanged. Update the stale comment above the fallback (drop the "Will become load-bearing…#141" note — it is now done).
+
+- [ ] **Step 4: Run — expect PASS** (all three).
+
+Run: `cargo test -p ferro-ddl-lowering`
+Expected: PASS (new tests + existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ferro-ddl-lowering/src/lib.rs
+git commit -m "fix(ddl-lowering): compare storage tokens in schema drift (uuid≡char32) (#141)"
+```
+
+---
+
+### Task 2: migrate diff takes the declared envelope (behavior-preserving refactor)
+
+**Files:**
+- Modify: `src/migrate.rs` (`plan_table_migration`, the existing-column drift path at ~628, `shadow_compare_migration_plan`, `_render_migration_sql_for_test`, `_shadow_compare_migration_plan_for_test`, and `internal_migrate`'s call sites)
+
+**Interfaces:**
+- Produces: `plan_table_migration(table_lower: &str, declared: &IrEnvelope<SchemaIrPayload>, live: &[LiveColumn], live_indexes: &[LiveIndex], backend: SqlDialect, opts: MigrateOptions) -> PyResult<MigrationPlan>` — takes the declared IR envelope instead of `schema: &serde_json::Value`.
+
+This task does **not** change behavior: callers still build the declared envelope via `schema_json_to_schema_ir`. It isolates the signature change so Task 4's source-swap is a small delta.
+
+- [ ] **Step 1: Change `plan_table_migration`'s signature.** Replace the `schema: &serde_json::Value` param with `declared: &IrEnvelope<SchemaIrPayload>`, and delete the internal producer call:
+
+```rust
+pub fn plan_table_migration(
+    table_lower: &str,
+    declared: &IrEnvelope<SchemaIrPayload>,
+    live: &[LiveColumn],
+    live_indexes: &[LiveIndex],
+    backend: SqlDialect,
+    opts: MigrateOptions,
+) -> PyResult<MigrationPlan> {
+    if !opts.updates {
+        return Ok(MigrationPlan::new());
+    }
+    let old_ir = live_columns_to_schema_ir(table_lower, live, live_indexes, backend);
+    let new_ir = declared;                                   // was: schema_json_to_schema_ir(...)
+    let mut typed_plan = plan_from_ir(&old_ir, new_ir, backend_dialect(backend));
+    // ... rest unchanged ...
+```
+
+(Adjust the borrow: `plan_from_ir(&old_ir, new_ir, …)` — `new_ir` is already `&IrEnvelope`.)
+
+- [ ] **Step 2: Update the existing-column drift path (~line 628).** Wherever `schema_json_to_schema_ir` is called to build the model IR for the drift check, make that function take/receive the declared envelope the same way. (Read ~600–650; if it is a helper like `plan_existing_column`-adjacent code, thread `declared: &IrEnvelope<SchemaIrPayload>` through it instead of `schema`.)
+
+- [ ] **Step 3: Update `shadow_compare_migration_plan`.** It calls both `plan_table_migration` (IR) and `plan_table_migration_legacy` (JSON). Give it both: build `declared` once via `schema_json_to_schema_ir(table_lower, schema, backend)` and pass `&declared` to `plan_table_migration`; keep passing `schema` to the legacy planner. Signature: keep `schema: &serde_json::Value` (legacy needs it) and build the declared envelope inside.
+
+- [ ] **Step 4: Update `internal_migrate` call sites.** Before the `plan_table_migration` call (~line 1012), build the declared envelope and pass it:
+
+```rust
+        let declared = schema_json_to_schema_ir(&table_lower, &schema, backend);
+        let mut plan = plan_table_migration(&table_lower, &declared, &live, &live_indexes, backend, opts)?;
+```
+
+`shadow_compare_migration_plan(&table_lower, &schema, …)` stays as-is (it builds its own declared internally per Step 3).
+
+- [ ] **Step 5: Update the test helpers.** `_render_migration_sql_for_test` and `_shadow_compare_migration_plan_for_test` currently parse `schema_json` and call into the planner. Make them build `declared = schema_json_to_schema_ir(name, &schema, dialect)` and pass `&declared` to `plan_table_migration`. Keep their `schema_json` parameter for now (Task 3 swaps the input).
+
+- [ ] **Step 6: Build + run the full suite — behavior must be identical.**
+
+Run: `cargo build` then `cargo test --no-default-features --features testing` and `uv run pytest tests/test_migrate_plan.py tests/test_shadow_reports.py -q`
+Expected: PASS (no behavior change; `schema_json_to_schema_ir` still runs, just lifted to call sites).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/migrate.rs
+git commit -m "refactor(migrate): plan_table_migration takes the declared IR envelope (#141)"
+```
+
+---
+
+### Task 3: test helpers consume the Python IR + the uuid regression
+
+**Files:**
+- Modify: `src/migrate.rs` (`_render_migration_sql_for_test`, `_shadow_compare_migration_plan_for_test`), `src/ferro/_core.pyi`
+- Modify: `tests/test_migrate_plan.py`, `tests/test_shadow_reports.py` (the 4 call sites + a compile helper)
+
+**Interfaces:**
+- Produces: `_render_migration_sql_for_test(name, schema_ir_json, live_columns_json, dialect, updates=true, destructive=false, live_indexes_json="")` — the model side now arrives as a compiled SchemaIR envelope, not enriched schema JSON.
+
+- [ ] **Step 1: Change `_render_migration_sql_for_test` to take `schema_ir_json`.** Replace the `schema_json` param with `schema_ir_json: String`; deserialize it into the declared single-model envelope instead of calling `schema_json_to_schema_ir`:
+
+```rust
+    let declared: IrEnvelope<SchemaIrPayload> = serde_json::from_str(&schema_ir_json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("invalid schema_ir_json: {e}"))
+    })?;
+    // ... pass &declared to plan_table_migration(name, &declared, &live, &live_indexes, dialect, opts)
+```
+
+Update the `#[pyo3(signature = …)]`. Do the same for `_shadow_compare_migration_plan_for_test`, but it also drives the **legacy** planner — so it takes **both** `schema_ir_json` (IR side) and `schema_json` (legacy side).
+
+- [ ] **Step 2: Update `src/ferro/_core.pyi`** signatures for both helpers.
+
+- [ ] **Step 3: Add a Python compile helper + update the 4 call sites.** In `tests/test_migrate_plan.py` (and reused by `tests/test_shadow_reports.py`), add a helper that compiles one model to its SchemaIR envelope JSON, then update the existing `_render_migration_sql_for_test(...)` calls to pass it:
+
+```python
+import json
+from ferro.ir.compiler import compile_registry_schema_ir  # whole-registry compile
+
+def _schema_ir_json_for(table_name: str) -> str:
+    """The compiled SchemaIR envelope, narrowed to one model's table."""
+    env = compile_registry_schema_ir()
+    env = {**env, "payload": {**env["payload"],
+            "models": [m for m in env["payload"]["models"] if m["table_name"] == table_name]}}
+    return json.dumps(env)
+```
+
+> Implementer: confirm `compile_registry_schema_ir()`'s envelope shape (`payload.models[].table_name`) against `src/ferro/ir/compiler.py`. If the existing tests build ad-hoc schema dicts rather than real registered models, prefer compiling the real model (register it, resolve relationships) so the IR matches production. Adapt each of the 4 call sites to pass `schema_ir_json=_schema_ir_json_for(table)` instead of the old `schema_json=`.
+
+- [ ] **Step 4: Write the uuid regression test (the Example-1 guard).** In `tests/test_migrate_plan.py`:
+
+```python
+@pytest.mark.parametrize("dialect", ["sqlite"])
+def test_derived_uuid_column_does_not_drift_when_consuming_python_ir(dialect):
+    # Model: a derived uuid column (no explicit db_type → omitted in the wire IR).
+    schema_ir = json.dumps({
+        "ir_kind": "schema", "ir_version": 1,
+        "payload": {"dialect_agnostic": True, "models": [{
+            "table_name": "acct",
+            "columns": [{"name": "id", "logical_type": "string", "format": "uuid",
+                         "nullable": False, "primary_key": True}],  # NOTE: no "db_type"
+            "indexes": [], "uniques": [], "foreign_keys": [], "checks": [],
+        }]},
+    })
+    live = json.dumps([{"name": "id", "declared_type": "uuid_text",
+                        "is_nullable": False, "is_primary_key": True}])
+    stmts, warns = _render_migration_sql_for_test("acct", schema_ir, live, dialect)
+    assert stmts == [], f"unexpected DDL: {stmts}"
+    assert warns == [], f"unexpected drift warning: {warns}"
+```
+
+> Implementer: match the exact `SchemaColumn`/`SchemaModel` JSON field names to `ferro-schema-ir` (e.g. `db_type_explicit`, `autoincrement`, `index`, `unique` may need defaults — check `#[serde(default)]` on the struct; add only the fields without defaults). The key assertion is **no statements and no warning** — before Task 1's fix this would emit the "use Alembic" drift warning.
+
+- [ ] **Step 5: Run.**
+
+Run: `cargo build && uv run pytest tests/test_migrate_plan.py tests/test_shadow_reports.py -q`
+Expected: PASS, including the new uuid regression.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/migrate.rs src/ferro/_core.pyi tests/test_migrate_plan.py tests/test_shadow_reports.py
+git commit -m "test(migrate): consume Python SchemaIR in test helpers + uuid no-drift regression (#141)"
+```
+
+---
+
+### Task 4: runtime cutover — consume the Python modelset, delete the Rust producer
+
+**Files:**
+- Modify: `src/state.rs` (new `SCHEMA_IR_MODELSET` global), `src/lib.rs` (register the setter pyfunction), `src/migrate.rs` (`_set_schema_ir_modelset` pyfunction, `declared_envelope_for`, `internal_migrate` + `shadow_compare_migration_plan` consume the store, **delete `schema_json_to_schema_ir`**), `src/ferro/__init__.py` (compile + push in `connect`; add a `migrate` wrapper)
+- Test: `tests/test_auto_migrate.py`
+
+**Interfaces:**
+- Consumes: `compile_registry_schema_ir()` (Python, returns the envelope dict), `IrEnvelope<SchemaIrPayload>` (Rust)
+- Produces: `_set_schema_ir_modelset(json: String)` pyfunction; `declared_envelope_for(modelset, table) -> Option<IrEnvelope<SchemaIrPayload>>`
+
+- [ ] **Step 1: Add the store.** In `src/state.rs`, mirroring `MODEL_REGISTRY` (line 19):
+
+```rust
+pub static SCHEMA_IR_MODELSET: Lazy<RwLock<Option<IrEnvelope<SchemaIrPayload>>>> =
+    Lazy::new(|| RwLock::new(None));
+```
+
+(Import `IrEnvelope`, `SchemaIrPayload` from `ferro_schema_ir`.)
+
+- [ ] **Step 2: Add the setter pyfunction.** In `src/migrate.rs`:
+
+```rust
+/// Push the Python-compiled SchemaIR modelset for the runtime migrate diff to
+/// consume. Called by the `connect`/`migrate` Python wrappers after the registry
+/// is complete and relationships are resolved.
+#[pyfunction]
+#[pyo3(name = "_set_schema_ir_modelset")]
+pub fn _set_schema_ir_modelset(json: String) -> PyResult<()> {
+    let envelope: IrEnvelope<SchemaIrPayload> = serde_json::from_str(&json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("invalid schema_ir_modelset json: {e}"))
+    })?;
+    if envelope.ir_kind != "schema" {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "expected ir_kind 'schema', got '{}'", envelope.ir_kind
+        )));
+    }
+    *crate::state::SCHEMA_IR_MODELSET.write().map_err(|_| {
+        pyo3::exceptions::PyRuntimeError::new_err("Failed to lock SchemaIR modelset")
+    })? = Some(envelope);
+    Ok(())
+}
+```
+
+Register it in `src/lib.rs` next to the other `wrap_pyfunction!` calls.
+
+- [ ] **Step 3: Add the per-table extractor.** In `src/migrate.rs`:
+
+```rust
+/// Narrow the declared modelset to a single-model envelope for `table`,
+/// matching the shape `plan_table_migration` expects (old vs new are both
+/// single-model). Returns None if the model is absent from the modelset.
+fn declared_envelope_for(
+    modelset: &IrEnvelope<SchemaIrPayload>,
+    table: &str,
+) -> Option<IrEnvelope<SchemaIrPayload>> {
+    let model = modelset.payload.models.iter().find(|m| m.table_name == table)?;
+    Some(IrEnvelope {
+        ir_kind: "schema".to_string(),
+        ir_version: modelset.ir_version,
+        payload: SchemaIrPayload {
+            dialect_agnostic: modelset.payload.dialect_agnostic,
+            models: vec![model.clone()],
+        },
+    })
+}
+```
+
+- [ ] **Step 4: Consume the store in `internal_migrate`.** Read the modelset once at the top (after the `MODEL_REGISTRY` read), error if unset:
+
+```rust
+    let modelset = {
+        let guard = crate::state::SCHEMA_IR_MODELSET.read().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("Failed to lock SchemaIR modelset")
+        })?;
+        guard.clone().ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err(
+            "SchemaIR modelset not set — connect()/migrate() must push it before migrating"
+        ))?
+    };
+```
+
+Then in the loop, replace Task 2's `let declared = schema_json_to_schema_ir(...)` with:
+
+```rust
+        let Some(declared) = declared_envelope_for(&modelset, &table_lower) else { continue };
+        let mut plan = plan_table_migration(&table_lower, &declared, &live, &live_indexes, backend, opts)?;
+```
+
+And update `shadow_compare_migration_plan` to take the declared envelope from the modelset for its IR side (pass `&declared` in; keep `schema` for legacy). Adjust its call at ~1015 to pass `&declared`.
+
+- [ ] **Step 5: Delete `schema_json_to_schema_ir`.** It now has no callers. Remove the whole function (migrate.rs ~118–250) and any imports that become unused (`canonical_to_db_type_token`, `single_index_name`, etc. — let the compiler flag them).
+
+- [ ] **Step 6: Push the IR from Python.** In `src/ferro/__init__.py`, in `connect` (after `resolve_relationships()`, before `_core_connect`):
+
+```python
+    import json as _json
+    from ._core import _set_schema_ir_modelset
+    from .ir.compiler import compile_registry_schema_ir
+    resolve_relationships()
+    _set_schema_ir_modelset(_json.dumps(compile_registry_schema_ir()))
+```
+
+Add a `migrate` Python wrapper that does the same before delegating to the Rust entrypoint (rename the import to `_core_migrate` and expose a Python `migrate`):
+
+```python
+from ._core import migrate as _core_migrate
+
+def migrate(using=None, updates=True, destructive=False):
+    from .relations import resolve_relationships
+    resolve_relationships()
+    _set_schema_ir_modelset(_json.dumps(compile_registry_schema_ir()))
+    return _core_migrate(using=using, updates=updates, destructive=destructive)
+```
+
+> Implementer: confirm `migrate` is currently re-exported at `__init__.py:19`; replace that re-export with the wrapper and keep it in `__all__`. Keep the wrapper `async`/awaitable consistent with how `_core_migrate` returns (it returns an awaitable — see `migrate.rs:1086`).
+
+- [ ] **Step 7: Add integration tests.** In `tests/test_auto_migrate.py`, parametrized over the backend matrix: a model with a **derived uuid PK** on an existing table, connected with `auto_migrate`/`migrate_updates` twice — assert **no warning** is emitted and **no DDL** runs on the second pass (the end-to-end Example-1 guard). Follow the file's existing harness + warning-capture pattern.
+
+- [ ] **Step 8: Build + run.**
+
+Run: `cargo build && cargo test --no-default-features --features testing && uv run pytest tests/test_auto_migrate.py -q -k "uuid or drift"`
+Expected: PASS. `schema_json_to_schema_ir` no longer exists (grep returns nothing).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/state.rs src/lib.rs src/migrate.rs src/ferro/__init__.py tests/test_auto_migrate.py
+git commit -m "feat(migrate): consume Python SchemaIR over FFI; delete Rust producer (#141)"
+```
+
+---
+
+### Task 5: full behavior-preservation + parity gate
+
+- [ ] **Step 1: Cross-emitter + IR contract + Alembic** (declared IR is now Python-sourced; emitted DDL must be unchanged)
+
+Run: `uv run pytest tests/test_db_type_cross_emitter_parity.py tests/test_cross_emitter_parity.py tests/test_ir_vectors_contract.py tests/test_alembic_autogenerate.py -q`
+Expected: PASS.
+
+- [ ] **Step 2: IR-vs-legacy parity + auto-migrate matrix** (the Python-derived column ops must still match the legacy planner)
+
+Run: `uv run pytest -m "backend_matrix or postgres_only" --db-backends=sqlite,postgres tests/test_auto_migrate.py tests/test_migrate_plan.py tests/test_shadow_reports.py -q`
+Expected: PASS on SQLite (incl. the uuid regressions); Postgres via CI if no local server — note in the PR.
+
+- [ ] **Step 3: Full Rust suite** — `cargo test --no-default-features --features testing` → PASS.
+
+- [ ] **Step 4: Confirm the producer is gone** — `grep -rn schema_json_to_schema_ir src/` returns nothing.
+
+- [ ] **Step 5: Open the PR** into the integration branch
+
+```bash
+git push -u origin feat/ir-p8.5-141-single-schema-ir-producer
+gh pr create --base feat/ir-p8.5-lowering-consolidation --title "feat(migrate): single SchemaIR producer — Python over FFI (#141)" --body "<single declared-IR producer; uuid-on-SQLite drift fixed at the diff boundary; schema_json_to_schema_ir deleted; parity column-scoped stays green; CI must run the postgres matrix>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** uuid fix (T1); declared-envelope refactor (T2); test-helper consume + uuid unit regression (T3); runtime FFI cutover + producer deletion + Python push + integration guard (T4); behavior-preservation + parity gate (T5). The "single producer" goal = `schema_json_to_schema_ir` deleted (T4/T5 Step 4). Observed side unchanged. ✅
+
+**Placeholder scan:** implementer notes mark each spot needing a constructor/field-name confirmation against existing code (the `SchemaColumn` test helper, the envelope field names, the `migrate` re-export). No `TODO`/`TBD`; the PR-body `<...>` is filled at PR time. ✅
+
+**Type consistency:** `plan_table_migration(…, declared: &IrEnvelope<SchemaIrPayload>, …)` (T2) is consumed by `internal_migrate`/`shadow_compare` and the test helpers (T2–T4); `declared_envelope_for -> Option<IrEnvelope<SchemaIrPayload>>` (T4) feeds it; `_set_schema_ir_modelset(String)` (T4) populates `SCHEMA_IR_MODELSET: RwLock<Option<IrEnvelope<SchemaIrPayload>>>` (T4); `schema_columns_storage_drift` keeps its signature (T1). ✅

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -141,6 +141,7 @@ Runtime migration IR cutover (target: `v0.13.0`).
 | [#118](https://github.com/syn54x/ferro-orm/issues/118) | Complete executable SQL emission from `MigrationPlan` for all ops (SQLite + Postgres) | none | No action | Continues #90 scaffold |
 | [#119](https://github.com/syn54x/ferro-orm/issues/119) | Wire `auto_migrate` / `plan_table_migration` to execute ferro-migrate IR plans | none | No action — behavior must remain observably identical | IR planner becomes primary; legacy path deprecated |
 | [#120](https://github.com/syn54x/ferro-orm/issues/120) | Parity gate + shadow comparison (IR vs legacy, `create_tables`, Alembic) | none | No action | Legacy planner retained deprecated; removal in Phase 9 |
+| [#144](https://github.com/syn54x/ferro-orm/issues/144) | `migrate_updates` now reconciles standalone indexes on existing tables: adds missing Ferro-named indexes (`idx_*` / `uq_*`) and, under `migrate_destructive`, drops orphaned ones | minor | No action required — index reconciliation is automatic under existing flags; hand-created user indexes (names not starting with `idx_`/`uq_`) are never touched | Covered by integration tests in `tests/test_auto_migrate.py` |
 
 - **Migration impact:** `none` for public APIs — `connect(auto_migrate=...)` and `ferro.migrate` signatures unchanged.
 - **Internal change:** `auto_migrate` executes `ferro-migrate` `SchemaIR(old,new)` plans as the primary path. The legacy enriched-JSON diff walk in `src/migrate.rs` is **deprecated** and kept for shadow comparison until Phase 9 removal.

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -16,12 +16,13 @@ from ._core import (
     clear_registry,
     create_tables,
     evict_instance,
-    migrate,
+    migrate as _core_migrate,
     reset_engine,
     set_default_connection,
     version,
 )
 from ._core import (
+    _set_schema_ir_modelset,
     connect as _core_connect,
 )
 from .base import DbType, DbTypeToken, FerroField, FerroNullable, ForeignKey, varchar
@@ -112,9 +113,12 @@ async def connect(
     For schema changes beyond these (renames, primary-key changes, complex
     transforms), use the Alembic bridge — see ``docs/guide/migrations.md``.
     """
+    import json as _json
+    from .ir.compiler import compile_registry_schema_ir
     from .relations import resolve_relationships
 
     resolve_relationships()
+    _set_schema_ir_modelset(_json.dumps(compile_registry_schema_ir()))
 
     pool_config = pool or PoolConfig()
     await _core_connect(
@@ -128,6 +132,27 @@ async def connect(
         migrate_updates=migrate_updates,
         migrate_destructive=migrate_destructive,
     )
+
+
+async def migrate(using=None, updates=True, destructive=False):
+    """
+    Manually run the auto-migrate pass against a connected engine.
+
+    Compiles and pushes the current registry SchemaIR to the Rust runtime,
+    then delegates to the Rust migrate entrypoint.
+
+    Args:
+        using: Named connection to migrate, or None for the default.
+        updates: If True (default), add missing columns and reconcile type/nullability drift.
+        destructive: If True, also drop live columns absent from the model. Implies ``updates``.
+    """
+    import json as _json
+    from .ir.compiler import compile_registry_schema_ir
+    from .relations import resolve_relationships
+
+    resolve_relationships()
+    _set_schema_ir_modelset(_json.dumps(compile_registry_schema_ir()))
+    return await _core_migrate(using=using, updates=updates, destructive=destructive)
 
 
 __all__ = [

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -46,12 +46,15 @@ def _render_migration_sql_for_test(
     dialect: str,
     updates: bool = True,
     destructive: bool = False,
+    live_indexes_json: str = "",
 ) -> tuple[list[str], list[str]]:
     """Test-only: render the auto-migrate diff for one table without a database.
 
     ``live_columns_json`` is a JSON array of objects with the LiveColumn shape
     (``name``, ``declared_type``, ``is_nullable``, ``is_primary_key``,
-    ``char_max_len``, ``is_enum_udt``). Returns ``(statements, warnings)``.
+    ``char_max_len``, ``is_enum_udt``). ``live_indexes_json`` is a JSON array
+    of objects with the LiveIndex shape (``name``, ``columns``, ``unique``).
+    Returns ``(statements, warnings)``.
     """
     ...
 
@@ -62,8 +65,9 @@ def _shadow_compare_migration_plan_for_test(
     dialect: str,
     updates: bool = True,
     destructive: bool = False,
+    live_indexes_json: str = "",
 ) -> str:
-    """Test-only: compare IR-primary vs legacy migration planners."""
+    """Test-only: compare IR-primary vs legacy migration planners (column-domain scoped)."""
     ...
 
 def _shadow_compare_query_plan_for_test(

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -41,7 +41,7 @@ def _render_create_table_sql_for_test(
 
 def _render_migration_sql_for_test(
     name: str,
-    schema_json: str,
+    schema_ir_json: str,
     live_columns_json: str,
     dialect: str,
     updates: bool = True,
@@ -50,16 +50,18 @@ def _render_migration_sql_for_test(
 ) -> tuple[list[str], list[str]]:
     """Test-only: render the auto-migrate diff for one table without a database.
 
-    ``live_columns_json`` is a JSON array of objects with the LiveColumn shape
-    (``name``, ``declared_type``, ``is_nullable``, ``is_primary_key``,
-    ``char_max_len``, ``is_enum_udt``). ``live_indexes_json`` is a JSON array
-    of objects with the LiveIndex shape (``name``, ``columns``, ``unique``).
+    ``schema_ir_json`` is a compiled SchemaIR envelope (``IrEnvelope<SchemaIrPayload>``
+    serialized as JSON). ``live_columns_json`` is a JSON array of objects with the
+    LiveColumn shape (``name``, ``declared_type``, ``is_nullable``, ``is_primary_key``,
+    ``char_max_len``, ``is_enum_udt``). ``live_indexes_json`` is a JSON array of objects
+    with the LiveIndex shape (``name``, ``columns``, ``unique``).
     Returns ``(statements, warnings)``.
     """
     ...
 
 def _shadow_compare_migration_plan_for_test(
     name: str,
+    schema_ir_json: str,
     schema_json: str,
     live_columns_json: str,
     dialect: str,
@@ -67,7 +69,11 @@ def _shadow_compare_migration_plan_for_test(
     destructive: bool = False,
     live_indexes_json: str = "",
 ) -> str:
-    """Test-only: compare IR-primary vs legacy migration planners (column-domain scoped)."""
+    """Test-only: compare IR-primary vs legacy migration planners (column-domain scoped).
+
+    ``schema_ir_json`` drives the IR planner (compiled SchemaIR envelope);
+    ``schema_json`` drives the legacy planner (enriched Ferro schema JSON).
+    """
     ...
 
 def _shadow_compare_query_plan_for_test(
@@ -212,3 +218,4 @@ def reset_engine() -> None: ...
 def set_default_connection(name: str) -> None: ...
 def clear_registry() -> None: ...
 def version() -> str: ...
+def _set_schema_ir_modelset(json: str) -> None: ...

--- a/src/ferro/ir/compiler.py
+++ b/src/ferro/ir/compiler.py
@@ -99,25 +99,6 @@ def _logical_type(col_info: dict[str, Any]) -> str:
     return "unknown"
 
 
-def _default_db_type(col_info: dict[str, Any]) -> str:
-    """Map schema metadata to the default canonical Ferro ``db_type`` token."""
-    field_type, field_format = _effective_type_and_format(col_info)
-    if field_type == "integer":
-        return "bigint"
-    if field_type == "number":
-        return "text"
-    if field_type == "string":
-        if field_format == "date-time":
-            return "timestamptz"
-        if field_format == "date":
-            return "date"
-        if field_format == "time":
-            return "time"
-        if field_format == "uuid":
-            return "uuid"
-        return "text"
-    return "text"
-
 
 def _effective_type_and_format(col_info: dict[str, Any]) -> tuple[Any, Any]:
     """Resolve concrete type/format from direct fields or ``anyOf`` unions."""
@@ -169,7 +150,6 @@ def _column_ir(
     column_ir = {
         "name": col_name,
         "logical_type": _logical_type(col_info),
-        "db_type": db_type_value if db_type_explicit else _default_db_type(col_info),
         "nullable": _is_nullable(col_name, col_info, required_fields),
         "primary_key": bool(col_info.get("primary_key", False)),
         "autoincrement": bool(col_info.get("autoincrement", False)),
@@ -182,6 +162,7 @@ def _column_ir(
     if isinstance(enum_values, list):
         column_ir["enum_values"] = list(enum_values)
     if db_type_explicit:
+        column_ir["db_type"] = db_type_value
         column_ir["db_type_explicit"] = True
     enum_type_name = col_info.get("enum_type_name")
     if isinstance(enum_type_name, str) and enum_type_name:

--- a/src/introspect.rs
+++ b/src/introspect.rs
@@ -40,6 +40,23 @@ pub struct LiveColumn {
     pub is_enum_udt: bool,
 }
 
+/// One live standalone index that Ferro owns (its name follows the `idx_`/`uq_`
+/// convention). Deserialize exists for `_render_migration_sql_for_test`.
+#[derive(Clone, Debug, serde::Deserialize)]
+pub struct LiveIndex {
+    pub name: String,
+    #[serde(default)]
+    pub columns: Vec<String>,
+    #[serde(default)]
+    pub unique: bool,
+}
+
+/// Ferro emits standalone indexes as `idx_<table>_<cols>` and uniques as
+/// `uq_<table>_<cols>`. Reconciliation only ever touches names it owns.
+pub(crate) fn is_ferro_index_name(name: &str) -> bool {
+    name.starts_with("idx_") || name.starts_with("uq_")
+}
+
 /// One live SQLite index covering some column, with enough context to decide
 /// whether it can be dropped ahead of `ALTER TABLE ... DROP COLUMN`.
 #[derive(Clone, Debug)]
@@ -230,6 +247,79 @@ pub async fn sqlite_indexes_covering_column(
     Ok(covering)
 }
 
+/// Live standalone indexes Ferro owns on `table`, normalized across backends.
+pub async fn live_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>> {
+    match engine.backend() {
+        SqlDialect::Sqlite => sqlite_table_indexes(engine, table).await,
+        SqlDialect::Postgres => postgres_table_indexes(engine, table).await,
+    }
+}
+
+async fn sqlite_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>> {
+    let list_sql = format!("PRAGMA index_list({})", quote_ident(table));
+    let index_rows = engine
+        .fetch_all_sql_unprepared(&list_sql)
+        .await
+        .map_err(|e| introspection_error("PRAGMA index_list", table, e))?;
+
+    let mut out = Vec::new();
+    for index_row in &index_rows {
+        let Some(name) = row_string(index_row, "name") else { continue };
+        if !is_ferro_index_name(&name) {
+            continue;
+        }
+        let unique = row_bool(index_row, "unique");
+        let info_sql = format!("PRAGMA index_info({})", quote_ident(&name));
+        let col_rows = engine
+            .fetch_all_sql_unprepared(&info_sql)
+            .await
+            .map_err(|e| introspection_error("PRAGMA index_info", table, e))?;
+        // PRAGMA index_info returns rows in `seqno` order already.
+        let columns: Vec<String> = col_rows.iter().filter_map(|r| row_string(r, "name")).collect();
+        out.push(LiveIndex { name, columns, unique });
+    }
+    Ok(out)
+}
+
+async fn postgres_table_indexes(engine: &EngineHandle, table: &str) -> PyResult<Vec<LiveIndex>> {
+    // One row per (index, column); `pos` orders columns within the index.
+    let sql = r#"
+        SELECT cl.relname::text AS index_name,
+               i.indisunique     AS is_unique,
+               a.attname::text   AS column_name,
+               array_position(i.indkey::smallint[], a.attnum) AS pos
+        FROM pg_index i
+        JOIN pg_class cl ON cl.oid = i.indexrelid
+        JOIN pg_class t  ON t.oid  = i.indrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(i.indkey)
+        WHERE n.nspname = current_schema()
+          AND t.relname = $1
+          AND NOT i.indisprimary
+        ORDER BY cl.relname, pos
+        "#;
+    let rows = engine
+        .fetch_all_sql_unprepared_with_binds(sql, &[EngineBindValue::String(table.to_string())])
+        .await
+        .map_err(|e| introspection_error("pg_index", table, e))?;
+
+    // Group ordered rows into indexes (rows are already ordered by name, pos).
+    let mut out: Vec<LiveIndex> = Vec::new();
+    for row in &rows {
+        let Some(name) = row_string(row, "index_name") else { continue };
+        if !is_ferro_index_name(&name) {
+            continue;
+        }
+        let unique = row_bool(row, "is_unique");
+        let Some(column) = row_string(row, "column_name") else { continue };
+        match out.last_mut() {
+            Some(last) if last.name == name => last.columns.push(column),
+            _ => out.push(LiveIndex { name, columns: vec![column], unique }),
+        }
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,6 +335,15 @@ mod tests {
         })
         .await
         .unwrap()
+    }
+
+    #[test]
+    fn ferro_index_names_are_recognized() {
+        assert!(is_ferro_index_name("idx_user_email"));
+        assert!(is_ferro_index_name("uq_user_email"));
+        assert!(!is_ferro_index_name("sqlite_autoindex_user_1"));
+        assert!(!is_ferro_index_name("user_email_key"));
+        assert!(!is_ferro_index_name("my_custom_index"));
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ mod schema;
 mod schema_bind;
 mod state;
 
-use crate::state::MODEL_REGISTRY;
+use crate::state::{MODEL_REGISTRY, SCHEMA_IR_MODELSET};
 use pyo3::prelude::*;
 
 /// Logs a debug message through Python's logging system.
@@ -68,18 +68,21 @@ fn version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
 
-/// Clears the global model registry.
+/// Clears the global model registry and resets the SchemaIR modelset.
 ///
 /// Primarily used for cleaning up state between tests.
 ///
 /// # Errors
-/// Returns a `PyErr` if the registry lock cannot be acquired.
+/// Returns a `PyErr` if either registry lock cannot be acquired.
 #[pyfunction]
 fn clear_registry() -> PyResult<()> {
     let mut registry = MODEL_REGISTRY
         .write()
         .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("Failed to lock Model Registry"))?;
     registry.clear();
+    *SCHEMA_IR_MODELSET
+        .write()
+        .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("Failed to lock SchemaIR modelset"))? = None;
     Ok(())
 }
 
@@ -126,6 +129,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(version, m)?)?;
     m.add_function(wrap_pyfunction!(schema::create_tables, m)?)?;
     m.add_function(wrap_pyfunction!(migrate::migrate, m)?)?;
+    m.add_function(wrap_pyfunction!(migrate::_set_schema_ir_modelset, m)?)?;
     m.add_function(wrap_pyfunction!(
         schema::_render_create_table_sql_for_test,
         m

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -16,9 +16,7 @@
 use crate::backend::EngineHandle;
 use ferro_ddl_lowering::{
     CanonicalType, Dialect, apply_canonical_type, canonical_to_db_type_token,
-    composite_index_name, composite_unique_index_name, db_check_constraint_name,
     information_schema_to_db_type_token, schema_columns_storage_drift,
-    single_index_name, single_unique_index_name as ddl_single_unique_index_name,
 };
 use ferro_migrate::{BackendDialect, MigrationOp, emit_sql_with_ir, plan_from_ir};
 use ferro_schema_ir::{
@@ -31,7 +29,7 @@ use crate::introspect::{
 };
 use crate::schema::{
     ColumnPlan, build_column_plan, internal_create_tables,
-    order_schemas_for_creation, property_json_type_and_format, sql_dialect_to_lowering,
+    order_schemas_for_creation, sql_dialect_to_lowering,
 };
 use crate::state::{IDENTITY_MAP, MODEL_REGISTRY, SqlDialect, engine_for_connection};
 use pyo3::prelude::*;
@@ -56,45 +54,6 @@ fn resolve_col_schema<'a>(
     raw_col
 }
 
-fn migrate_column_bool(
-    raw_col: &serde_json::Value,
-    resolved: &serde_json::Value,
-    key: &str,
-) -> Option<bool> {
-    raw_col
-        .get(key)
-        .or_else(|| resolved.get(key))
-        .and_then(|value| value.as_bool())
-}
-
-fn migrate_column_object<'a>(
-    raw_col: &'a serde_json::Value,
-    resolved: &'a serde_json::Value,
-    key: &str,
-) -> Option<&'a serde_json::Map<String, serde_json::Value>> {
-    raw_col
-        .get(key)
-        .or_else(|| resolved.get(key))
-        .and_then(|value| value.as_object())
-}
-
-fn migrate_check_expression(col_name: &str, col_info: &serde_json::Value) -> Option<String> {
-    let values = col_info.get("enum").and_then(|v| v.as_array())?;
-    if values.is_empty() {
-        return None;
-    }
-    let rendered: Vec<String> = values
-        .iter()
-        .map(|v| match v {
-            serde_json::Value::String(s) => format!("'{}'", s.replace('\'', "''")),
-            serde_json::Value::Number(n) => n.to_string(),
-            serde_json::Value::Bool(b) => b.to_string(),
-            other => format!("'{}'", other.to_string().replace('\'', "''")),
-        })
-        .collect();
-    Some(format!("\"{}\" IN ({})", col_name, rendered.join(", ")))
-}
-
 fn schema_ir_column<'a>(
     envelope: &'a IrEnvelope<SchemaIrPayload>,
     table: &str,
@@ -115,134 +74,42 @@ fn backend_dialect(backend: SqlDialect) -> BackendDialect {
     }
 }
 
-fn schema_json_to_schema_ir(
-    table_lower: &str,
-    schema: &serde_json::Value,
-    backend: SqlDialect,
-) -> IrEnvelope<SchemaIrPayload> {
-    let mut columns = Vec::new();
-    let mut foreign_keys = Vec::new();
-    let mut checks = Vec::new();
-    let mut indexes: Vec<SchemaIndex> = Vec::new();
-    let mut uniques: Vec<SchemaUnique> = Vec::new();
-    if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
-        for (name, raw_col) in properties {
-            let resolved = resolve_col_schema(schema, raw_col);
-            let col_plan = build_column_plan(table_lower, name, raw_col, schema, backend);
-            let db_type_explicit = raw_col
-                .get("db_type")
-                .or_else(|| resolved.get("db_type"))
-                .and_then(|v| v.as_str());
-            let db_type = db_type_explicit
-                .map(str::to_string)
-                .unwrap_or_else(|| canonical_to_db_type_token(col_plan.canonical, sql_dialect_to_lowering(backend)));
-            columns.push(SchemaColumn {
-                name: name.clone(),
-                logical_type: property_json_type_and_format(resolved)
-                    .0
-                    .unwrap_or("unknown")
-                    .to_string(),
-                db_type: Some(db_type),
-                db_type_explicit: db_type_explicit.map(|_| true),
-                nullable: col_plan.is_nullable,
-                primary_key: col_plan.is_primary_key,
-                autoincrement: col_plan.autoincrement,
-                unique: col_plan.is_unique,
-                index: migrate_column_bool(raw_col, resolved, "index").unwrap_or(false),
-                default: resolved.get("default").cloned(),
-                format: resolved
-                    .get("format")
-                    .and_then(|v| v.as_str())
-                    .map(str::to_string),
-                enum_values: resolved.get("enum").and_then(|v| v.as_array()).cloned(),
-                enum_type_name: resolved
-                    .get("enum_type_name")
-                    .and_then(|v| v.as_str())
-                    .map(str::to_string),
-                postgres_native_enum: false,
-            });
-
-            if migrate_column_bool(raw_col, resolved, "index").unwrap_or(false) {
-                indexes.push(SchemaIndex {
-                    name: single_index_name(table_lower, name),
-                    columns: vec![name.clone()],
-                    unique: false,
-                });
-            }
-            if col_plan.is_unique {
-                uniques.push(SchemaUnique {
-                    name: ddl_single_unique_index_name(table_lower, name),
-                    columns: vec![name.clone()],
-                });
-            }
-
-            if let Some(fk_info) = migrate_column_object(raw_col, resolved, "foreign_key") {
-                let to_table = fk_info
-                    .get("to_table")
-                    .and_then(|t| t.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let on_delete = fk_info
-                    .get("on_delete")
-                    .and_then(|o| o.as_str())
-                    .map(str::to_string);
-                foreign_keys.push(SchemaForeignKey {
-                    column: name.clone(),
-                    to_table,
-                    to_column: fk_info
-                        .get("to_column")
-                        .and_then(|c| c.as_str())
-                        .unwrap_or("id")
-                        .to_string(),
-                    on_delete,
-                    name: None,
-                });
-            }
-
-            if migrate_column_bool(raw_col, resolved, "db_check").unwrap_or(false)
-                && let Some(expression) = migrate_check_expression(name, resolved)
-            {
-                checks.push(SchemaCheck {
-                    name: db_check_constraint_name(table_lower, name),
-                    expression,
-                });
-            }
-        }
+/// Push the Python-compiled SchemaIR modelset for the runtime migrate diff to
+/// consume. Called by the `connect`/`migrate` Python wrappers after the registry
+/// is complete and relationships are resolved.
+#[pyfunction]
+#[pyo3(name = "_set_schema_ir_modelset")]
+pub fn _set_schema_ir_modelset(json: String) -> PyResult<()> {
+    let envelope: IrEnvelope<SchemaIrPayload> = serde_json::from_str(&json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("invalid schema_ir_modelset json: {e}"))
+    })?;
+    if envelope.ir_kind != "schema" {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "expected ir_kind 'schema', got '{}'", envelope.ir_kind
+        )));
     }
-    for group in schema.get("ferro_composite_indexes").and_then(|g| g.as_array()).into_iter().flatten() {
-        let cols: Vec<String> = group.as_array().map(|a| a.iter().filter_map(|c| c.as_str().map(String::from)).collect()).unwrap_or_default();
-        if cols.len() >= 2 {
-            let refs: Vec<&str> = cols.iter().map(String::as_str).collect();
-            indexes.push(SchemaIndex { name: composite_index_name(table_lower, &refs), columns: cols, unique: false });
-        }
-    }
-    for group in schema.get("ferro_composite_uniques").and_then(|g| g.as_array()).into_iter().flatten() {
-        let cols: Vec<String> = group.as_array().map(|a| a.iter().filter_map(|c| c.as_str().map(String::from)).collect()).unwrap_or_default();
-        if cols.len() >= 2 {
-            let refs: Vec<&str> = cols.iter().map(String::as_str).collect();
-            uniques.push(SchemaUnique { name: composite_unique_index_name(table_lower, &refs), columns: cols });
-        }
-    }
-    indexes.sort_by(|a, b| a.name.cmp(&b.name));
-    uniques.sort_by(|a, b| a.name.cmp(&b.name));
-    columns.sort_by(|a, b| a.name.cmp(&b.name));
+    *crate::state::SCHEMA_IR_MODELSET.write().map_err(|_| {
+        pyo3::exceptions::PyRuntimeError::new_err("Failed to lock SchemaIR modelset")
+    })? = Some(envelope);
+    Ok(())
+}
 
-    IrEnvelope {
+/// Narrow the declared modelset to a single-model envelope for `table`,
+/// matching the shape `plan_table_migration` expects (old vs new are both
+/// single-model). Returns None if the model is absent from the modelset.
+fn declared_envelope_for(
+    modelset: &IrEnvelope<SchemaIrPayload>,
+    table: &str,
+) -> Option<IrEnvelope<SchemaIrPayload>> {
+    let model = modelset.payload.models.iter().find(|m| m.table_name == table)?;
+    Some(IrEnvelope {
         ir_kind: "schema".to_string(),
-        ir_version: 1,
+        ir_version: modelset.ir_version,
         payload: SchemaIrPayload {
-            dialect_agnostic: true,
-            models: vec![SchemaModel {
-                model_name: table_lower.to_string(),
-                table_name: table_lower.to_string(),
-                columns,
-                foreign_keys,
-                indexes,
-                uniques,
-                checks,
-            }],
+            dialect_agnostic: modelset.payload.dialect_agnostic,
+            models: vec![model.clone()],
         },
-    }
+    })
 }
 
 fn live_columns_to_schema_ir(
@@ -487,7 +354,7 @@ fn render_alter(stmt: &sea_query::TableAlterStatement, backend: SqlDialect) -> S
 /// default. These abort the migration ("fail loudly").
 pub fn plan_table_migration(
     table_lower: &str,
-    schema: &serde_json::Value,
+    declared: &IrEnvelope<SchemaIrPayload>,
     live: &[LiveColumn],
     live_indexes: &[LiveIndex],
     backend: SqlDialect,
@@ -498,8 +365,8 @@ pub fn plan_table_migration(
     }
 
     let old_ir = live_columns_to_schema_ir(table_lower, live, live_indexes, backend);
-    let new_ir = schema_json_to_schema_ir(table_lower, schema, backend);
-    let mut typed_plan = plan_from_ir(&old_ir, &new_ir, backend_dialect(backend));
+    let new_ir = declared;
+    let mut typed_plan = plan_from_ir(&old_ir, new_ir, backend_dialect(backend));
 
     if !opts.destructive {
         typed_plan
@@ -535,7 +402,7 @@ pub fn plan_table_migration(
         operations: exec_ops,
         warnings: typed_plan.warnings,
     };
-    let emission = emit_sql_with_ir(&exec_plan, &old_ir, &new_ir, backend_dialect(backend))
+    let emission = emit_sql_with_ir(&exec_plan, &old_ir, new_ir, backend_dialect(backend))
         .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.message))?;
 
     plan.statements = emission.statements;
@@ -614,6 +481,7 @@ fn plan_table_migration_legacy(
 
 fn shadow_compare_migration_plan(
     table_lower: &str,
+    declared: &IrEnvelope<SchemaIrPayload>,
     schema: &serde_json::Value,
     live: &[LiveColumn],
     live_indexes: &[LiveIndex],
@@ -625,9 +493,7 @@ fn shadow_compare_migration_plan(
     }
     // Build the old and new IRs for the column-domain emission.
     let old_ir = live_columns_to_schema_ir(table_lower, live, live_indexes, backend);
-    let new_ir = schema_json_to_schema_ir(table_lower, schema, backend);
-
-    let mut typed_plan = plan_from_ir(&old_ir, &new_ir, backend_dialect(backend));
+    let mut typed_plan = plan_from_ir(&old_ir, declared, backend_dialect(backend));
 
     if !opts.destructive {
         typed_plan
@@ -653,7 +519,7 @@ fn shadow_compare_migration_plan(
         operations: column_ops,
         warnings: typed_plan.warnings,
     };
-    let emission = emit_sql_with_ir(&column_plan, &old_ir, &new_ir, backend_dialect(backend))
+    let emission = emit_sql_with_ir(&column_plan, &old_ir, declared, backend_dialect(backend))
         .map_err(|e| e.message)?;
 
     let legacy = plan_table_migration_legacy(table_lower, schema, live, live_indexes, backend, opts)
@@ -996,6 +862,14 @@ pub async fn internal_migrate(engine: Arc<EngineHandle>, opts: MigrateOptions) -
         })?;
         registry.clone()
     };
+    let modelset = {
+        let guard = crate::state::SCHEMA_IR_MODELSET.read().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("Failed to lock SchemaIR modelset")
+        })?;
+        guard.clone().ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err(
+            "SchemaIR modelset not set — connect()/migrate() must push it before migrating"
+        ))?
+    };
     let backend = engine.backend();
 
     let mut warnings = Vec::new();
@@ -1009,10 +883,11 @@ pub async fn internal_migrate(engine: Arc<EngineHandle>, opts: MigrateOptions) -
         };
         let live_indexes = live_table_indexes(&engine, &table_lower).await?;
 
-        let mut plan = plan_table_migration(&table_lower, &schema, &live, &live_indexes, backend, opts)?;
+        let Some(declared) = declared_envelope_for(&modelset, &table_lower) else { continue };
+        let mut plan = plan_table_migration(&table_lower, &declared, &live, &live_indexes, backend, opts)?;
         if engine.is_shadow_runtime_enabled()
             && let Err(diff) =
-                shadow_compare_migration_plan(&table_lower, &schema, &live, &live_indexes, backend, opts)
+                shadow_compare_migration_plan(&table_lower, &declared, &schema, &live, &live_indexes, backend, opts)
         {
             crate::log_debug(format!("⚠️ Ferro shadow runtime mismatch: {diff}"));
             if std::env::var("FERRO_SHADOW_RUNTIME_STRICT")
@@ -1107,10 +982,10 @@ pub fn migrate(
 /// unrecognized, or the diff contains an unsafe change.
 #[pyfunction]
 #[pyo3(name = "_render_migration_sql_for_test")]
-#[pyo3(signature = (name, schema_json, live_columns_json, dialect, updates=true, destructive=false, live_indexes_json=String::new()))]
+#[pyo3(signature = (name, schema_ir_json, live_columns_json, dialect, updates=true, destructive=false, live_indexes_json=String::new()))]
 pub fn _render_migration_sql_for_test(
     name: String,
-    schema_json: String,
+    schema_ir_json: String,
     live_columns_json: String,
     dialect: String,
     updates: bool,
@@ -1127,8 +1002,8 @@ pub fn _render_migration_sql_for_test(
             )));
         }
     };
-    let schema: serde_json::Value = serde_json::from_str(&schema_json).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!("Invalid JSON schema: {}", e))
+    let declared: IrEnvelope<SchemaIrPayload> = serde_json::from_str(&schema_ir_json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("invalid schema_ir_json: {e}"))
     })?;
     let live: Vec<LiveColumn> = serde_json::from_str(&live_columns_json).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("Invalid live-columns JSON: {}", e))
@@ -1143,7 +1018,7 @@ pub fn _render_migration_sql_for_test(
 
     let table_lower = name.to_lowercase();
     let opts = MigrateOptions::laddered(updates, destructive);
-    let plan = plan_table_migration(&table_lower, &schema, &live, &live_indexes, backend, opts)?;
+    let plan = plan_table_migration(&table_lower, &declared, &live, &live_indexes, backend, opts)?;
 
     let mut statements = plan.statements;
     for col_name in &plan.drop_columns {
@@ -1167,11 +1042,13 @@ fn migration_plan_snapshot(plan: &MigrationPlan) -> serde_json::Value {
 /// Test-only: compare IR-primary vs legacy migration planners for shadow fixtures.
 ///
 /// Returns JSON with `matches`, `ir`, and `legacy` plan snapshots.
+/// `schema_ir_json` drives the IR planner; `schema_json` drives the legacy planner.
 #[pyfunction]
 #[pyo3(name = "_shadow_compare_migration_plan_for_test")]
-#[pyo3(signature = (name, schema_json, live_columns_json, dialect, updates=true, destructive=false, live_indexes_json=String::new()))]
+#[pyo3(signature = (name, schema_ir_json, schema_json, live_columns_json, dialect, updates=true, destructive=false, live_indexes_json=String::new()))]
 pub fn _shadow_compare_migration_plan_for_test(
     name: String,
+    schema_ir_json: String,
     schema_json: String,
     live_columns_json: String,
     dialect: String,
@@ -1189,6 +1066,9 @@ pub fn _shadow_compare_migration_plan_for_test(
             )));
         }
     };
+    let new_ir: IrEnvelope<SchemaIrPayload> = serde_json::from_str(&schema_ir_json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("invalid schema_ir_json: {e}"))
+    })?;
     let schema: serde_json::Value = serde_json::from_str(&schema_json).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("Invalid JSON schema: {}", e))
     })?;
@@ -1208,7 +1088,6 @@ pub fn _shadow_compare_migration_plan_for_test(
 
     // Build column-domain IR plan (filter AddIndex/DropIndex) for parity comparison.
     let old_ir = live_columns_to_schema_ir(&table_lower, &live, &live_indexes, backend);
-    let new_ir = schema_json_to_schema_ir(&table_lower, &schema, backend);
     let mut typed_plan = plan_from_ir(&old_ir, &new_ir, backend_dialect(backend));
     if !opts.destructive {
         typed_plan
@@ -1254,7 +1133,185 @@ pub fn _shadow_compare_migration_plan_for_test(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ferro_ddl_lowering::{
+        canonical_to_db_type_token, composite_index_name, composite_unique_index_name,
+        db_check_constraint_name, single_index_name,
+        single_unique_index_name as ddl_single_unique_index_name,
+    };
+    use crate::schema::property_json_type_and_format;
     use serde_json::json;
+
+    fn migrate_column_bool(
+        raw_col: &serde_json::Value,
+        resolved: &serde_json::Value,
+        key: &str,
+    ) -> Option<bool> {
+        raw_col
+            .get(key)
+            .or_else(|| resolved.get(key))
+            .and_then(|value| value.as_bool())
+    }
+
+    fn migrate_column_object<'a>(
+        raw_col: &'a serde_json::Value,
+        resolved: &'a serde_json::Value,
+        key: &str,
+    ) -> Option<&'a serde_json::Map<String, serde_json::Value>> {
+        raw_col
+            .get(key)
+            .or_else(|| resolved.get(key))
+            .and_then(|value| value.as_object())
+    }
+
+    fn migrate_check_expression(col_name: &str, col_info: &serde_json::Value) -> Option<String> {
+        let values = col_info.get("enum").and_then(|v| v.as_array())?;
+        if values.is_empty() {
+            return None;
+        }
+        let rendered: Vec<String> = values
+            .iter()
+            .map(|v| match v {
+                serde_json::Value::String(s) => format!("'{}'", s.replace('\'', "''")),
+                serde_json::Value::Number(n) => n.to_string(),
+                serde_json::Value::Bool(b) => b.to_string(),
+                other => format!("'{}'", other.to_string().replace('\'', "''")),
+            })
+            .collect();
+        Some(format!("\"{}\" IN ({})", col_name, rendered.join(", ")))
+    }
+
+    /// Test-only helper: convert a Ferro-enriched JSON schema into a single-model
+    /// `IrEnvelope<SchemaIrPayload>`. Production code now consumes the Python-compiled
+    /// modelset pushed via `_set_schema_ir_modelset`.
+    fn schema_json_to_schema_ir(
+        table_lower: &str,
+        schema: &serde_json::Value,
+        backend: SqlDialect,
+    ) -> IrEnvelope<SchemaIrPayload> {
+        let mut columns = Vec::new();
+        let mut foreign_keys = Vec::new();
+        let mut checks = Vec::new();
+        let mut indexes: Vec<SchemaIndex> = Vec::new();
+        let mut uniques: Vec<SchemaUnique> = Vec::new();
+        if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
+            for (name, raw_col) in properties {
+                let resolved = resolve_col_schema(schema, raw_col);
+                let col_plan = build_column_plan(table_lower, name, raw_col, schema, backend);
+                let db_type_explicit = raw_col
+                    .get("db_type")
+                    .or_else(|| resolved.get("db_type"))
+                    .and_then(|v| v.as_str());
+                let db_type = db_type_explicit
+                    .map(str::to_string)
+                    .unwrap_or_else(|| canonical_to_db_type_token(col_plan.canonical, sql_dialect_to_lowering(backend)));
+                columns.push(SchemaColumn {
+                    name: name.clone(),
+                    logical_type: property_json_type_and_format(resolved)
+                        .0
+                        .unwrap_or("unknown")
+                        .to_string(),
+                    db_type: Some(db_type),
+                    db_type_explicit: db_type_explicit.map(|_| true),
+                    nullable: col_plan.is_nullable,
+                    primary_key: col_plan.is_primary_key,
+                    autoincrement: col_plan.autoincrement,
+                    unique: col_plan.is_unique,
+                    index: migrate_column_bool(raw_col, resolved, "index").unwrap_or(false),
+                    default: resolved.get("default").cloned(),
+                    format: resolved
+                        .get("format")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                    enum_values: resolved.get("enum").and_then(|v| v.as_array()).cloned(),
+                    enum_type_name: resolved
+                        .get("enum_type_name")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                    postgres_native_enum: false,
+                });
+
+                if migrate_column_bool(raw_col, resolved, "index").unwrap_or(false) {
+                    indexes.push(SchemaIndex {
+                        name: single_index_name(table_lower, name),
+                        columns: vec![name.clone()],
+                        unique: false,
+                    });
+                }
+                if col_plan.is_unique {
+                    uniques.push(SchemaUnique {
+                        name: ddl_single_unique_index_name(table_lower, name),
+                        columns: vec![name.clone()],
+                    });
+                }
+
+                if let Some(fk_info) = migrate_column_object(raw_col, resolved, "foreign_key") {
+                    let to_table = fk_info
+                        .get("to_table")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let on_delete = fk_info
+                        .get("on_delete")
+                        .and_then(|o| o.as_str())
+                        .map(str::to_string);
+                    foreign_keys.push(SchemaForeignKey {
+                        column: name.clone(),
+                        to_table,
+                        to_column: fk_info
+                            .get("to_column")
+                            .and_then(|c| c.as_str())
+                            .unwrap_or("id")
+                            .to_string(),
+                        on_delete,
+                        name: None,
+                    });
+                }
+
+                if migrate_column_bool(raw_col, resolved, "db_check").unwrap_or(false)
+                    && let Some(expression) = migrate_check_expression(name, resolved)
+                {
+                    checks.push(SchemaCheck {
+                        name: db_check_constraint_name(table_lower, name),
+                        expression,
+                    });
+                }
+            }
+        }
+        for group in schema.get("ferro_composite_indexes").and_then(|g| g.as_array()).into_iter().flatten() {
+            let cols: Vec<String> = group.as_array().map(|a| a.iter().filter_map(|c| c.as_str().map(String::from)).collect()).unwrap_or_default();
+            if cols.len() >= 2 {
+                let refs: Vec<&str> = cols.iter().map(String::as_str).collect();
+                indexes.push(SchemaIndex { name: composite_index_name(table_lower, &refs), columns: cols, unique: false });
+            }
+        }
+        for group in schema.get("ferro_composite_uniques").and_then(|g| g.as_array()).into_iter().flatten() {
+            let cols: Vec<String> = group.as_array().map(|a| a.iter().filter_map(|c| c.as_str().map(String::from)).collect()).unwrap_or_default();
+            if cols.len() >= 2 {
+                let refs: Vec<&str> = cols.iter().map(String::as_str).collect();
+                uniques.push(SchemaUnique { name: composite_unique_index_name(table_lower, &refs), columns: cols });
+            }
+        }
+        indexes.sort_by(|a, b| a.name.cmp(&b.name));
+        uniques.sort_by(|a, b| a.name.cmp(&b.name));
+        columns.sort_by(|a, b| a.name.cmp(&b.name));
+
+        IrEnvelope {
+            ir_kind: "schema".to_string(),
+            ir_version: 1,
+            payload: SchemaIrPayload {
+                dialect_agnostic: true,
+                models: vec![SchemaModel {
+                    model_name: table_lower.to_string(),
+                    table_name: table_lower.to_string(),
+                    columns,
+                    foreign_keys,
+                    indexes,
+                    uniques,
+                    checks,
+                }],
+            },
+        }
+    }
 
     const UPDATES: MigrateOptions = MigrateOptions {
         updates: true,
@@ -1294,7 +1351,8 @@ mod tests {
         backend: SqlDialect,
         opts: MigrateOptions,
     ) -> MigrationPlan {
-        let ir = plan_table_migration(table, schema, live, live_indexes, backend, opts)
+        let declared = schema_json_to_schema_ir(table, schema, backend);
+        let ir = plan_table_migration(table, &declared, live, live_indexes, backend, opts)
             .unwrap_or_else(|e| panic!("IR planner failed for '{table}': {e}"));
         let legacy = plan_table_migration_legacy(table, schema, live, live_indexes, backend, opts)
             .unwrap_or_else(|e| panic!("legacy planner failed for '{table}': {e}"));
@@ -1304,7 +1362,7 @@ mod tests {
             assert_eq!(ir.statements, legacy.statements, "statements mismatch on {table:?} ({backend:?})");
             assert_eq!(ir.drop_columns, legacy.drop_columns, "drop_columns mismatch on {table:?} ({backend:?})");
             assert_eq!(ir.warnings, legacy.warnings, "warnings mismatch on {table:?} ({backend:?})");
-            shadow_compare_migration_plan(table, schema, live, live_indexes, backend, opts)
+            shadow_compare_migration_plan(table, &declared, schema, live, live_indexes, backend, opts)
                 .unwrap_or_else(|diff| panic!("shadow compare failed: {diff}"));
             return ir;
         }
@@ -1347,7 +1405,7 @@ mod tests {
             emission.warnings, legacy.warnings,
             "warnings mismatch on {table:?} ({backend:?})"
         );
-        shadow_compare_migration_plan(table, schema, live, live_indexes, backend, opts)
+        shadow_compare_migration_plan(table, &declared, schema, live, live_indexes, backend, opts)
             .unwrap_or_else(|diff| panic!("shadow compare failed: {diff}"));
         ir
     }
@@ -1372,7 +1430,8 @@ mod tests {
         opts: MigrateOptions,
         needle: &str,
     ) {
-        let ir_err = plan_table_migration(table, schema, live, live_indexes, backend, opts)
+        let declared = schema_json_to_schema_ir(table, schema, backend);
+        let ir_err = plan_table_migration(table, &declared, live, live_indexes, backend, opts)
             .expect_err("IR planner should fail");
         let legacy_err = plan_table_migration_legacy(table, schema, live, live_indexes, backend, opts)
             .expect_err("legacy planner should fail");
@@ -1504,8 +1563,9 @@ mod tests {
         }];
 
         for backend in [SqlDialect::Sqlite, SqlDialect::Postgres] {
+            let declared = schema_json_to_schema_ir("doc", &schema, backend);
             let err =
-                plan_table_migration("doc", &schema, &live_cols, &[], backend, UPDATES).unwrap_err();
+                plan_table_migration("doc", &declared, &live_cols, &[], backend, UPDATES).unwrap_err();
             let message = err.to_string();
             assert!(message.contains("doc.created_at"), "{message}");
             assert!(message.contains("Alembic"), "{message}");
@@ -1521,7 +1581,8 @@ mod tests {
             }
         });
         let live_cols = vec![live("name", "varchar")];
-        let err = plan_table_migration("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES)
+        let declared = schema_json_to_schema_ir("doc", &schema, SqlDialect::Sqlite);
+        let err = plan_table_migration("doc", &declared, &live_cols, &[], SqlDialect::Sqlite, UPDATES)
             .unwrap_err();
         assert!(err.to_string().contains("primary key"), "{err}");
     }
@@ -2032,13 +2093,15 @@ mod tests {
                 "id": {"type": "integer", "primary_key": true},
             }
         });
+        let ir = schema_json_to_schema_ir("doc", &schema, SqlDialect::Sqlite);
+        let ir_json = serde_json::to_string(&ir).unwrap();
         let live_json = json!([
             {"name": "id", "declared_type": "integer", "is_primary_key": true, "is_nullable": false},
             {"name": "stale", "declared_type": "varchar"},
         ]);
         let (statements, warnings) = _render_migration_sql_for_test(
             "Doc".to_string(),
-            schema.to_string(),
+            ir_json,
             live_json.to_string(),
             "sqlite".to_string(),
             true,

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -137,7 +137,7 @@ fn schema_json_to_schema_ir(
                     .0
                     .unwrap_or("unknown")
                     .to_string(),
-                db_type,
+                db_type: Some(db_type),
                 db_type_explicit: db_type_explicit.map(|_| true),
                 nullable: col_plan.is_nullable,
                 primary_key: col_plan.is_primary_key,
@@ -224,11 +224,11 @@ fn live_columns_to_schema_ir(
         .map(|col| SchemaColumn {
             name: col.name.clone(),
             logical_type: "unknown".to_string(),
-            db_type: information_schema_to_db_type_token(
+            db_type: Some(information_schema_to_db_type_token(
                 &col.declared_type,
                 col.char_max_len,
                 dialect,
-            ),
+            )),
             db_type_explicit: None,
             nullable: col.is_nullable,
             primary_key: col.is_primary_key,
@@ -728,7 +728,7 @@ fn schema_column_for_drift(
     SchemaColumn {
         name: name.to_string(),
         logical_type: "unknown".to_string(),
-        db_type,
+        db_type: Some(db_type),
         db_type_explicit: None,
         nullable,
         primary_key,

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -16,7 +16,9 @@
 use crate::backend::EngineHandle;
 use ferro_ddl_lowering::{
     CanonicalType, Dialect, apply_canonical_type, canonical_to_db_type_token,
-    db_check_constraint_name, information_schema_to_db_type_token, schema_columns_storage_drift,
+    composite_index_name, composite_unique_index_name, db_check_constraint_name,
+    information_schema_to_db_type_token, schema_columns_storage_drift,
+    single_index_name, single_unique_index_name as ddl_single_unique_index_name,
 };
 use ferro_migrate::{BackendDialect, MigrationOp, emit_sql_with_ir, plan_from_ir};
 use ferro_schema_ir::{
@@ -24,7 +26,8 @@ use ferro_schema_ir::{
     SchemaModel, SchemaUnique,
 };
 use crate::introspect::{
-    LiveColumn, live_table_columns, quote_ident, sqlite_indexes_covering_column,
+    LiveColumn, LiveIndex, live_table_columns, live_table_indexes, quote_ident,
+    sqlite_indexes_covering_column,
 };
 use crate::schema::{
     ColumnPlan, build_column_plan, internal_create_tables,
@@ -120,6 +123,8 @@ fn schema_json_to_schema_ir(
     let mut columns = Vec::new();
     let mut foreign_keys = Vec::new();
     let mut checks = Vec::new();
+    let mut indexes: Vec<SchemaIndex> = Vec::new();
+    let mut uniques: Vec<SchemaUnique> = Vec::new();
     if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
         for (name, raw_col) in properties {
             let resolved = resolve_col_schema(schema, raw_col);
@@ -157,6 +162,20 @@ fn schema_json_to_schema_ir(
                 postgres_native_enum: false,
             });
 
+            if migrate_column_bool(raw_col, resolved, "index").unwrap_or(false) {
+                indexes.push(SchemaIndex {
+                    name: single_index_name(table_lower, name),
+                    columns: vec![name.clone()],
+                    unique: false,
+                });
+            }
+            if col_plan.is_unique {
+                uniques.push(SchemaUnique {
+                    name: ddl_single_unique_index_name(table_lower, name),
+                    columns: vec![name.clone()],
+                });
+            }
+
             if let Some(fk_info) = migrate_column_object(raw_col, resolved, "foreign_key") {
                 let to_table = fk_info
                     .get("to_table")
@@ -190,6 +209,22 @@ fn schema_json_to_schema_ir(
             }
         }
     }
+    for group in schema.get("ferro_composite_indexes").and_then(|g| g.as_array()).into_iter().flatten() {
+        let cols: Vec<String> = group.as_array().map(|a| a.iter().filter_map(|c| c.as_str().map(String::from)).collect()).unwrap_or_default();
+        if cols.len() >= 2 {
+            let refs: Vec<&str> = cols.iter().map(String::as_str).collect();
+            indexes.push(SchemaIndex { name: composite_index_name(table_lower, &refs), columns: cols, unique: false });
+        }
+    }
+    for group in schema.get("ferro_composite_uniques").and_then(|g| g.as_array()).into_iter().flatten() {
+        let cols: Vec<String> = group.as_array().map(|a| a.iter().filter_map(|c| c.as_str().map(String::from)).collect()).unwrap_or_default();
+        if cols.len() >= 2 {
+            let refs: Vec<&str> = cols.iter().map(String::as_str).collect();
+            uniques.push(SchemaUnique { name: composite_unique_index_name(table_lower, &refs), columns: cols });
+        }
+    }
+    indexes.sort_by(|a, b| a.name.cmp(&b.name));
+    uniques.sort_by(|a, b| a.name.cmp(&b.name));
     columns.sort_by(|a, b| a.name.cmp(&b.name));
 
     IrEnvelope {
@@ -202,8 +237,8 @@ fn schema_json_to_schema_ir(
                 table_name: table_lower.to_string(),
                 columns,
                 foreign_keys,
-                indexes: Vec::<SchemaIndex>::new(),
-                uniques: Vec::<SchemaUnique>::new(),
+                indexes,
+                uniques,
                 checks,
             }],
         },
@@ -213,6 +248,7 @@ fn schema_json_to_schema_ir(
 fn live_columns_to_schema_ir(
     table_lower: &str,
     live: &[LiveColumn],
+    live_indexes: &[LiveIndex],
     backend: SqlDialect,
 ) -> IrEnvelope<SchemaIrPayload> {
     let dialect = match backend {
@@ -253,7 +289,9 @@ fn live_columns_to_schema_ir(
                 table_name: table_lower.to_string(),
                 columns,
                 foreign_keys: Vec::<SchemaForeignKey>::new(),
-                indexes: Vec::<SchemaIndex>::new(),
+                indexes: live_indexes.iter().map(|i| SchemaIndex {
+                    name: i.name.clone(), columns: i.columns.clone(), unique: i.unique,
+                }).collect(),
                 uniques: Vec::<SchemaUnique>::new(),
                 checks: Vec::<SchemaCheck>::new(),
             }],
@@ -451,6 +489,7 @@ pub fn plan_table_migration(
     table_lower: &str,
     schema: &serde_json::Value,
     live: &[LiveColumn],
+    live_indexes: &[LiveIndex],
     backend: SqlDialect,
     opts: MigrateOptions,
 ) -> PyResult<MigrationPlan> {
@@ -458,14 +497,14 @@ pub fn plan_table_migration(
         return Ok(MigrationPlan::new());
     }
 
-    let old_ir = live_columns_to_schema_ir(table_lower, live, backend);
+    let old_ir = live_columns_to_schema_ir(table_lower, live, live_indexes, backend);
     let new_ir = schema_json_to_schema_ir(table_lower, schema, backend);
     let mut typed_plan = plan_from_ir(&old_ir, &new_ir, backend_dialect(backend));
 
     if !opts.destructive {
         typed_plan
             .operations
-            .retain(|op| !matches!(op, MigrationOp::DropColumn { .. }));
+            .retain(|op| !matches!(op, MigrationOp::DropColumn { .. } | MigrationOp::DropIndex { .. }));
     }
 
     let mut plan = MigrationPlan::new();
@@ -510,6 +549,7 @@ fn plan_table_migration_legacy(
     table_lower: &str,
     schema: &serde_json::Value,
     live: &[LiveColumn],
+    _live_indexes: &[LiveIndex],
     backend: SqlDialect,
     opts: MigrateOptions,
 ) -> PyResult<MigrationPlan> {
@@ -576,23 +616,59 @@ fn shadow_compare_migration_plan(
     table_lower: &str,
     schema: &serde_json::Value,
     live: &[LiveColumn],
+    live_indexes: &[LiveIndex],
     backend: SqlDialect,
     opts: MigrateOptions,
 ) -> Result<(), String> {
-    let ir = plan_table_migration(table_lower, schema, live, backend, opts)
+    if !opts.updates {
+        return Ok(());
+    }
+    // Build the old and new IRs for the column-domain emission.
+    let old_ir = live_columns_to_schema_ir(table_lower, live, live_indexes, backend);
+    let new_ir = schema_json_to_schema_ir(table_lower, schema, backend);
+
+    let mut typed_plan = plan_from_ir(&old_ir, &new_ir, backend_dialect(backend));
+
+    if !opts.destructive {
+        typed_plan
+            .operations
+            .retain(|op| !matches!(op, MigrationOp::DropColumn { .. } | MigrationOp::DropIndex { .. }));
+    }
+
+    // Separate out DropColumn and standalone index ops; only column-domain ops
+    // are compared to legacy (which never produces standalone index statements).
+    let mut drop_columns: Vec<String> = Vec::new();
+    let mut column_ops: Vec<MigrationOp> = Vec::new();
+    for op in typed_plan.operations {
+        match &op {
+            MigrationOp::DropColumn { column, .. } => drop_columns.push(column.clone()),
+            MigrationOp::AddIndex { .. } | MigrationOp::DropIndex { .. } => {
+                // filtered out — legacy never produces standalone index ops
+            }
+            _ => column_ops.push(op),
+        }
+    }
+
+    let column_plan = ferro_migrate::MigrationPlan {
+        operations: column_ops,
+        warnings: typed_plan.warnings,
+    };
+    let emission = emit_sql_with_ir(&column_plan, &old_ir, &new_ir, backend_dialect(backend))
+        .map_err(|e| e.message)?;
+
+    let legacy = plan_table_migration_legacy(table_lower, schema, live, live_indexes, backend, opts)
         .map_err(|e| e.to_string())?;
-    let legacy = plan_table_migration_legacy(table_lower, schema, live, backend, opts)
-        .map_err(|e| e.to_string())?;
-    if ir.statements == legacy.statements
-        && ir.drop_columns == legacy.drop_columns
-        && ir.warnings == legacy.warnings
+
+    if emission.statements == legacy.statements
+        && drop_columns == legacy.drop_columns
+        && emission.warnings == legacy.warnings
     {
         return Ok(());
     }
     Err(format!(
         "shadow migration-plan mismatch for '{}': ir={} legacy={}",
         table_lower,
-        serde_json::to_string(&ir.statements).unwrap_or_else(|_| "<ir>".to_string()),
+        serde_json::to_string(&emission.statements).unwrap_or_else(|_| "<ir>".to_string()),
         serde_json::to_string(&legacy.statements).unwrap_or_else(|_| "<legacy>".to_string())
     ))
 }
@@ -931,11 +1007,12 @@ pub async fn internal_migrate(engine: Arc<EngineHandle>, opts: MigrateOptions) -
             // Freshly created (or otherwise absent) tables have nothing to diff.
             continue;
         };
+        let live_indexes = live_table_indexes(&engine, &table_lower).await?;
 
-        let mut plan = plan_table_migration(&table_lower, &schema, &live, backend, opts)?;
+        let mut plan = plan_table_migration(&table_lower, &schema, &live, &live_indexes, backend, opts)?;
         if engine.is_shadow_runtime_enabled()
             && let Err(diff) =
-                shadow_compare_migration_plan(&table_lower, &schema, &live, backend, opts)
+                shadow_compare_migration_plan(&table_lower, &schema, &live, &live_indexes, backend, opts)
         {
             crate::log_debug(format!("⚠️ Ferro shadow runtime mismatch: {diff}"));
             if std::env::var("FERRO_SHADOW_RUNTIME_STRICT")
@@ -1030,7 +1107,7 @@ pub fn migrate(
 /// unrecognized, or the diff contains an unsafe change.
 #[pyfunction]
 #[pyo3(name = "_render_migration_sql_for_test")]
-#[pyo3(signature = (name, schema_json, live_columns_json, dialect, updates=true, destructive=false))]
+#[pyo3(signature = (name, schema_json, live_columns_json, dialect, updates=true, destructive=false, live_indexes_json=String::new()))]
 pub fn _render_migration_sql_for_test(
     name: String,
     schema_json: String,
@@ -1038,6 +1115,7 @@ pub fn _render_migration_sql_for_test(
     dialect: String,
     updates: bool,
     destructive: bool,
+    live_indexes_json: String,
 ) -> PyResult<(Vec<String>, Vec<String>)> {
     let backend = match dialect.as_str() {
         "postgres" => SqlDialect::Postgres,
@@ -1055,10 +1133,17 @@ pub fn _render_migration_sql_for_test(
     let live: Vec<LiveColumn> = serde_json::from_str(&live_columns_json).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("Invalid live-columns JSON: {}", e))
     })?;
+    let live_indexes: Vec<LiveIndex> = if live_indexes_json.is_empty() {
+        Vec::new()
+    } else {
+        serde_json::from_str(&live_indexes_json).map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("Invalid live-indexes JSON: {}", e))
+        })?
+    };
 
     let table_lower = name.to_lowercase();
     let opts = MigrateOptions::laddered(updates, destructive);
-    let plan = plan_table_migration(&table_lower, &schema, &live, backend, opts)?;
+    let plan = plan_table_migration(&table_lower, &schema, &live, &live_indexes, backend, opts)?;
 
     let mut statements = plan.statements;
     for col_name in &plan.drop_columns {
@@ -1084,7 +1169,7 @@ fn migration_plan_snapshot(plan: &MigrationPlan) -> serde_json::Value {
 /// Returns JSON with `matches`, `ir`, and `legacy` plan snapshots.
 #[pyfunction]
 #[pyo3(name = "_shadow_compare_migration_plan_for_test")]
-#[pyo3(signature = (name, schema_json, live_columns_json, dialect, updates=true, destructive=false))]
+#[pyo3(signature = (name, schema_json, live_columns_json, dialect, updates=true, destructive=false, live_indexes_json=String::new()))]
 pub fn _shadow_compare_migration_plan_for_test(
     name: String,
     schema_json: String,
@@ -1092,6 +1177,7 @@ pub fn _shadow_compare_migration_plan_for_test(
     dialect: String,
     updates: bool,
     destructive: bool,
+    live_indexes_json: String,
 ) -> PyResult<String> {
     let backend = match dialect.as_str() {
         "postgres" => SqlDialect::Postgres,
@@ -1109,17 +1195,55 @@ pub fn _shadow_compare_migration_plan_for_test(
     let live: Vec<LiveColumn> = serde_json::from_str(&live_columns_json).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("Invalid live-columns JSON: {}", e))
     })?;
+    let live_indexes: Vec<LiveIndex> = if live_indexes_json.is_empty() {
+        Vec::new()
+    } else {
+        serde_json::from_str(&live_indexes_json).map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("Invalid live-indexes JSON: {}", e))
+        })?
+    };
 
     let table_lower = name.to_lowercase();
     let opts = MigrateOptions::laddered(updates, destructive);
-    let ir = plan_table_migration(&table_lower, &schema, &live, backend, opts)?;
-    let legacy = plan_table_migration_legacy(&table_lower, &schema, &live, backend, opts)?;
-    let matches = ir.statements == legacy.statements
-        && ir.drop_columns == legacy.drop_columns
-        && ir.warnings == legacy.warnings;
+
+    // Build column-domain IR plan (filter AddIndex/DropIndex) for parity comparison.
+    let old_ir = live_columns_to_schema_ir(&table_lower, &live, &live_indexes, backend);
+    let new_ir = schema_json_to_schema_ir(&table_lower, &schema, backend);
+    let mut typed_plan = plan_from_ir(&old_ir, &new_ir, backend_dialect(backend));
+    if !opts.destructive {
+        typed_plan
+            .operations
+            .retain(|op| !matches!(op, MigrationOp::DropColumn { .. } | MigrationOp::DropIndex { .. }));
+    }
+    let mut drop_columns: Vec<String> = Vec::new();
+    let mut column_ops: Vec<MigrationOp> = Vec::new();
+    for op in typed_plan.operations {
+        match &op {
+            MigrationOp::DropColumn { column, .. } => drop_columns.push(column.clone()),
+            MigrationOp::AddIndex { .. } | MigrationOp::DropIndex { .. } => {}
+            _ => column_ops.push(op),
+        }
+    }
+    let column_plan = ferro_migrate::MigrationPlan {
+        operations: column_ops,
+        warnings: typed_plan.warnings,
+    };
+    let emission = emit_sql_with_ir(&column_plan, &old_ir, &new_ir, backend_dialect(backend))
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.message))?;
+
+    let legacy = plan_table_migration_legacy(&table_lower, &schema, &live, &live_indexes, backend, opts)?;
+
+    let matches = emission.statements == legacy.statements
+        && drop_columns == legacy.drop_columns
+        && emission.warnings == legacy.warnings;
+    let ir_snapshot = serde_json::json!({
+        "statements": emission.statements,
+        "drop_columns": drop_columns,
+        "warnings": emission.warnings,
+    });
     let payload = serde_json::json!({
         "matches": matches,
-        "ir": migration_plan_snapshot(&ir),
+        "ir": ir_snapshot,
         "legacy": migration_plan_snapshot(&legacy),
     });
     serde_json::to_string(&payload).map_err(|e| {
@@ -1166,26 +1290,64 @@ mod tests {
         table: &str,
         schema: &serde_json::Value,
         live: &[LiveColumn],
+        live_indexes: &[LiveIndex],
         backend: SqlDialect,
         opts: MigrateOptions,
     ) -> MigrationPlan {
-        let ir = plan_table_migration(table, schema, live, backend, opts)
+        let ir = plan_table_migration(table, schema, live, live_indexes, backend, opts)
             .unwrap_or_else(|e| panic!("IR planner failed for '{table}': {e}"));
-        let legacy = plan_table_migration_legacy(table, schema, live, backend, opts)
+        let legacy = plan_table_migration_legacy(table, schema, live, live_indexes, backend, opts)
             .unwrap_or_else(|e| panic!("legacy planner failed for '{table}': {e}"));
+
+        if !opts.updates {
+            // Both planners return empty when updates is off; skip column-domain diffing.
+            assert_eq!(ir.statements, legacy.statements, "statements mismatch on {table:?} ({backend:?})");
+            assert_eq!(ir.drop_columns, legacy.drop_columns, "drop_columns mismatch on {table:?} ({backend:?})");
+            assert_eq!(ir.warnings, legacy.warnings, "warnings mismatch on {table:?} ({backend:?})");
+            shadow_compare_migration_plan(table, schema, live, live_indexes, backend, opts)
+                .unwrap_or_else(|diff| panic!("shadow compare failed: {diff}"));
+            return ir;
+        }
+
+        // Build column-domain IR emission for parity comparison.
+        // AddIndex/DropIndex are filtered out because legacy never produces standalone index ops.
+        let old_ir = live_columns_to_schema_ir(table, live, live_indexes, backend);
+        let new_ir = schema_json_to_schema_ir(table, schema, backend);
+        let mut typed_plan = plan_from_ir(&old_ir, &new_ir, backend_dialect(backend));
+        if !opts.destructive {
+            typed_plan
+                .operations
+                .retain(|op| !matches!(op, MigrationOp::DropColumn { .. } | MigrationOp::DropIndex { .. }));
+        }
+        let mut drop_columns_col: Vec<String> = Vec::new();
+        let mut column_ops: Vec<MigrationOp> = Vec::new();
+        for op in typed_plan.operations {
+            match &op {
+                MigrationOp::DropColumn { column, .. } => drop_columns_col.push(column.clone()),
+                MigrationOp::AddIndex { .. } | MigrationOp::DropIndex { .. } => {}
+                _ => column_ops.push(op),
+            }
+        }
+        let column_plan_ops = ferro_migrate::MigrationPlan {
+            operations: column_ops,
+            warnings: typed_plan.warnings,
+        };
+        let emission = emit_sql_with_ir(&column_plan_ops, &old_ir, &new_ir, backend_dialect(backend))
+            .unwrap_or_else(|e| panic!("IR column-domain emission failed for '{table}': {e:?}"));
+
         assert_eq!(
-            ir.statements, legacy.statements,
+            emission.statements, legacy.statements,
             "statements mismatch on {table:?} ({backend:?})"
         );
         assert_eq!(
-            ir.drop_columns, legacy.drop_columns,
+            drop_columns_col, legacy.drop_columns,
             "drop_columns mismatch on {table:?} ({backend:?})"
         );
         assert_eq!(
-            ir.warnings, legacy.warnings,
+            emission.warnings, legacy.warnings,
             "warnings mismatch on {table:?} ({backend:?})"
         );
-        shadow_compare_migration_plan(table, schema, live, backend, opts)
+        shadow_compare_migration_plan(table, schema, live, live_indexes, backend, opts)
             .unwrap_or_else(|diff| panic!("shadow compare failed: {diff}"));
         ir
     }
@@ -1194,23 +1356,25 @@ mod tests {
         table: &str,
         schema: &serde_json::Value,
         live: &[LiveColumn],
+        live_indexes: &[LiveIndex],
         backend: SqlDialect,
         opts: MigrateOptions,
     ) {
-        plan_with_ir_legacy_parity(table, schema, live, backend, opts);
+        plan_with_ir_legacy_parity(table, schema, live, live_indexes, backend, opts);
     }
 
     fn assert_ir_legacy_parity_err(
         table: &str,
         schema: &serde_json::Value,
         live: &[LiveColumn],
+        live_indexes: &[LiveIndex],
         backend: SqlDialect,
         opts: MigrateOptions,
         needle: &str,
     ) {
-        let ir_err = plan_table_migration(table, schema, live, backend, opts)
+        let ir_err = plan_table_migration(table, schema, live, live_indexes, backend, opts)
             .expect_err("IR planner should fail");
-        let legacy_err = plan_table_migration_legacy(table, schema, live, backend, opts)
+        let legacy_err = plan_table_migration_legacy(table, schema, live, live_indexes, backend, opts)
             .expect_err("legacy planner should fail");
         assert!(
             ir_err.to_string().contains(needle),
@@ -1240,7 +1404,7 @@ mod tests {
                 },
             ];
             let plan =
-                plan_with_ir_legacy_parity("invoice", &schema, &live_cols, backend, UPDATES);
+                plan_with_ir_legacy_parity("invoice", &schema, &live_cols, &[], backend, UPDATES);
             assert_eq!(
                 plan.statements.len(),
                 1,
@@ -1271,7 +1435,7 @@ mod tests {
             live("number", "varchar"),
         ];
         let plan =
-            plan_with_ir_legacy_parity("invoice", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("invoice", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         // db_type "date" renders date_text on SQLite — identical to CREATE TABLE.
         assert!(
             plan.statements[0].contains("date_text"),
@@ -1293,7 +1457,7 @@ mod tests {
             ..live("id", "integer")
         }];
 
-        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         assert_eq!(plan.statements.len(), 2, "{:?}", plan.statements);
         assert!(
             plan.statements[0].contains("NOT NULL"),
@@ -1312,7 +1476,7 @@ mod tests {
         );
 
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert_eq!(
             plan.statements.len(),
             1,
@@ -1341,7 +1505,7 @@ mod tests {
 
         for backend in [SqlDialect::Sqlite, SqlDialect::Postgres] {
             let err =
-                plan_table_migration("doc", &schema, &live_cols, backend, UPDATES).unwrap_err();
+                plan_table_migration("doc", &schema, &live_cols, &[], backend, UPDATES).unwrap_err();
             let message = err.to_string();
             assert!(message.contains("doc.created_at"), "{message}");
             assert!(message.contains("Alembic"), "{message}");
@@ -1357,7 +1521,7 @@ mod tests {
             }
         });
         let live_cols = vec![live("name", "varchar")];
-        let err = plan_table_migration("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES)
+        let err = plan_table_migration("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES)
             .unwrap_err();
         assert!(err.to_string().contains("primary key"), "{err}");
     }
@@ -1376,7 +1540,7 @@ mod tests {
         }];
 
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert!(
             !plan.statements[0].to_uppercase().contains("UNIQUE"),
             "inline UNIQUE must be stripped on SQLite: {}",
@@ -1389,7 +1553,7 @@ mod tests {
         );
         assert_eq!(plan.warnings.len(), 1);
 
-        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         assert!(
             plan.statements[0].to_uppercase().contains("UNIQUE"),
             "Postgres keeps the inline UNIQUE: {}",
@@ -1411,7 +1575,7 @@ mod tests {
             ..live("id", "integer")
         }];
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert_eq!(plan.statements.len(), 2, "{:?}", plan.statements);
         assert!(
             plan.statements[1].contains("\"idx_doc_status\""),
@@ -1440,6 +1604,7 @@ mod tests {
             "invoice",
             &schema,
             &live_cols,
+            &[],
             SqlDialect::Postgres,
             UPDATES,
         );
@@ -1450,7 +1615,7 @@ mod tests {
         );
 
         let plan =
-            plan_with_ir_legacy_parity("invoice", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("invoice", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert_eq!(plan.statements.len(), 1, "{:?}", plan.statements);
         assert_eq!(plan.warnings.len(), 1);
         assert!(
@@ -1482,6 +1647,7 @@ mod tests {
             "invoice",
             &schema,
             &live_cols,
+            &[],
             SqlDialect::Postgres,
             UPDATES,
         );
@@ -1515,7 +1681,7 @@ mod tests {
                 ..live("b", "character varying")
             },
         ];
-        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         assert!(
             plan.statements
                 .contains(&"ALTER TABLE \"doc\" ALTER COLUMN \"a\" SET NOT NULL".to_string()),
@@ -1549,7 +1715,7 @@ mod tests {
                 ..live("status", "USER-DEFINED")
             },
         ];
-        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         assert!(plan.statements.is_empty(), "{:?}", plan.statements);
     }
 
@@ -1569,7 +1735,7 @@ mod tests {
             ..live("id", "integer")
         }];
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         let sql = &plan.statements[0];
         assert!(sql.contains("ADD COLUMN \"motto\""), "{sql}");
         assert!(
@@ -1602,7 +1768,7 @@ mod tests {
                 ..live("meta", "jsonb")
             },
         ];
-        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         assert!(
             !plan
                 .statements
@@ -1630,7 +1796,7 @@ mod tests {
             is_primary_key: true,
             ..live("id", "integer")
         }];
-        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+        let plan = plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         assert!(
             plan.statements.iter().any(|sql| {
                 sql.contains("ADD CONSTRAINT \"ck_doc_status\"")
@@ -1665,7 +1831,7 @@ mod tests {
             ..live("id", "integer")
         }];
         let plan =
-            plan_with_ir_legacy_parity(table, &schema, &live_cols, SqlDialect::Postgres, UPDATES);
+            plan_with_ir_legacy_parity(table, &schema, &live_cols, &[], SqlDialect::Postgres, UPDATES);
         let check_sql = plan
             .statements
             .iter()
@@ -1697,7 +1863,7 @@ mod tests {
             live("count", "varchar"),
         ];
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert!(plan.statements.is_empty(), "{:?}", plan.statements);
         assert_eq!(plan.warnings.len(), 1, "{:?}", plan.warnings);
         assert!(
@@ -1724,7 +1890,7 @@ mod tests {
             live("name", "varchar"),
         ];
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert!(plan.statements.is_empty());
         assert_eq!(plan.warnings.len(), 1);
         assert!(
@@ -1752,12 +1918,12 @@ mod tests {
         ];
 
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, DESTRUCTIVE);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, DESTRUCTIVE);
         assert_eq!(plan.drop_columns, vec!["legacy_notes".to_string()]);
 
         // Without the destructive flag the extra column is untouched.
         let plan =
-            plan_with_ir_legacy_parity("doc", &schema, &live_cols, SqlDialect::Sqlite, UPDATES);
+            plan_with_ir_legacy_parity("doc", &schema, &live_cols, &[], SqlDialect::Sqlite, UPDATES);
         assert!(plan.drop_columns.is_empty());
 
         // A live PK column missing from the model is a hard error.
@@ -1771,6 +1937,7 @@ mod tests {
                 "doc",
                 &schema_without_id,
                 &live_cols,
+                &[],
                 backend,
                 DESTRUCTIVE,
                 "primary key",
@@ -1801,6 +1968,7 @@ mod tests {
             "doc",
             &schema,
             &live_cols,
+            &[],
             SqlDialect::Sqlite,
             UPDATES,
         );
@@ -1820,6 +1988,7 @@ mod tests {
             "invoice",
             &schema,
             &live_cols,
+            &[],
             SqlDialect::Sqlite,
             MigrateOptions::default(),
         );
@@ -1874,6 +2043,7 @@ mod tests {
             "sqlite".to_string(),
             true,
             true,
+            String::new(),
         )
         .unwrap();
         assert_eq!(
@@ -1900,7 +2070,7 @@ mod tests {
                     ..live("number", varchar_spelling)
                 },
             ];
-            assert_ir_legacy_parity("invoice", &invoice, &live_cols, backend, UPDATES);
+            assert_ir_legacy_parity("invoice", &invoice, &live_cols, &[], backend, UPDATES);
         }
 
         let not_null_default = json!({
@@ -1917,6 +2087,7 @@ mod tests {
             "doc",
             &not_null_default,
             &id_only,
+            &[],
             SqlDialect::Postgres,
             UPDATES,
         );
@@ -1924,6 +2095,7 @@ mod tests {
             "doc",
             &not_null_default,
             &id_only,
+            &[],
             SqlDialect::Sqlite,
             UPDATES,
         );
@@ -1939,6 +2111,7 @@ mod tests {
                 "doc",
                 &not_null_no_default,
                 &id_only,
+                &[],
                 backend,
                 UPDATES,
                 "Alembic",
@@ -1955,6 +2128,7 @@ mod tests {
             "doc",
             &pk_guard,
             &[live("name", "varchar")],
+            &[],
             SqlDialect::Sqlite,
             UPDATES,
             "primary key",
@@ -1978,6 +2152,7 @@ mod tests {
                 "doc",
                 &destructive_pk_drop_schema,
                 &destructive_pk_drop_live,
+                &[],
                 backend,
                 DESTRUCTIVE,
                 "primary key",
@@ -2002,6 +2177,7 @@ mod tests {
             "doc",
             &destructive_schema,
             &destructive_live,
+            &[],
             SqlDialect::Sqlite,
             DESTRUCTIVE,
         );
@@ -2009,6 +2185,7 @@ mod tests {
             "doc",
             &destructive_schema,
             &destructive_live,
+            &[],
             SqlDialect::Postgres,
             DESTRUCTIVE,
         );
@@ -2019,6 +2196,7 @@ mod tests {
                 "invoice",
                 &invoice,
                 &no_updates_live,
+                &[],
                 backend,
                 MigrateOptions::default(),
             );
@@ -2039,6 +2217,7 @@ mod tests {
             "doc",
             &multi_col_schema,
             &multi_col_live,
+            &[],
             SqlDialect::Sqlite,
             UPDATES,
         );

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -15,8 +15,8 @@
 
 use crate::backend::EngineHandle;
 use ferro_ddl_lowering::{
-    Dialect, db_check_constraint_name, information_schema_to_db_type_token,
-    schema_columns_storage_drift,
+    CanonicalType, Dialect, apply_canonical_type, canonical_to_db_type_token,
+    db_check_constraint_name, information_schema_to_db_type_token, schema_columns_storage_drift,
 };
 use ferro_migrate::{BackendDialect, MigrationOp, emit_sql_with_ir, plan_from_ir};
 use ferro_schema_ir::{
@@ -27,9 +27,8 @@ use crate::introspect::{
     LiveColumn, live_table_columns, quote_ident, sqlite_indexes_covering_column,
 };
 use crate::schema::{
-    CanonicalType, ColumnPlan, apply_canonical_type, build_column_plan,
-    canonical_to_db_type_token, internal_create_tables,
-    order_schemas_for_creation, property_json_type_and_format,
+    ColumnPlan, build_column_plan, internal_create_tables,
+    order_schemas_for_creation, property_json_type_and_format, sql_dialect_to_lowering,
 };
 use crate::state::{IDENTITY_MAP, MODEL_REGISTRY, SqlDialect, engine_for_connection};
 use pyo3::prelude::*;
@@ -131,7 +130,7 @@ fn schema_json_to_schema_ir(
                 .and_then(|v| v.as_str());
             let db_type = db_type_explicit
                 .map(str::to_string)
-                .unwrap_or_else(|| canonical_to_db_type_token(col_plan.canonical, backend));
+                .unwrap_or_else(|| canonical_to_db_type_token(col_plan.canonical, sql_dialect_to_lowering(backend)));
             columns.push(SchemaColumn {
                 name: name.clone(),
                 logical_type: property_json_type_and_format(resolved)
@@ -772,7 +771,7 @@ fn plan_existing_column(
                 .or_else(|| resolved.get("db_type"))
                 .and_then(|v| v.as_str())
                 .map(str::to_string)
-                .unwrap_or_else(|| canonical_to_db_type_token(col_plan.canonical, backend));
+                .unwrap_or_else(|| canonical_to_db_type_token(col_plan.canonical, sql_dialect_to_lowering(backend)));
             let live_db_type = information_schema_to_db_type_token(
                 &live.declared_type,
                 live.char_max_len,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -5,6 +5,7 @@
 
 use crate::backend::EngineHandle;
 use crate::state::{MODEL_REGISTRY, SqlDialect, engine_for_connection};
+use ferro_ddl_lowering::{CanonicalType, Dialect, apply_canonical_type, canonical_from_parts};
 use pyo3::prelude::*;
 use sea_query::{
     Alias, ColumnDef, ForeignKey, ForeignKeyAction, Index, PostgresQueryBuilder,
@@ -130,134 +131,6 @@ pub(crate) fn order_schemas_for_creation(
     ordered
 }
 
-/// Canonical, backend-resolved column type shared by every Rust DDL path —
-/// CREATE TABLE, ALTER TABLE ADD COLUMN, and schema diffing. The pair
-/// `canonical_column_type` → `apply_canonical_type` is the single source of
-/// truth for "what SQL type does this model field get"; any path that needs a
-/// column type must go through it so emitters cannot drift. See AGENTS.md § I-1.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum CanonicalType {
-    Integer,
-    SmallInt,
-    BigInt,
-    Double,
-    Decimal,
-    Boolean,
-    Json,
-    Text,
-    /// `varchar` with optional length (`.string()` / `.string_len(n)`).
-    Varchar(Option<u32>),
-    Char(u32),
-    Uuid,
-    /// SQLite rendering of the `timestamp`/`timestamptz` tokens (`.date_time()`).
-    DateTime,
-    Timestamp,
-    TimestampTz,
-    Date,
-    Time,
-    Blob,
-}
-
-/// Map a resolved [`CanonicalType`] back to the canonical Ferro `db_type` token
-/// vocabulary used in SchemaIR and cross-emitter parity tests.
-pub(crate) fn canonical_to_db_type_token(canonical: CanonicalType, backend: SqlDialect) -> String {
-    match canonical {
-        CanonicalType::Integer => "int".to_string(),
-        CanonicalType::SmallInt => "smallint".to_string(),
-        CanonicalType::BigInt => "bigint".to_string(),
-        CanonicalType::Double => "double".to_string(),
-        CanonicalType::Decimal => "numeric".to_string(),
-        CanonicalType::Boolean => "boolean".to_string(),
-        CanonicalType::Json => "json".to_string(),
-        CanonicalType::Text => "text".to_string(),
-        CanonicalType::Varchar(None) => "varchar".to_string(),
-        CanonicalType::Varchar(Some(n)) => format!("varchar({n})"),
-        CanonicalType::Char(n) => match (backend, n) {
-            (SqlDialect::Sqlite, 32) => "uuid".to_string(),
-            _ => format!("char({n})"),
-        },
-        CanonicalType::Uuid => "uuid".to_string(),
-        CanonicalType::DateTime | CanonicalType::Timestamp => "timestamp".to_string(),
-        CanonicalType::TimestampTz => "timestamptz".to_string(),
-        CanonicalType::Date => "date".to_string(),
-        CanonicalType::Time => "time".to_string(),
-        CanonicalType::Blob => "bytea".to_string(),
-    }
-}
-
-pub(crate) fn apply_canonical_type(col_def: &mut ColumnDef, canonical: CanonicalType) {
-    match canonical {
-        CanonicalType::Integer => {
-            col_def.integer();
-        }
-        CanonicalType::SmallInt => {
-            col_def.small_integer();
-        }
-        CanonicalType::BigInt => {
-            col_def.big_integer();
-        }
-        CanonicalType::Double => {
-            col_def.double();
-        }
-        CanonicalType::Decimal => {
-            col_def.decimal();
-        }
-        CanonicalType::Boolean => {
-            col_def.boolean();
-        }
-        CanonicalType::Json => {
-            col_def.json();
-        }
-        CanonicalType::Text => {
-            col_def.text();
-        }
-        CanonicalType::Varchar(None) => {
-            col_def.string();
-        }
-        CanonicalType::Varchar(Some(n)) => {
-            col_def.string_len(n);
-        }
-        CanonicalType::Char(n) => {
-            col_def.char_len(n);
-        }
-        CanonicalType::Uuid => {
-            col_def.uuid();
-        }
-        CanonicalType::DateTime => {
-            col_def.date_time();
-        }
-        CanonicalType::Timestamp => {
-            col_def.timestamp();
-        }
-        CanonicalType::TimestampTz => {
-            col_def.timestamp_with_time_zone();
-        }
-        CanonicalType::Date => {
-            col_def.date();
-        }
-        CanonicalType::Time => {
-            col_def.time();
-        }
-        CanonicalType::Blob => {
-            col_def.blob();
-        }
-    }
-}
-
-fn json_type_to_canonical(json_type: &str, backend: SqlDialect) -> CanonicalType {
-    match json_type {
-        "integer" => CanonicalType::Integer,
-        "string" => CanonicalType::Varchar(None),
-        "number" => CanonicalType::Double,
-        "boolean" => match backend {
-            // SQLite stores booleans as integers.
-            SqlDialect::Sqlite => CanonicalType::Integer,
-            SqlDialect::Postgres => CanonicalType::Boolean,
-        },
-        "object" | "array" => CanonicalType::Json,
-        _ => CanonicalType::Varchar(None),
-    }
-}
 
 /// Unique index name for `ferro_composite_uniques`; matches Python Alembic `_build_sa_table`.
 fn composite_unique_index_name(table_lower: &str, col_names: &[&str]) -> String {
@@ -333,78 +206,31 @@ fn db_check_constraint_name(table_lower: &str, col_name: &str) -> String {
     raw
 }
 
-fn parse_varchar_token(token: &str) -> Option<u32> {
-    let body = token.strip_prefix("varchar(")?.strip_suffix(')')?;
-    let n: u32 = body.parse().ok()?;
-    if n == 0 { None } else { Some(n) }
-}
-
-/// Map a canonical `db_type` token to a [`CanonicalType`]. Returns `None` when
-/// the token is unrecognized (the caller falls back to the JSON-type cascade).
-/// Strict per-class-definition validation runs in
-/// `metaclass._validate_db_type_options`.
-///
-/// Duplicated on the Python side in `src/ferro/migrations/alembic.py
-/// ::_db_type_to_sa_type`. Add new tokens to both emitters in the same change
-/// and update the parity test. See AGENTS.md § I-1.
-fn db_type_token_to_canonical(token: &str, backend: SqlDialect) -> Option<CanonicalType> {
-    // Per-dialect resolution is chosen to byte-match SA's compilation in the
-    // Alembic bridge. SQLite emits the typed keyword (BIGINT, SMALLINT,
-    // CHAR(32), DATETIME) and lets SQLite type affinity normalize at
-    // runtime; the parity test (U5) pins both sides token-for-token.
-    match token {
-        "text" => Some(CanonicalType::Text),
-        "smallint" => Some(CanonicalType::SmallInt),
-        "int" => Some(CanonicalType::Integer),
-        "bigint" => Some(CanonicalType::BigInt),
-        "uuid" => Some(match backend {
-            SqlDialect::Sqlite => CanonicalType::Char(32),
-            SqlDialect::Postgres => CanonicalType::Uuid,
-        }),
-        "timestamp" => Some(match backend {
-            SqlDialect::Sqlite => CanonicalType::DateTime,
-            SqlDialect::Postgres => CanonicalType::Timestamp,
-        }),
-        "timestamptz" => Some(match backend {
-            SqlDialect::Sqlite => CanonicalType::DateTime,
-            SqlDialect::Postgres => CanonicalType::TimestampTz,
-        }),
-        "date" => Some(CanonicalType::Date),
-        "time" => Some(CanonicalType::Time),
-        other => parse_varchar_token(other).map(|n| CanonicalType::Varchar(Some(n))),
+/// Translate the runtime backend tag to the lowering crate's dialect at the call seam.
+/// (Unifying these enums is tracked separately as #146 / Phase 8.6.)
+pub(crate) fn sql_dialect_to_lowering(backend: SqlDialect) -> Dialect {
+    match backend {
+        SqlDialect::Sqlite => Dialect::Sqlite,
+        SqlDialect::Postgres => Dialect::Postgres,
     }
 }
 
-/// Resolve a model property to its backend-specific [`CanonicalType`].
-///
-/// `db_type` is the canonical user-facing storage knob: when present and
-/// recognized it overrides every other column-type branch. Otherwise the
-/// Pydantic JSON type/format cascade decides.
+/// Resolve a model property to its backend-specific [`CanonicalType`] via the
+/// shared lowering crate. `db_type` (when set) wins; otherwise the Pydantic
+/// JSON type/format cascade decides; unknown types fall back to `varchar`.
 pub(crate) fn canonical_column_type(
     raw_col_info: &serde_json::Value,
     resolved_col_info: &serde_json::Value,
     backend: SqlDialect,
 ) -> CanonicalType {
-    let db_type_token = raw_col_info
+    let db_type = raw_col_info
         .get("db_type")
         .or_else(|| resolved_col_info.get("db_type"))
-        .and_then(|v| v.as_str());
-    if let Some(token) = db_type_token
-        && let Some(canonical) = db_type_token_to_canonical(token, backend)
-    {
-        return canonical;
-    }
-
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
     let (json_type, format) = property_json_type_and_format(resolved_col_info);
-    match (json_type, format) {
-        (Some("string"), Some("date-time")) => CanonicalType::TimestampTz,
-        (Some("string"), Some("date")) => CanonicalType::Date,
-        (Some("string"), Some("uuid")) => CanonicalType::Uuid,
-        (Some(_), Some("decimal")) => CanonicalType::Decimal,
-        (Some("string"), Some("binary")) => CanonicalType::Blob,
-        (Some(t), _) => json_type_to_canonical(t, backend),
-        (None, _) => CanonicalType::Varchar(None),
-    }
+    canonical_from_parts(json_type.unwrap_or(""), format, db_type, sql_dialect_to_lowering(backend))
+        .unwrap_or(CanonicalType::Varchar(None))
 }
 
 fn render_check_values(col_info: &serde_json::Value) -> Option<String> {
@@ -1128,14 +954,6 @@ mod tests {
     }
 
     #[test]
-    fn test_db_type_unknown_token_maps_to_none() {
-        assert_eq!(
-            db_type_token_to_canonical("banana", SqlDialect::Postgres),
-            None
-        );
-    }
-
-    #[test]
     fn test_unknown_db_type_token_falls_back_to_json_cascade() {
         // An unrecognized token must not change behavior: the JSON-type
         // cascade decides, exactly as before the CanonicalType refactor.
@@ -1147,11 +965,17 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_varchar_token_rejects_zero_and_garbage() {
-        assert_eq!(parse_varchar_token("varchar(0)"), None);
-        assert_eq!(parse_varchar_token("varchar(abc)"), None);
-        assert_eq!(parse_varchar_token("varchar()"), None);
-        assert_eq!(parse_varchar_token("varchar(10)"), Some(10));
+    fn canonical_column_type_unknown_and_missing_type_fall_back_to_varchar() {
+        let unknown = serde_json::json!({ "type": "mystery" });
+        assert_eq!(
+            canonical_column_type(&unknown, &unknown, SqlDialect::Postgres),
+            CanonicalType::Varchar(None)
+        );
+        let no_type = serde_json::json!({});
+        assert_eq!(
+            canonical_column_type(&no_type, &no_type, SqlDialect::Sqlite),
+            CanonicalType::Varchar(None)
+        );
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,6 +5,7 @@
 
 use crate::backend::{BackendKind, EngineConnection, EngineHandle};
 use dashmap::DashMap;
+use ferro_schema_ir::{IrEnvelope, SchemaIrPayload};
 use once_cell::sync::Lazy;
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
@@ -18,6 +19,13 @@ pub type SqlDialect = BackendKind;
 /// Global registry mapping model names to their Pydantic-generated JSON schemas.
 pub static MODEL_REGISTRY: Lazy<RwLock<HashMap<String, serde_json::Value>>> =
     Lazy::new(|| RwLock::new(HashMap::new()));
+
+/// Python-compiled SchemaIR modelset pushed by the `connect`/`migrate` wrappers.
+///
+/// Populated before `internal_migrate` runs so the runtime diff can consume the
+/// canonical Python domain IR instead of re-deriving it on the Rust side.
+pub static SCHEMA_IR_MODELSET: Lazy<RwLock<Option<IrEnvelope<SchemaIrPayload>>>> =
+    Lazy::new(|| RwLock::new(None));
 
 /// The global runtime engine, initialized via `connect()`.
 pub static ENGINE: Lazy<RwLock<Option<Arc<EngineHandle>>>> = Lazy::new(|| RwLock::new(None));

--- a/tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json
+++ b/tests/fixtures/ir_vectors/schema_invoice_baseline_v1.json
@@ -15,7 +15,6 @@
             {
               "name": "id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": false,
               "primary_key": true,
               "autoincrement": true,
@@ -27,7 +26,6 @@
             {
               "name": "number",
               "logical_type": "string",
-              "db_type": "varchar(64)",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -39,7 +37,6 @@
             {
               "name": "customer_id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -51,7 +48,6 @@
             {
               "name": "created_at",
               "logical_type": "datetime",
-              "db_type": "timestamptz",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -73,19 +69,25 @@
           "indexes": [
             {
               "name": "idx_invoice_created_at",
-              "columns": ["created_at"],
+              "columns": [
+                "created_at"
+              ],
               "unique": false
             },
             {
               "name": "idx_invoice_customer_id",
-              "columns": ["customer_id"],
+              "columns": [
+                "customer_id"
+              ],
               "unique": false
             }
           ],
           "uniques": [
             {
               "name": "uq_invoice_number",
-              "columns": ["number"]
+              "columns": [
+                "number"
+              ]
             }
           ],
           "checks": [

--- a/tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json
+++ b/tests/fixtures/ir_vectors/schema_phase1_fixture_models_v1.json
@@ -15,7 +15,6 @@
             {
               "name": "email",
               "logical_type": "string",
-              "db_type": "text",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -27,7 +26,6 @@
             {
               "name": "id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": true,
               "primary_key": true,
               "autoincrement": true,
@@ -39,7 +37,6 @@
             {
               "name": "org_id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -84,7 +81,6 @@
             {
               "name": "id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": true,
               "primary_key": true,
               "autoincrement": true,
@@ -96,7 +92,6 @@
             {
               "name": "name",
               "logical_type": "string",
-              "db_type": "text",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -108,7 +103,6 @@
             {
               "name": "slug",
               "logical_type": "string",
-              "db_type": "text",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -145,7 +139,6 @@
             {
               "name": "id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": true,
               "primary_key": true,
               "autoincrement": true,
@@ -157,7 +150,6 @@
             {
               "name": "name",
               "logical_type": "string",
-              "db_type": "text",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -169,7 +161,6 @@
             {
               "name": "org_id",
               "logical_type": "integer",
-              "db_type": "bigint",
               "nullable": false,
               "primary_key": false,
               "autoincrement": false,
@@ -211,5 +202,5 @@
       ]
     }
   },
-  "fingerprint": "e32e8b0dbb67269dc456904d344dca7cecd506aabe1837a544fc9fba5efc3d3d"
+  "fingerprint": "aafcfe76d373bbce78092eb728456ddc7ff1d6a6f3ac647514e210bc84af143e"
 }

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -340,9 +340,7 @@ async def test_migrate_updates_not_null_without_default_fails_loudly(
 ):
     """A new NOT NULL field with no literal default cannot backfill existing
     rows; connecting must fail with an error naming the field."""
-    import json as _json
-
-    from ferro._core import register_model_schema
+    from datetime import datetime
 
     await ferro.connect(db_url)
     await execute(
@@ -350,22 +348,10 @@ async def test_migrate_updates_not_null_without_default_fails_loudly(
     )
     ferro.reset_engine()
 
-    register_model_schema(
-        "MigStrict",
-        _json.dumps(
-            {
-                "properties": {
-                    "id": {"type": "integer", "primary_key": True},
-                    "name": {"type": "string", "ferro_nullable": False},
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "ferro_nullable": False,
-                    },
-                }
-            }
-        ),
-    )
+    class MigStrict(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+        created_at: datetime
 
     with pytest.raises(ValueError, match=r"migstrict\.created_at"):
         await ferro.connect(db_url, migrate_updates=True)
@@ -383,21 +369,9 @@ async def test_sqlite_type_drift_warns_and_leaves_column_untouched(
     )
     ferro.reset_engine()
 
-    import json as _json
-
-    from ferro._core import register_model_schema
-
-    register_model_schema(
-        "MigDrift",
-        _json.dumps(
-            {
-                "properties": {
-                    "id": {"type": "integer", "primary_key": True},
-                    "count": {"type": "integer", "ferro_nullable": False},
-                }
-            }
-        ),
-    )
+    class MigDrift(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        count: int
 
     with pytest.warns(UserWarning, match=r"migdrift\.count.*Alembic"):
         await ferro.connect(db_url, migrate_updates=True)
@@ -527,10 +501,6 @@ async def test_postgres_type_and_nullability_reconciliation(db_url, clean_regist
     """Postgres gets native ALTER COLUMN: type changes via USING cast (with
     existing data), SET NOT NULL, and no lingering server default after a
     backfilled NOT NULL add."""
-    import json as _json
-
-    from ferro._core import register_model_schema
-
     await ferro.connect(db_url)
     await execute(
         'CREATE TABLE "migpg" ("id" serial PRIMARY KEY, '
@@ -539,27 +509,16 @@ async def test_postgres_type_and_nullability_reconciliation(db_url, clean_regist
     await execute('INSERT INTO "migpg" ("total", "note") VALUES (41, NULL)')
     ferro.reset_engine()
 
-    register_model_schema(
-        "MigPg",
-        _json.dumps(
-            {
-                "properties": {
-                    "id": {"type": "integer", "primary_key": True},
-                    "total": {
-                        "type": "integer",
-                        "db_type": "bigint",
-                        "ferro_nullable": False,
-                    },
-                    "note": {"type": "string", "ferro_nullable": True},
-                    "status": {
-                        "type": "string",
-                        "ferro_nullable": False,
-                        "default": "draft",
-                    },
-                }
-            }
-        ),
-    )
+    # Assignment style (defaults outside Annotated) sidesteps #155: under
+    # Python 3.14 / PEP 649, an assigned field plus an
+    # `Annotated[T, FerroField(default=...)]` sibling (like `status`) makes
+    # deferred-annotation evaluation fail; the metaclass swallows it and drops
+    # ALL annotations, so Pydantic then flags `id` as a non-annotated attribute.
+    class MigPg(Model):
+        id: int | None = ferro.Field(primary_key=True, default=None)
+        total: int = ferro.Field(db_type="bigint")
+        note: str | None = None
+        status: str = ferro.Field(default="draft")
 
     await ferro.connect(db_url, migrate_updates=True)
 
@@ -847,4 +806,132 @@ async def test_index_reconcile_user_index_survives_auto_migrate(
     assert "idx_idxusermodel_m_n" in names_after_destructive
     assert "my_custom_idx" in names_after_destructive, (
         "user index must survive destructive auto-migrate"
+    )
+
+
+# ---------------------------------------------------------------------------
+# IR cutover — Python SchemaIR over FFI (issue #141 Task 4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_uuid_pk_derived_second_pass_is_noop(db_url, db_backend, clean_registry):
+    """End-to-end Example-1 guard (issue #141 Task 4):
+    A model with a derived UUID primary key (default_factory=uuid4) connected via
+    migrate_updates twice must produce no DDL and no warning on the second pass.
+    This exercises the Python→Rust SchemaIR FFI path: the Rust runtime must
+    recognise the table as already up-to-date after the first migrate pass."""
+    import warnings as _warnings
+
+    class UuidPkItem(Model):
+        id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
+        label: str
+
+    # First connect: creates the table (auto_migrate) and runs migrate_updates.
+    await ferro.connect(db_url, migrate_updates=True)
+    ferro.reset_engine()
+
+    # Second connect: same model, same schema — must be a complete no-op.
+    from ferro import clear_registry
+    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+
+    class UuidPkItem(Model):  # noqa: F811 — intentional re-declaration for second connect
+        id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
+        label: str
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        await ferro.connect(db_url, migrate_updates=True)
+
+    ferro_warnings = [
+        w for w in caught if issubclass(w.category, UserWarning)
+        and "ferro auto-migrate" in str(w.message)
+    ]
+    assert ferro_warnings == [], (
+        f"Expected no ferro auto-migrate warnings on second pass; got: "
+        f"{[str(w.message) for w in ferro_warnings]}"
+    )
+
+    # Additionally verify that no DDL ran — the live `id` column must still carry
+    # the UUID storage type from the first pass (not a replacement type).
+    if db_backend == "sqlite":
+        columns = _sqlite_columns(db_url, "uuidpkitem")
+        id_type = columns["id"][2].lower()
+        assert "char" in id_type or "uuid" in id_type, (
+            f"Expected uuid/char storage type for `id` after second pass; got '{id_type}' "
+            "(a different type would mean DDL ran on the second pass)"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_uuid_pk_derived_drift_is_stable(db_url, db_backend, clean_registry):
+    """Drift check: a UUID PK model connected with migrate_updates multiple times
+    must not report any DDL drift. The storage-token comparison must see the
+    uuid_text / uuid declared type as stable after the first connect."""
+    import warnings as _warnings
+
+    class UuidDriftModel(Model):
+        id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
+        name: str
+
+    # Bootstrap: create the table.
+    await ferro.connect(db_url, auto_migrate=True)
+    ferro.reset_engine()
+
+    # First migrate_updates pass — should apply nothing (fresh table).
+    from ferro import clear_registry
+    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+
+    class UuidDriftModel(Model):  # noqa: F811
+        id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
+        name: str
+
+    with _warnings.catch_warnings(record=True) as caught_first:
+        _warnings.simplefilter("always")
+        await ferro.connect(db_url, migrate_updates=True)
+
+    ferro.reset_engine()
+
+    # Second migrate_updates pass — must be identical to the first (idempotent).
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+
+    class UuidDriftModel(Model):  # noqa: F811
+        id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
+        name: str
+
+    with _warnings.catch_warnings(record=True) as caught_second:
+        _warnings.simplefilter("always")
+        await ferro.connect(db_url, migrate_updates=True)
+
+    drift_warnings_first = [
+        w for w in caught_first
+        if issubclass(w.category, UserWarning) and "ferro auto-migrate" in str(w.message)
+    ]
+    drift_warnings_second = [
+        w for w in caught_second
+        if issubclass(w.category, UserWarning) and "ferro auto-migrate" in str(w.message)
+    ]
+
+    assert drift_warnings_first == [], (
+        f"UUID PK must not trigger drift warning on first migrate_updates: "
+        f"{[str(w.message) for w in drift_warnings_first]}"
+    )
+    assert drift_warnings_second == [], (
+        f"UUID PK must not trigger drift warning on second migrate_updates: "
+        f"{[str(w.message) for w in drift_warnings_second]}"
     )

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -580,3 +580,271 @@ async def test_postgres_type_and_nullability_reconciliation(db_url, clean_regist
     assert (
         data[0]["status"] == "draft"
     ), "existing rows backfilled with the literal default"
+
+
+# ---------------------------------------------------------------------------
+# Index reconciliation (issue #144)
+# ---------------------------------------------------------------------------
+
+
+def _live_index_names(db_url: str, db_backend: str, table: str) -> set[str]:
+    """Return the set of index names on *table* in the live DB.
+
+    For SQLite we use PRAGMA index_list (synchronous raw driver).
+    For Postgres we query pg_indexes via the same synchronous psycopg path used
+    elsewhere in this file.  The postgres_base_url / db_schema_name fixtures are
+    not available here so we parse the search_path from db_url directly.
+    """
+    if db_backend == "sqlite":
+        return _sqlite_index_names(db_url, table)
+
+    # Postgres: extract connection params from the async URL.
+    # URL form: postgres://user:pass@host:port/dbname?options=-c search_path=<schema>
+    import re
+    import psycopg
+
+    m = re.search(r"search_path=([^&]+)", db_url)
+    schema = m.group(1) if m else "public"
+    # Build a synchronous libpq-style DSN by replacing the async scheme.
+    sync_url = db_url.replace("postgres://", "postgresql://", 1)
+    # Strip the options query param for psycopg (it handles search_path separately).
+    base_url = sync_url.split("?")[0]
+
+    with psycopg.connect(base_url, options=f"-c search_path={schema}") as conn:
+        rows = conn.execute(
+            "SELECT indexname FROM pg_indexes WHERE schemaname = %s AND tablename = %s",
+            (schema, table),
+        ).fetchall()
+    return {r[0] for r in rows}
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_index_reconcile_adds_composite_index_to_existing_table(
+    db_url, db_backend, clean_registry
+):
+    """migrate_updates adds a composite Ferro-named index to a pre-existing
+    table that was created without it."""
+    from typing import ClassVar
+
+    class IdxCompModel(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        col_a: int
+        col_b: int
+
+    # Create the table without any indexes.
+    await ferro.connect(db_url)
+    if db_backend == "sqlite":
+        await execute(
+            'CREATE TABLE "idxcompmodel" '
+            '("id" integer PRIMARY KEY AUTOINCREMENT, '
+            '"col_a" integer NOT NULL, "col_b" integer NOT NULL)'
+        )
+    else:
+        await execute(
+            'CREATE TABLE "idxcompmodel" '
+            '("id" serial PRIMARY KEY, '
+            '"col_a" integer NOT NULL, "col_b" integer NOT NULL)'
+        )
+    ferro.reset_engine()
+
+    # Re-register a NEW model class with the composite index annotation.
+    from ferro import clear_registry
+    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+
+    class IdxCompModel(Model):  # noqa: F811 — intentional redefinition
+        __ferro_composite_indexes__: ClassVar[tuple[tuple[str, ...], ...]] = (
+            ("col_a", "col_b"),
+        )
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        col_a: int
+        col_b: int
+
+    await ferro.connect(db_url, migrate_updates=True)
+
+    names = _live_index_names(db_url, db_backend, "idxcompmodel")
+    assert "idx_idxcompmodel_col_a_col_b" in names, (
+        f"expected composite index idx_idxcompmodel_col_a_col_b, got: {names}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_index_reconcile_adds_single_column_index_to_existing_column(
+    db_url, db_backend, clean_registry
+):
+    """migrate_updates creates idx_<table>_<col> when index=True is added to an
+    existing column that was originally created without an index."""
+
+    class IdxSingleModel(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        status: str
+
+    # Create table with 'status' but no index on it.
+    await ferro.connect(db_url)
+    if db_backend == "sqlite":
+        await execute(
+            'CREATE TABLE "idxsinglemodel" '
+            '("id" integer PRIMARY KEY AUTOINCREMENT, "status" varchar NOT NULL)'
+        )
+    else:
+        await execute(
+            'CREATE TABLE "idxsinglemodel" '
+            '("id" serial PRIMARY KEY, "status" varchar NOT NULL)'
+        )
+    ferro.reset_engine()
+
+    # Re-register with index=True on the existing column.
+    from ferro import clear_registry
+    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+
+    class IdxSingleModel(Model):  # noqa: F811
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        status: Annotated[str, FerroField(index=True)]
+
+    await ferro.connect(db_url, migrate_updates=True)
+
+    names = _live_index_names(db_url, db_backend, "idxsinglemodel")
+    assert "idx_idxsinglemodel_status" in names, (
+        f"expected idx_idxsinglemodel_status, got: {names}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_index_reconcile_noop_when_index_already_present(
+    db_url, db_backend, clean_registry
+):
+    """Running migrate_updates a second time when the index already exists must
+    be a no-op: the index remains and auto-migrate does not fail (false-alarm guard)."""
+    from typing import ClassVar
+
+    class IdxNoopModel(Model):
+        __ferro_composite_indexes__: ClassVar[tuple[tuple[str, ...], ...]] = (
+            ("x", "y"),
+        )
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        x: int
+        y: int
+
+    # First connect creates the table + index.
+    await ferro.connect(db_url, auto_migrate=True)
+    names_after_first = _live_index_names(db_url, db_backend, "idxnoopmodel")
+    assert "idx_idxnoopmodel_x_y" in names_after_first
+    ferro.reset_engine()
+
+    # Second connect — same model, same index already present.
+    await ferro.connect(db_url, migrate_updates=True)
+
+    names_after_second = _live_index_names(db_url, db_backend, "idxnoopmodel")
+    assert "idx_idxnoopmodel_x_y" in names_after_second, (
+        "index must survive second migrate_updates pass (no-op guard)"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_index_reconcile_destructive_drops_removed_composite_index(
+    db_url, db_backend, clean_registry
+):
+    """When a composite index is removed from the model:
+    - migrate_destructive=True drops it.
+    - migrate_updates=True (non-destructive) leaves it intact."""
+    from typing import ClassVar
+
+    class IdxDropModel(Model):
+        __ferro_composite_indexes__: ClassVar[tuple[tuple[str, ...], ...]] = (
+            ("p", "q"),
+        )
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        p: int
+        q: int
+
+    # Bootstrap with the index present.
+    await ferro.connect(db_url, auto_migrate=True)
+    names = _live_index_names(db_url, db_backend, "idxdropmodel")
+    assert "idx_idxdropmodel_p_q" in names
+    ferro.reset_engine()
+
+    # Re-register model WITHOUT the composite index.
+    from ferro import clear_registry
+    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+    _PENDING_RELATIONS.clear()
+    _JOIN_TABLE_REGISTRY.clear()
+
+    class IdxDropModel(Model):  # noqa: F811
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        p: int
+        q: int
+
+    # Non-destructive: index must remain.
+    await ferro.connect(db_url, migrate_updates=True)
+    names_after_updates = _live_index_names(db_url, db_backend, "idxdropmodel")
+    assert "idx_idxdropmodel_p_q" in names_after_updates, (
+        "non-destructive pass must leave orphaned ferro index intact"
+    )
+    ferro.reset_engine()
+
+    # Destructive: index must be dropped.
+    await ferro.connect(db_url, migrate_destructive=True)
+    names_after_destructive = _live_index_names(db_url, db_backend, "idxdropmodel")
+    assert "idx_idxdropmodel_p_q" not in names_after_destructive, (
+        "migrate_destructive must drop the orphaned ferro index"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_index_reconcile_user_index_survives_auto_migrate(
+    db_url, db_backend, clean_registry
+):
+    """A hand-created user index (name does NOT start with idx_/uq_) must
+    survive both non-destructive and destructive auto-migrate passes unchanged."""
+    from typing import ClassVar
+
+    class IdxUserModel(Model):
+        __ferro_composite_indexes__: ClassVar[tuple[tuple[str, ...], ...]] = (
+            ("m", "n"),
+        )
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        m: int
+        n: int
+
+    # Create table with a Ferro composite index AND a custom user index.
+    await ferro.connect(db_url, auto_migrate=True)
+    await execute('CREATE INDEX "my_custom_idx" ON "idxusermodel" ("m")')
+
+    names_initial = _live_index_names(db_url, db_backend, "idxusermodel")
+    assert "idx_idxusermodel_m_n" in names_initial
+    assert "my_custom_idx" in names_initial
+    ferro.reset_engine()
+
+    # Non-destructive pass: both indexes must survive.
+    await ferro.connect(db_url, migrate_updates=True)
+    names_after_updates = _live_index_names(db_url, db_backend, "idxusermodel")
+    assert "idx_idxusermodel_m_n" in names_after_updates
+    assert "my_custom_idx" in names_after_updates, (
+        "user index must survive non-destructive auto-migrate"
+    )
+    ferro.reset_engine()
+
+    # Destructive pass: Ferro index still present (model still has it), user index still present.
+    await ferro.connect(db_url, migrate_destructive=True)
+    names_after_destructive = _live_index_names(db_url, db_backend, "idxusermodel")
+    assert "idx_idxusermodel_m_n" in names_after_destructive
+    assert "my_custom_idx" in names_after_destructive, (
+        "user index must survive destructive auto-migrate"
+    )

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -314,6 +314,24 @@ def test_schema_ir_compiler_emits_db_check_expression_for_closed_domain(
     ]
 
 
+def test_compiler_omits_db_type_for_non_explicit_columns(clean_model_registry: None) -> None:
+    from ferro import Model, Field, clear_registry
+    from ferro.schema_metadata import build_model_schema
+    from ferro.ir.compiler import compile_schema_ir_payload
+
+    clear_registry()
+    M = type("Acct", (Model,), {
+        "__annotations__": {"id": int | None, "balance": int, "code": str},
+        "id": Field(default=None, primary_key=True),
+        "code": Field(db_type="varchar(32)"),
+    })
+    cols = {c["name"]: c for c in compile_schema_ir_payload("Acct", build_model_schema(M))["models"][0]["columns"]}
+    assert "db_type" not in cols["balance"], cols["balance"]   # non-explicit -> omitted
+    assert "db_type" not in cols["id"], cols["id"]             # non-explicit -> omitted
+    assert cols["code"]["db_type"] == "varchar(32)"            # explicit -> kept
+    assert cols["code"]["db_type_explicit"] is True
+
+
 def test_schema_ir_compiler_includes_join_table_models(clean_model_registry: None) -> None:
     from ferro.ir import compile_registry_schema_ir
     from ferro.relations import resolve_relationships

--- a/tests/test_migrate_plan.py
+++ b/tests/test_migrate_plan.py
@@ -223,3 +223,57 @@ def test_updates_false_produces_no_plan():
 def test_unknown_dialect_is_rejected():
     with pytest.raises(ValueError, match="Unknown dialect"):
         render(schema_with({}), PK_ONLY_LIVE, "mysql")
+
+
+# ---------------------------------------------------------------------------
+# Index no-op guard (issue #144) — unit-level assertion
+# ---------------------------------------------------------------------------
+
+# Live-column list for IdxNoopModel: id (PK) + x + y
+_NOOP_LIVE_COLUMNS = [
+    {
+        "name": "id",
+        "declared_type": "integer",
+        "is_primary_key": True,
+        "is_nullable": False,
+    },
+    {"name": "x", "declared_type": "integer", "is_nullable": False},
+    {"name": "y", "declared_type": "integer", "is_nullable": False},
+]
+
+# Schema with a composite index over (x, y).
+_NOOP_SCHEMA = {
+    "properties": {
+        "id": {"type": "integer", "primary_key": True},
+        "x": {"type": "integer", "ferro_nullable": False},
+        "y": {"type": "integer", "ferro_nullable": False},
+    },
+    "ferro_composite_indexes": [["x", "y"]],
+}
+
+# Canonical index name the planner would have created.
+_NOOP_LIVE_INDEXES = [
+    {"name": "idx_idxnoopmodel_x_y", "columns": ["x", "y"], "unique": False}
+]
+
+
+@pytest.mark.parametrize("dialect", ["sqlite", "postgres"])
+def test_index_noop_emits_zero_ddl_when_index_already_present(dialect):
+    """Planner must produce an empty statement list when the composite index
+    already exists in the live schema — no DROP INDEX + CREATE INDEX churn
+    (false-alarm class of bug, issue #144)."""
+    stmts, warns = _render_migration_sql_for_test(
+        "idxnoopmodel",
+        json.dumps(_NOOP_SCHEMA),
+        json.dumps(_NOOP_LIVE_COLUMNS),
+        dialect,
+        True,   # updates
+        False,  # destructive
+        json.dumps(_NOOP_LIVE_INDEXES),
+    )
+    assert stmts == [], (
+        f"[{dialect}] expected no DDL when index already present, got: {stmts}"
+    )
+    assert warns == [], (
+        f"[{dialect}] expected no warnings when index already present, got: {warns}"
+    )

--- a/tests/test_migrate_plan.py
+++ b/tests/test_migrate_plan.py
@@ -10,11 +10,18 @@ import json
 import pytest
 
 from ferro._core import _render_migration_sql_for_test
+from ferro.ir.compiler import compile_schema_ir_payload, wrap_schema_ir
+
+
+def _compile_schema_ir_json(schema: dict, name: str) -> str:
+    """Compile an ad-hoc schema dict into a SchemaIR envelope JSON string."""
+    payload = compile_schema_ir_payload(name, schema)
+    return json.dumps(wrap_schema_ir(payload))
 
 
 def render(schema, live, dialect, *, updates=True, destructive=False, name="Invoice"):
     return _render_migration_sql_for_test(
-        name, json.dumps(schema), json.dumps(live), dialect, updates, destructive
+        name, _compile_schema_ir_json(schema, name.lower()), json.dumps(live), dialect, updates, destructive
     )
 
 
@@ -264,7 +271,7 @@ def test_index_noop_emits_zero_ddl_when_index_already_present(dialect):
     (false-alarm class of bug, issue #144)."""
     stmts, warns = _render_migration_sql_for_test(
         "idxnoopmodel",
-        json.dumps(_NOOP_SCHEMA),
+        _compile_schema_ir_json(_NOOP_SCHEMA, "idxnoopmodel"),
         json.dumps(_NOOP_LIVE_COLUMNS),
         dialect,
         True,   # updates
@@ -277,3 +284,27 @@ def test_index_noop_emits_zero_ddl_when_index_already_present(dialect):
     assert warns == [], (
         f"[{dialect}] expected no warnings when index already present, got: {warns}"
     )
+
+
+@pytest.mark.parametrize("dialect", ["sqlite"])
+def test_derived_uuid_column_does_not_drift_when_consuming_python_ir(dialect):
+    """A derived uuid column (no explicit db_type) must produce no DDL and no warning
+    when the live column has type 'uuid_text' — the storage-token comparison path
+    (Task 1 fix) must handle the None db_type case correctly."""
+    schema_ir = json.dumps({
+        "ir_kind": "schema", "ir_version": 1,
+        "payload": {"dialect_agnostic": True, "models": [{
+            "model_name": "acct",
+            "table_name": "acct",
+            "columns": [{"name": "id", "logical_type": "uuid", "format": "uuid",
+                         "nullable": False, "primary_key": True,
+                         "autoincrement": False, "unique": False, "index": False,
+                         "default": None}],
+            "indexes": [], "uniques": [], "foreign_keys": [], "checks": [],
+        }]},
+    })
+    live = json.dumps([{"name": "id", "declared_type": "uuid_text",
+                        "is_nullable": False, "is_primary_key": True}])
+    stmts, warns = _render_migration_sql_for_test("acct", schema_ir, live, dialect)
+    assert stmts == [], f"unexpected DDL: {stmts}"
+    assert warns == [], f"unexpected drift warning: {warns}"

--- a/tests/test_shadow_reports.py
+++ b/tests/test_shadow_reports.py
@@ -11,7 +11,14 @@ from ferro._core import (
     _shadow_compare_migration_plan_for_test,
     _shadow_compare_query_plan_for_test,
 )
+from ferro.ir.compiler import compile_schema_ir_payload, wrap_schema_ir
 from ferro.query.builder import _query_ir_payload_to_json
+
+
+def _compile_schema_ir_json(schema: dict, name: str) -> str:
+    """Compile an ad-hoc schema dict into a SchemaIR envelope JSON string."""
+    payload = compile_schema_ir_payload(name, schema)
+    return json.dumps(wrap_schema_ir(payload))
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -55,19 +62,21 @@ def _report_for_backend(dialect: str) -> dict:
     create_table_sql, create_table_extras = _render_create_table_sql_for_test(
         "ShadowUser", json.dumps(schema), dialect
     )
+    _schema_ir_json = _compile_schema_ir_json(schema, "shadowuser")
+    _live_json = json.dumps(
+        [
+            {
+                "name": "id",
+                "declared_type": "integer",
+                "is_primary_key": True,
+                "is_nullable": False,
+            }
+        ]
+    )
     migration_stmts, migration_warns = _render_migration_sql_for_test(
         "ShadowUser",
-        json.dumps(schema),
-        json.dumps(
-            [
-                {
-                    "name": "id",
-                    "declared_type": "integer",
-                    "is_primary_key": True,
-                    "is_nullable": False,
-                }
-            ]
-        ),
+        _schema_ir_json,
+        _live_json,
         dialect,
         True,
         False,
@@ -75,17 +84,9 @@ def _report_for_backend(dialect: str) -> dict:
     migration_compare = json.loads(
         _shadow_compare_migration_plan_for_test(
             "ShadowUser",
+            _schema_ir_json,
             json.dumps(schema),
-            json.dumps(
-                [
-                    {
-                        "name": "id",
-                        "declared_type": "integer",
-                        "is_primary_key": True,
-                        "is_nullable": False,
-                    }
-                ]
-            ),
+            _live_json,
             dialect,
             True,
             False,


### PR DESCRIPTION
Promotes the **Phase 8.5** integration branch to `main`, completing the IR-first single-source-of-truth phase for the migration path: one canonical type-lowering library, an honest wire IR, and a single (Python) producer of the declared SchemaIR that the runtime consumes over FFI.

## Closes
- Closes #139 — [Epic] IR-P8.5 Lowering consolidation & single-source-of-truth closeout
- Closes #140 — Runtime CREATE consumes ferro-ddl-lowering (single lowering library)
- Closes #143 — `db_type` carried only when explicit (honest wire IR)
- Closes #144 — Reconcile indexes & uniques in auto-migrate
- Closes #141 — Single SchemaIR producer: Rust consumes the Python-compiled SchemaIR over FFI

## What landed (4 sub-issue PRs, each reviewed + merged into this branch)
- **#140** — the CREATE path routes through `ferro-ddl-lowering`; deleted the parallel `CanonicalType`/mappers in `src/schema.rs`.
- **#143** — `SchemaColumn.db_type` is `Option`, present only for explicitly-typed columns; non-explicit columns derive from `logical_type`/`format`. Zero DDL change.
- **#144** — auto-migrate reconciles standalone Ferro-named indexes/uniques (ADD always; DROP under `migrate_destructive`), byte-identical to the create path.
- **#141** — runtime auto-migrate consumes the Python-compiled SchemaIR over FFI; the Rust producer is removed from production. Fixed the uuid + `time` storage-token drift false alarms at the diff boundary.

## Deferred to Phase 9 (not in this PR)
- **#142** (remove duplicated lowering helpers from `src/migrate.rs`) — its own scope ties it to the legacy-planner removal; moved to milestone IR-P9.

## Validation
Each sub-issue PR landed green (cross-emitter + IR contract + Alembic + auto-migrate matrix on SQLite; Postgres via CI). This PR re-runs the full suite against `main` — **the Postgres backend matrix must be green before merge.**

## Next (Epic 8.6, #145)
Create-path unification (#153), datetime→timestamptz coarseness (#154), the Py3.14 deferred-annotation metaclass bug (#155), dialect-enum unification (#146).