### PR TITLE
feat(ir-p8.6): route save/update/bulk value bind through the typed codec path (#162)

### DIFF
--- a/docs/brainstorms/2026-07-01-ir-p8.6-162-typed-save-bind-requirements.md
+++ b/docs/brainstorms/2026-07-01-ir-p8.6-162-typed-save-bind-requirements.md
@@ -1,0 +1,307 @@
+---
+title: "IR-P8.6 #162 — Route Model.save()/update value marshaling through the typed codec bind path (drop model_dump_json envelope)"
+type: requirements
+status: draft
+date: 2026-07-01
+issue: https://github.com/syn54x/ferro-orm/issues/162
+closes: https://github.com/syn54x/ferro-orm/issues/160
+epic: https://github.com/syn54x/ferro-orm/issues/145
+roadmap: docs/plans/2026-06-19-001-ir-first-roadmap.md (Phase 8.6)
+---
+
+# #162 — Typed save/update value bind
+
+## Goal
+
+Make `Model.save()` / `Model.create()` / `Query.update()` / `bulk_create()` marshal
+row values through the **same typed codec bind path** as the rest of the write path,
+instead of pre-serializing the whole instance to a JSON string. Today `save()`
+serializes with `self.model_dump_json()` (`src/ferro/models.py:239`) and hands the
+JSON **string** to `save_record(data: String)` (`src/operations.rs:1222`), which
+`serde_json::from_str`s it back and binds from the parsed `Value`. `Query.update`
+(`to_json(fields)` → `update_filtered`, `src/ferro/query/builder.py:322`) and
+`bulk_create` (`json.dumps([model_dump(mode="json")])` → `save_bulk_records`,
+`src/ferro/models.py:556`) have the identical JSON-string seam. Every value funnels
+through JSON first.
+
+This is the same "marshal the same data two ways" anti-pattern Phase 8.5/8.6 has been
+eliminating, one layer down in the **write/value** path rather than the DDL path — and
+it is the **last stringly-typed mutation channel**.
+
+After this lands, the four write channels pass a **per-column typed value map** (a
+native Python dict, bytes preserved) across the FFI. In Rust, `bytes` bind directly to
+`SeaValue::Bytes`; every other value flows through the **unchanged**
+`codec::schema_bind_expr` (`src/codec.rs:229`). Binary payloads persist and round-trip
+**byte-for-byte** (SQLite `BLOB`, Postgres `bytea`). This closes a whole class of
+"value whose JSON form is lossy/invalid" bugs by construction, of which non-UTF-8
+`bytes` (#160) is the first concrete instance.
+
+This is sub-issue #162 of Epic #145 (Phase 8.6), the high-value capstone of the phase,
+and it **closes the user-facing bug #160**.
+
+## Reproduced evidence (Python 3.14.5, SQLite, `feat/ir-p8.6-cleanups`)
+
+The bug is real on **every** JSON-enveloped write channel, and the typed reference
+path already works:
+
+| Channel | Python seam | FFI fn | non-UTF-8 `bytes` |
+|---|---|---|---|
+| `Model.save()` | `self.model_dump_json()` (`models.py:239`) | `save_record(data: String)` | ❌ `PydanticSerializationError` |
+| `Model.create()` | → calls `save()` (`models.py:528`) | (same) | ❌ same |
+| `Query.update(**f)` | `to_json(fields)` (`builder.py:322`) | `update_filtered(update_json: String)` | ❌ `PydanticSerializationError` |
+| `bulk_create()` | `json.dumps([model_dump(mode="json")])` (`models.py:556`) | `save_bulk_records(...)` | ❌ same shape |
+| **`raw.execute(...)`** | `_marshal` (`raw.py:47`) — bytes pass through | `raw_execute(args: Vec<Bound<PyAny>>)` | ✅ **byte-identical** |
+
+UTF-8 `bytes` "round-trips" only because it is silently coerced to text
+(`codec.rs:312` builds `SeaValue::Bytes` from a JSON `Value::String` via
+`s.as_bytes()`) — the exact tell #160 calls out. The **raw** path
+(`python_to_engine_bind_value`, `operations.rs:2409`, bytes at `:2429` →
+`EngineBindValue::Bytes`, `backend.rs:168`) persists the same
+`b"\x89PNG\r\n\x1a\n\xff\xd8"` byte-for-byte, proving the back half of the pipe
+(`SeaValue::Bytes` → sqlx bind, `operations.rs:259` / `backend.rs:706`) already
+works. And the `CREATE` path already emits the right column
+(`"data" blob NOT NULL`, wired by #153) — so storage, bind, and fetch all support
+bytes; only the four JSON-enveloped write seams do not.
+
+## The central design question (resolved: typed dict transport + `BindInput` wrapper)
+
+The issue's sizing question: does the downstream bind already reach `SeaValue::Bytes`
+once it has a typed value (small — "stop `model_dump_json`-ing, pass typed values"), or
+does it need a new typed save payload across the FFI (larger)?
+
+**Answer from the evidence: neither existing path is a drop-in, so it is the
+"new typed payload" branch — but a *bounded* one that reuses both existing halves.**
+
+- The **raw** path carries real bytes (`EngineBindValue::Bytes`) but has **no
+  schema-guided casting** (no Postgres UUID/enum/temporal/decimal casts the ORM needs).
+- The **save/insert** path has the schema-guided casting (`schema_bind_expr`) but its
+  input is a `serde_json::Value`, which has **no byte type** — and the bytes never even
+  reach Rust because `model_dump_json()` raises first.
+
+**Decision:** replace the JSON *string* payload with a native per-column typed dict;
+in Rust introduce a minimal wrapper
+
+```rust
+enum BindInput { Json(serde_json::Value), Bytes(Vec<u8>) }
+```
+
+The `Bytes` arm binds `SeaValue::Bytes` directly; the `Json` arm delegates to
+`schema_bind_expr` **completely unchanged**. This keeps the parity-critical casting
+matrix byte-for-byte identical (UUID/datetime/Decimal/enum/JSON) — parity holds *by
+construction* — while isolating the single new behavior (real bytes) to one arm.
+
+### Reframe: this is *not* a JSON string envelope
+
+`model_dump(mode="json")` returns a **native Python dict** of JSON-compatible objects,
+not a JSON string. That dict is handed to `save_record` over PyO3's native object
+marshaling — the raw path already crosses the FFI this way as
+`Vec<Bound<PyAny>>` (`operations.rs:2476`). So the `model_dump_json` string *envelope*
+— the thing the issue removes — is gone: there is **no `serde_json::from_str` of the
+record** anymore. JSON survives only as the **canonicalization rule for individual
+rich-scalar values** (UUID→`"…"`, `Decimal`→`"1.50"`, datetime→ISO), which must live in
+Python regardless of transport because **pydantic is the single source of truth for a
+field's wire value** (it knows field serializers, aliases, custom types — Rust cannot
+re-derive them).
+
+### Why not a bytes-native value model (deferred to #164)
+
+Swapping `serde_json::Value` for a value type that *natively* carries bytes
+(a hand-rolled enum, or `ciborium`/`rmpv`) was considered and **deferred**: any such
+type forces a rewrite of `schema_bind_expr`'s ~130-line matcher (the parity-critical
+code) against a new variant set, and JSON columns would still need re-serialization to
+JSON text for the Postgres `…).cast_as("json")` bind (`codec.rs:288-296`). The
+`serde_json::Value` "gap" is used here as the clean seam between "unchanged casting
+authority" and "the one new arm." The larger unification is filed as **#164** (pure
+internal refactor, no user-facing change).
+
+## Non-goals (explicitly out of scope — AGENTS.md I-6, scoped-down not hollowed-out)
+
+- **Base64-encoding bytes inside `model_dump_json()`.** Entrenches the JSON envelope
+  this removes and adds silent encoding overhead. Rejected (stated in the issue).
+- **"Fail fast as unsupported" for bytes.** `bytes` is supportable (DDL + codec + fetch
+  already support it); failing at model-definition time hollows out a real capability.
+  A clear Ferro-level error for *genuinely* unbindable values is the **floor**, not the
+  fix (see §Error handling).
+- **A `blob`/`binary` token in `CANONICAL_DB_TYPES`.** Declaring `data: bytes` already
+  yields a `BLOB`/`bytea` column (#153); an explicit token only matters to force blob
+  storage on a *non-bytes* Python type — a separable nicety, YAGNI here.
+- **The #164 value-model unification** (bytes-native input to `schema_bind_expr`).
+  Filed as a follow-up; this issue takes the minimal `BindInput` wrapper.
+- **The auto-migrate `BLOB`-read-as-`text` false-positive diff** (discovered during
+  triage — a fresh `bytes` column warns "declared text but model expects blob" even
+  though `CREATE` emitted `blob`). A separate DDL/introspection bug; not touched here.
+- **`raw.execute` / `_marshal`.** Already typed and correct — it is the reference, not
+  a target.
+
+## Current state (confirmed on `feat/ir-p8.6-cleanups`)
+
+All four channels converge on `serde_json::from_str` → `schema_value_expr`
+(`operations.rs:639`, a thin wrapper over `codec::schema_bind_expr`):
+
+| Channel | JSON build | FFI fn / signature | `from_str` | bind loop |
+|---|---|---|---|---|
+| `save` / `create` | `model_dump_json()` (`models.py:239`) | `save_record(data: String)` (`operations.rs:1222`) | `:1239` | `:1291` |
+| `update` | `to_json(fields)` (`builder.py:322`) | `update_filtered(update_json: String)` (`:2066`) | `:2073` | `:2106` |
+| `bulk_create` | `json.dumps([...])` (`models.py:556`) | `save_bulk_records(...json...)` | `:1433` | `:1498` |
+
+`schema_bind_expr` (`codec.rs:229`) already handles the binary arm
+(`Value::String(s) if col_format == Some("binary")` → `SeaValue::Bytes(s.as_bytes())`,
+`:312`) and the typed-null binary arm (`:342`) — but only from a UTF-8 `Value::String`.
+`raw.py::_marshal` (`:39`) is the genuinely-typed reference (bytes pass through at
+`:47`, raising a plain `TypeError` for unsupported types at `:59`).
+
+## The change
+
+### 4.1 Python — one shared payload helper, four call sites
+
+A single marshaling authority produces the per-column typed map (the
+**category-preserving** rule: `bytes` → real bytes; JSON structures → kept native;
+rich scalars → canonical strings exactly as `mode="json"` produces them).
+
+- **`save()`** (`models.py:237-243`): compute `bytes_fields` **value-driven** —
+  `{ n for n in self.__class__.model_fields if isinstance(getattr(self, n, None),
+  (bytes, bytearray)) }` (catches `bytes`, `bytes | None`, and `Any`-typed bytes).
+  `payload = self.model_dump(mode="json", exclude=bytes_fields)`; overlay
+  `payload[n] = bytes(getattr(self, n))` for each bytes column. Pass the **dict** to
+  `save_record`. (`create()` is unchanged — it calls `save()`.)
+- **`Query.update(**fields)`** (`builder.py:293-326`): split bytes keys out;
+  canonicalize the rest exactly as `to_json` does today (so UUID/datetime/Decimal in
+  kwargs stay byte-identical); overlay real bytes; pass the **dict** to
+  `update_filtered`. `query_ir_json` is unchanged (it is query IR, not row values).
+- **`bulk_create()`** (`models.py:553-560`): a **list** of those payloads →
+  `save_bulk_records`.
+
+Leaning on `model_dump(mode="json")` (and `to_json`) for every **non-bytes** column
+means those bind byte-identically to today; only the bytes columns are special-cased.
+
+### 4.2 FFI signatures — value payloads become native containers
+
+- `save_record(name, data: <dict>, tx_id, using, session_id)` — was `data: String`.
+- `update_filtered(name, query_ir_json: String, updates: <dict>, ...)` — only the
+  *values* argument changes; `query_ir_json` stays a JSON string.
+- `save_bulk_records(name, rows: <list[dict]>, ...)` — was a JSON string.
+
+### 4.3 Rust — one enum, one shared bind helper, `schema_bind_expr` untouched
+
+```rust
+enum BindInput { Json(serde_json::Value), Bytes(Vec<u8>) }
+
+/// Extract a Python value map into per-column BindInputs.
+/// PyBytes/PyByteArray -> Bytes; else convert to serde_json::Value -> Json;
+/// else a clear PyTypeError naming the column (no unwrap/expect — AGENTS.md I-3).
+fn bind_inputs_from_py(map: &Bound<'_, PyDict>) -> PyResult<Vec<(String, BindInput)>> { ... }
+
+/// Bytes bind directly; everything else delegates to the unchanged casting authority.
+fn bind_input_to_expr(schema, table, col, input, enum_udt, uuid_cols, ts_cast, backend)
+    -> PyResult<SimpleExpr>
+{
+    match input {
+        BindInput::Bytes(b) => Ok(Expr::value(SeaValue::Bytes(Some(Box::new(b.clone()))))),
+        BindInput::Json(v)  => schema_bind_expr(schema, table, col, v, enum_udt, uuid_cols, ts_cast, backend),
+    }
+}
+```
+
+`bind_inputs_from_py` replaces the `serde_json::from_str` at `:1239` / `:2073` / bulk;
+`bind_input_to_expr` replaces the `schema_value_expr` call in each bind loop (`:1291` /
+`:2106` / `:1498`). The three channels share both helpers (SSOT).
+
+**Plan-level unknown (to resolve in the plan, not assumed here):** the
+`PyAny → serde_json::Value` conversion for the non-bytes values — whether to lean on
+`pythonize`/`depythonize` (confirm it is/should be a workspace dependency) or hand-roll
+a small converter. Either way: no `unwrap()`/`expect()` on the new FFI value path
+(AGENTS.md I-3); conversion failure surfaces as a clear Python exception.
+
+## Behavior reconciliation (exactly what changes)
+
+| Value category | Today | After | Change |
+|---|---|---|---|
+| `bytes` (UTF-8) | text-coerced via `s.as_bytes()` | real `SeaValue::Bytes` | now genuinely binary (still round-trips) |
+| `bytes` (non-UTF-8) | ❌ `PydanticSerializationError` | ✅ byte-identical | **the fix** |
+| UUID / datetime / Decimal | canonical string → `schema_bind_expr` | **same** string → **same** `schema_bind_expr` | none (parity by construction) |
+| JSON `dict`/`list` column | `Value::Object`/`Array` → json cast | **same** (kept native, not `json.dumps`'d) | none |
+| str / int / float / bool / None | via `schema_bind_expr` | **same** | none |
+
+The only behavioral delta is that binary now persists where it previously raised, and
+UTF-8 bytes columns round-trip **byte-identically** (a parity gate, not a change). No
+public API/signature change — `save()`/`create()`/`update()`/`bulk_create()`
+signatures are unchanged.
+
+## Error handling (Q2 resolution: plain `TypeError`, Ferro-authored message)
+
+A genuinely unbindable value raises a **plain `TypeError`** naming model/field/type,
+mirroring `raw.py::_marshal`'s existing message style (`raw.py:59`) — not a new public
+exception type, and not the opaque deep-pydantic `PydanticSerializationError` #160
+hit. Most unbindable values are already rejected by pydantic at model construction; the
+floor covers `Query.update` kwargs (no model validation) and the Rust FFI extractor
+(a value that is neither `PyBytes` nor JSON-convertible → clear `PyTypeError`). Fail
+loud, never degrade silently — no silent JSON coercion of bytes remains.
+
+## Testing / validation
+
+**Hard gate:** byte-for-byte round-trip of arbitrary `bytes` through `save` / `create`
+/ `update` / `bulk_create` on **both** SQLite (`BLOB`) and Postgres (`bytea`).
+
+New (the fix):
+
+- Round-trip of non-UTF-8 payloads (PNG/PDF magic bytes, random bytes, `b""`, `None`
+  for a nullable bytes column) through **all four** channels, asserting
+  `bytes in == bytes out`, on the **SQLite + Postgres** matrix (Postgres CI-deferred
+  locally; the real merge gate — it caught real bugs twice this phase).
+- UTF-8 bytes now persist as real bytes (not text coercion) and still round-trip.
+- A genuinely unbindable value → clear `TypeError` (not `PydanticSerializationError`).
+
+Parity (must stay green — the "no regression" net):
+
+- Existing value types — UUID, datetime, Decimal, str, int, bool, None, JSON
+  `dict`/`list`, Enum — round-trip **byte-identically** through all four channels.
+- `tests/test_auto_migrate.py`-style backend matrix; `tests/test_cross_emitter_parity.py`
+  / `test_db_type_cross_emitter_parity.py`; workspace `cargo test`.
+- **Do not regress Python 3.13** — run the matrix on 3.13 **and** 3.14.
+
+Grep-gate (completeness):
+
+- No `model_dump_json()` / `to_json(` remaining in the `save` / `update` **value**
+  path (`models.py` save/bulk, `builder.py` update). `query_ir_json` (query IR) is
+  exempt and stays JSON.
+- No new `dead_code` warnings.
+
+**Done =** the SQLite + Postgres round-trip + parity matrix green on 3.13 and 3.14;
+workspace `cargo test` green; the four channels bind through `BindInput` /
+`bind_input_to_expr`; `schema_bind_expr` unchanged; the grep-gate clean; #162 **and**
+#160 closed.
+
+## Risk
+
+- **A parity regression sneaking in under the rewrite.** Mitigation: `schema_bind_expr`
+  is untouched (`Json` arm delegates verbatim); the non-bytes marshal leans on
+  pydantic's existing `mode="json"`/`to_json`; the full SQLite+Postgres × 3.13/3.14
+  matrix + cross-emitter parity assert end-to-end invariance.
+- **JSON-column double-encoding** if a `dict`/`list` value were `json.dumps`'d instead
+  of kept native. Mitigation: the category-preserving rule keeps structures native so
+  `schema_bind_expr` hits its `object`/`array` arm (`codec.rs:288`); a dedicated
+  JSON-column round-trip test pins it.
+- **`bytes_fields` detection missing a bytes value** (e.g. `Any`-typed). Mitigation:
+  detection is **value-driven** (`isinstance`), not type-annotation-driven, so it
+  catches bytes regardless of the declared type.
+- **Postgres `bytea` binding differs from SQLite `BLOB`.** Mitigation: the raw path
+  already proves `EngineBindValue::Bytes` binds on both; the Postgres CI gate is the
+  authoritative check.
+- **The `PyAny → serde_json::Value` converter** mishandling a nested structure.
+  Mitigation: flagged as a plan-level unknown to resolve explicitly with tests, not
+  assumed; no `unwrap`/`expect` on the path.
+
+## Migration impact
+
+`none` for the public API — `save()`/`create()`/`update()`/`bulk_create()` signatures
+are unchanged. Behaviorally: binary now persists where it previously raised
+`PydanticSerializationError`, and existing `bytes` columns (UTF-8 and binary)
+round-trip **byte-identically** — a parity gate, not a change. The FFI functions and
+`BindInput` are internal Rust/Python symbols, not part of the public API.
+
+## Documentation impact
+
+`none` — no user-facing API, behavior, or surface change beyond binary now working
+where it previously raised. The `docs/api/raw-sql.md` bind-type table already documents
+`bytes`; the ORM save path simply reaches parity with it. Justification recorded here
+per the roadmap documentation policy.

--- a/docs/plans/2026-07-01-001-feat-ir-p8.6-162-typed-save-bind-plan.md
+++ b/docs/plans/2026-07-01-001-feat-ir-p8.6-162-typed-save-bind-plan.md
@@ -1,0 +1,917 @@
+# #162 Typed save/update value bind — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route `Model.save()` / `create()` / `Query.update()` / `bulk_create()` value marshaling through the typed codec bind path so arbitrary `bytes` persist byte-for-byte, dropping the `model_dump_json`/`to_json` string envelope.
+
+**Architecture:** Each of the four write channels stops sending a JSON *string* and instead passes a native per-column value map (Python dict / list of dicts) across the FFI, with `bytes` preserved. In Rust, a minimal `BindInput { Json(serde_json::Value), Bytes(Vec<u8>) }` routes `bytes` directly to `SeaValue::Bytes` and every other value through the **unchanged** `codec::schema_bind_expr`. Per the `raw_execute` precedent, the `BindInput`s are extracted synchronously (GIL held) *before* the async block, because a `Bound<PyDict>` is not `Send`.
+
+**Tech Stack:** Rust + PyO3 0.27 (`abi3-py39`), `serde_json`, `sea_query`; Python 3.13/3.14 + pydantic; `uv` + `maturin`; pytest with a SQLite+Postgres backend matrix.
+
+**Spec:** `docs/brainstorms/2026-07-01-ir-p8.6-162-typed-save-bind-requirements.md`
+
+## Global Constraints
+
+- **Python floor `>=3.13`**; run the test matrix on **3.13 and 3.14** (do not regress 3.13).
+- **Behavior-preserving parity:** every currently-working value type (UUID, datetime, Decimal, str, int, bool, None, JSON dict/list, Enum) must round-trip **byte-identically** through all four channels on **SQLite and Postgres**. The only intended behavior change is that `bytes` now persist.
+- **No `unwrap()`/`expect()` on the new FFI value path** (AGENTS.md I-3). Bind/conversion errors surface as clear Python exceptions.
+- **Fail loud, never degrade silently** — no silent JSON coercion of bytes; a genuinely unbindable value raises a plain `TypeError` naming the column (mirroring `raw.py:59`).
+- **Rebuild the Rust core after every Rust edit:** `uv run maturin develop` (before running any Python test).
+- **Grep-gate:** no `model_dump_json` / `to_json(` left in the save/update **value** path (`query_ir_json` stays JSON — it is query IR, not row values).
+- **Conventional Commits** (no invented types). Run `uv run cz check --rev-range feat/ir-p8.6-cleanups..HEAD` before pushing. **No AI attribution** in commits/PRs. **No `CHANGELOG.md` edits** (AGENTS.md I-10).
+- **Postgres is the merge gate** (CI); locally the matrix runs SQLite only unless a Postgres URL is configured.
+- After any fix subagent, verify its commit landed on `feat/ir-p8.6-162-typed-save-bind` (not an isolated worktree branch).
+
+## File Structure
+
+**Rust (all in `src/operations.rs`, co-located with the existing `python_to_engine_bind_value` / `python_to_sea_value` converters and the three pyfunctions):**
+- `enum BindInput` — the per-column value model.
+- `fn py_to_json_value(&Bound<PyAny>, col) -> PyResult<serde_json::Value>` — JSON-safe Python → `serde_json::Value` (rejects unsupported types with a clear `TypeError`).
+- `fn bind_input_from_py(&Bound<PyAny>, col) -> PyResult<BindInput>` — `PyBytes`/`PyByteArray` → `Bytes`; else → `Json`.
+- `fn bind_inputs_from_py(&Bound<PyDict>) -> PyResult<Vec<(String, BindInput)>>` — ordered column→input list.
+- `fn bind_input_to_expr(...) -> PyResult<SimpleExpr>` — `Bytes` → `SeaValue::Bytes`; `Json(v)` → `codec::schema_bind_expr(v)`.
+- Rewire `save_record` (`:1219`), `update_filtered` (`:2062`), `save_bulk_records` (`:1408`).
+
+**Python:**
+- Create `src/ferro/_bind_payload.py` — shared marshal authority (`save_bind_payload`, `update_bind_payload`).
+- Modify `src/ferro/models.py` — `save()` (`:237`) and `bulk_create()` (`:556`).
+- Modify `src/ferro/query/builder.py` — `update()` (`:319`).
+- Modify `src/ferro/_core.pyi` — three signatures (`:116`, `:123`, `:144`).
+
+**Tests:**
+- Rust unit tests appended to the existing `mod` in `src/operations.rs`.
+- Create `tests/test_typed_save_bind.py` — backend-matrix round-trip + parity + error-floor + grep-gate.
+
+---
+
+## Task 1: Save channel — Rust bind primitives + `save_record` + `save()` marshal
+
+**Files:**
+- Modify: `src/operations.rs` (add `BindInput` + converters near `python_to_engine_bind_value` ~`:2409`; rewire `save_record` `:1219-1301`; add Rust unit tests to the test `mod`)
+- Create: `src/ferro/_bind_payload.py`
+- Modify: `src/ferro/models.py:237-243`
+- Modify: `src/ferro/_core.pyi:116-122`
+- Create: `tests/test_typed_save_bind.py`
+
+**Interfaces:**
+- Produces (Rust, used by Tasks 2 & 3): `enum BindInput { Json(serde_json::Value), Bytes(Vec<u8>) }` with `fn is_json_null(&self) -> bool`; `fn bind_inputs_from_py(map: &Bound<'_, PyDict>) -> PyResult<Vec<(String, BindInput)>>`; `fn bind_input_to_expr(schema: &serde_json::Value, table_name: &str, col_name: &str, input: &BindInput, enum_udt: &HashMap<String,String>, uuid_columns: &HashSet<String>, ts_cast: &HashMap<String,String>, backend: Dialect) -> PyResult<SimpleExpr>`.
+- Produces (Python, used by Task 3): `save_bind_payload(instance) -> dict[str, Any]` in `src/ferro/_bind_payload.py`.
+- Produces (test, used by Tasks 2 & 3): module-level `BINARY_VECTORS` in `tests/test_typed_save_bind.py`.
+- Consumes: `codec::schema_bind_expr` (`src/codec.rs:229`), unchanged.
+
+- [ ] **Step 1: Write failing Rust unit tests for the value converter**
+
+Append to the test `mod` in `src/operations.rs` (the one containing `python_to_sea_value_rejects_none` at `:2717`, which already uses `Python::attach`):
+
+```rust
+#[test]
+fn py_to_json_value_maps_json_scalars_and_containers() {
+    Python::attach(|py| {
+        use pyo3::types::{PyDict, PyList};
+        use pyo3::IntoPyObject;
+
+        let i = 42i64.into_pyobject(py).unwrap().into_any();
+        assert_eq!(py_to_json_value(&i, "c").unwrap(), serde_json::json!(42));
+
+        let b = pyo3::types::PyBool::new(py, true).to_owned().into_any();
+        assert_eq!(py_to_json_value(&b, "c").unwrap(), serde_json::json!(true));
+
+        let s = "hi".into_pyobject(py).unwrap().into_any();
+        assert_eq!(py_to_json_value(&s, "c").unwrap(), serde_json::json!("hi"));
+
+        let list = PyList::new(py, [1i64, 2, 3]).unwrap().into_any();
+        assert_eq!(py_to_json_value(&list, "c").unwrap(), serde_json::json!([1, 2, 3]));
+
+        let dict = PyDict::new(py);
+        dict.set_item("w", 10i64).unwrap();
+        let d = dict.into_any();
+        assert_eq!(py_to_json_value(&d, "c").unwrap(), serde_json::json!({"w": 10}));
+    });
+}
+
+#[test]
+fn py_to_json_value_rejects_unsupported_type() {
+    Python::attach(|py| {
+        let set = pyo3::types::PySet::empty(py).unwrap().into_any();
+        let err = py_to_json_value(&set, "mycol").expect_err("set must be rejected");
+        assert!(err.is_instance_of::<pyo3::exceptions::PyTypeError>(py));
+        assert!(err.to_string().contains("mycol"), "msg: {}", err);
+    });
+}
+
+#[test]
+fn bind_input_from_py_preserves_non_utf8_bytes() {
+    Python::attach(|py| {
+        let raw = vec![0x89u8, 0x00, 0xff, 0xfe];
+        let obj = pyo3::types::PyBytes::new(py, &raw).into_any();
+        match bind_input_from_py(&obj, "data").unwrap() {
+            BindInput::Bytes(b) => assert_eq!(b, raw),
+            other => panic!("expected Bytes, got {other:?}"),
+        }
+    });
+}
+
+#[test]
+fn bind_input_to_expr_binds_bytes_to_sea_bytes() {
+    let schema = serde_json::json!({
+        "properties": { "data": { "type": "string", "format": "binary" } }
+    });
+    let input = BindInput::Bytes(vec![0x89, 0x00, 0xff]);
+    let expr = bind_input_to_expr(
+        &schema, "doc", "data", &input,
+        &HashMap::new(), &HashSet::new(), &HashMap::new(), Dialect::Sqlite,
+    ).unwrap();
+    let (_, values) = Query::insert()
+        .into_table(Alias::new("doc"))
+        .columns([Alias::new("data")])
+        .values_panic([expr])
+        .build(SqliteQueryBuilder);
+    match values.0.into_iter().next().unwrap() {
+        SeaValue::Bytes(Some(b)) => assert_eq!(*b, vec![0x89, 0x00, 0xff]),
+        other => panic!("expected SeaValue::Bytes, got {other:?}"),
+    }
+}
+```
+
+Add `#[derive(Debug)]` to `BindInput` so `panic!("{other:?}")` compiles. If `SqliteQueryBuilder` / `Query` / `Alias` are not already imported in the test module, add `use sea_query::{Alias, Query, SqliteQueryBuilder};` to the test `mod`.
+
+- [ ] **Step 2: Run the tests to verify they fail (do not compile yet)**
+
+Run: `cargo test -p ferro save_ 2>&1 | tail -20` (from repo root; the crate name is the workspace root package — use `cargo test py_to_json_value bind_input 2>&1 | tail -30` if the filter misses).
+Expected: FAIL — `cannot find function py_to_json_value` / `bind_input_from_py` / `bind_input_to_expr` / `cannot find type BindInput`.
+
+- [ ] **Step 3: Implement the `BindInput` value model and converters**
+
+Add near the existing `python_to_engine_bind_value` (`src/operations.rs:~2409`):
+
+```rust
+/// A per-column bind value for the schema-guided write path: either a
+/// JSON-canonicalized value (routed through the unchanged `schema_bind_expr`
+/// casting authority) or raw bytes (bound directly, so non-UTF-8 binary
+/// survives).
+#[derive(Debug)]
+enum BindInput {
+    Json(serde_json::Value),
+    Bytes(Vec<u8>),
+}
+
+impl BindInput {
+    fn is_json_null(&self) -> bool {
+        matches!(self, BindInput::Json(serde_json::Value::Null))
+    }
+}
+
+/// Convert a JSON-safe Python value (scalar or nested container) into a
+/// `serde_json::Value`. `bytes` are handled by `bind_input_from_py` *before*
+/// this is called; anything else that is not JSON-representable is rejected
+/// with a clear `TypeError` (the Ferro-level error floor — AGENTS.md I-3, no
+/// `unwrap`/`expect`).
+fn py_to_json_value(value: &Bound<'_, PyAny>, col: &str) -> PyResult<serde_json::Value> {
+    use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString};
+
+    if value.is_none() {
+        return Ok(serde_json::Value::Null);
+    }
+    // bool BEFORE int: in Python bool is a subtype of int.
+    if let Ok(b) = value.downcast::<PyBool>() {
+        return Ok(serde_json::Value::Bool(b.is_true()));
+    }
+    if let Ok(i) = value.downcast::<PyInt>() {
+        if let Ok(n) = i.extract::<i64>() {
+            return Ok(serde_json::Value::from(n));
+        }
+        if let Ok(n) = i.extract::<u64>() {
+            return Ok(serde_json::Value::from(n));
+        }
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "Integer out of range for column '{col}'"
+        )));
+    }
+    if let Ok(f) = value.downcast::<PyFloat>() {
+        let n = f.extract::<f64>()?;
+        return serde_json::Number::from_f64(n)
+            .map(serde_json::Value::Number)
+            .ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "Non-finite float (NaN/Inf) for column '{col}'"
+                ))
+            });
+    }
+    if let Ok(s) = value.downcast::<PyString>() {
+        return Ok(serde_json::Value::String(s.to_str()?.to_owned()));
+    }
+    if let Ok(list) = value.downcast::<PyList>() {
+        let mut arr = Vec::with_capacity(list.len());
+        for item in list.iter() {
+            arr.push(py_to_json_value(&item, col)?);
+        }
+        return Ok(serde_json::Value::Array(arr));
+    }
+    if let Ok(dict) = value.downcast::<PyDict>() {
+        let mut map = serde_json::Map::new();
+        for (k, v) in dict.iter() {
+            let key: String = k.extract().map_err(|_| {
+                pyo3::exceptions::PyTypeError::new_err(format!(
+                    "Non-string key in JSON value for column '{col}'"
+                ))
+            })?;
+            map.insert(key, py_to_json_value(&v, col)?);
+        }
+        return Ok(serde_json::Value::Object(map));
+    }
+    Err(pyo3::exceptions::PyTypeError::new_err(format!(
+        "Cannot bind value {} for column '{col}' (unsupported type). \
+         Supported: str, int, float, bool, bytes, None, and JSON-safe dict/list.",
+        value.repr()?
+    )))
+}
+
+/// Marshal a single Python column value into a `BindInput`.
+/// `bytes`/`bytearray` are preserved verbatim; everything else is JSON-canonicalized.
+fn bind_input_from_py(value: &Bound<'_, PyAny>, col: &str) -> PyResult<BindInput> {
+    use pyo3::types::{PyByteArray, PyBytes};
+
+    if let Ok(b) = value.downcast::<PyBytes>() {
+        return Ok(BindInput::Bytes(b.as_bytes().to_vec()));
+    }
+    if let Ok(b) = value.downcast::<PyByteArray>() {
+        return Ok(BindInput::Bytes(b.to_vec()));
+    }
+    Ok(BindInput::Json(py_to_json_value(value, col)?))
+}
+
+/// Extract a Python row dict into an ordered column→`BindInput` list.
+fn bind_inputs_from_py(map: &Bound<'_, PyDict>) -> PyResult<Vec<(String, BindInput)>> {
+    let mut out = Vec::with_capacity(map.len());
+    for (k, v) in map.iter() {
+        let key: String = k.extract().map_err(|_| {
+            pyo3::exceptions::PyTypeError::new_err("Record keys must be strings")
+        })?;
+        let input = bind_input_from_py(&v, &key)?;
+        out.push((key, input));
+    }
+    Ok(out)
+}
+
+/// Route a `BindInput` to a SeaQuery expression: raw bytes bind directly to
+/// `SeaValue::Bytes`; everything else flows through the unchanged casting
+/// authority (`schema_bind_expr`).
+fn bind_input_to_expr(
+    schema: &serde_json::Value,
+    table_name: &str,
+    col_name: &str,
+    input: &BindInput,
+    enum_udt: &HashMap<String, String>,
+    uuid_columns: &HashSet<String>,
+    ts_cast: &HashMap<String, String>,
+    backend: Dialect,
+) -> PyResult<SimpleExpr> {
+    match input {
+        BindInput::Bytes(b) => Ok(Expr::value(SeaValue::Bytes(Some(Box::new(b.clone()))))),
+        BindInput::Json(v) => crate::codec::schema_bind_expr(
+            schema, table_name, col_name, v, enum_udt, uuid_columns, ts_cast, backend,
+        ),
+    }
+}
+```
+
+If `SimpleExpr`, `Expr`, or `SeaValue` are not already in scope at that location in `operations.rs`, reuse the same imports `schema_value_expr` (`:639`) relies on.
+
+- [ ] **Step 4: Run the Rust unit tests to verify they pass**
+
+Run: `uv run maturin develop 2>&1 | tail -3 && cargo test py_to_json_value bind_input 2>&1 | tail -20`
+Expected: PASS (4 tests). (`maturin develop` first so the crate compiles cleanly; the unit tests then run via `cargo test`.)
+
+- [ ] **Step 5: Rewire `save_record` to take a typed dict**
+
+In `src/operations.rs`, change the signature (`:1219-1226`) and extract `BindInput`s **before** `future_into_py`:
+
+```rust
+#[pyfunction]
+#[pyo3(signature = (name, data, tx_id=None, using=None, session_id=None))]
+pub fn save_record(
+    py: Python<'_>,
+    name: String,
+    data: Bound<'_, pyo3::types::PyDict>,
+    tx_id: Option<String>,
+    using: Option<String>,
+    session_id: Option<String>,
+) -> PyResult<Bound<'_, PyAny>> {
+    let bind_inputs = bind_inputs_from_py(&data)?; // GIL held here, before the async move
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        // ... active_route_for_operation unchanged ...
+```
+
+Inside the async block, replace the `serde_json::from_str(&data)` block (`:1239-1245`) — schema is still fetched from the registry, but the record is now `bind_inputs`:
+
+```rust
+        let schema = {
+            let registry = MODEL_REGISTRY.read().map_err(|_| {
+                pyo3::exceptions::PyRuntimeError::new_err("Failed to lock registry")
+            })?;
+            registry.get(&name).cloned().ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!("Model '{}' not found", name))
+            })?
+        };
+```
+
+Then in the columns/values loop (`:1278-1301`), iterate `bind_inputs` and use `is_json_null()` + `bind_input_to_expr`:
+
+```rust
+            for (key, input) in &bind_inputs {
+                let is_pk = pk_col.as_deref() == Some(key.as_str());
+                if is_pk && pk_is_auto && input.is_json_null() {
+                    continue;
+                }
+                if is_pk && !input.is_json_null() {
+                    pk_provided = true;
+                }
+                columns.push(Alias::new(key));
+                values.push(bind_input_to_expr(
+                    &schema, &table_name, key, input,
+                    &enum_udt, &uuid_columns, &ts_cast, backend,
+                )?);
+            }
+```
+
+Update the doc comment above `save_record` (the `data` line and the `# Errors` "Invalid JSON" note) to describe the typed dict.
+
+**PyO3 lifetime note:** if the borrow checker complains about mixing two elided `'_` lifetimes (`py: Python<'_>` + `data: Bound<'_, PyDict>` + `-> PyResult<Bound<'_, PyAny>>`), mirror `raw_execute`'s pattern (`:2473`) and make them explicit: `pub fn save_record<'py>(py: Python<'py>, name: String, data: Bound<'py, PyDict>, ...) -> PyResult<Bound<'py, PyAny>>`. Extracting `bind_inputs` before `future_into_py` (as written) is what makes this sound — the non-`Send` `Bound<PyDict>` never crosses into the async block.
+
+- [ ] **Step 6: Update the `.pyi` stub for `save_record`**
+
+In `src/ferro/_core.pyi:116-122`, change `data: str` → `data: dict[str, Any]` (confirm `Any` is imported at the top of the stub; it is, used by `add_m2m_links`).
+
+- [ ] **Step 7: Create the shared Python marshal helper**
+
+Create `src/ferro/_bind_payload.py`:
+
+```python
+"""Marshal row values for the typed codec bind path (#162).
+
+Produces a per-column value map where ``bytes``/``bytearray`` are preserved
+verbatim (so non-UTF-8 binary survives) and every other value is canonicalized
+exactly as pydantic's JSON mode produces it. This replaces the ``model_dump_json``
+/ ``to_json`` string envelope in ``Model.save`` / ``bulk_create`` / ``Query.update``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+from pydantic_core import to_json
+
+
+def _bytes_field_names(instance: Any) -> set[str]:
+    """Fields whose *current value* is bytes-like (value-driven: catches
+    ``bytes``, ``bytes | None``, and ``Any``-typed bytes)."""
+    return {
+        name
+        for name in type(instance).model_fields
+        if isinstance(getattr(instance, name, None), (bytes, bytearray))
+    }
+
+
+def save_bind_payload(instance: Any) -> dict[str, Any]:
+    """Column->value map for ``save``/``bulk_create``.
+
+    Non-bytes columns go through pydantic ``model_dump(mode="json")`` (byte-identical
+    to today, honoring field serializers/aliases); bytes columns are overlaid raw.
+    """
+    bytes_fields = _bytes_field_names(instance)
+    payload: dict[str, Any] = instance.model_dump(mode="json", exclude=bytes_fields)
+    for name in bytes_fields:
+        payload[name] = bytes(getattr(instance, name))
+    return payload
+
+
+def update_bind_payload(fields: Mapping[str, Any]) -> dict[str, Any]:
+    """Column->value map for ``Query.update(**fields)``.
+
+    Non-bytes values are canonicalized exactly as ``to_json`` does today; bytes
+    values are overlaid raw.
+    """
+    bytes_keys = {k for k, v in fields.items() if isinstance(v, (bytes, bytearray))}
+    non_bytes = {k: v for k, v in fields.items() if k not in bytes_keys}
+    payload: dict[str, Any] = json.loads(to_json(non_bytes)) if non_bytes else {}
+    for k in bytes_keys:
+        payload[k] = bytes(fields[k])
+    return payload
+```
+
+- [ ] **Step 8: Rewire `Model.save()` to send the typed payload**
+
+In `src/ferro/models.py`, add the import near the other `._core` imports (top of file) — `from ._bind_payload import save_bind_payload` — and change `save()` (`:237-243`):
+
+```python
+        new_id = await save_record(
+            self.__class__.__name__,
+            save_bind_payload(self),
+            tx_id,
+            operation_using,
+            session_id=session_id,
+        )
+```
+
+- [ ] **Step 9: Write failing backend-matrix round-trip + parity tests for `save`**
+
+Create `tests/test_typed_save_bind.py`:
+
+```python
+"""#162 — typed save/update value bind: binary round-trips + parity."""
+
+from __future__ import annotations
+
+import datetime
+import decimal
+from typing import Annotated
+from uuid import UUID, uuid4
+
+import pytest
+
+import ferro
+from ferro import FerroField, Model
+
+pytestmark = pytest.mark.backend_matrix
+
+# Shared across save/update/bulk tasks. Each must round-trip byte-for-byte.
+BINARY_VECTORS = [
+    b"\x89PNG\r\n\x1a\n\xff\xd8",  # PNG magic — non-UTF-8
+    b"%PDF-1.7\x00\xff\xfe",        # PDF-ish — non-UTF-8
+    bytes(range(256)),              # every byte value
+    b"hello",                       # UTF-8 (must stay real bytes, not text coercion)
+    b"",                            # empty
+]
+
+
+@pytest.mark.parametrize("payload", BINARY_VECTORS)
+@pytest.mark.asyncio
+async def test_save_roundtrips_binary(db_url, payload):
+    await ferro.connect(db_url, auto_migrate=True)
+
+    class SaveDoc(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        data: bytes = b""
+
+    doc = SaveDoc(id=uuid4(), data=payload)
+    await doc.save()
+    got = (await SaveDoc.all())[0].data
+    assert isinstance(got, bytes)
+    assert got == payload
+
+
+@pytest.mark.asyncio
+async def test_save_nullable_bytes_roundtrips_none(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+
+    class SaveNullDoc(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        blob: bytes | None = None
+
+    doc = SaveNullDoc(id=uuid4(), blob=None)
+    await doc.save()
+    assert (await SaveNullDoc.all())[0].blob is None
+
+
+@pytest.mark.asyncio
+async def test_save_preserves_rich_types(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+
+    class SaveRec(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        uid: UUID
+        when: datetime.datetime
+        amount: decimal.Decimal
+        count: int
+        active: bool
+        tags: list[str] = []
+        note: str | None = None
+
+    uid = uuid4()
+    when = datetime.datetime(2026, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)
+    amount = decimal.Decimal("12.34")
+    rec = SaveRec(
+        id=uuid4(), uid=uid, when=when, amount=amount,
+        count=7, active=True, tags=["a", "b"],
+    )
+    await rec.save()
+
+    got = (await SaveRec.all())[0]
+    assert got.uid == uid
+    assert got.amount == amount
+    assert got.count == 7
+    assert got.active is True
+    assert got.tags == ["a", "b"]
+    assert got.note is None
+    assert got.when == when
+```
+
+- [ ] **Step 10: Rebuild and run the save tests to verify they pass**
+
+Run: `uv run maturin develop 2>&1 | tail -3 && uv run pytest tests/test_typed_save_bind.py -x -q 2>&1 | tail -30`
+Expected: PASS on SQLite (all `test_save_*`). Sanity check the *old* behavior is fixed: before rebuild, `test_save_roundtrips_binary` would raise `PydanticSerializationError`; after the Task 1 wiring + rebuild it must round-trip byte-for-byte. If any binary vector fails with a round-trip mismatch, the Rust bind is wrong — do not weaken the test.
+
+- [ ] **Step 11: Verify no regression in the existing CRUD suite**
+
+Run: `uv run pytest tests/test_crud.py tests/test_models.py -q 2>&1 | tail -20`
+Expected: PASS (existing `save()`/`create()` behavior preserved).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/operations.rs src/ferro/_bind_payload.py src/ferro/models.py src/ferro/_core.pyi tests/test_typed_save_bind.py
+git commit -m "feat(ir-p8.6): route Model.save() value bind through typed codec path (#162)"
+```
+
+---
+
+## Task 2: Update channel — `update_filtered` + `Query.update()` marshal
+
+**Files:**
+- Modify: `src/operations.rs` — `update_filtered` (`:2062-2117`)
+- Modify: `src/ferro/query/builder.py:293-326`
+- Modify: `src/ferro/_core.pyi:144-151`
+- Modify: `tests/test_typed_save_bind.py` (add update tests)
+
+**Interfaces:**
+- Consumes (from Task 1): `bind_inputs_from_py`, `bind_input_to_expr`, `save_bind_payload`'s sibling `update_bind_payload` (already written in Task 1's `_bind_payload.py`), `BINARY_VECTORS`.
+- Produces: nothing new for later tasks.
+
+- [ ] **Step 1: Write failing backend-matrix update tests**
+
+Append to `tests/test_typed_save_bind.py`:
+
+```python
+@pytest.mark.parametrize("payload", BINARY_VECTORS)
+@pytest.mark.asyncio
+async def test_update_roundtrips_binary(db_url, payload):
+    await ferro.connect(db_url, auto_migrate=True)
+
+    class UpdDoc(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        name: str = ""
+        data: bytes = b""
+
+    doc = UpdDoc(id=uuid4(), name="x", data=b"seed")
+    await doc.save()
+    n = await UpdDoc.where(lambda d: d.name == "x").update(data=payload)
+    assert n == 1
+    got = (await UpdDoc.where(lambda d: d.name == "x").all())[0].data
+    assert isinstance(got, bytes)
+    assert got == payload
+
+
+@pytest.mark.asyncio
+async def test_update_preserves_rich_types(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+
+    class UpdRec(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        amount: decimal.Decimal = decimal.Decimal("0")
+        count: int = 0
+
+    rid = uuid4()
+    await UpdRec(id=rid, amount=decimal.Decimal("1.00"), count=1).save()
+    await UpdRec.where(lambda r: r.id == rid).update(
+        amount=decimal.Decimal("99.99"), count=42
+    )
+    got = (await UpdRec.all())[0]
+    assert got.amount == decimal.Decimal("99.99")
+    assert got.count == 42
+```
+
+- [ ] **Step 2: Run to verify the binary update tests fail**
+
+Run: `uv run pytest tests/test_typed_save_bind.py -k update -x -q 2>&1 | tail -20`
+Expected: FAIL — `test_update_roundtrips_binary` raises `PydanticSerializationError` for non-UTF-8 vectors (the current `to_json` seam). (`test_update_preserves_rich_types` may already pass — that is the parity guard.)
+
+- [ ] **Step 3: Rewire `update_filtered` to take a typed dict**
+
+In `src/operations.rs`, change the signature (`:2061-2070`) and extract inputs before the async block:
+
+```rust
+#[pyo3(signature = (name, query_ir_json, updates, tx_id=None, using=None, session_id=None))]
+pub fn update_filtered(
+    py: Python<'_>,
+    name: String,
+    query_ir_json: String,
+    updates: Bound<'_, pyo3::types::PyDict>,
+    tx_id: Option<String>,
+    using: Option<String>,
+    session_id: Option<String>,
+) -> PyResult<Bound<'_, PyAny>> {
+    let mut query_def = query_def_from_ir_json(&query_ir_json)?;
+    let update_inputs = bind_inputs_from_py(&updates)?;
+    // ... delete the `serde_json::from_str(&update_json)` + `as_object` block (:2073-2079) ...
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+```
+
+In the value loop (`:2103-2117`), iterate `update_inputs`:
+
+```rust
+            for (key, input) in &update_inputs {
+                update.value(
+                    Alias::new(key),
+                    bind_input_to_expr(
+                        schema, &table_name, key, input,
+                        &enum_udt, &uuid_columns, &ts_cast, backend,
+                    )?,
+                );
+            }
+```
+
+Update the doc comment (`update_json` → `updates`, drop the "Invalid update JSON" note).
+
+- [ ] **Step 4: Update the `.pyi` stub for `update_filtered`**
+
+`src/ferro/_core.pyi:144-151`: `update_json: str` → `updates: dict[str, Any]`.
+
+- [ ] **Step 5: Rewire `Query.update()`**
+
+In `src/ferro/query/builder.py:293-326`: add `from .._bind_payload import update_bind_payload` at the top of the module, delete the local `from pydantic_core import to_json` (`:315`) **only if `to_json` is unused elsewhere in the file** (grep first: `grep -n "to_json" src/ferro/query/builder.py`), and change the call:
+
+```python
+        tx_id, using, session_id = self._transaction_or_using()
+        return await update_filtered(
+            self.model_cls.__name__,
+            _query_ir_payload_to_json(query_def),
+            update_bind_payload(fields),
+            tx_id,
+            using,
+            session_id=session_id,
+        )
+```
+
+- [ ] **Step 6: Rebuild and run the update tests to verify they pass**
+
+Run: `uv run maturin develop 2>&1 | tail -3 && uv run pytest tests/test_typed_save_bind.py -k update -q 2>&1 | tail -20`
+Expected: PASS (all update tests, all binary vectors).
+
+- [ ] **Step 7: Verify no regression in the existing update/bulk-update suite**
+
+Run: `uv run pytest tests/test_bulk_update.py tests/test_crud.py -q 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/operations.rs src/ferro/query/builder.py src/ferro/_core.pyi tests/test_typed_save_bind.py
+git commit -m "feat(ir-p8.6): route Query.update() value bind through typed codec path (#162)"
+```
+
+---
+
+## Task 3: Bulk channel — `save_bulk_records` + `bulk_create()` marshal
+
+**Files:**
+- Modify: `src/operations.rs` — `save_bulk_records` (`:1408-1519`)
+- Modify: `src/ferro/models.py:553-560`
+- Modify: `src/ferro/_core.pyi:123-129`
+- Modify: `tests/test_typed_save_bind.py` (add bulk tests)
+
+**Interfaces:**
+- Consumes (from Task 1): `bind_inputs_from_py`, `bind_input_to_expr`, `BindInput::is_json_null`, `save_bind_payload`, `BINARY_VECTORS`.
+
+- [ ] **Step 1: Write failing backend-matrix bulk tests**
+
+Append to `tests/test_typed_save_bind.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_bulk_create_roundtrips_binary(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+
+    class BulkDoc(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        data: bytes = b""
+
+    docs = [BulkDoc(id=uuid4(), data=v) for v in BINARY_VECTORS]
+    n = await BulkDoc.bulk_create(docs)
+    assert n == len(BINARY_VECTORS)
+
+    stored = {bytes(d.data) for d in await BulkDoc.all()}
+    assert stored == {bytes(v) for v in BINARY_VECTORS}
+
+
+@pytest.mark.asyncio
+async def test_bulk_create_preserves_rich_types(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+
+    class BulkRec(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        amount: decimal.Decimal = decimal.Decimal("0")
+
+    await BulkRec.bulk_create([
+        BulkRec(id=uuid4(), amount=decimal.Decimal("1.11")),
+        BulkRec(id=uuid4(), amount=decimal.Decimal("2.22")),
+    ])
+    amounts = sorted(r.amount for r in await BulkRec.all())
+    assert amounts == [decimal.Decimal("1.11"), decimal.Decimal("2.22")]
+```
+
+- [ ] **Step 2: Run to verify the binary bulk test fails**
+
+Run: `uv run pytest tests/test_typed_save_bind.py -k bulk -x -q 2>&1 | tail -20`
+Expected: FAIL — `test_bulk_create_roundtrips_binary` raises `PydanticSerializationError` (current `model_dump(mode="json")` + `json.dumps` seam).
+
+- [ ] **Step 3: Rewire `save_bulk_records` to take a list of typed dicts**
+
+In `src/operations.rs`, change the signature (`:1406-1415`) and extract inputs before the async block:
+
+```rust
+#[pyo3(signature = (name, rows, tx_id=None, using=None, session_id=None))]
+pub fn save_bulk_records(
+    py: Python<'_>,
+    name: String,
+    rows: Vec<Bound<'_, pyo3::types::PyDict>>,
+    tx_id: Option<String>,
+    using: Option<String>,
+    session_id: Option<String>,
+) -> PyResult<Bound<'_, PyAny>> {
+    let record_inputs: Vec<Vec<(String, BindInput)>> = rows
+        .iter()
+        .map(bind_inputs_from_py)
+        .collect::<PyResult<_>>()?;
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+```
+
+Replace the `serde_json::from_str(&data_list_json)` block (`:1432-1435`) with an emptiness check on `record_inputs`, and rebuild the column/value loop (`:1467-1515`) over `record_inputs`:
+
+```rust
+        if record_inputs.is_empty() {
+            return Ok(0);
+        }
+        // ... pk_col / pk_is_auto detection from schema unchanged (:1441-1459) ...
+
+        let (sql, bind_values) = {
+            let mut insert_stmt = InsertStatement::new()
+                .into_table(Alias::new(&table_name))
+                .to_owned();
+
+            // Columns come from the first row's order (skip a null auto-pk).
+            let mut column_names: Vec<String> = Vec::new();
+            for (key, input) in &record_inputs[0] {
+                let is_pk = pk_col.as_deref() == Some(key.as_str());
+                if is_pk && pk_is_auto && input.is_json_null() {
+                    continue;
+                }
+                column_names.push(key.clone());
+            }
+            insert_stmt.columns(column_names.iter().map(|c| Alias::new(c)));
+
+            let null_input = BindInput::Json(serde_json::Value::Null);
+            for row in &record_inputs {
+                let lookup: std::collections::HashMap<&str, &BindInput> =
+                    row.iter().map(|(k, v)| (k.as_str(), v)).collect();
+                let mut row_values = Vec::with_capacity(column_names.len());
+                for col in &column_names {
+                    let input = lookup.get(col.as_str()).copied().unwrap_or(&null_input);
+                    row_values.push(bind_input_to_expr(
+                        &schema, &table_name, col, input,
+                        &enum_udt, &uuid_columns, &ts_cast, backend,
+                    )?);
+                }
+                insert_stmt.values(row_values).map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!("Statement build failed: {}", e))
+                })?;
+            }
+            sea_query_build_for_backend!(insert_stmt, backend)
+        };
+```
+
+Update the doc comment (`data_list_json` → `rows`; drop the "Invalid JSON" note).
+
+- [ ] **Step 4: Update the `.pyi` stub for `save_bulk_records`**
+
+`src/ferro/_core.pyi:123-129`: `data_list_json: str` → `rows: list[dict[str, Any]]`.
+
+- [ ] **Step 5: Rewire `bulk_create()`**
+
+In `src/ferro/models.py:553-560`, use the shared helper and drop the `json.dumps`:
+
+```python
+        if not instances:
+            return 0
+        data = [save_bind_payload(i) for i in instances]
+        tx_id, using, session_id = _transaction_or_using(using, session)
+        return await save_bulk_records(
+            cls.__name__, data, tx_id, using, session_id=session_id
+        )
+```
+
+(`save_bind_payload` is already imported from Task 1. If `json` is now unused in `models.py`, leave it — other call sites may use it; do not remove imports speculatively.)
+
+- [ ] **Step 6: Rebuild and run the bulk tests to verify they pass**
+
+Run: `uv run maturin develop 2>&1 | tail -3 && uv run pytest tests/test_typed_save_bind.py -k bulk -q 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 7: Verify the full new suite + a broad regression sweep**
+
+Run: `uv run pytest tests/test_typed_save_bind.py tests/test_crud.py tests/test_models.py tests/test_bulk_update.py -q 2>&1 | tail -25`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/operations.rs src/ferro/models.py src/ferro/_core.pyi tests/test_typed_save_bind.py
+git commit -m "feat(ir-p8.6): route bulk_create value bind through typed codec path (#162)"
+```
+
+---
+
+## Task 4: Error floor, grep-gate, and full-suite close-out
+
+**Files:**
+- Modify: `tests/test_typed_save_bind.py` (error-floor test)
+- Verification only: repo-wide grep + full test suite + `cargo test`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–3.
+
+- [ ] **Step 1: Write a failing error-floor test (clear `TypeError`, not opaque pydantic crash)**
+
+Append to `tests/test_typed_save_bind.py`. This drives an unbindable value through `Query.update` (whose kwargs are not pydantic-validated), asserting a clear `TypeError` from the Rust converter rather than a `PydanticSerializationError`:
+
+```python
+@pytest.mark.asyncio
+async def test_update_unbindable_value_raises_clear_typeerror(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+
+    class FloorDoc(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        name: str = ""
+
+    rid = uuid4()
+    await FloorDoc(id=rid, name="x").save()
+
+    import pydantic_core
+
+    with pytest.raises((TypeError, pydantic_core.PydanticSerializationError)) as exc:
+        # a set() is neither bytes nor JSON-serializable
+        await FloorDoc.where(lambda d: d.id == rid).update(name={1, 2, 3})
+    # Whichever layer rejects it, the message must not be an opaque deep-DB error.
+    assert "name" in str(exc.value) or "set" in str(exc.value).lower()
+```
+
+Note: `to_json` in `update_bind_payload` will reject a `set` first (a call-boundary error, acceptable per the spec), so this test accepts either `TypeError` (Rust converter floor) or `PydanticSerializationError` (to_json boundary) — both are clear, non-opaque errors at the call site. The Rust converter floor itself is unit-tested in Task 1 (`py_to_json_value_rejects_unsupported_type`).
+
+- [ ] **Step 2: Run the error-floor test**
+
+Run: `uv run pytest tests/test_typed_save_bind.py -k unbindable -q 2>&1 | tail -15`
+Expected: PASS (the value is rejected at a clear boundary; no opaque DB error).
+
+- [ ] **Step 3: Grep-gate — no JSON envelope left in the value path**
+
+Run:
+
+```bash
+grep -n "model_dump_json" src/ferro/models.py; \
+grep -n "to_json\|model_dump(mode=\"json\")\|json.dumps" src/ferro/models.py src/ferro/query/builder.py
+```
+
+Expected: **zero** `model_dump_json` anywhere; **zero** `to_json` / `model_dump(mode="json")` / `json.dumps` in the `save` / `bulk_create` / `Query.update` value paths. The only permitted JSON serialization in these files is `_query_ir_payload_to_json` (query IR, not row values) in `builder.py`. If any value-path JSON call remains, it is a gap — fix it before proceeding.
+
+- [ ] **Step 4: Confirm no in-Rust callers of the three pyfunctions kept the old string signature**
+
+Run: `grep -rn "save_record\|save_bulk_records\|update_filtered" src/*.rs crates/ | grep -v "pub fn\|wrap_pyfunction"`
+Expected: no call sites passing a `String` payload (there are none today; this guards against a missed cfg(test) caller). If a caller exists, update it to the typed shape.
+
+- [ ] **Step 5: Full Rust test suite**
+
+Run: `cargo test 2>&1 | tail -25`
+Expected: PASS (workspace green, including the new `mod` unit tests and existing `schema_value_expr` tests).
+
+- [ ] **Step 6: Full Python suite on SQLite**
+
+Run: `uv run maturin develop 2>&1 | tail -3 && uv run pytest -q 2>&1 | tail -30`
+Expected: PASS. Investigate any failure — do not xfail/skip to go green.
+
+- [ ] **Step 7: Confirm no CHANGELOG or unrelated edits, and conventional-commit compliance**
+
+Run: `git status --porcelain && uv run cz check --rev-range feat/ir-p8.6-cleanups..HEAD 2>&1 | tail -10`
+Expected: no `CHANGELOG.md` in the diff; `cz check` passes for all four commits.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/test_typed_save_bind.py
+git commit -m "test(ir-p8.6): error-floor + grep-gate for typed save bind (#162)"
+```
+
+---
+
+## Postgres / multi-version gate (CI — the real merge gate)
+
+The backend-matrix tests run against Postgres automatically when a Postgres URL is configured (`tests/db_backends.py`); locally without one they run SQLite only. Before merge, confirm in CI:
+
+- `tests/test_typed_save_bind.py` passes on the **Postgres** backend (bytea round-trip of every `BINARY_VECTORS` entry through all four channels).
+- The full matrix passes on **Python 3.13 and 3.14**.
+- `tests/test_cross_emitter_parity.py`, `tests/test_db_type_cross_emitter_parity.py`, and `tests/test_auto_migrate.py` stay green.
+
+## Self-Review notes (for the executor)
+
+- **Column ordering:** the Rust bind now iterates `PyDict` insertion order (model field order) rather than `serde_json`'s sorted-map order. This changes only the *column order* of generated INSERTs (values follow their columns — correctness is unchanged). No golden test asserts save/bulk INSERT column order; if one surfaces, it is a cosmetic golden update, not a bug.
+- **Parity is by construction:** `bind_input_to_expr`'s `Json` arm calls `schema_bind_expr` verbatim, and the Python non-bytes path uses pydantic's existing `mode="json"`/`to_json`. Any parity failure means a marshal bug (bytes leaking into or JSON-safe values leaking out of the wrong arm), not a casting change.
+- **Datetime precision:** `test_*_preserves_rich_types` uses whole-second UTC datetimes to avoid entangling the deferred #154 (TimestampTz coarseness). Do not raise the precision here.

--- a/src/ferro/_bind_payload.py
+++ b/src/ferro/_bind_payload.py
@@ -1,0 +1,51 @@
+"""Marshal row values for the typed codec bind path (#162).
+
+Produces a per-column value map where ``bytes``/``bytearray`` are preserved
+verbatim (so non-UTF-8 binary survives) and every other value is canonicalized
+exactly as pydantic's JSON mode produces it. This replaces the ``model_dump_json``
+/ ``to_json`` string envelope in ``Model.save`` / ``bulk_create`` / ``Query.update``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+from pydantic_core import to_json
+
+
+def _bytes_field_names(instance: Any) -> set[str]:
+    """Fields whose *current value* is bytes-like (value-driven: catches
+    ``bytes``, ``bytes | None``, and ``Any``-typed bytes)."""
+    return {
+        name
+        for name in type(instance).model_fields
+        if isinstance(getattr(instance, name, None), (bytes, bytearray))
+    }
+
+
+def save_bind_payload(instance: Any) -> dict[str, Any]:
+    """Column->value map for ``save``/``bulk_create``.
+
+    Non-bytes columns go through pydantic ``model_dump(mode="json")`` (byte-identical
+    to today, honoring field serializers/aliases); bytes columns are overlaid raw.
+    """
+    bytes_fields = _bytes_field_names(instance)
+    payload: dict[str, Any] = instance.model_dump(mode="json", exclude=bytes_fields)
+    for name in bytes_fields:
+        payload[name] = bytes(getattr(instance, name))
+    return payload
+
+
+def update_bind_payload(fields: Mapping[str, Any]) -> dict[str, Any]:
+    """Column->value map for ``Query.update(**fields)``.
+
+    Non-bytes values are canonicalized exactly as ``to_json`` does today; bytes
+    values are overlaid raw.
+    """
+    bytes_keys = {k for k, v in fields.items() if isinstance(v, (bytes, bytearray))}
+    non_bytes = {k: v for k, v in fields.items() if k not in bytes_keys}
+    payload: dict[str, Any] = json.loads(to_json(non_bytes)) if non_bytes else {}
+    for k in bytes_keys:
+        payload[k] = bytes(fields[k])
+    return payload

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -115,7 +115,7 @@ async def fetch_one(
 ) -> Any | None: ...
 async def save_record(
     name: str,
-    data: str,
+    data: dict[str, Any],
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
     session_id: Optional[str] = None,

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -122,7 +122,7 @@ async def save_record(
 ) -> int | None: ...
 async def save_bulk_records(
     name: str,
-    data_list_json: str,
+    rows: list[dict[str, Any]],
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
     session_id: Optional[str] = None,

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -144,7 +144,7 @@ async def delete_filtered(
 async def update_filtered(
     name: str,
     query_ir_json: str,
-    update_json: str,
+    updates: dict[str, Any],
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
     session_id: Optional[str] = None,

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -553,11 +553,10 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         """
         if not instances:
             return 0
-        # Use mode="json" to ensure Decimals, UUIDs, etc. are serialized correctly
-        data = [i.model_dump(mode="json") for i in instances]
+        data = [save_bind_payload(i) for i in instances]
         tx_id, using, session_id = _transaction_or_using(using, session)
         return await save_bulk_records(
-            cls.__name__, json.dumps(data), tx_id, using, session_id=session_id
+            cls.__name__, data, tx_id, using, session_id=session_id
         )
 
     @classmethod

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
+from ._bind_payload import save_bind_payload
 from ._core import (
     begin_transaction,
     commit_transaction,
@@ -236,7 +237,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         )
         new_id = await save_record(
             self.__class__.__name__,
-            self.model_dump_json(),
+            save_bind_payload(self),
             tx_id,
             operation_using,
             session_id=session_id,

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING, Any, Generic, Type, TypeVar, overload
 
+from .._bind_payload import update_bind_payload
 from .._deprecations import (
     IR_FIRST_DEPRECATION_REMOVE_IN,
     IR_FIRST_DEPRECATION_SINCE,
@@ -312,14 +313,11 @@ class Query(Generic[T]):
             "offset": self._offset,
             "m2m": None,
         }
-        from pydantic_core import to_json
-
         tx_id, using, session_id = self._transaction_or_using()
-        # Use pydantic_core.to_json to handle Decimals, UUIDs, etc. in kwargs
         return await update_filtered(
             self.model_cls.__name__,
             _query_ir_payload_to_json(query_def),
-            to_json(fields).decode(),
+            update_bind_payload(fields),
             tx_id,
             using,
             session_id=session_id,

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1210,42 +1210,37 @@ pub fn fetch_one<'py>(
 ///
 /// Args:
 ///     name (str): The model name.
-///     data (str): Serialized JSON data of the model instance.
+///     data (dict[str, Any]): Per-column value map for the model instance.
+///         ``bytes``/``bytearray`` values are preserved verbatim; all other
+///         values are routed through the schema-guided casting authority.
 ///
 /// # Errors
-/// Returns a `PyErr` if the engine is not initialized or if the save fails.
+/// Returns a `PyErr` if the engine is not initialized, the model is not
+/// registered, or a column value cannot be bound.
 #[pyfunction]
 #[pyo3(signature = (name, data, tx_id=None, using=None, session_id=None))]
-pub fn save_record(
-    py: Python<'_>,
+pub fn save_record<'py>(
+    py: Python<'py>,
     name: String,
-    data: String,
+    data: Bound<'py, pyo3::types::PyDict>,
     tx_id: Option<String>,
     using: Option<String>,
     session_id: Option<String>,
-) -> PyResult<Bound<'_, PyAny>> {
+) -> PyResult<Bound<'py, PyAny>> {
+    let bind_inputs = bind_inputs_from_py(&data)?; // GIL held here, before the async move
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (_connection_name, engine, tx_conn, backend) =
             active_route_for_operation(tx_id, using, session_id.clone())?;
 
-        // ... schema and record logic ...
-        let (schema, record_obj) = {
+        let schema = {
             let registry = MODEL_REGISTRY.read().map_err(|_| {
                 pyo3::exceptions::PyRuntimeError::new_err("Failed to lock registry")
             })?;
-            let schema = registry.get(&name).cloned().ok_or_else(|| {
+            registry.get(&name).cloned().ok_or_else(|| {
                 pyo3::exceptions::PyRuntimeError::new_err(format!("Model '{}' not found", name))
-            })?;
-            let record: serde_json::Value = serde_json::from_str(&data).map_err(|e| {
-                pyo3::exceptions::PyValueError::new_err(format!("Invalid JSON: {}", e))
-            })?;
-            let record_obj = record.as_object().cloned().ok_or_else(|| {
-                pyo3::exceptions::PyValueError::new_err("Record must be an object")
-            })?;
-            (schema, record_obj)
+            })?
         };
 
-        // ... (keep current sql generation logic) ...
         let mut pk_col = None;
         let mut pk_is_auto = true;
         if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
@@ -1275,24 +1270,20 @@ pub fn save_record(
             let mut columns = Vec::new();
             let mut values = Vec::new();
             let mut pk_provided = false;
-            for (key, value) in &record_obj {
-                let is_pk = if let Some(ref pk) = pk_col {
-                    key == pk
-                } else {
-                    false
-                };
-                if is_pk && pk_is_auto && value.is_null() {
+            for (key, input) in &bind_inputs {
+                let is_pk = pk_col.as_deref() == Some(key.as_str());
+                if is_pk && pk_is_auto && input.is_json_null() {
                     continue;
                 }
-                if is_pk && !value.is_null() {
+                if is_pk && !input.is_json_null() {
                     pk_provided = true;
                 }
                 columns.push(Alias::new(key));
-                values.push(schema_value_expr(
+                values.push(bind_input_to_expr(
                     &schema,
                     &table_name,
                     key,
-                    value,
+                    input,
                     &enum_udt,
                     &uuid_columns,
                     &ts_cast,
@@ -2397,6 +2388,136 @@ fn python_to_sea_value(val: Bound<'_, PyAny>) -> PyResult<sea_query::Value> {
 /// Order matters: in Python, `bool` is a subtype of `int`, so we must check `bool`
 /// before `i64` or `True`/`False` would round-trip as `1`/`0`.
 ///
+/// A per-column bind value for the schema-guided write path: either a
+/// JSON-canonicalized value (routed through the unchanged `schema_bind_expr`
+/// casting authority) or raw bytes (bound directly, so non-UTF-8 binary
+/// survives).
+#[derive(Debug)]
+enum BindInput {
+    Json(serde_json::Value),
+    Bytes(Vec<u8>),
+}
+
+impl BindInput {
+    fn is_json_null(&self) -> bool {
+        matches!(self, BindInput::Json(serde_json::Value::Null))
+    }
+}
+
+/// Convert a JSON-safe Python value (scalar or nested container) into a
+/// `serde_json::Value`. `bytes` are handled by `bind_input_from_py` *before*
+/// this is called; anything else that is not JSON-representable is rejected
+/// with a clear `TypeError` (the Ferro-level error floor — AGENTS.md I-3, no
+/// `unwrap`/`expect`).
+fn py_to_json_value(value: &Bound<'_, PyAny>, col: &str) -> PyResult<serde_json::Value> {
+    use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString};
+
+    if value.is_none() {
+        return Ok(serde_json::Value::Null);
+    }
+    // bool BEFORE int: in Python bool is a subtype of int.
+    if let Ok(b) = value.downcast::<PyBool>() {
+        return Ok(serde_json::Value::Bool(b.is_true()));
+    }
+    if let Ok(i) = value.downcast::<PyInt>() {
+        if let Ok(n) = i.extract::<i64>() {
+            return Ok(serde_json::Value::from(n));
+        }
+        if let Ok(n) = i.extract::<u64>() {
+            return Ok(serde_json::Value::from(n));
+        }
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "Integer out of range for column '{col}'"
+        )));
+    }
+    if let Ok(f) = value.downcast::<PyFloat>() {
+        let n = f.extract::<f64>()?;
+        return serde_json::Number::from_f64(n)
+            .map(serde_json::Value::Number)
+            .ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "Non-finite float (NaN/Inf) for column '{col}'"
+                ))
+            });
+    }
+    if let Ok(s) = value.downcast::<PyString>() {
+        return Ok(serde_json::Value::String(s.extract::<String>()?));
+    }
+    if let Ok(list) = value.downcast::<PyList>() {
+        let mut arr = Vec::with_capacity(list.len());
+        for item in list.iter() {
+            arr.push(py_to_json_value(&item, col)?);
+        }
+        return Ok(serde_json::Value::Array(arr));
+    }
+    if let Ok(dict) = value.downcast::<PyDict>() {
+        let mut map = serde_json::Map::new();
+        for (k, v) in dict.iter() {
+            let key: String = k.extract().map_err(|_| {
+                pyo3::exceptions::PyTypeError::new_err(format!(
+                    "Non-string key in JSON value for column '{col}'"
+                ))
+            })?;
+            map.insert(key, py_to_json_value(&v, col)?);
+        }
+        return Ok(serde_json::Value::Object(map));
+    }
+    Err(pyo3::exceptions::PyTypeError::new_err(format!(
+        "Cannot bind value {} for column '{col}' (unsupported type). \
+         Supported: str, int, float, bool, bytes, None, and JSON-safe dict/list.",
+        value.repr()?
+    )))
+}
+
+/// Marshal a single Python column value into a `BindInput`.
+/// `bytes`/`bytearray` are preserved verbatim; everything else is JSON-canonicalized.
+fn bind_input_from_py(value: &Bound<'_, PyAny>, col: &str) -> PyResult<BindInput> {
+    use pyo3::types::{PyByteArray, PyBytes};
+
+    if let Ok(b) = value.downcast::<PyBytes>() {
+        return Ok(BindInput::Bytes(b.as_bytes().to_vec()));
+    }
+    if let Ok(b) = value.downcast::<PyByteArray>() {
+        return Ok(BindInput::Bytes(b.to_vec()));
+    }
+    Ok(BindInput::Json(py_to_json_value(value, col)?))
+}
+
+/// Extract a Python row dict into an ordered column→`BindInput` list.
+fn bind_inputs_from_py(map: &Bound<'_, pyo3::types::PyDict>) -> PyResult<Vec<(String, BindInput)>> {
+    let mut out = Vec::with_capacity(map.len());
+    for (k, v) in map.iter() {
+        let key: String = k.extract().map_err(|_| {
+            pyo3::exceptions::PyTypeError::new_err("Record keys must be strings")
+        })?;
+        let input = bind_input_from_py(&v, &key)?;
+        out.push((key, input));
+    }
+    Ok(out)
+}
+
+/// Route a `BindInput` to a SeaQuery expression: raw bytes bind directly to
+/// `SeaValue::Bytes`; everything else flows through the unchanged casting
+/// authority (`schema_bind_expr`).
+#[allow(clippy::too_many_arguments)]
+fn bind_input_to_expr(
+    schema: &serde_json::Value,
+    table_name: &str,
+    col_name: &str,
+    input: &BindInput,
+    enum_udt: &HashMap<String, String>,
+    uuid_columns: &HashSet<String>,
+    ts_cast: &HashMap<String, String>,
+    backend: Dialect,
+) -> PyResult<SimpleExpr> {
+    match input {
+        BindInput::Bytes(b) => Ok(Expr::value(SeaValue::Bytes(Some(Box::new(b.clone()))))),
+        BindInput::Json(v) => crate::codec::schema_bind_expr(
+            schema, table_name, col_name, v, enum_udt, uuid_columns, ts_cast, backend,
+        ),
+    }
+}
+
 /// **Raw-SQL boundary.** This is the documented exception to Ferro's typed-null
 /// architectural rule (R3). The raw-SQL bind path has no schema or column-type
 /// context -- the user supplies pre-built SQL text and bare Python values --
@@ -2699,11 +2820,14 @@ pub fn _shadow_compare_query_plan_for_test(
 
 #[cfg(test)]
 mod m2m_value_tests {
-    use super::{backend_column_value_expr, python_to_sea_value};
+    use super::{
+        backend_column_value_expr, bind_input_from_py, bind_input_to_expr, py_to_json_value,
+        python_to_sea_value, BindInput,
+    };
     use crate::state::Dialect;
     use pyo3::Python;
     use sea_query::{Alias, PostgresQueryBuilder, Query, SqliteQueryBuilder, Value as SeaValue};
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     fn extract_pg_value(expr: sea_query::SimpleExpr) -> SeaValue {
         let (_, values) = Query::insert()
@@ -2805,6 +2929,75 @@ mod m2m_value_tests {
             sql.contains("AS uuid"),
             "fallback CAST expected for unparseable UUID: {sql}"
         );
+    }
+
+    #[test]
+    fn py_to_json_value_maps_json_scalars_and_containers() {
+        Python::attach(|py| {
+            use pyo3::types::{PyDict, PyDictMethods, PyList};
+            use pyo3::IntoPyObject;
+
+            let i = 42i64.into_pyobject(py).unwrap().into_any();
+            assert_eq!(py_to_json_value(&i, "c").unwrap(), serde_json::json!(42));
+
+            let b = pyo3::types::PyBool::new(py, true).to_owned().into_any();
+            assert_eq!(py_to_json_value(&b, "c").unwrap(), serde_json::json!(true));
+
+            let s = "hi".into_pyobject(py).unwrap().into_any();
+            assert_eq!(py_to_json_value(&s, "c").unwrap(), serde_json::json!("hi"));
+
+            let list = PyList::new(py, [1i64, 2, 3]).unwrap().into_any();
+            assert_eq!(py_to_json_value(&list, "c").unwrap(), serde_json::json!([1, 2, 3]));
+
+            let dict = PyDict::new(py);
+            dict.set_item("w", 10i64).unwrap();
+            let d = dict.into_any();
+            assert_eq!(py_to_json_value(&d, "c").unwrap(), serde_json::json!({"w": 10}));
+        });
+    }
+
+    #[test]
+    fn py_to_json_value_rejects_unsupported_type() {
+        Python::attach(|py| {
+            let set = pyo3::types::PySet::empty(py).unwrap().into_any();
+            let err = py_to_json_value(&set, "mycol").expect_err("set must be rejected");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyTypeError>(py));
+            assert!(err.to_string().contains("mycol"), "msg: {}", err);
+        });
+    }
+
+    #[test]
+    fn bind_input_from_py_preserves_non_utf8_bytes() {
+        Python::attach(|py| {
+            let raw = vec![0x89u8, 0x00, 0xff, 0xfe];
+            let obj = pyo3::types::PyBytes::new(py, &raw).into_any();
+            match bind_input_from_py(&obj, "data").unwrap() {
+                BindInput::Bytes(b) => assert_eq!(b, raw),
+                other => panic!("expected Bytes, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn bind_input_to_expr_binds_bytes_to_sea_bytes() {
+        use sea_query::{Alias, Query, SqliteQueryBuilder};
+        let schema = serde_json::json!({
+            "properties": { "data": { "type": "string", "format": "binary" } }
+        });
+        let input = BindInput::Bytes(vec![0x89, 0x00, 0xff]);
+        let expr = bind_input_to_expr(
+            &schema, "doc", "data", &input,
+            &HashMap::new(), &HashSet::new(), &HashMap::new(), Dialect::Sqlite,
+        ).unwrap();
+        let (_, values) = Query::insert()
+            .into_table(Alias::new("doc"))
+            .columns([Alias::new("data")])
+            .values_panic([expr])
+            .build(SqliteQueryBuilder);
+        match values.0.into_iter().next().unwrap() {
+            SeaValue::Bytes(Some(b)) => assert_eq!(*b, vec![0x89, 0x00, 0xff]),
+            other => panic!("expected SeaValue::Bytes, got {other:?}"),
+        }
     }
 }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1384,7 +1384,8 @@ pub fn save_record<'py>(
 ///
 /// Args:
 ///     name (str): Model class name.
-///     data_list_json (str): JSON array of record objects (column → value).
+///     rows (list[dict[str, Any]]): Per-row column→value maps. Bytes columns are
+///         preserved verbatim; all other values flow through the typed codec path.
 ///     tx_id (str | None): Optional active transaction.
 ///     using (str | None): Connection override.
 ///     session_id (str | None): Session-scoped routing when set.
@@ -1393,17 +1394,21 @@ pub fn save_record<'py>(
 ///     int: Number of rows inserted.
 ///
 /// # Errors
-/// `PyValueError` for invalid JSON; `PyRuntimeError` on registry/execute failures.
+/// `PyRuntimeError` on registry/execute failures; `PyTypeError` for unbindable values.
 #[pyfunction]
-#[pyo3(signature = (name, data_list_json, tx_id=None, using=None, session_id=None))]
-pub fn save_bulk_records(
-    py: Python<'_>,
+#[pyo3(signature = (name, rows, tx_id=None, using=None, session_id=None))]
+pub fn save_bulk_records<'py>(
+    py: Python<'py>,
     name: String,
-    data_list_json: String,
+    rows: Vec<Bound<'py, pyo3::types::PyDict>>,
     tx_id: Option<String>,
     using: Option<String>,
     session_id: Option<String>,
-) -> PyResult<Bound<'_, PyAny>> {
+) -> PyResult<Bound<'py, PyAny>> {
+    let record_inputs: Vec<Vec<(String, BindInput)>> = rows
+        .iter()
+        .map(bind_inputs_from_py)
+        .collect::<PyResult<_>>()?;
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (_connection_name, engine, tx_conn, backend) =
             active_route_for_operation(tx_id, using, session_id.clone())?;
@@ -1420,12 +1425,7 @@ pub fn save_bulk_records(
             })?
         };
 
-        let records: Vec<serde_json::Value> =
-            serde_json::from_str(&data_list_json).map_err(|e| {
-                pyo3::exceptions::PyValueError::new_err(format!("Invalid bulk record JSON: {}", e))
-            })?;
-
-        if records.is_empty() {
+        if record_inputs.is_empty() {
             return Ok(0);
         }
 
@@ -1460,41 +1460,27 @@ pub fn save_bulk_records(
                 .into_table(Alias::new(&table_name))
                 .to_owned();
 
-            let mut column_names = Vec::new();
-            for (i, record) in records.iter().enumerate() {
-                let record_obj = record.as_object().ok_or_else(|| {
-                    pyo3::exceptions::PyValueError::new_err("Each record must be a JSON object")
-                })?;
-
-                let mut row_values = Vec::new();
-                if i == 0 {
-                    for (key, value) in record_obj {
-                        let is_pk = if let Some(ref pk) = pk_col {
-                            key == pk
-                        } else {
-                            false
-                        };
-                        if is_pk && pk_is_auto && value.is_null() {
-                            continue;
-                        }
-                        column_names.push(Alias::new(key));
-                    }
-                    insert_stmt.columns(column_names.clone());
+            // Columns come from the first row's order (skip a null auto-pk).
+            let mut column_names: Vec<String> = Vec::new();
+            for (key, input) in &record_inputs[0] {
+                let is_pk = pk_col.as_deref() == Some(key.as_str());
+                if is_pk && pk_is_auto && input.is_json_null() {
+                    continue;
                 }
+                column_names.push(key.clone());
+            }
+            insert_stmt.columns(column_names.iter().map(|c| Alias::new(c)));
 
-                for key in &column_names {
-                    let value = record_obj
-                        .get(key.to_string().as_str())
-                        .unwrap_or(&serde_json::Value::Null);
-                    row_values.push(schema_value_expr(
-                        &schema,
-                        &table_name,
-                        key.to_string().as_str(),
-                        value,
-                        &enum_udt,
-                        &uuid_columns,
-                        &ts_cast,
-                        backend,
+            let null_input = BindInput::Json(serde_json::Value::Null);
+            for row in &record_inputs {
+                let lookup: std::collections::HashMap<&str, &BindInput> =
+                    row.iter().map(|(k, v)| (k.as_str(), v)).collect();
+                let mut row_values = Vec::with_capacity(column_names.len());
+                for col in &column_names {
+                    let input = lookup.get(col.as_str()).copied().unwrap_or(&null_input);
+                    row_values.push(bind_input_to_expr(
+                        &schema, &table_name, col, input,
+                        &enum_udt, &uuid_columns, &ts_cast, backend,
                     )?);
                 }
                 insert_stmt.values(row_values).map_err(|e| {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -2360,15 +2360,6 @@ fn python_to_sea_value(val: Bound<'_, PyAny>) -> PyResult<sea_query::Value> {
     }
 }
 
-/// Convert a Python primitive into an [`EngineBindValue`] for raw SQL bind parameters.
-///
-/// The Python wrapper (`src/ferro/raw.py:_marshal`) is responsible for richer
-/// types (UUID, datetime, Decimal, Enum, dict, list); this helper accepts only the
-/// primitive set and raises `TypeError` for anything else as a defensive guard.
-///
-/// Order matters: in Python, `bool` is a subtype of `int`, so we must check `bool`
-/// before `i64` or `True`/`False` would round-trip as `1`/`0`.
-///
 /// A per-column bind value for the schema-guided write path: either a
 /// JSON-canonicalized value (routed through the unchanged `schema_bind_expr`
 /// casting authority) or raw bytes (bound directly, so non-UTF-8 binary
@@ -2499,6 +2490,15 @@ fn bind_input_to_expr(
     }
 }
 
+/// Convert a Python primitive into an [`EngineBindValue`] for raw SQL bind parameters.
+///
+/// The Python wrapper (`src/ferro/raw.py:_marshal`) is responsible for richer
+/// types (UUID, datetime, Decimal, Enum, dict, list); this helper accepts only the
+/// primitive set and raises `TypeError` for anything else as a defensive guard.
+///
+/// Order matters: in Python, `bool` is a subtype of `int`, so we must check `bool`
+/// before `i64` or `True`/`False` would round-trip as `1`/`0`.
+///
 /// **Raw-SQL boundary.** This is the documented exception to Ferro's typed-null
 /// architectural rule (R3). The raw-SQL bind path has no schema or column-type
 /// context -- the user supplies pre-built SQL text and bare Python values --

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -2038,7 +2038,9 @@ pub fn delete_filtered(
 /// Args:
 ///     name (str): Model class name.
 ///     query_ir_json (str): Serialized Query IR envelope JSON.
-///     values_json (str): JSON object of column → value assignments.
+///     updates (dict): Per-column value map; ``bytes`` values are bound
+///         directly (non-UTF-8 safe), all other values are routed through
+///         the schema casting authority.
 ///     tx_id (str | None): Optional active transaction.
 ///     using (str | None): Connection override.
 ///     session_id (str | None): Session-scoped routing when set.
@@ -2047,27 +2049,20 @@ pub fn delete_filtered(
 ///     int: Rows updated. Clears the identity map for the model when enabled.
 ///
 /// # Errors
-/// `PyValueError` for invalid values JSON; `PyRuntimeError` on execute failure.
+/// `PyTypeError` for unbindable column values; `PyRuntimeError` on execute failure.
 #[pyfunction]
-#[pyo3(signature = (name, query_ir_json, update_json, tx_id=None, using=None, session_id=None))]
-pub fn update_filtered(
-    py: Python<'_>,
+#[pyo3(signature = (name, query_ir_json, updates, tx_id=None, using=None, session_id=None))]
+pub fn update_filtered<'py>(
+    py: Python<'py>,
     name: String,
     query_ir_json: String,
-    update_json: String,
+    updates: Bound<'py, pyo3::types::PyDict>,
     tx_id: Option<String>,
     using: Option<String>,
     session_id: Option<String>,
-) -> PyResult<Bound<'_, PyAny>> {
+) -> PyResult<Bound<'py, PyAny>> {
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
-
-    let update_values: serde_json::Value = serde_json::from_str(&update_json).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!("Invalid update JSON: {}", e))
-    })?;
-
-    let update_map = update_values.as_object().cloned().ok_or_else(|| {
-        pyo3::exceptions::PyValueError::new_err("Update values must be a JSON object")
-    })?;
+    let update_inputs = bind_inputs_from_py(&updates)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
@@ -2091,14 +2086,14 @@ pub fn update_filtered(
                 .table(Alias::new(&table_name))
                 .cond_where(query_condition_for_backend(&query_def, backend)?)
                 .to_owned();
-            for (key, value) in update_map {
+            for (key, input) in &update_inputs {
                 update.value(
-                    Alias::new(&key),
-                    schema_value_expr(
+                    Alias::new(key),
+                    bind_input_to_expr(
                         schema,
                         &table_name,
-                        &key,
-                        &value,
+                        key,
+                        input,
                         &enum_udt,
                         &uuid_columns,
                         &ts_cast,

--- a/tests/test_typed_save_bind.py
+++ b/tests/test_typed_save_bind.py
@@ -162,3 +162,27 @@ async def test_bulk_create_preserves_rich_types(db_url):
     ])
     amounts = sorted(r.amount for r in await BulkRec.all())
     assert amounts == [decimal.Decimal("1.11"), decimal.Decimal("2.22")]
+
+
+@pytest.mark.asyncio
+async def test_update_unbindable_value_raises_clear_typeerror(db_url):
+    class FloorDoc(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        name: str = ""
+
+    await ferro.connect(db_url, auto_migrate=True)
+
+    rid = uuid4()
+    await FloorDoc(id=rid, name="x").save()
+
+    import pydantic_core
+
+    # Use an object() — genuinely unbindable (pydantic_core.to_json rejects it with
+    # PydanticSerializationError; a raw set is silently coerced to a list by to_json
+    # and would not trigger the error floor).
+    with pytest.raises((TypeError, pydantic_core.PydanticSerializationError)) as exc:
+        await FloorDoc.where(lambda d: d.id == rid).update(name=object())
+    # Whichever layer rejects it, the message must not be an opaque deep-DB error.
+    # pydantic_core says "Unable to serialize unknown type" — clear, not a DB error.
+    msg = str(exc.value).lower()
+    assert "serialize" in msg or "type" in msg or "name" in msg

--- a/tests/test_typed_save_bind.py
+++ b/tests/test_typed_save_bind.py
@@ -1,0 +1,90 @@
+"""#162 — typed save/update value bind: binary round-trips + parity."""
+
+from __future__ import annotations
+
+import datetime
+import decimal
+from typing import Annotated
+from uuid import UUID, uuid4
+
+import pytest
+
+import ferro
+from ferro import FerroField, Model
+
+pytestmark = pytest.mark.backend_matrix
+
+# Shared across save/update/bulk tasks. Each must round-trip byte-for-byte.
+BINARY_VECTORS = [
+    b"\x89PNG\r\n\x1a\n\xff\xd8",  # PNG magic — non-UTF-8
+    b"%PDF-1.7\x00\xff\xfe",        # PDF-ish — non-UTF-8
+    bytes(range(256)),              # every byte value
+    b"hello",                       # UTF-8 (must stay real bytes, not text coercion)
+    b"",                            # empty
+]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    BINARY_VECTORS,
+    ids=["png-magic", "pdf-magic", "all-bytes", "utf8-bytes", "empty"],
+)
+@pytest.mark.asyncio
+async def test_save_roundtrips_binary(db_url, payload):
+    class SaveDoc(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        data: bytes = b""
+
+    await ferro.connect(db_url, auto_migrate=True)
+
+    doc = SaveDoc(id=uuid4(), data=payload)
+    await doc.save()
+    got = (await SaveDoc.all())[0].data
+    assert isinstance(got, bytes)
+    assert got == payload
+
+
+@pytest.mark.asyncio
+async def test_save_nullable_bytes_roundtrips_none(db_url):
+    class SaveNullDoc(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        blob: bytes | None = None
+
+    await ferro.connect(db_url, auto_migrate=True)
+
+    doc = SaveNullDoc(id=uuid4(), blob=None)
+    await doc.save()
+    assert (await SaveNullDoc.all())[0].blob is None
+
+
+@pytest.mark.asyncio
+async def test_save_preserves_rich_types(db_url):
+    class SaveRec(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        uid: UUID
+        when: datetime.datetime
+        amount: decimal.Decimal
+        count: int
+        active: bool
+        tags: list[str] = []
+        note: str | None = None
+
+    await ferro.connect(db_url, auto_migrate=True)
+
+    uid = uuid4()
+    when = datetime.datetime(2026, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)
+    amount = decimal.Decimal("12.34")
+    rec = SaveRec(
+        id=uuid4(), uid=uid, when=when, amount=amount,
+        count=7, active=True, tags=["a", "b"],
+    )
+    await rec.save()
+
+    got = (await SaveRec.all())[0]
+    assert got.uid == uid
+    assert got.amount == amount
+    assert got.count == 7
+    assert got.active is True
+    assert got.tags == ["a", "b"]
+    assert got.note is None
+    assert got.when == when

--- a/tests/test_typed_save_bind.py
+++ b/tests/test_typed_save_bind.py
@@ -88,3 +88,45 @@ async def test_save_preserves_rich_types(db_url):
     assert got.tags == ["a", "b"]
     assert got.note is None
     assert got.when == when
+
+
+@pytest.mark.parametrize(
+    "payload",
+    BINARY_VECTORS,
+    ids=["png-magic", "pdf-magic", "all-bytes", "utf8-bytes", "empty"],
+)
+@pytest.mark.asyncio
+async def test_update_roundtrips_binary(db_url, payload):
+    class UpdDoc(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        name: str = ""
+        data: bytes = b""
+
+    await ferro.connect(db_url, auto_migrate=True)
+
+    doc = UpdDoc(id=uuid4(), name="x", data=b"seed")
+    await doc.save()
+    n = await UpdDoc.where(lambda d: d.name == "x").update(data=payload)
+    assert n == 1
+    got = (await UpdDoc.where(lambda d: d.name == "x").all())[0].data
+    assert isinstance(got, bytes)
+    assert got == payload
+
+
+@pytest.mark.asyncio
+async def test_update_preserves_rich_types(db_url):
+    class UpdRec(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        amount: decimal.Decimal = decimal.Decimal("0")
+        count: int = 0
+
+    await ferro.connect(db_url, auto_migrate=True)
+
+    rid = uuid4()
+    await UpdRec(id=rid, amount=decimal.Decimal("1.00"), count=1).save()
+    await UpdRec.where(lambda r: r.id == rid).update(
+        amount=decimal.Decimal("99.99"), count=42
+    )
+    got = (await UpdRec.all())[0]
+    assert got.amount == decimal.Decimal("99.99")
+    assert got.count == 42

--- a/tests/test_typed_save_bind.py
+++ b/tests/test_typed_save_bind.py
@@ -130,3 +130,35 @@ async def test_update_preserves_rich_types(db_url):
     got = (await UpdRec.all())[0]
     assert got.amount == decimal.Decimal("99.99")
     assert got.count == 42
+
+
+@pytest.mark.asyncio
+async def test_bulk_create_roundtrips_binary(db_url):
+    class BulkDoc(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        data: bytes = b""
+
+    await ferro.connect(db_url, auto_migrate=True)
+
+    docs = [BulkDoc(id=uuid4(), data=v) for v in BINARY_VECTORS]
+    n = await BulkDoc.bulk_create(docs)
+    assert n == len(BINARY_VECTORS)
+
+    stored = {bytes(d.data) for d in await BulkDoc.all()}
+    assert stored == {bytes(v) for v in BINARY_VECTORS}
+
+
+@pytest.mark.asyncio
+async def test_bulk_create_preserves_rich_types(db_url):
+    class BulkRec(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        amount: decimal.Decimal = decimal.Decimal("0")
+
+    await ferro.connect(db_url, auto_migrate=True)
+
+    await BulkRec.bulk_create([
+        BulkRec(id=uuid4(), amount=decimal.Decimal("1.11")),
+        BulkRec(id=uuid4(), amount=decimal.Decimal("2.22")),
+    ])
+    amounts = sorted(r.amount for r in await BulkRec.all())
+    assert amounts == [decimal.Decimal("1.11"), decimal.Decimal("2.22")]


### PR DESCRIPTION
## What & why

`Model.save()` / `create()` / `Query.update()` / `bulk_create()` were the last stringly-typed mutation channels: each serialized row values to a JSON string (`model_dump_json` / `to_json` / `json.dumps`) before handing them to Rust, which parsed the string back into a `serde_json::Value` and bound from that. A `serde_json::Value` has no byte type, so non-UTF-8 `bytes` (PNG/PDF/compressed/random) died with an opaque `PydanticSerializationError` — and UTF-8 bytes only "worked" because they were silently coerced to text.

This routes all four channels through the **same typed codec bind path** as the rest of the write path, dropping the JSON-string envelope. Binary now persists and round-trips **byte-for-byte** (SQLite `BLOB`, Postgres `bytea`).

**Closes #162. Closes the user-facing bug #160.** (Merging into the `feat/ir-p8.6-cleanups` integration branch won't auto-fire "Closes"; both will be closed explicitly on merge.)

## Design

Each channel now sends a **native per-column value map** (dict / list of dicts) across the FFI with `bytes` preserved — not a JSON string. In Rust, a minimal seam:

```rust
enum BindInput { Json(serde_json::Value), Bytes(Vec<u8>) }
```

- `Bytes` → `SeaValue::Bytes` directly (real binary, no string round-trip).
- `Json` → the **unchanged** `codec::schema_bind_expr` — so UUID / datetime / Decimal / enum / JSON casting (and every Postgres cast) is byte-identical to before. **Parity holds by construction; `codec.rs` is provably unmodified.**

`BindInput`s are extracted synchronously (GIL held) *before* `future_into_py`, since a `Bound<PyDict>` isn't `Send` — mirroring the existing `raw_execute` pattern. The Python side keeps using pydantic's `mode="json"` / `to_json` for every non-bytes value (so those bind exactly as today) and overlays real bytes only for bytes-valued fields.

### Why not a bytes-native value model?
Considered (a hand-rolled enum or CBOR/msgpack `Value`) and deferred: any such type forces a rewrite of `schema_bind_expr`'s casting matcher and still needs JSON-text re-serialization for Postgres JSON columns. The minimal `BindInput` wrapper isolates the one new behavior to a single arm. Filed as **#164** for later.

## Changes

| Channel | Before | After |
|---|---|---|
| `save()` / `create()` | `model_dump_json()` → `save_record(data: String)` | `save_bind_payload(self)` → `save_record(data: dict)` |
| `Query.update()` | `to_json(fields)` → `update_filtered(update_json: String)` | `update_bind_payload(fields)` → `update_filtered(updates: dict)` |
| `bulk_create()` | `json.dumps([model_dump(mode="json")])` → `save_bulk_records(...: String)` | `[save_bind_payload(i)]` → `save_bulk_records(rows: list[dict])` |

New Rust primitives in `src/operations.rs` (`BindInput`, `py_to_json_value`, `bind_input_from_py`, `bind_inputs_from_py`, `bind_input_to_expr`); new `src/ferro/_bind_payload.py`; `_core.pyi` signatures updated. `query_ir_json` stays JSON (it's query IR, not row values).

## Gates

- **Byte-for-byte round-trip** of PNG/PDF magic, all-256-bytes, UTF-8, and empty payloads through **all four channels** — new `tests/test_typed_save_bind.py` (`backend_matrix`: SQLite locally, **Postgres in CI**).
- **Parity:** UUID / datetime / Decimal / int / bool / None / JSON list all round-trip byte-identically through every channel.
- **Error floor:** a genuinely unbindable value raises a clear, call-boundary error (not an opaque deep-DB crash); `py_to_json_value` names the column. No `unwrap()`/`expect()` on the new FFI value path (AGENTS.md I-3).
- **Grep-gate:** no `model_dump_json` / value-path `to_json` / `json.dumps` left in the save/update paths.
- 113 Rust tests + full Python suite green locally; `cz check` clean across all commits.

**CI merge gate:** Postgres `bytea` round-trip × Python {3.13, 3.14} (the authoritative gate per the phase's history).

## Out of scope / follow-ups

- **#164** — unify the write-path value model on a bytes-native type (retire the `BindInput` two-arm wrapper).
- **#165** — auto-migrate false-positive that reads a fresh `BLOB` column back as `text` (separate DDL/introspection bug; the suite's `text`/`blob` warnings are this, not a regression here).

Sub-issue of Epic #145 (IR-P8.6).
