### PR TITLE
fix(ir-p8.6): datetime/timestamptz coarseness — stop silent Postgres column reinterpretation (#154)

### DIFF
--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -444,6 +444,27 @@ pub fn is_timestamp_tz_conversion(old: CanonicalType, new: CanonicalType) -> boo
     )
 }
 
+/// The single-source warning for a refused `timestamp`⇄`timestamptz` auto-migrate
+/// conversion on Postgres. Emitted identically by the IR emitter and the legacy
+/// migrate planner so the shadow comparator sees matching plans.
+pub fn timestamp_tz_conversion_warning(
+    table: &str,
+    column: &str,
+    old_db_type: &str,
+    new_target: &str,
+    keep_db_type: &str,
+) -> String {
+    format!(
+        "Column '{table}.{column}' is '{old_db_type}' in the database but the model maps \
+         `datetime` to '{new_target}'. Ferro will not auto-convert it — a \
+         timestamp/timestamptz cast reinterprets existing values under the \
+         connection's timezone and can silently shift your data. To keep the column \
+         as-is, annotate the field with db_type=\"{keep_db_type}\". To convert it \
+         intentionally, use a reviewed migration (Alembic) with an explicit source \
+         timezone."
+    )
+}
+
 /// SQLite declared-type string for a canonical type (parity-pinned).
 pub fn sqlite_declared_type(canonical: CanonicalType) -> String {
     match canonical {
@@ -761,6 +782,17 @@ mod tests {
         assert_eq!(canonical_from_parts("integer", None, "", Dialect::Sqlite), Ok(CanonicalType::Integer));
         // unknown is an error (CREATE path maps this to Varchar at its call site)
         assert!(canonical_from_parts("mystery", None, "", Dialect::Postgres).is_err());
+    }
+
+    #[test]
+    fn timestamp_tz_conversion_warning_names_column_db_type_and_alembic() {
+        let w = timestamp_tz_conversion_warning(
+            "event", "occurred_at", "timestamp", "timestamptz", "timestamp",
+        );
+        let col = w.find("event.occurred_at").expect("names the column");
+        let dbt = w.find("db_type").expect("names db_type");
+        let alembic = w.find("Alembic").expect("names Alembic");
+        assert!(col < dbt && dbt < alembic, "tokens must appear in order: {w}");
     }
 
     #[test]

--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -432,6 +432,18 @@ pub fn pg_alter_type_target(canonical: CanonicalType) -> String {
     }
 }
 
+/// A `timestamp` ⇄ `timestamptz` change. Casting between them silently
+/// reinterprets stored values under the session `TimeZone`, so auto-migrate
+/// refuses it on Postgres (warn + skip) instead of executing it. `DateTime`
+/// is the naive side (it lowers to the same `"timestamp"` token as `Timestamp`).
+pub fn is_timestamp_tz_conversion(old: CanonicalType, new: CanonicalType) -> bool {
+    use CanonicalType::*;
+    matches!(
+        (old, new),
+        (Timestamp | DateTime, TimestampTz) | (TimestampTz, Timestamp | DateTime)
+    )
+}
+
 /// SQLite declared-type string for a canonical type (parity-pinned).
 pub fn sqlite_declared_type(canonical: CanonicalType) -> String {
     match canonical {
@@ -749,5 +761,22 @@ mod tests {
         assert_eq!(canonical_from_parts("integer", None, "", Dialect::Sqlite), Ok(CanonicalType::Integer));
         // unknown is an error (CREATE path maps this to Varchar at its call site)
         assert!(canonical_from_parts("mystery", None, "", Dialect::Postgres).is_err());
+    }
+
+    #[test]
+    fn is_timestamp_tz_conversion_matches_only_the_reinterpreting_pair() {
+        use CanonicalType::*;
+        // The reinterpreting pair, both directions (DateTime is the naive alias).
+        assert!(is_timestamp_tz_conversion(Timestamp, TimestampTz));
+        assert!(is_timestamp_tz_conversion(TimestampTz, Timestamp));
+        assert!(is_timestamp_tz_conversion(DateTime, TimestampTz));
+        assert!(is_timestamp_tz_conversion(TimestampTz, DateTime));
+        // Not a tz reinterpretation.
+        assert!(!is_timestamp_tz_conversion(Integer, BigInt));
+        assert!(!is_timestamp_tz_conversion(Varchar(None), Integer));
+        assert!(!is_timestamp_tz_conversion(Timestamp, Timestamp));
+        assert!(!is_timestamp_tz_conversion(TimestampTz, TimestampTz));
+        assert!(!is_timestamp_tz_conversion(Date, TimestampTz));
+        assert!(!is_timestamp_tz_conversion(Timestamp, Date));
     }
 }

--- a/crates/ferro-migrate/src/emit.rs
+++ b/crates/ferro-migrate/src/emit.rs
@@ -6,6 +6,7 @@ use ferro_ddl_lowering::{
     db_check_constraint_name, fk_action_from_str, fk_action_sql, is_timestamp_tz_conversion,
     literal_default_value, pg_alter_type_target, quote_ident, render_db_check, single_index_name,
     single_unique_index_name, sqlite_declared_type, sqlite_type_storage_drift,
+    timestamp_tz_conversion_warning,
 };
 use ferro_schema_ir::{IrEnvelope, SchemaColumn, SchemaIrPayload, SchemaModel};
 use sea_query::{
@@ -442,17 +443,12 @@ fn emit_alter_column_type(
                 }
             })?;
             if is_timestamp_tz_conversion(old_canonical, new_canonical) {
-                result.warnings.push(format!(
-                    "Column '{table}.{column}' is '{old}' in the database but the model maps \
-                     `datetime` to '{new}'. Ferro will not auto-convert it — a \
-                     timestamp/timestamptz cast reinterprets existing values under the \
-                     connection's timezone and can silently shift your data. To keep the column \
-                     as-is, annotate the field with db_type=\"{keep}\". To convert it \
-                     intentionally, use a reviewed migration (Alembic) with an explicit source \
-                     timezone.",
-                    old = old_col.db_type.as_deref().unwrap_or(""),
-                    new = pg_alter_type_target(new_canonical),
-                    keep = canonical_to_db_type_token(old_canonical, ld),
+                result.warnings.push(timestamp_tz_conversion_warning(
+                    table,
+                    column,
+                    old_col.db_type.as_deref().unwrap_or(""),
+                    &pg_alter_type_target(new_canonical),
+                    &canonical_to_db_type_token(old_canonical, ld),
                 ));
                 return Ok(result);
             }

--- a/crates/ferro-migrate/src/emit.rs
+++ b/crates/ferro-migrate/src/emit.rs
@@ -2,10 +2,10 @@
 
 use crate::{Dialect, EmissionError, EmissionResult, MigrationOp, MigrationPlan};
 use ferro_ddl_lowering::{
-    self, apply_canonical_type, canonical_from_schema_column, db_check_constraint_name,
-    fk_action_from_str, fk_action_sql, literal_default_value, pg_alter_type_target, quote_ident,
-    render_db_check, single_index_name, single_unique_index_name, sqlite_declared_type,
-    sqlite_type_storage_drift,
+    self, apply_canonical_type, canonical_from_schema_column, canonical_to_db_type_token,
+    db_check_constraint_name, fk_action_from_str, fk_action_sql, is_timestamp_tz_conversion,
+    literal_default_value, pg_alter_type_target, quote_ident, render_db_check, single_index_name,
+    single_unique_index_name, sqlite_declared_type, sqlite_type_storage_drift,
 };
 use ferro_schema_ir::{IrEnvelope, SchemaColumn, SchemaIrPayload, SchemaModel};
 use sea_query::{
@@ -433,6 +433,29 @@ fn emit_alter_column_type(
                     ),
                 }
             })?;
+            let old_canonical = canonical_from_schema_column(old_col, ld).map_err(|message| {
+                EmissionError {
+                    message: format!(
+                        "Cannot alter type for '{}.{}': {}",
+                        table, column, message
+                    ),
+                }
+            })?;
+            if is_timestamp_tz_conversion(old_canonical, new_canonical) {
+                result.warnings.push(format!(
+                    "Column '{table}.{column}' is '{old}' in the database but the model maps \
+                     `datetime` to '{new}'. Ferro will not auto-convert it — a \
+                     timestamp/timestamptz cast reinterprets existing values under the \
+                     connection's timezone and can silently shift your data. To keep the column \
+                     as-is, annotate the field with db_type=\"{keep}\". To convert it \
+                     intentionally, use a reviewed migration (Alembic) with an explicit source \
+                     timezone.",
+                    old = old_col.db_type.as_deref().unwrap_or(""),
+                    new = pg_alter_type_target(new_canonical),
+                    keep = canonical_to_db_type_token(old_canonical, ld),
+                ));
+                return Ok(result);
+            }
             let target = pg_alter_type_target(new_canonical);
             result.statements.push(format!(
                 "ALTER TABLE {table} ALTER COLUMN {col} TYPE {target} USING {col}::{target}",

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -902,6 +902,53 @@ fn plan_from_ir_composite_all_new_columns_emits_add_index() {
     );
 }
 
+#[test]
+fn emit_alter_type_refuses_timestamp_to_timestamptz_on_postgres() {
+    // Live column is naive `timestamp`; the model maps `datetime` -> timestamptz.
+    let old_ir = envelope(vec![schema_model(
+        "event",
+        vec![col("occurred_at", "timestamp", false)],
+    )]);
+    let new_ir = envelope(vec![schema_model(
+        "event",
+        vec![ir_col("occurred_at", "datetime", None, false, false, false)],
+    )]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnType {
+            table: "event".to_string(),
+            column: "occurred_at".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result = emit_sql_with_ir(&plan, &old_ir, &new_ir, Dialect::Postgres).unwrap();
+    assert!(
+        result.statements.is_empty(),
+        "expected no ALTER statement, got {:?}",
+        result.statements
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert!(result.warnings[0].contains("occurred_at"));
+    assert!(result.warnings[0].contains("db_type"));
+    assert!(result.warnings[0].contains("Alembic"));
+}
+
+#[test]
+fn emit_alter_type_still_alters_int_to_bigint_on_postgres() {
+    let old_ir = envelope(vec![schema_model("m", vec![col("n", "int", false)])]);
+    let new_ir = envelope(vec![schema_model("m", vec![col("n", "bigint", false)])]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnType {
+            table: "m".to_string(),
+            column: "n".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result = emit_sql_with_ir(&plan, &old_ir, &new_ir, Dialect::Postgres).unwrap();
+    assert_eq!(result.statements.len(), 1);
+    assert!(result.statements[0].contains("ALTER COLUMN"));
+    assert!(result.warnings.is_empty());
+}
+
 // KTD-2/KTD-3 golden: `render_create_table` must be byte-identical to TODAY's
 // runtime JSON path (`build_create_table_sqls`) for the comprehensive fixture,
 // emitting FKs INLINE in the CREATE TABLE on BOTH backends.

--- a/docs/brainstorms/2026-07-01-ir-p8.6-154-datetime-tz-coarseness-requirements.md
+++ b/docs/brainstorms/2026-07-01-ir-p8.6-154-datetime-tz-coarseness-requirements.md
@@ -1,0 +1,327 @@
+---
+title: "IR-P8.6 #154 — datetime→timestamptz coarseness: stop auto-migrate from silently reinterpreting an external timestamp column"
+type: requirements
+status: draft
+date: 2026-07-01
+issue: https://github.com/syn54x/ferro-orm/issues/154
+epic: https://github.com/syn54x/ferro-orm/issues/145
+roadmap: docs/plans/2026-06-19-001-ir-first-roadmap.md (Phase 8.6)
+---
+
+# #154 — datetime / timestamptz coarseness (reframed as a data-safety fix)
+
+## Goal
+
+Stop Postgres auto-migrate from **silently executing a data-reinterpreting
+`timestamp` → `timestamptz` cast** on a column the user created outside Ferro.
+Today, pointing a plain `datetime` model field at a pre-existing
+`timestamp without time zone` column and connecting with `migrate_updates=True`
+runs `ALTER COLUMN … TYPE timestamptz USING …` with **no warning and no consent**,
+reinterpreting every stored value under the connection's session timezone.
+
+After this lands, that specific `timestamp` ⇄ `timestamptz` conversion is
+**refused and explained** on Postgres — auto-migrate emits a warning (naming both
+remediations: the `db_type` override to keep the column, or Alembic to convert it
+intentionally) and **leaves the column untouched** — mirroring the warn-and-skip
+posture SQLite already has in the same emitter. Ferro-managed columns, the
+`db_type` escape hatch, and every other type change (`int`→`bigint`, …) are
+behavior-preserved.
+
+This is sub-issue #154 of Epic #145 (Phase 8.6), a **pre-existing coarseness**
+surfaced during the #141 final review (#141 only widened the surface — the new
+`("datetime", _)` arm matches any format; the legacy `("string", Some("date-time"))`
+arm had the same coarseness).
+
+## Reproduced evidence (Postgres 18.4 via docker, `feat/ir-p8.6-cleanups`)
+
+The issue text says the drift produces *"a spurious `AlterColumnType` + 'use
+Alembic' warning."* **That is inaccurate for Postgres.** The "use Alembic" warning
+is SQLite-only (`emit.rs:457`). On Postgres the drift **silently executes** a real
+cast — a data-safety defect, not a cosmetic false positive.
+
+**[A] External naive `timestamp` + a plain `datetime` model, then
+`connect(migrate_updates=True)`** — live `information_schema` before/after:
+
+```python
+# CREATE TABLE "event" ("id" serial PRIMARY KEY, "occurred_at" timestamp NOT NULL)  -- outside Ferro
+class Event(Model):
+    occurred_at: dt.datetime          # no db_type override
+
+# [A] BEFORE live type : 'timestamp without time zone'
+# [A] AFTER  live type : 'timestamp with time zone'      <- SILENTLY REWRITTEN
+# [A] warnings emitted : []                              <- NO warning
+```
+
+`internal_migrate` (`src/migrate.rs:908`) executes the statement
+`emit_alter_column_type` produced for Postgres (`emit.rs:437`):
+
+```sql
+ALTER TABLE "event" ALTER COLUMN "occurred_at" TYPE timestamptz USING "occurred_at"::timestamptz
+```
+
+**What that cast does to data** (the exact statement, replayed in `psql` with a
+non-UTC deployment session timezone):
+
+```
+BEFORE:  2026-01-15 09:00:00        -- app convention: naive = UTC ("9am UTC")
+SET TimeZone = 'America/New_York';
+AFTER:   2026-01-15 09:00:00-05     -- Postgres read the naive value as 9am New York
+         (= 2026-01-15 14:00:00 UTC)  -- every value shifted 5 hours, silently
+```
+
+**[B] Control — Ferro-created (`timestamptz`) column:** round-trips with no drift,
+no rewrite, no warning. Ferro-managed date-time columns are unaffected.
+
+```
+# [B] BEFORE live type : 'timestamp with time zone'
+# [B] AFTER  live type : 'timestamp with time zone'    (unchanged, no warning)
+```
+
+**[C] The escape hatch already exists and works** — `Field(db_type="timestamp")`
+(`tests/test_db_type_validation.py:92` proves `db_type="timestamptz"` is accepted
+symmetrically):
+
+```python
+class Event3(Model):
+    occurred_at: Annotated[dt.datetime, FerroField(db_type="timestamp")]
+
+# [C] BEFORE live type : 'timestamp without time zone'
+# [C] AFTER  live type : 'timestamp without time zone'   (untouched, no warning)
+```
+
+## The central design question (the issue's a/b/c fork, resolved)
+
+The issue offers: **(a)** distinguish naive vs tz-aware `datetime` in the SchemaIR;
+**(b)** treat `Timestamp` ≡ `TimestampTz` as storage-equivalent for drift; **(c)**
+accept as correct — a real type difference worth flagging.
+
+The reproduction reframes the fork. The harm is not "we flag a difference we
+shouldn't" — it is "we **silently reinterpret the user's data**." So:
+
+- **(a) is impossible from the annotation and already shipped where it is
+  possible.** Python's `datetime.datetime` carries **no** naive/aware distinction —
+  tz-awareness is a runtime property of *values*, not the type. Ferro cannot infer
+  intent, so it applies an opinionated default (`datetime` → `timestamptz`,
+  `lib.rs:297`). The one place precision *is* expressible — an explicit
+  `db_type` — already works (evidence [C]). There is nothing precise left to build
+  from the type alone; building IR-level "naive datetime" inference would be a
+  feature with no signal to drive it (YAGNI).
+- **(b) as stated is wrong** — it is *silent*. Suppressing the drift at the
+  detection layer removes the warning too, giving the user no signal and no
+  guidance. It also mislabels the types "storage-equivalent" when on Postgres they
+  interpret data differently.
+- **(c) is what ships today** — and today "flagging" on Postgres means *silently
+  executing* the cast. The defect lives under (c).
+
+**Decision: the reframed fix — detect, refuse, explain.** Keep drift *detection*
+exactly as-is (it correctly sees `timestamp` ≠ `timestamptz`, `lib.rs:730` — that is
+what lets us warn). Change only the *remediation* on Postgres: refuse the
+`timestamp` ⇄ `timestamptz` cast, emit a warning naming both remediations, and leave
+the column untouched. This is the same warn-and-skip SQLite already performs in the
+same function (`emit.rs:456–466`), given Postgres-honest wording.
+
+### Why the fix lives at the emission layer, not drift detection
+
+`schema_columns_storage_drift` (`lib.rs:231`) → `diff_model_columns` pushes
+`MigrationOp::AlterColumnType` (`lib.rs:261`) → the single shared emitter
+`emit_alter_column_type` (`emit.rs:587`, reached by both the IR and the legacy
+planner paths) turns it into SQL. Warn-and-skip needs the drift **detected** (so we
+can warn) but the **remediation** changed from execute → warn. That is the emission
+layer. Suppressing at detection would be silent; changing detection would also
+suppress genuine `db_type` type changes. The emitter already holds `old_col` and
+`new_col` (`emit.rs:585–586`), so it has everything the decision needs.
+
+## Current state (confirmed on `feat/ir-p8.6-cleanups`)
+
+- `canonical_from_parts` (`crates/ferro-ddl-lowering/src/lib.rs:297`) maps
+  `("datetime", _)` → `CanonicalType::TimestampTz` unconditionally; the legacy arm
+  `("string", Some("date-time"))` (`:283`) does the same. On Postgres,
+  `TimestampTz` → token `"timestamptz"`; naive `Timestamp` → `"timestamp"`
+  (`:169–170`).
+- Live introspection: `information_schema_to_db_type_token` maps
+  `"timestamp without time zone"` → `"timestamp"` and `"timestamp with time zone"` →
+  `"timestamptz"` (`:201–202`), consumed by `live_columns_to_schema_ir`
+  (`src/migrate.rs`).
+- Drift: `schema_columns_storage_drift` compares canonical **tokens**; on Postgres
+  `"timestamp"` ≠ `"timestamptz"` → **drift = true** (pinned `lib.rs:730`). On
+  SQLite both merge to `"timestamp"` → **drift = false** (pinned `lib.rs:691–700`),
+  so **SQLite is unaffected**.
+- Remediation: `emit_alter_column_type` (`emit.rs:402`) — **Postgres** pushes the
+  real `ALTER … USING` cast (`:437`) with no warning; **SQLite** already
+  warn-and-skips via `sqlite_type_storage_drift` (`:456`, "use Alembic"). Because
+  `timestamp`/`timestamptz` share the SQLite `Temporal` class, SQLite emits neither
+  a statement nor a warning for this pair — harmless (SQLite stores temporals as
+  text; no reinterpretation).
+- The `db_type` override exists end-to-end: `Field(db_type=...)`
+  (`src/ferro/fields.py`) → `schema_metadata.py` → `compiler.py` sets
+  `column_ir["db_type"]` / `db_type_explicit`, which `db_type_token_to_canonical`
+  resolves (`"timestamp"` → `Timestamp`, `lib.rs:126–128`).
+
+**This is Postgres-only.** SQLite merges the two types at the token layer, so the
+drift never fires there and no `ALTER` is ever attempted.
+
+## The change
+
+### 4.1 A pure predicate in `ferro-ddl-lowering`
+
+Next to its canonical siblings, unit-testable, total:
+
+```rust
+/// A `timestamp` ⇄ `timestamptz` change. Casting between them silently
+/// reinterprets stored values under the session TimeZone, so auto-migrate
+/// refuses it on Postgres (warn + skip) instead of executing it.
+pub fn is_timestamp_tz_conversion(old: CanonicalType, new: CanonicalType) -> bool {
+    use CanonicalType::*;
+    matches!(
+        (old, new),
+        (Timestamp | DateTime, TimestampTz) | (TimestampTz, Timestamp | DateTime)
+    )
+}
+```
+
+`DateTime` is included because on Postgres `canonical_to_db_type_token` collapses
+`DateTime` and `Timestamp` to the same `"timestamp"` token (`:169`); both are the
+naive side of the pair.
+
+### 4.2 Postgres branch of `emit_alter_column_type` refuses the conversion
+
+Before building the `ALTER` (`emit.rs:428+`), resolve `old_col`'s canonical too and
+short-circuit when the pair is a timestamp⇄timestamptz reinterpretation:
+
+```rust
+let old_canonical = canonical_from_schema_column(old_col, ld).map_err(|message| {
+    EmissionError { message: format!("Cannot alter type for '{table}.{column}': {message}") }
+})?;
+if is_timestamp_tz_conversion(old_canonical, new_canonical) {
+    result.warnings.push(format!(
+        "Column '{table}.{column}' is '{}' in the database but the model maps \
+         `datetime` to '{}'. Ferro will not auto-convert it — a timestamp⇄timestamptz \
+         cast reinterprets existing values under the connection's timezone and can \
+         silently shift your data. To keep the column as-is, annotate the field with \
+         db_type=\"{}\". To convert it intentionally, use a reviewed migration \
+         (Alembic) with an explicit source timezone.",
+        old_col.db_type.as_deref().unwrap_or(""),
+        pg_alter_type_target(new_canonical),
+        canonical_to_db_type_token(old_canonical, ld),
+    ));
+    return Ok(result); // skip the ALTER — column untouched
+}
+```
+
+Two deliberate wording choices:
+
+- **Do not copy SQLite's reason.** SQLite says "SQLite cannot change column types in
+  place." On Postgres that is false (it *can* — that is the problem). The Postgres
+  reason is "*won't*, because it would reinterpret your data."
+- **Lead with `db_type`, then Alembic.** For the common case (adopting Ferro over an
+  existing naive column) `db_type="timestamp"` is the real answer — self-contained,
+  no external tool, no data risk. Alembic is the secondary path for the minority who
+  genuinely want the naive→aware conversion (which needs an explicit source
+  timezone Ferro cannot infer).
+
+Nothing else in `emit_alter_column_type` changes. Detection, the IR mapping
+(`canonical_from_parts`), and introspection are untouched.
+
+## Behavior reconciliation (exactly what changes)
+
+| Scenario | Today | After |
+|---|---|---|
+| PG: external `timestamp` + `datetime` model | **silent** `ALTER … USING` (data shifts) | **warn + skip**, column untouched |
+| PG: `db_type="timestamp"` override | no drift ✓ | no drift ✓ (unchanged) |
+| PG: Ferro-created `timestamptz` | no drift ✓ | no drift ✓ (unchanged) |
+| PG: `int`→`bigint` and all other type alters | auto-runs | auto-runs (unchanged) |
+| SQLite: any datetime/timestamp/timestamptz | merged, no drift ✓ | merged, no drift ✓ (unchanged) |
+
+The only behavior change is the first row: a silent, data-reinterpreting rewrite
+becomes a loud, actionable warning that touches nothing. This is the deliberate
+"fix the divergence you consolidate" posture (same as #158's SQLite-warning
+addition) and aligns with AGENTS.md "fail loud, never degrade silently."
+
+## Error handling
+
+`is_timestamp_tz_conversion` is total (a `matches!`, cannot fail). The added
+`canonical_from_schema_column(old_col, …)` reuses the existing fallible resolver and
+propagates via the existing `EmissionError` path (same shape as the `new_col`
+resolution two lines below it) — **no** new `unwrap()`/`expect()` on any path
+(AGENTS.md I-3). The warn-and-skip returns `Ok(result)` exactly like the SQLite
+branch already does.
+
+## Testing / validation
+
+Hard gate: the silent Postgres rewrite is gone (column untouched + warning), and
+**nothing else** changes.
+
+**Rust unit tests** (`crates/ferro-ddl-lowering`, `crates/ferro-migrate`):
+
+- `is_timestamp_tz_conversion`: both directions `true`; `int`→`bigint`,
+  `varchar`→`int`, `Timestamp`→`Timestamp`, `Date`→`TimestampTz` all `false`.
+- `emit_alter_column_type` Postgres: temporal pair → `warnings` has the message,
+  `statements` empty; a non-temporal drift (`int`→`bigint`) → `statements` has the
+  `ALTER`, `warnings` empty (regression guard).
+
+**Python gate** (`tests/test_auto_migrate.py`, `postgres_only`, promoted from the
+reproduction) — the merge-blocking test:
+
+- External `timestamp` + `datetime` model + `migrate_updates=True` →
+  `pytest.warns(UserWarning, match=r"event\.occurred_at.*db_type.*Alembic")`
+  **and** assert the live column is *still* `timestamp without time zone` (proves
+  skip, not execute).
+- Control: `db_type="timestamp"` override → no warning, column unchanged.
+- Control: Ferro-created `timestamptz` → no warning, no drift.
+
+**Existing safety net (must stay green):**
+
+- `tests/test_auto_migrate.py` on the **SQLite + Postgres** matrix (Postgres CI is
+  the real gate — CI-deferred locally). Don't regress Python 3.13 or 3.14.
+- Workspace `cargo test` (macOS: `cargo test --no-default-features --features
+  testing`) incl. `-p ferro-ddl-lowering -p ferro-migrate`; the drift/equivalence
+  fixtures (`lib.rs:691–731`) are untouched and must stay green.
+- The legacy planner + shadow-compare (`shadow_compare_migration_plan`) both flow
+  through the same shared `emit_alter_column_type`, so both paths get the identical
+  warn-and-skip — the plan **verifies** this (does not assume it) as its one
+  cross-path check.
+
+**Grep-gate (completeness):**
+
+- The new predicate `is_timestamp_tz_conversion` is referenced by the Postgres
+  emitter and its unit tests.
+- No new `unwrap()`/`expect()`/`dead_code` warnings introduced by the change.
+
+**Done =** workspace `cargo test` green + `test_auto_migrate.py` green on **SQLite
+and Postgres**; the external-`timestamp` + `datetime` case warns and leaves the
+column untouched; the `db_type` and Ferro-created controls unchanged; the grep-gate
+clean.
+
+## Risk
+
+- **A legitimate migration gets suppressed.** A user who *wants* naive→aware no
+  longer gets it auto-applied. Mitigation: that conversion was never safe to
+  auto-apply (session-timezone reinterpretation); the warning names the correct path
+  (Alembic + explicit source tz). This is the intended behavior change.
+- **Shadow-compare mismatch** between the legacy and IR planners. Mitigation: both
+  call the one shared emitter, so both change identically; the plan verifies the
+  shadow comparator stays quiet on this case.
+- **Wording drift from the SQLite message.** Mitigation: the two messages are
+  deliberately different (Postgres "won't" vs SQLite "cannot"); a unit test pins the
+  Postgres text's key tokens (`db_type`, `Alembic`).
+- **Scope creep to other type alters.** Mitigation: the predicate matches *only* the
+  timestamp⇄timestamptz pair; a regression test asserts `int`→`bigint` still
+  auto-runs.
+
+## Migration impact
+
+`user-visible behavior change, Postgres only, safety-improving`. Previously, a plain
+`datetime` model over an external `timestamp` column would silently rewrite that
+column to `timestamptz` on connect (reinterpreting data). It now warns and leaves
+the column untouched. No public API change; no change for Ferro-managed columns,
+SQLite, the `db_type` escape hatch, or any other type conversion. Users who relied on
+the silent conversion get an explicit, safer path (`db_type` or Alembic).
+
+## Documentation impact
+
+A short note in the auto-migrate / type-mapping docs: `datetime` maps to
+`timestamptz`; to bind a naive `timestamp` column use `db_type="timestamp"`; Ferro
+will not auto-convert between the two (it warns). Per the roadmap documentation
+policy and memory `docs-show-both-declaration-styles`, any field-declaration example
+added shows both the Assignment and `Annotated` styles. The plan sizes the exact
+docs edit.

--- a/docs/pages/howto/timestamps.md
+++ b/docs/pages/howto/timestamps.md
@@ -49,6 +49,18 @@ def utcnow() -> datetime:
 
 Avoid naive `datetime.now()` — it captures the server's local clock, which makes values ambiguous and breaks comparisons across hosts and DST changes. Keep storage in UTC and convert to the user's timezone only at the display layer.
 
+### Naive vs timezone-aware columns
+
+A `datetime` field maps to Postgres `timestamptz` (SQLite stores both the same
+way). If you point a model at a pre-existing plain `timestamp` (no time zone)
+column, Ferro will **not** silently convert it — auto-migrate warns and leaves the
+column untouched, because a `timestamp` → `timestamptz` cast reinterprets stored
+values under the connection's timezone and can shift your data.
+
+- To keep the column naive, declare the field with `db_type="timestamp"`.
+- To convert it intentionally, run a reviewed migration (Alembic) with an explicit
+  source timezone, e.g. `USING occurred_at AT TIME ZONE 'UTC'`.
+
 ## See Also
 
 - [Models & Fields guide](../guide/models-and-fields.md) — field defaults and `default_factory`

--- a/docs/plans/2026-07-01-002-fix-ir-p8.6-154-datetime-tz-coarseness-plan.md
+++ b/docs/plans/2026-07-01-002-fix-ir-p8.6-154-datetime-tz-coarseness-plan.md
@@ -1,0 +1,467 @@
+# #154 datetime/timestamptz coarseness — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop Postgres auto-migrate from silently executing a data-reinterpreting `timestamp` ⇄ `timestamptz` cast on an externally-created column — refuse it, warn (naming the `db_type` override and Alembic), and leave the column untouched.
+
+**Architecture:** Drift *detection* is unchanged (it correctly sees `timestamp` ≠ `timestamptz`). The fix is at the *remediation* layer: a new pure predicate `is_timestamp_tz_conversion` in `ferro-ddl-lowering` identifies the reinterpreting pair, and the Postgres branch of `emit_alter_column_type` (`ferro-migrate`) short-circuits to a warn-and-skip instead of emitting the `ALTER … USING` cast — mirroring the warn-and-skip SQLite already performs in the same function. Postgres-only; SQLite already merges the two types so no drift fires there.
+
+**Tech Stack:** Rust (workspace crates `ferro-ddl-lowering`, `ferro-migrate`); PyO3 core rebuilt with `uv run maturin develop`; Python 3.13/3.14 + pytest with a SQLite+Postgres backend matrix.
+
+**Spec:** `docs/brainstorms/2026-07-01-ir-p8.6-154-datetime-tz-coarseness-requirements.md`
+
+## Global Constraints
+
+- **Behavior-preserving** for Ferro-managed date-time columns (they must keep round-tripping with **no** drift), the `db_type` escape hatch, SQLite, and every non-temporal type change (`int`→`bigint`, …). The **only** intended behavior change: the Postgres external-`timestamp` + `datetime` case now warns-and-skips instead of silently rewriting.
+- **Fail loud, never degrade silently** (AGENTS.md I-6). **No `unwrap()`/`expect()`** on any new path (AGENTS.md I-3) — reuse the existing `EmissionError` propagation.
+- **Rebuild the Rust core after every Rust edit:** `uv run maturin develop` before running any Python test.
+- **Rust tests (macOS):** `cargo test -p ferro-ddl-lowering` and `cargo test -p ferro-migrate` run standalone (leaf crates, no PyO3 link — verified green at 44 passed). The workspace-wide run needs `cargo test --no-default-features --features testing` (default feature set fails to link locally).
+- **Postgres is the merge gate** (CI). The Python gate test is `postgres_only`; locally run it with a Postgres URL configured. Don't regress Python 3.13 or 3.14.
+- **Conventional Commits** (no invented types). Run `uv run cz check --rev-range feat/ir-p8.6-cleanups..HEAD` before pushing. **No AI attribution** in commits/PRs. **No `CHANGELOG.md` edits** (AGENTS.md I-10).
+- **Docs show both declaration styles** — any docs *example that declares fields* shows Assignment + Annotated tabs (memory `docs-show-both-declaration-styles`). (Task 4 adds a prose note, not a new declaration example.)
+- After any fix subagent, verify its commit landed on `feat/ir-p8.6-154-datetime-tz-coarseness` (not an isolated worktree branch) (memory `sdd-fix-subagent-worktree-gotcha`).
+
+## File Structure
+
+- `crates/ferro-ddl-lowering/src/lib.rs` — add `pub fn is_timestamp_tz_conversion(old, new) -> bool` (after `pg_alter_type_target`, ~`:433`); add unit tests to the existing `#[cfg(test)] mod tests` (`:543`).
+- `crates/ferro-migrate/src/emit.rs` — import the predicate + `canonical_to_db_type_token` (use block `:4-9`); add the Postgres warn-and-skip short-circuit inside `emit_alter_column_type` (`:413-442`).
+- `crates/ferro-migrate/src/tests.rs` — add two emitter tests using the existing `envelope`/`schema_model`/`col`/`ir_col` helpers.
+- `tests/test_auto_migrate.py` — add the `postgres_only` gate test (promoted from the reproduction), modeled on `test_sqlite_type_drift_warns_and_leaves_column_untouched` (`:362`).
+- `docs/pages/howto/timestamps.md` — a note in the "Timezone Notes" section (`:38`).
+
+---
+
+## Task 1: `is_timestamp_tz_conversion` predicate (ferro-ddl-lowering)
+
+**Files:**
+- Modify: `crates/ferro-ddl-lowering/src/lib.rs` (add fn after `pg_alter_type_target` ~`:433`; add tests in `mod tests` `:543`)
+
+**Interfaces:**
+- Produces (used by Task 2): `pub fn is_timestamp_tz_conversion(old: CanonicalType, new: CanonicalType) -> bool`
+- Consumes: the existing `CanonicalType` enum (`:22`), unchanged.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Add to `mod tests` in `crates/ferro-ddl-lowering/src/lib.rs` (near the drift tests ~`:731`):
+
+```rust
+#[test]
+fn is_timestamp_tz_conversion_matches_only_the_reinterpreting_pair() {
+    use CanonicalType::*;
+    // The reinterpreting pair, both directions (DateTime is the naive alias).
+    assert!(is_timestamp_tz_conversion(Timestamp, TimestampTz));
+    assert!(is_timestamp_tz_conversion(TimestampTz, Timestamp));
+    assert!(is_timestamp_tz_conversion(DateTime, TimestampTz));
+    assert!(is_timestamp_tz_conversion(TimestampTz, DateTime));
+    // Not a tz reinterpretation.
+    assert!(!is_timestamp_tz_conversion(Integer, BigInt));
+    assert!(!is_timestamp_tz_conversion(Varchar(None), Integer));
+    assert!(!is_timestamp_tz_conversion(Timestamp, Timestamp));
+    assert!(!is_timestamp_tz_conversion(TimestampTz, TimestampTz));
+    assert!(!is_timestamp_tz_conversion(Date, TimestampTz));
+    assert!(!is_timestamp_tz_conversion(Timestamp, Date));
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p ferro-ddl-lowering is_timestamp_tz_conversion_matches_only_the_reinterpreting_pair`
+Expected: FAIL — `cannot find function \`is_timestamp_tz_conversion\``.
+
+- [ ] **Step 3: Implement the predicate**
+
+Add after `pg_alter_type_target` (ends ~`:433`) in `crates/ferro-ddl-lowering/src/lib.rs`:
+
+```rust
+/// A `timestamp` ⇄ `timestamptz` change. Casting between them silently
+/// reinterprets stored values under the session `TimeZone`, so auto-migrate
+/// refuses it on Postgres (warn + skip) instead of executing it. `DateTime`
+/// is the naive side (it lowers to the same `"timestamp"` token as `Timestamp`).
+pub fn is_timestamp_tz_conversion(old: CanonicalType, new: CanonicalType) -> bool {
+    use CanonicalType::*;
+    matches!(
+        (old, new),
+        (Timestamp | DateTime, TimestampTz) | (TimestampTz, Timestamp | DateTime)
+    )
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p ferro-ddl-lowering is_timestamp_tz_conversion_matches_only_the_reinterpreting_pair`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full crate suite (no regressions)**
+
+Run: `cargo test -p ferro-ddl-lowering`
+Expected: PASS (was 44 passed; now 45).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ferro-ddl-lowering/src/lib.rs
+git commit -m "feat(ir-p8.6): add is_timestamp_tz_conversion predicate (#154)"
+```
+
+---
+
+## Task 2: Postgres warn-and-skip in `emit_alter_column_type` (ferro-migrate)
+
+**Files:**
+- Modify: `crates/ferro-migrate/src/emit.rs` (use block `:4-9`; Postgres branch of `emit_alter_column_type` `:413-442`)
+- Modify: `crates/ferro-migrate/src/tests.rs` (add two tests using existing helpers)
+
+**Interfaces:**
+- Consumes (from Task 1): `is_timestamp_tz_conversion`; plus existing `canonical_from_schema_column`, `pg_alter_type_target`, `canonical_to_db_type_token`.
+- Produces: no new public symbol — a behavior change to `emit_alter_column_type` (Postgres: temporal pair → `warnings` gets the message, `statements` stays empty).
+
+- [ ] **Step 1: Write the two failing emitter tests**
+
+Add to `crates/ferro-migrate/src/tests.rs` (after `plan_from_ir_detects_add_drop_and_alter_ops` ~`:266`). These drive the op through the single shared emitter `emit_sql_with_ir`:
+
+```rust
+#[test]
+fn emit_alter_type_refuses_timestamp_to_timestamptz_on_postgres() {
+    // Live column is naive `timestamp`; the model maps `datetime` -> timestamptz.
+    let old_ir = envelope(vec![schema_model(
+        "event",
+        vec![col("occurred_at", "timestamp", false)],
+    )]);
+    let new_ir = envelope(vec![schema_model(
+        "event",
+        vec![ir_col("occurred_at", "datetime", None, false, false, false)],
+    )]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnType {
+            table: "event".to_string(),
+            column: "occurred_at".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result = emit_sql_with_ir(&plan, &old_ir, &new_ir, Dialect::Postgres).unwrap();
+    assert!(
+        result.statements.is_empty(),
+        "expected no ALTER statement, got {:?}",
+        result.statements
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert!(result.warnings[0].contains("occurred_at"));
+    assert!(result.warnings[0].contains("db_type"));
+    assert!(result.warnings[0].contains("Alembic"));
+}
+
+#[test]
+fn emit_alter_type_still_alters_int_to_bigint_on_postgres() {
+    let old_ir = envelope(vec![schema_model("m", vec![col("n", "int", false)])]);
+    let new_ir = envelope(vec![schema_model("m", vec![col("n", "bigint", false)])]);
+    let plan = MigrationPlan {
+        operations: vec![MigrationOp::AlterColumnType {
+            table: "m".to_string(),
+            column: "n".to_string(),
+        }],
+        warnings: Vec::new(),
+    };
+    let result = emit_sql_with_ir(&plan, &old_ir, &new_ir, Dialect::Postgres).unwrap();
+    assert_eq!(result.statements.len(), 1);
+    assert!(result.statements[0].contains("ALTER COLUMN"));
+    assert!(result.warnings.is_empty());
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p ferro-migrate emit_alter_type_`
+Expected: `emit_alter_type_refuses_...` FAILS (it currently emits the ALTER statement, warnings empty); `emit_alter_type_still_alters_int_to_bigint...` PASSES (guards existing behavior).
+
+- [ ] **Step 3: Import the predicate and token helper**
+
+In `crates/ferro-migrate/src/emit.rs`, extend the `use ferro_ddl_lowering::{…}` block (`:4-9`) to add `canonical_to_db_type_token` and `is_timestamp_tz_conversion` (alphabetical within the list):
+
+```rust
+use ferro_ddl_lowering::{
+    self, apply_canonical_type, canonical_from_schema_column, canonical_to_db_type_token,
+    db_check_constraint_name, fk_action_from_str, fk_action_sql, is_timestamp_tz_conversion,
+    literal_default_value, pg_alter_type_target, quote_ident, render_db_check, single_index_name,
+    single_unique_index_name, sqlite_declared_type, sqlite_type_storage_drift,
+};
+```
+
+- [ ] **Step 4: Add the warn-and-skip short-circuit**
+
+In `emit_alter_column_type`, Postgres branch, replace the block that computes `new_canonical` and pushes the `ALTER` (`:428-442`) with the version that resolves `old_canonical` first and short-circuits on the reinterpreting pair:
+
+```rust
+            let new_canonical = canonical_from_schema_column(new_col, ld).map_err(|message| {
+                EmissionError {
+                    message: format!(
+                        "Cannot alter type for '{}.{}': {}",
+                        table, column, message
+                    ),
+                }
+            })?;
+            let old_canonical = canonical_from_schema_column(old_col, ld).map_err(|message| {
+                EmissionError {
+                    message: format!(
+                        "Cannot alter type for '{}.{}': {}",
+                        table, column, message
+                    ),
+                }
+            })?;
+            if is_timestamp_tz_conversion(old_canonical, new_canonical) {
+                result.warnings.push(format!(
+                    "Column '{table}.{column}' is '{old}' in the database but the model maps \
+                     `datetime` to '{new}'. Ferro will not auto-convert it — a \
+                     timestamp/timestamptz cast reinterprets existing values under the \
+                     connection's timezone and can silently shift your data. To keep the column \
+                     as-is, annotate the field with db_type=\"{keep}\". To convert it \
+                     intentionally, use a reviewed migration (Alembic) with an explicit source \
+                     timezone.",
+                    old = old_col.db_type.as_deref().unwrap_or(""),
+                    new = pg_alter_type_target(new_canonical),
+                    keep = canonical_to_db_type_token(old_canonical, ld),
+                ));
+                return Ok(result);
+            }
+            let target = pg_alter_type_target(new_canonical);
+            result.statements.push(format!(
+                "ALTER TABLE {table} ALTER COLUMN {col} TYPE {target} USING {col}::{target}",
+                table = quote_ident(table),
+                col = quote_ident(column),
+                target = target,
+            ));
+```
+
+- [ ] **Step 5: Rebuild the core and run the tests**
+
+Run: `cargo test -p ferro-migrate emit_alter_type_`
+Expected: both PASS.
+
+- [ ] **Step 6: Run both crate suites (no regressions)**
+
+Run: `cargo test -p ferro-ddl-lowering -p ferro-migrate`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ferro-migrate/src/emit.rs crates/ferro-migrate/src/tests.rs
+git commit -m "fix(ir-p8.6): warn-and-skip timestamp/timestamptz auto-migrate on postgres (#154)"
+```
+
+---
+
+## Task 3: Python auto-migrate gate test (Postgres)
+
+**Files:**
+- Modify: `tests/test_auto_migrate.py` (add one `postgres_only` test near `test_sqlite_type_drift_warns_and_leaves_column_untouched` `:362`; imports `datetime` + `psycopg` already available via conftest fixtures)
+
+**Interfaces:**
+- Consumes: `ferro.connect`, `ferro.execute`, `ferro.reset_engine`; the conftest fixtures `db_url`, `postgres_base_url`, `db_schema_name`; the Rust behavior from Tasks 1–2.
+
+- [ ] **Step 1: Rebuild the core so Python sees the new behavior**
+
+Run: `uv run maturin develop`
+Expected: builds cleanly (exit 0).
+
+- [ ] **Step 2: Write the gate test**
+
+Add to `tests/test_auto_migrate.py` (top-of-file already has `from typing import Annotated`, `import pytest`, `import ferro`, `from ferro import Model, execute`, `from ferro.base import FerroField`; add `import datetime as dt` and `import psycopg` if not present):
+
+```python
+def _pg_live_type(base_url: str, schema: str, table: str, column: str) -> str:
+    import psycopg
+
+    with psycopg.connect(base_url, autocommit=True) as conn:
+        row = conn.execute(
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_schema = %s AND table_name = %s AND column_name = %s",
+            (schema, table, column),
+        ).fetchone()
+    return row[0] if row else "<absent>"
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
+async def test_pg_datetime_over_external_naive_timestamp_warns_and_skips(
+    db_url, postgres_base_url, db_schema_name, clean_registry
+):
+    """An external plain `timestamp` column + a `datetime` model must NOT be
+    silently rewritten to `timestamptz`; auto-migrate warns and leaves it. (#154)"""
+    import datetime as dt
+
+    await ferro.connect(db_url)
+    await execute(
+        'CREATE TABLE "event" '
+        '("id" serial PRIMARY KEY, "occurred_at" timestamp NOT NULL)'
+    )
+    ferro.reset_engine()
+
+    class Event(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        occurred_at: dt.datetime
+
+    with pytest.warns(UserWarning, match=r"event\.occurred_at.*db_type.*Alembic"):
+        await ferro.connect(db_url, migrate_updates=True)
+
+    # The external column is untouched — no silent reinterpretation.
+    assert (
+        _pg_live_type(postgres_base_url, db_schema_name, "event", "occurred_at")
+        == "timestamp without time zone"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
+async def test_pg_datetime_db_type_override_keeps_naive_no_drift(
+    db_url, postgres_base_url, db_schema_name, clean_registry
+):
+    """The escape hatch: db_type="timestamp" over an external naive column
+    produces no drift, no warning, and no rewrite. (#154)"""
+    import datetime as dt
+    import warnings as _warnings
+
+    await ferro.connect(db_url)
+    await execute(
+        'CREATE TABLE "event2" '
+        '("id" serial PRIMARY KEY, "occurred_at" timestamp NOT NULL)'
+    )
+    ferro.reset_engine()
+
+    class Event2(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        occurred_at: Annotated[dt.datetime, FerroField(db_type="timestamp")]
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error", UserWarning)  # any drift warning -> failure
+        await ferro.connect(db_url, migrate_updates=True)
+
+    assert (
+        _pg_live_type(postgres_base_url, db_schema_name, "event2", "occurred_at")
+        == "timestamp without time zone"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
+async def test_pg_ferro_created_timestamptz_no_drift(
+    db_url, postgres_base_url, db_schema_name, clean_registry
+):
+    """Control: a Ferro-created (timestamptz) column reconnects with no drift
+    and no warning — Ferro-managed date-time columns are unaffected. (#154)"""
+    import datetime as dt
+    import warnings as _warnings
+
+    class Event3(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        occurred_at: dt.datetime
+
+    await ferro.connect(db_url, auto_migrate=True)  # Ferro creates it -> timestamptz
+    assert (
+        _pg_live_type(postgres_base_url, db_schema_name, "event3", "occurred_at")
+        == "timestamp with time zone"
+    )
+    ferro.reset_engine()
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error", UserWarning)
+        await ferro.connect(db_url, migrate_updates=True)
+
+    assert (
+        _pg_live_type(postgres_base_url, db_schema_name, "event3", "occurred_at")
+        == "timestamp with time zone"
+    )
+```
+
+Note: `clean_registry` is the registry-isolation fixture used elsewhere in this
+file (e.g. `:252`); if a test in this module already relies on the module-level
+`pytestmark = pytest.mark.backend_matrix`, the `postgres_only` marker on these two
+functions overrides the matrix to Postgres only.
+
+- [ ] **Step 3: Run the gate tests against Postgres**
+
+Run:
+```bash
+FERRO_POSTGRES_URL=postgres://postgres:password@localhost:5432/postgres \
+  uv run pytest tests/test_auto_migrate.py -k "test_pg_" \
+  -p no:cacheprovider --db-backends=postgres -v
+```
+Expected: both PASS. (Requires a local Postgres, e.g. `docker run --name local-pg -e POSTGRES_PASSWORD=password -p 5432:5432 -d postgres`.)
+
+- [ ] **Step 4: Verify no shadow-runtime mismatch (both planner paths agree)**
+
+The legacy planner and the IR planner both emit through the same
+`emit_alter_column_type`, so the shadow comparator must stay quiet. Re-run the
+gate under strict shadow mode:
+
+Run:
+```bash
+FERRO_SHADOW_RUNTIME_STRICT=1 \
+  FERRO_POSTGRES_URL=postgres://postgres:password@localhost:5432/postgres \
+  uv run pytest tests/test_auto_migrate.py -k "test_pg_" \
+  -p no:cacheprovider --db-backends=postgres -v
+```
+Expected: both PASS (no `Ferro shadow runtime mismatch` RuntimeError). If it fails, the legacy path diverged — stop and reconcile before continuing (do not silence the comparator).
+
+- [ ] **Step 5: Run the SQLite matrix (no regression on the unaffected backend)**
+
+Run: `uv run pytest tests/test_auto_migrate.py -p no:cacheprovider -q`
+Expected: PASS (SQLite; the two new tests skip without a Postgres provider).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_auto_migrate.py
+git commit -m "test(ir-p8.6): postgres gate for datetime/timestamptz warn-and-skip (#154)"
+```
+
+---
+
+## Task 4: Documentation note
+
+**Files:**
+- Modify: `docs/pages/howto/timestamps.md` ("Timezone Notes" section, `:38-50`)
+
+**Interfaces:** none (prose only; no new field-declaration example, so the both-styles rule is not triggered).
+
+- [ ] **Step 1: Add the note**
+
+Append to the "Timezone Notes" section of `docs/pages/howto/timestamps.md` (after the existing UTC guidance ~`:50`):
+
+```markdown
+### Naive vs timezone-aware columns
+
+A `datetime` field maps to Postgres `timestamptz` (SQLite stores both the same
+way). If you point a model at a pre-existing plain `timestamp` (no time zone)
+column, Ferro will **not** silently convert it — auto-migrate warns and leaves the
+column untouched, because a `timestamp` → `timestamptz` cast reinterprets stored
+values under the connection's timezone and can shift your data.
+
+- To keep the column naive, declare the field with `db_type="timestamp"`.
+- To convert it intentionally, run a reviewed migration (Alembic) with an explicit
+  source timezone, e.g. `USING occurred_at AT TIME ZONE 'UTC'`.
+```
+
+- [ ] **Step 2: Verify the docs build/render (if a docs build is configured)**
+
+Run: `uv run mkdocs build --strict 2>/dev/null || echo "mkdocs not configured — skip"`
+Expected: builds without warnings, or the skip message.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/pages/howto/timestamps.md
+git commit -m "docs(ir-p8.6): note datetime/timestamptz mapping + db_type escape hatch (#154)"
+```
+
+---
+
+## Final verification (before requesting whole-branch review)
+
+- [ ] `cargo test -p ferro-ddl-lowering -p ferro-migrate` — green.
+- [ ] `uv run maturin develop` — clean.
+- [ ] Postgres gate (Task 3 Steps 3–4) — green, incl. strict shadow mode.
+- [ ] `uv run pytest -p no:cacheprovider -q` (full SQLite suite) — green; no 3.13/3.14 regression.
+- [ ] `uv run cz check --rev-range feat/ir-p8.6-cleanups..HEAD` — all commits conventional.
+- [ ] Grep-gate: `rg is_timestamp_tz_conversion crates/` shows the definition + emitter use + unit test; no stray `ALTER COLUMN .* TYPE timestamptz` path remains for this case.
+- [ ] No `CHANGELOG.md` edits; no AI attribution in commits.
+```

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -15,8 +15,9 @@
 
 use crate::backend::EngineHandle;
 use ferro_ddl_lowering::{
-    CanonicalType, Dialect, apply_canonical_type, canonical_to_db_type_token,
-    information_schema_to_db_type_token, schema_columns_storage_drift,
+    CanonicalType, Dialect, apply_canonical_type, canonical_from_schema_column,
+    canonical_to_db_type_token, information_schema_to_db_type_token, is_timestamp_tz_conversion,
+    schema_columns_storage_drift, timestamp_tz_conversion_warning,
 };
 use ferro_migrate::{MigrationOp, emit_sql_with_ir, plan_from_ir};
 use ferro_schema_ir::{
@@ -728,13 +729,27 @@ fn plan_existing_column(
             if !live.is_enum_udt
                 && schema_columns_storage_drift(&live_col, &model_col, dialect)
             {
-                let target = pg_alter_type_target(col_plan.canonical);
-                plan.statements.push(format!(
-                    "ALTER TABLE {table} ALTER COLUMN {col} TYPE {target} USING {col}::{target}",
-                    table = quote_ident(table_lower),
-                    col = quote_ident(col_name),
-                    target = target,
-                ));
+                let old_canonical = canonical_from_schema_column(&live_col, dialect);
+                match old_canonical {
+                    Ok(old_c) if is_timestamp_tz_conversion(old_c, col_plan.canonical) => {
+                        plan.warnings.push(timestamp_tz_conversion_warning(
+                            table_lower,
+                            col_name,
+                            live_col.db_type.as_deref().unwrap_or(""),
+                            &pg_alter_type_target(col_plan.canonical),
+                            &canonical_to_db_type_token(old_c, dialect),
+                        ));
+                    }
+                    _ => {
+                        let target = pg_alter_type_target(col_plan.canonical);
+                        plan.statements.push(format!(
+                            "ALTER TABLE {table} ALTER COLUMN {col} TYPE {target} USING {col}::{target}",
+                            table = quote_ident(table_lower),
+                            col = quote_ident(col_name),
+                            target = target,
+                        ));
+                    }
+                }
             }
             if !col_plan.is_nullable && live.is_nullable {
                 plan.statements.push(format!(

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -382,6 +382,110 @@ async def test_sqlite_type_drift_warns_and_leaves_column_untouched(
     ), "no DDL may run for SQLite type drift"
 
 
+def _pg_live_type(base_url: str, schema: str, table: str, column: str) -> str:
+    import psycopg
+
+    with psycopg.connect(base_url, autocommit=True) as conn:
+        row = conn.execute(
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_schema = %s AND table_name = %s AND column_name = %s",
+            (schema, table, column),
+        ).fetchone()
+    return row[0] if row else "<absent>"
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
+async def test_pg_datetime_over_external_naive_timestamp_warns_and_skips(
+    db_url, postgres_base_url, db_schema_name, clean_registry
+):
+    """An external plain `timestamp` column + a `datetime` model must NOT be
+    silently rewritten to `timestamptz`; auto-migrate warns and leaves it. (#154)"""
+    import datetime as dt
+
+    await ferro.connect(db_url)
+    await execute(
+        'CREATE TABLE "event" '
+        '("id" serial PRIMARY KEY, "occurred_at" timestamp NOT NULL)'
+    )
+    ferro.reset_engine()
+
+    class Event(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        occurred_at: dt.datetime
+
+    with pytest.warns(UserWarning, match=r"event\.occurred_at.*db_type.*Alembic"):
+        await ferro.connect(db_url, migrate_updates=True)
+
+    # The external column is untouched — no silent reinterpretation.
+    assert (
+        _pg_live_type(postgres_base_url, db_schema_name, "event", "occurred_at")
+        == "timestamp without time zone"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
+async def test_pg_datetime_db_type_override_keeps_naive_no_drift(
+    db_url, postgres_base_url, db_schema_name, clean_registry
+):
+    """The escape hatch: db_type="timestamp" over an external naive column
+    produces no drift, no warning, and no rewrite. (#154)"""
+    import datetime as dt
+    import warnings as _warnings
+
+    await ferro.connect(db_url)
+    await execute(
+        'CREATE TABLE "event2" '
+        '("id" serial PRIMARY KEY, "occurred_at" timestamp NOT NULL)'
+    )
+    ferro.reset_engine()
+
+    class Event2(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        occurred_at: Annotated[dt.datetime, FerroField(db_type="timestamp")]
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error", UserWarning)  # any drift warning -> failure
+        await ferro.connect(db_url, migrate_updates=True)
+
+    assert (
+        _pg_live_type(postgres_base_url, db_schema_name, "event2", "occurred_at")
+        == "timestamp without time zone"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
+async def test_pg_ferro_created_timestamptz_no_drift(
+    db_url, postgres_base_url, db_schema_name, clean_registry
+):
+    """Control: a Ferro-created (timestamptz) column reconnects with no drift
+    and no warning — Ferro-managed date-time columns are unaffected. (#154)"""
+    import datetime as dt
+    import warnings as _warnings
+
+    class Event3(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        occurred_at: dt.datetime
+
+    await ferro.connect(db_url, auto_migrate=True)  # Ferro creates it -> timestamptz
+    assert (
+        _pg_live_type(postgres_base_url, db_schema_name, "event3", "occurred_at")
+        == "timestamp with time zone"
+    )
+    ferro.reset_engine()
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error", UserWarning)
+        await ferro.connect(db_url, migrate_updates=True)
+
+    assert (
+        _pg_live_type(postgres_base_url, db_schema_name, "event3", "occurred_at")
+        == "timestamp with time zone"
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.backend_matrix
 async def test_migrate_destructive_drops_removed_columns(


### PR DESCRIPTION
Sub-issue of #145 (Phase 8.6). Targets the integration branch `feat/ir-p8.6-cleanups`, not `main`.

## What & why

`#154` was filed as a low-priority "coarse type mapping → spurious warning." Reproducing it on Postgres showed something more serious: **auto-migrate silently reinterprets data.**

A `datetime` model field maps to `timestamptz` (Python's `datetime` annotation carries no naive/aware distinction, so Ferro can't infer intent). If you point such a field at a pre-existing plain `timestamp` column and connect with `migrate_updates=True`, auto-migrate **silently executes**:

```sql
ALTER TABLE "event" ALTER COLUMN "occurred_at" TYPE timestamptz USING "occurred_at"::timestamptz
```

That `USING` cast reinterprets every stored value under the connection's session timezone — no warning, no consent:

```
BEFORE: 2026-01-15 09:00:00        -- app convention: naive = UTC ("9am UTC")
AFTER:  2026-01-15 09:00:00-05     -- read as 9am America/New_York = 14:00 UTC — every value shifted 5h
```

The "use Alembic" warning the issue assumed only exists on SQLite; on Postgres the cast just ran.

## The fix

Drift **detection** is unchanged (it correctly sees `timestamp` ≠ `timestamptz` — that's what lets us warn). Only the **remediation** changes: a pure predicate `is_timestamp_tz_conversion` (`ferro-ddl-lowering`) identifies the reinterpreting pair, and both emitters — the IR `emit_alter_column_type` and the legacy `plan_existing_column` — now **warn-and-skip** it instead of executing the cast, leaving the column untouched. The warning is single-sourced (`timestamp_tz_conversion_warning`) so the two planners stay byte-identical (keeps the shadow comparator honest until the legacy path is removed in Phase 9 / #108).

The warning names both remediations, with Postgres-honest wording (it *won't* convert, not *can't*):
- keep the column naive → annotate `db_type="timestamp"` (already worked; now the only drift-free path)
- convert intentionally → Alembic with an explicit source timezone

Behavior change is **Postgres-only** and limited to this one case. Every other type change (`int`→`bigint`, …) still auto-runs; Ferro-managed `timestamptz` columns and SQLite are unaffected.

## Verification

- Rust: `ferro-ddl-lowering` 14 + `ferro-migrate` 46 — green
- Full SQLite suite: 700 passed, 1 xfailed (known 3.14), 0 failed
- **Postgres gate with the shadow comparator enabled + strict** (`FERRO_SHADOW_RUNTIME=1 FERRO_SHADOW_RUNTIME_STRICT=1`): 3/3 passed, **0 shadow mismatch** — the IR and legacy planners agree
- Postgres CI is the merge gate.

New `postgres_only` gate tests in `tests/test_auto_migrate.py`: external-`timestamp` warns-and-skips (asserts the live column stays `timestamp without time zone`), the `db_type="timestamp"` escape hatch (no warning, unchanged), and a Ferro-created `timestamptz` control.

## Docs & impact

- Spec: `docs/brainstorms/2026-07-01-ir-p8.6-154-datetime-tz-coarseness-requirements.md`
- Plan: `docs/plans/2026-07-01-002-fix-ir-p8.6-154-datetime-tz-coarseness-plan.md`
- User docs: a "Naive vs timezone-aware columns" note in `howto/timestamps.md`

Migration impact: **Postgres-only, safety-improving** — a previously silent, data-reinterpreting rewrite becomes a loud, actionable warning that touches nothing. No public API change.

Addresses #154.
