### PR TITLE
fix(ir-p8.6): stop false-positive BLOB drift warning on SQLite (#165)

### DIFF
--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -140,6 +140,7 @@ pub fn db_type_token_to_canonical(token: &str, dialect: Dialect) -> Option<Canon
         "numeric" => Some(CanonicalType::Decimal),
         "json" => Some(CanonicalType::Json),
         "bytea" => Some(CanonicalType::Blob),
+        "blob" => Some(CanonicalType::Blob),
         "varchar" => Some(CanonicalType::Varchar(None)),
         other => parse_varchar_token(other)
             .map(|n| CanonicalType::Varchar(Some(n)))
@@ -191,6 +192,7 @@ pub fn information_schema_to_db_type_token(
         "numeric" => "numeric",
         "json" | "jsonb" => "json",
         "bytea" => "bytea",
+        "blob" => "blob",
         "text" => "text",
         "integer" => "int",
         "smallint" => "smallint",
@@ -622,6 +624,10 @@ mod tests {
             information_schema_to_db_type_token("boolean", None, Dialect::Postgres),
             "boolean"
         );
+        assert_eq!(
+            information_schema_to_db_type_token("BLOB", None, Dialect::Sqlite),
+            "blob"
+        );
     }
 
     #[test]
@@ -730,6 +736,61 @@ mod tests {
         assert!(!schema_columns_storage_drift(&a, &b, Dialect::Sqlite));
         // Cross-check: same tokens DO differ on Postgres (Timestamp vs TimestampTz).
         assert!(schema_columns_storage_drift(&a, &b, Dialect::Postgres));
+    }
+
+    #[test]
+    fn db_type_token_to_canonical_resolves_blob() {
+        assert_eq!(
+            db_type_token_to_canonical("blob", Dialect::Sqlite),
+            Some(CanonicalType::Blob)
+        );
+        assert_eq!(
+            db_type_token_to_canonical("blob", Dialect::Postgres),
+            Some(CanonicalType::Blob)
+        );
+    }
+
+    /// The one cross-consumer guard: the token a live SQLite BLOB normalizes to
+    /// must satisfy BOTH planner consumers at once — `db_type_token_to_canonical`
+    /// (the IR planner) resolves it to `Blob`, AND `sqlite_type_class` (the legacy
+    /// planner's SQLite arm) classes it the same as the model's declared blob.
+    /// This is why the token is "blob", not the canonical "bytea": `sqlite_type_class`
+    /// only recognizes Blob for strings containing "blob". (#165)
+    #[test]
+    fn live_sqlite_blob_round_trips_through_both_consumers() {
+        let token = information_schema_to_db_type_token("BLOB", None, Dialect::Sqlite);
+        // IR-path consumer.
+        assert_eq!(
+            db_type_token_to_canonical(&token, Dialect::Sqlite),
+            Some(CanonicalType::Blob)
+        );
+        // Legacy-path consumer: same class as the model's declared blob type.
+        assert_eq!(
+            sqlite_type_class(&token),
+            sqlite_type_class(&sqlite_declared_type(CanonicalType::Blob))
+        );
+    }
+
+    /// A live BLOB column must NOT drift against a `binary` (bytes) model column,
+    /// while a genuine text↔blob difference still drifts. (#165)
+    #[test]
+    fn blob_model_does_not_drift_against_live_blob_on_sqlite() {
+        // Live column: introspected via the real normalizer, logical_type "unknown".
+        let live_token = information_schema_to_db_type_token("BLOB", None, Dialect::Sqlite);
+        let live = col_with_db_type("data", "unknown", None, Some(&live_token));
+        // Model column: Python SchemaIR compiler emits logical_type "binary", db_type None.
+        let model = col_with_db_type("data", "binary", None, None);
+        assert!(
+            !schema_columns_storage_drift(&live, &model, Dialect::Sqlite),
+            "a live BLOB column must not read as drifted against a bytes model"
+        );
+
+        // Genuine diff preserved: a live TEXT column vs the same bytes model DOES drift.
+        let live_text = col_with_db_type("data", "unknown", None, Some("text"));
+        assert!(
+            schema_columns_storage_drift(&live_text, &model, Dialect::Sqlite),
+            "a real text→blob difference must still be detected"
+        );
     }
 
     #[test]

--- a/docs/brainstorms/2026-07-01-ir-p8.6-165-blob-introspection-false-positive-requirements.md
+++ b/docs/brainstorms/2026-07-01-ir-p8.6-165-blob-introspection-false-positive-requirements.md
@@ -94,7 +94,14 @@ for `bytea`, `text`, `int`, `varchar`, … but **no arm for `blob`**. A live SQL
 - **Legacy planner path.** `plan_existing_column` SQLite arm (`src/migrate.rs:775`)
   feeds the normalizer's output token **directly** into `sqlite_type_class`:
   `sqlite_type_class("text")` = `Text` vs `sqlite_type_class(sqlite_declared_type(Blob))`
-  = `sqlite_type_class("blob")` = `Blob` → mismatch → **warning**.
+  = `sqlite_type_class("blob")` = `Blob` → mismatch → **warning**. Note: the runtime
+  legacy planner calls a **duplicate, byte-for-byte-identical** `sqlite_type_class`
+  (`src/migrate.rs:280`) and `sqlite_declared_type` (`src/migrate.rs:243`), **not** the
+  `ferro-ddl-lowering` copies — both classify `"blob"` → `Blob` and spell `Blob` →
+  `"blob"` the same way, so the shared normalizer fix reaches this path identically.
+  (This `migrate.rs` ⇄ `lib.rs` duplication is exactly the "parallel abstractions
+  synced by hand" pattern Epic 8.6 targets — a candidate for a future cleanup
+  sub-issue, out of scope for #165.)
 
 Postgres is immune on both paths: live `bytea` → `"bytea"` (`lib.rs:193`) →
 `db_type_token_to_canonical("bytea")` = `Blob` → matches the model's `Blob` → no
@@ -137,7 +144,11 @@ per-path patch. Answer to (c): confirmed below — genuine diffs still warn.
   (`lib.rs:173`) — the canonical Blob token for **both** dialects.
 - `sqlite_declared_type` (`lib.rs:469`): `Blob` → `"blob"` (`lib.rs:487`).
 - `sqlite_type_class` (`lib.rs:502`, `pub(crate)`): returns `Blob` for a declared
-  string containing `"blob"` or empty (`lib.rs:516`); `"bytea"` → `Numeric`.
+  string containing `"blob"` or empty (`lib.rs:516`); `"bytea"` → `Numeric`. The
+  runtime legacy planner uses a duplicate, identical copy at `src/migrate.rs:280`
+  (with `sqlite_declared_type` duplicated at `src/migrate.rs:243`); both agree on
+  `blob`, so the round-trip guard against the `lib.rs` copy is a valid proxy and the
+  Python gate under strict shadow exercises the actual runtime legacy path.
 - Model side: a plain `bytes` field compiles to `logical_type = "binary"` with **no**
   `db_type` (`src/ferro/ir/compiler.py:96`), resolving to `Blob` via the
   `("binary", _)` arm (`lib.rs:296`).
@@ -314,17 +325,24 @@ shadow-comparator (strict) stays quiet on the BLOB case; grep-gate clean.
   round-trip-everything guard (YAGNI, rejected above).
 - **`db_type="blob"` override behavior change.** Previously unrecognized (fell to the
   logical cascade); now resolves to `Blob`. This is strictly more correct and covered
-  by the `db_type_token_to_canonical("blob")` unit test; no path relied on the old
-  fall-through.
+  by the `db_type_token_to_canonical("blob")` unit test; no existing test or path
+  relied on the old fall-through. Note this override edge is **not** SQLite-only: a
+  field with an explicit `db_type="blob"` on **Postgres** now resolves to `Blob`
+  (emitting `bytea`) instead of the previous varchar fall-through — a strict
+  correctness improvement, but the "no Postgres change" framing below refers to the
+  false-positive fix itself, not this explicit-override edge.
 
 ## Migration impact
 
 `user-visible behavior change, SQLite only, warning-removal`. Previously, any model
 with a `bytes` field emitted a spurious "declared text but expects blob / use Alembic"
 warning on every connect against SQLite. That false positive is removed. No public API
-change; no change for Postgres, for genuine `text`⇄`blob` differences (still warned),
-or for any other column type. No SQL was ever emitted for the case, so there is no
-data-path or schema change.
+change; the false-positive fix does not change Postgres, genuine `text`⇄`blob`
+differences (still warned), or any other column type. (The one incidental edge: an
+explicit `db_type="blob"` override now resolves to `Blob` on both backends instead of
+falling through to varchar — see the Risk section; strictly more correct, no test
+relied on the old behavior.) No SQL was ever emitted for the false-positive case, so
+there is no data-path or schema change.
 
 ## Documentation impact
 

--- a/docs/brainstorms/2026-07-01-ir-p8.6-165-blob-introspection-false-positive-requirements.md
+++ b/docs/brainstorms/2026-07-01-ir-p8.6-165-blob-introspection-false-positive-requirements.md
@@ -1,0 +1,335 @@
+---
+title: "IR-P8.6 #165 — BLOB introspection false positive: stop auto-migrate from misreading a live SQLite BLOB column as text"
+type: requirements
+status: draft
+date: 2026-07-01
+issue: https://github.com/syn54x/ferro-orm/issues/165
+epic: https://github.com/syn54x/ferro-orm/issues/145
+roadmap: docs/plans/2026-06-19-001-ir-first-roadmap.md (Phase 8.6)
+---
+
+# #165 — BLOB introspection false positive (a pure schema-diff misread)
+
+## Goal
+
+Stop SQLite auto-migrate from warning, on **every connect**, that a freshly
+Ferro-created `BLOB` column is "declared `text` in the database but the model
+expects `blob`". The model and the database **agree** — the `CREATE TABLE`
+Ferro just ran emitted `"data" blob` and `PRAGMA table_info` reports `BLOB`.
+The warning is a **false positive** from the schema-diff introspection: the live
+type normalizer has no arm for `blob`, so a live BLOB column normalizes to the
+catch-all `text`, and the drift check then compares that phantom `text` against
+the model's `blob`.
+
+After this lands, a live SQLite `BLOB` column round-trips through introspection to
+the canonical `blob` token, so the drift check sees `blob == blob` and stays quiet.
+Genuine `text` ⇄ `blob` differences still warn. Postgres and every other column
+type are behavior-preserved.
+
+This is sub-issue #165 of Epic #145 (Phase 8.6) — the **last** open sub-issue;
+closing it completes the epic (7/7). It is the **mirror image of #154**: #154 was a
+Postgres-only defect (a live `timestamp` mis-handled); this is a **SQLite-only**
+false positive (a live `blob` mis-normalized). Unlike #154 there is **no data
+risk** — SQLite stores the BLOB regardless — so this is a pure introspection fix,
+not a remediation reframe.
+
+## Reproduced evidence (`feat/ir-p8.6-165-blob-introspection-false-positive`)
+
+**[A] SQLite (the bug) — fresh DB, model and DB agree, yet it warns.** The exact
+issue repro:
+
+```python
+class Document(Model):
+    id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+    name: str = ""
+    data: bytes = b""
+
+await connect(f"sqlite:{tmp}/d.db?mode=rwc", migrate_updates=True)
+```
+
+```
+WARN: ferro auto-migrate: Column 'document.data' is declared 'text' in the
+      database but the model expects 'blob'. SQLite cannot change column types
+      in place; use Alembic to migrate this column.
+CREATE: CREATE TABLE "document" ( "data" blob NOT NULL, "id" uuid_text PRIMARY KEY, "name" varchar NOT NULL )
+PRAGMA: {'name': 'data', 'type': 'BLOB'}
+```
+
+The `CREATE` emitted `blob`; PRAGMA confirms `BLOB`. Nothing needs migrating — the
+warning (and its misleading "use Alembic" instruction) is spurious.
+
+**[B] Postgres (control) — the mirror-image, NO false positive.** A live `bytea`
+column round-trips through the existing `"bytea" => "bytea"` arm, so the same model
+connected twice emits nothing:
+
+```
+PG WARNINGS: NONE
+PG COL: {'column_name': 'data', 'data_type': 'bytea'}
+```
+
+This is why the fix is SQLite-only: Postgres already has a normalizer arm for its
+blob spelling; SQLite does not.
+
+## Root cause (traced through both planner paths)
+
+The introspection normalizer `information_schema_to_db_type_token`
+(`crates/ferro-ddl-lowering/src/lib.rs:179`) maps live `information_schema` /
+`PRAGMA` spellings to the canonical Ferro `db_type` token vocabulary. It has arms
+for `bytea`, `text`, `int`, `varchar`, … but **no arm for `blob`**. A live SQLite
+`BLOB` (declared type `"BLOB"`, lowercased `"blob"`) falls through to the catch-all
+`_ => "text"` (`lib.rs:213`). Everything downstream then believes the live column is
+`text`. This single normalizer feeds **both** runtime planner paths, and the phantom
+`text` produces the warning in each:
+
+- **IR planner path.** `live_columns_to_schema_ir` (`src/migrate.rs:133`) stamps the
+  live column `db_type = "text"`. `schema_columns_storage_drift` (`lib.rs:231`)
+  resolves it via `canonical_from_schema_column` → `db_type_token_to_canonical("text")`
+  = `Text`, and the model column (logical_type `"binary"`, no `db_type`) →
+  `canonical_from_parts("binary", …)` = `Blob` (`lib.rs:296`). Comparing storage
+  tokens, `canonical_to_db_type_token(Text)` = `"text"` ≠ `canonical_to_db_type_token(Blob)`
+  = `"bytea"` → **drift = true** → an `AlterColumnType` op is emitted →
+  `emit_alter_column_type` SQLite arm (`crates/ferro-migrate/src/emit.rs:475`) calls
+  `sqlite_type_storage_drift("text", Blob)` = `Text ≠ Blob` → **warning**.
+
+- **Legacy planner path.** `plan_existing_column` SQLite arm (`src/migrate.rs:775`)
+  feeds the normalizer's output token **directly** into `sqlite_type_class`:
+  `sqlite_type_class("text")` = `Text` vs `sqlite_type_class(sqlite_declared_type(Blob))`
+  = `sqlite_type_class("blob")` = `Blob` → mismatch → **warning**.
+
+Postgres is immune on both paths: live `bytea` → `"bytea"` (`lib.rs:193`) →
+`db_type_token_to_canonical("bytea")` = `Blob` → matches the model's `Blob` → no
+drift, no warning (evidence [B]).
+
+### The subtlety that dictates the fix shape (the a/b/c fork, resolved)
+
+The prompt's design fork asked: (a) is the root cause solely the missing `blob` arm
+in `information_schema_to_db_type_token`, or does `sqlite_type_class` / the token
+vocabulary need work too; (b) shared normalizer vs per-path patch; (c) make sure the
+fix doesn't mask real `text`↔`blob` diffs. Resolved by the trace above:
+
+- **The two planner paths consume the normalizer's output differently**, which
+  constrains *which* token the live blob must normalize to:
+  - The **IR path** resolves the token to a `CanonicalType` via
+    `db_type_token_to_canonical`, which recognizes `"bytea"` → `Blob` but **not**
+    `"blob"` (`lib.rs:115`).
+  - The **legacy SQLite path** passes the token straight into `sqlite_type_class`
+    (`lib.rs:502`), which classifies `Blob` **only for strings containing `"blob"`**
+    (`lib.rs:516`) — `sqlite_type_class("bytea")` = `Numeric`, **not** `Blob`.
+- Therefore normalizing the live blob to the canonical token `"bytea"` (Approach ②
+  below) would fix the IR path but leave the **legacy path still warning**. The token
+  must be **`"blob"`**, and `db_type_token_to_canonical` must additionally learn
+  `"blob"` → `Blob` so the IR path resolves it (otherwise the IR side resolves to
+  `Err` and falls through to `schema_columns_storage_drift`'s raw-string fallback at
+  `lib.rs:251`, `"blob" != None` → still drifts).
+
+So the answer to (a) is: the missing `blob` arm is the root cause, but a *correct*
+fix requires **two** shared-vocabulary arms, chosen so the token round-trips through
+**both** consumers. Answer to (b): the shared normalizer (single-source), not a
+per-path patch. Answer to (c): confirmed below — genuine diffs still warn.
+
+## Current state (confirmed on `feat/ir-p8.6-165-…`)
+
+- `information_schema_to_db_type_token` (`lib.rs:179`): exact-match arms for
+  `bytea`/`text`/`int`/… ; **no** `blob` arm; catch-all `_ => "text"` (`lib.rs:213`).
+- `db_type_token_to_canonical` (`lib.rs:115`): `"bytea"` → `Blob` (`lib.rs:142`);
+  **no** `"blob"` arm (falls through to varchar/char parse → `None`).
+- `canonical_to_db_type_token` (`lib.rs:152`): `Blob` → `"bytea"` unconditionally
+  (`lib.rs:173`) — the canonical Blob token for **both** dialects.
+- `sqlite_declared_type` (`lib.rs:469`): `Blob` → `"blob"` (`lib.rs:487`).
+- `sqlite_type_class` (`lib.rs:502`, `pub(crate)`): returns `Blob` for a declared
+  string containing `"blob"` or empty (`lib.rs:516`); `"bytea"` → `Numeric`.
+- Model side: a plain `bytes` field compiles to `logical_type = "binary"` with **no**
+  `db_type` (`src/ferro/ir/compiler.py:96`), resolving to `Blob` via the
+  `("binary", _)` arm (`lib.rs:296`).
+- Consumers of the normalizer: `live_columns_to_schema_ir` (IR path, `migrate.rs:133`)
+  and `plan_existing_column` (legacy path, `migrate.rs:720` Postgres, `migrate.rs:769`
+  SQLite).
+
+**This is SQLite-only.** Postgres reports `bytea`, already handled; it never reports
+`blob`, so the new arm has no Postgres effect.
+
+## The change
+
+Two arms in the single-source `crates/ferro-ddl-lowering/src/lib.rs`. Nothing in
+`emit.rs`, `migrate.rs`, `canonical_to_db_type_token`, or `sqlite_type_class`
+changes — the fix is confined to the introspection vocabulary that both planners
+share.
+
+### 6.1 `information_schema_to_db_type_token` — normalize the live `blob` spelling
+
+Add an exact-match arm next to `"bytea" => "bytea"` (`lib.rs:193`):
+
+```rust
+"bytea" => "bytea",
+"blob" => "blob",   // live SQLite BLOB column (PRAGMA type "BLOB")
+```
+
+Postgres never emits `blob` (it reports `bytea`), so this arm is SQLite-only in
+effect; leaving it dialect-unconditional keeps the vocabulary total and matches how
+the other exact-match arms are written.
+
+### 6.2 `db_type_token_to_canonical` — resolve the `blob` token to `Blob`
+
+Add an arm next to `"bytea" => Some(Blob)` (`lib.rs:142`):
+
+```rust
+"bytea" => Some(CanonicalType::Blob),
+"blob" => Some(CanonicalType::Blob),
+```
+
+This lets the IR path resolve the now-`"blob"` live token to canonical `Blob`
+instead of falling to the raw-string drift fallback. It also makes an explicit
+`db_type="blob"` field override resolve correctly (previously it fell through to the
+logical-type cascade) — a small correctness bonus, no regression (the token was
+unrecognized before).
+
+### Why token `"blob"` round-trips through both consumers
+
+| Consumer | Call | Before (bug) | After |
+|---|---|---|---|
+| IR drift detection | `db_type_token_to_canonical(token)` | `"text"` → `Text` | `"blob"` → `Blob` ✓ |
+| Legacy SQLite drift | `sqlite_type_class(token)` | `"text"` → `Text` | `"blob"` → `Blob` ✓ |
+| Model side (unchanged) | `canonical_from_parts("binary", …)` | `Blob` | `Blob` |
+| Drift comparison | `canonical_to_db_type_token(Blob)` | `"bytea"` | `"bytea"` (both sides) → no drift |
+
+`canonical_to_db_type_token(Blob)` remains `"bytea"`; both the live and model columns
+resolve to canonical `Blob`, so the storage-token comparison is `"bytea" == "bytea"`
+→ no drift → the `AlterColumnType` op is never emitted → no warning. The legacy path
+short-circuits one layer earlier: `sqlite_type_class("blob") == sqlite_type_class("blob")`.
+
+## Rejected alternatives
+
+- **② Normalize live `blob` → `"bytea"`.** Fixes the IR path (`db_type_token_to_canonical("bytea")`
+  = `Blob`) but **not** the legacy SQLite path: `sqlite_type_class("bytea")` = `Numeric`
+  ≠ `Blob` → still warns. Would require an *additional* change teaching
+  `sqlite_type_class` that `"bytea"` is Blob, and mixes a Postgres type spelling into
+  SQLite introspection output. More surface, dialect-confusing, no benefit over ①.
+- **③ Per-path patches** in `emit.rs` (SQLite arm) and `migrate.rs` (legacy SQLite
+  arm). Two edits kept in sync by hand — the exact "parallel abstractions synced by
+  hand" anti-pattern Epic 8.6 exists to eliminate. Violates no-stopgap / single-source.
+- **Belt-and-suspenders round-trip assertion** guarding every future missing arm.
+  YAGNI — the two arms plus a round-trip unit test are the correct-and-complete fix
+  for the one type that was missing; a generic guard is scope the issue does not need.
+
+## Does the fix mask real `text` ⇄ `blob` diffs? No.
+
+Only the genuine `blob == blob` case stops warning. Both directions of a real
+difference still drift and warn, on both paths:
+
+| Scenario | IR path | Legacy SQLite path |
+|---|---|---|
+| live `BLOB`, model `bytes` (the bug) | `"bytea"`==`"bytea"` → **no warn** ✓ | `blob`==`blob` → **no warn** ✓ |
+| live `TEXT`, model `bytes` | `Text`(`"text"`) ≠ `Blob`(`"bytea"`) → warn ✓ | `Text` ≠ `Blob` → warn ✓ |
+| live `BLOB`, model `str` (varchar) | `Blob`(`"bytea"`) ≠ `Varchar`(`"varchar"`) → warn ✓ | `Blob` ≠ `Text` → warn ✓ |
+
+## Behavior reconciliation (exactly what changes)
+
+| Scenario | Today | After |
+|---|---|---|
+| SQLite: Ferro-created `BLOB` + `bytes` model | **spurious warn** every connect | no warn (column untouched) |
+| SQLite: live `TEXT` + `bytes` model | warns | warns (unchanged) |
+| SQLite: live `BLOB` + `str` model | warns | warns (unchanged) |
+| SQLite: every other type (int/varchar/datetime/…) | no false positive | unchanged |
+| Postgres: `bytea` + `bytes` model | no warn ✓ | no warn ✓ (unchanged) |
+| Postgres: any type | unchanged | unchanged |
+
+The only behavior change is the first row: a spurious warning disappears. No SQL is
+emitted or suppressed for BLOB columns in any scenario (SQLite never `ALTER`s column
+types — it only warns), so there is no data-path impact.
+
+## Error handling
+
+Both arms are pure `match` additions — total, cannot fail, **no** new
+`unwrap()`/`expect()` on any path (AGENTS.md I-3). `db_type_token_to_canonical`
+returns `Option`; the new arm returns `Some(Blob)`, and every existing caller already
+handles `None`/`Some` and the downstream `Result` from `canonical_from_parts`. No new
+error surface.
+
+## Testing / validation
+
+Hard gate: the spurious SQLite BLOB warning is gone, genuine `text`⇄`blob` diffs
+still warn, and **nothing else** changes (Postgres and all other types unaffected).
+
+**Rust unit tests** (`crates/ferro-ddl-lowering/src/lib.rs`):
+
+- Extend `information_schema_to_db_type_token_maps_live_spellings` (`lib.rs:600`):
+  `information_schema_to_db_type_token("BLOB", None, Sqlite)` == `"blob"`.
+- `db_type_token_to_canonical("blob", Sqlite)` == `Some(Blob)` (and `Postgres`).
+- **Round-trip guard** (the one cross-consumer check, pins the whole fix): for a live
+  SQLite blob, `let t = information_schema_to_db_type_token("BLOB", None, Sqlite)`, then
+  assert `db_type_token_to_canonical(&t, Sqlite) == Some(Blob)` **and**
+  `sqlite_type_class(&t) == sqlite_type_class(&sqlite_declared_type(Blob))` (both
+  `Blob`). This proves the token satisfies **both** planner consumers at once.
+- Regression: `schema_columns_storage_drift` for a live-`blob` column vs a `binary`
+  model column returns `false`; a live-`text` vs `binary` model column returns `true`
+  (genuine diff preserved).
+
+**Python gate** (`tests/test_auto_migrate.py`, SQLite + Postgres matrix, promoted from
+the reproduction) — the merge-blocking test:
+
+- SQLite: model with a `bytes` field + `migrate_updates=True`, connect **twice**;
+  assert the second connect emits **no** `UserWarning` matching `data.*blob` (proves
+  the false positive is gone). Assert `PRAGMA table_info` still reports the column
+  `BLOB` (proves the column was untouched, not silently altered).
+- SQLite control (genuine diff still warns): a pre-existing `TEXT` column adopted by a
+  `bytes` model still warns — `pytest.warns(UserWarning, match=r"declared 'text'.*expects 'blob'")`.
+- Postgres control: the same `bytes` model connected twice emits no warning and the
+  live column stays `bytea` (mirror-image regression guard).
+
+**Existing safety net (must stay green):**
+
+- `tests/test_auto_migrate.py` on the **SQLite + Postgres** matrix (Postgres CI is the
+  real merge gate; verified locally against the docker Postgres). Don't regress Python
+  3.13 or 3.14.
+- Per-crate Rust: `cargo test -p ferro-ddl-lowering` and `cargo test -p ferro-migrate`;
+  workspace `cargo test --no-default-features --features testing` (macOS). The existing
+  drift/equivalence fixtures are untouched and must stay green.
+- **IR-vs-legacy planner parity** with the shadow comparator ENABLED **and** strict:
+  `FERRO_SHADOW_RUNTIME=1 FERRO_SHADOW_RUNTIME_STRICT=1` (STRICT alone is a silent
+  no-op). Both planners flow through the same shared normalizer, so both change
+  identically; the plan **verifies** (does not assume) the comparator stays quiet on
+  the BLOB case as its one cross-path check.
+
+**Grep-gate (completeness):**
+
+- No remaining `_ => "text"` reachable by a live `blob` spelling (the new arm precedes
+  the catch-all).
+- No new `unwrap()`/`expect()`/`dead_code` warnings introduced by the change.
+
+**Done =** workspace/per-crate `cargo test` green + `test_auto_migrate.py` green on
+**SQLite and Postgres**; the fresh-`bytes`-model case emits no warning on repeated
+connect and the column stays BLOB; both genuine-diff controls still warn; the
+shadow-comparator (strict) stays quiet on the BLOB case; grep-gate clean.
+
+## Risk
+
+- **Masking a genuine `text`↔`blob` diff.** Mitigation: the fix only equates
+  `blob`==`blob`; both real-diff directions are pinned by unit + Python tests (table
+  above).
+- **Shadow-compare mismatch** between the legacy and IR planners. Mitigation: both
+  consume the one shared normalizer, so both change identically; the plan verifies the
+  comparator stays quiet (strict) on this case.
+- **Scope creep to other missing arms.** Mitigation: the change adds exactly the two
+  `blob` arms; the round-trip unit test guards only this type. No generic
+  round-trip-everything guard (YAGNI, rejected above).
+- **`db_type="blob"` override behavior change.** Previously unrecognized (fell to the
+  logical cascade); now resolves to `Blob`. This is strictly more correct and covered
+  by the `db_type_token_to_canonical("blob")` unit test; no path relied on the old
+  fall-through.
+
+## Migration impact
+
+`user-visible behavior change, SQLite only, warning-removal`. Previously, any model
+with a `bytes` field emitted a spurious "declared text but expects blob / use Alembic"
+warning on every connect against SQLite. That false positive is removed. No public API
+change; no change for Postgres, for genuine `text`⇄`blob` differences (still warned),
+or for any other column type. No SQL was ever emitted for the case, so there is no
+data-path or schema change.
+
+## Documentation impact
+
+None required. This removes a spurious warning; it introduces no new field-declaration
+syntax, `db_type` guidance, or type-mapping behavior a user must learn. (If the plan
+finds an existing auto-migrate doc that explicitly lists the false positive as
+expected, it will delete that note — but no new example is added, so the
+`docs-show-both-declaration-styles` policy does not apply here.)

--- a/docs/plans/2026-07-01-003-fix-ir-p8.6-165-blob-introspection-plan.md
+++ b/docs/plans/2026-07-01-003-fix-ir-p8.6-165-blob-introspection-plan.md
@@ -1,0 +1,307 @@
+# #165 BLOB introspection false positive — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop SQLite auto-migrate from emitting a spurious "declared text but the model expects blob / use Alembic" warning on every connect for a model with a `bytes` field, by teaching the shared introspection vocabulary to normalize a live SQLite `BLOB` column to the canonical `blob` token.
+
+**Architecture:** The bug is a single missing arm in the introspection normalizer `information_schema_to_db_type_token` (`ferro-ddl-lowering`): a live SQLite `blob` spelling falls through to the catch-all `_ => "text"`, so the drift check believes the column is `text`. This normalizer feeds **both** runtime planner paths (the IR planner via `live_columns_to_schema_ir` → `schema_columns_storage_drift`, and the legacy planner via `plan_existing_column`'s SQLite arm → `sqlite_type_class`). The two consumers read the output token differently, so the fix is **two** arms in the single-source `lib.rs`, choosing token `"blob"` (not `"bytea"`) because only `"blob"` round-trips through *both* `db_type_token_to_canonical` (IR path) **and** `sqlite_type_class` (legacy path). No emitter or planner code changes. SQLite-only in effect (Postgres already handles its `bytea` spelling).
+
+**Tech Stack:** Rust (workspace crate `ferro-ddl-lowering`); PyO3 core rebuilt with `uv run maturin develop`; Python 3.13/3.14 + pytest with a SQLite+Postgres backend matrix.
+
+**Spec:** `docs/brainstorms/2026-07-01-ir-p8.6-165-blob-introspection-false-positive-requirements.md`
+
+## Global Constraints
+
+- **Behavior-preserving** for Postgres (already correct), for genuine `text`⇄`blob` differences (must **still** warn, both directions), and for every other column type. The **only** intended behavior change: the spurious SQLite BLOB warning disappears. No SQL is emitted or suppressed for BLOB columns in any scenario (SQLite never `ALTER`s column types — it only warns).
+- **Fail loud, never degrade silently** (AGENTS.md I-6). **No `unwrap()`/`expect()`** on any new path (AGENTS.md I-3) — both changes are pure `match` arms with no new error surface.
+- **Rebuild the Rust core after every Rust edit:** `uv run maturin develop` before running any Python test.
+- **Rust tests (macOS):** `cargo test -p ferro-ddl-lowering` runs standalone (leaf crate, no PyO3 link). The workspace-wide run needs `cargo test --no-default-features --features testing` (default feature set fails to link locally). `sqlite_type_class` is `pub(crate)`, so the round-trip guard test must live in the crate's own `#[cfg(test)] mod tests`.
+- **Postgres is the merge gate** (CI). The Python Postgres control is `postgres_only`; locally run it with `FERRO_POSTGRES_URL` configured (a `local-pg` docker container is running). Don't regress Python 3.13 or 3.14.
+- **IR-vs-legacy planner parity** must be verified with the shadow comparator ENABLED **and** strict: `FERRO_SHADOW_RUNTIME=1 FERRO_SHADOW_RUNTIME_STRICT=1` (STRICT alone is a silent no-op — memory `shadow-comparator-needs-both-env-flags`).
+- **Conventional Commits** (no invented types). Run `uv run cz check --rev-range feat/ir-p8.6-cleanups..HEAD` before pushing. **No AI attribution** in commits/PRs (memory `no-ai-attribution`). **No `CHANGELOG.md` edits** (AGENTS.md I-10).
+- **No new docs** — this removes a spurious warning, introducing no new field-declaration syntax or type-mapping behavior. The `docs-show-both-declaration-styles` rule is not triggered (no example added).
+- After any fix subagent, verify its commit landed on `feat/ir-p8.6-165-blob-introspection-false-positive` (not an isolated worktree branch) (memory `sdd-fix-subagent-worktree-gotcha`).
+
+## File Structure
+
+- `crates/ferro-ddl-lowering/src/lib.rs` — add the `"blob" => "blob"` arm to `information_schema_to_db_type_token` (exact-match block, next to `"bytea" => "bytea"` `:193`); add the `"blob" => Some(Blob)` arm to `db_type_token_to_canonical` (next to `"bytea" => Some(Blob)` `:142`); add unit tests to the existing `#[cfg(test)] mod tests` (near `information_schema_to_db_type_token_maps_live_spellings` `:600` and the drift tests `:683-733`).
+- `tests/test_auto_migrate.py` — add one `sqlite_only` false-positive-gone test + one `sqlite_only` genuine-diff control + one `postgres_only` mirror-image control, modeled on `test_sqlite_type_drift_warns_and_leaves_column_untouched` (`:360`) and the `_pg_live_type` helper (`:385`).
+
+---
+
+## Task 1: Two introspection arms + Rust unit tests (ferro-ddl-lowering)
+
+**Files:**
+- Modify: `crates/ferro-ddl-lowering/src/lib.rs` — `information_schema_to_db_type_token` (`:193`), `db_type_token_to_canonical` (`:142`), and `mod tests` (`:600`, `:683`)
+
+**Interfaces:**
+- Produces (relied on by Task 2's runtime behavior): `information_schema_to_db_type_token("BLOB", _, Sqlite)` returns `"blob"`; `db_type_token_to_canonical("blob", _)` returns `Some(CanonicalType::Blob)`.
+- Consumes: existing `CanonicalType::Blob`, `canonical_to_db_type_token` (`Blob → "bytea"`, unchanged), `sqlite_type_class` (`pub(crate)`, `"blob" → Blob`, unchanged), `sqlite_declared_type` (`Blob → "blob"`, unchanged), `schema_columns_storage_drift`, and the test helper `col_with_db_type(name, logical_type, format, db_type)` (`:659`).
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Add to `mod tests` in `crates/ferro-ddl-lowering/src/lib.rs`. First, extend the existing `information_schema_to_db_type_token_maps_live_spellings` test (`:600`) with a BLOB assertion — insert before its closing brace (`:624`):
+
+```rust
+        assert_eq!(
+            information_schema_to_db_type_token("BLOB", None, Dialect::Sqlite),
+            "blob"
+        );
+```
+
+Then add three new tests near the drift tests (after `datetime_and_timestamp_are_storage_equivalent_on_sqlite` `:733`):
+
+```rust
+    #[test]
+    fn db_type_token_to_canonical_resolves_blob() {
+        assert_eq!(
+            db_type_token_to_canonical("blob", Dialect::Sqlite),
+            Some(CanonicalType::Blob)
+        );
+        assert_eq!(
+            db_type_token_to_canonical("blob", Dialect::Postgres),
+            Some(CanonicalType::Blob)
+        );
+    }
+
+    /// The one cross-consumer guard: the token a live SQLite BLOB normalizes to
+    /// must satisfy BOTH planner consumers at once — `db_type_token_to_canonical`
+    /// (the IR planner) resolves it to `Blob`, AND `sqlite_type_class` (the legacy
+    /// planner's SQLite arm) classes it the same as the model's declared blob.
+    /// This is why the token is "blob", not the canonical "bytea": `sqlite_type_class`
+    /// only recognizes Blob for strings containing "blob". (#165)
+    #[test]
+    fn live_sqlite_blob_round_trips_through_both_consumers() {
+        let token = information_schema_to_db_type_token("BLOB", None, Dialect::Sqlite);
+        // IR-path consumer.
+        assert_eq!(
+            db_type_token_to_canonical(&token, Dialect::Sqlite),
+            Some(CanonicalType::Blob)
+        );
+        // Legacy-path consumer: same class as the model's declared blob type.
+        assert_eq!(
+            sqlite_type_class(&token),
+            sqlite_type_class(&sqlite_declared_type(CanonicalType::Blob))
+        );
+    }
+
+    /// A live BLOB column must NOT drift against a `binary` (bytes) model column,
+    /// while a genuine text↔blob difference still drifts. (#165)
+    #[test]
+    fn blob_model_does_not_drift_against_live_blob_on_sqlite() {
+        // Live column: introspected via the real normalizer, logical_type "unknown".
+        let live_token = information_schema_to_db_type_token("BLOB", None, Dialect::Sqlite);
+        let live = col_with_db_type("data", "unknown", None, Some(&live_token));
+        // Model column: Python SchemaIR compiler emits logical_type "binary", db_type None.
+        let model = col_with_db_type("data", "binary", None, None);
+        assert!(
+            !schema_columns_storage_drift(&live, &model, Dialect::Sqlite),
+            "a live BLOB column must not read as drifted against a bytes model"
+        );
+
+        // Genuine diff preserved: a live TEXT column vs the same bytes model DOES drift.
+        let live_text = col_with_db_type("data", "unknown", None, Some("text"));
+        assert!(
+            schema_columns_storage_drift(&live_text, &model, Dialect::Sqlite),
+            "a real text→blob difference must still be detected"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p ferro-ddl-lowering blob`
+Expected: `db_type_token_to_canonical_resolves_blob` FAILS (`None != Some(Blob)`), `live_sqlite_blob_round_trips_through_both_consumers` FAILS (token is `"text"`), `blob_model_does_not_drift_against_live_blob_on_sqlite` FAILS (live blob currently drifts). Also run `cargo test -p ferro-ddl-lowering information_schema_to_db_type_token_maps_live_spellings` — FAILS (`"text" != "blob"`).
+
+- [ ] **Step 3: Add the introspection arm**
+
+In `information_schema_to_db_type_token`, exact-match block, add the `blob` arm immediately after `"bytea" => "bytea",` (`:193`):
+
+```rust
+        "bytea" => "bytea",
+        "blob" => "blob",
+```
+
+- [ ] **Step 4: Add the token-resolution arm**
+
+In `db_type_token_to_canonical`, add the `blob` arm immediately after `"bytea" => Some(CanonicalType::Blob),` (`:142`):
+
+```rust
+        "bytea" => Some(CanonicalType::Blob),
+        "blob" => Some(CanonicalType::Blob),
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p ferro-ddl-lowering blob` and `cargo test -p ferro-ddl-lowering information_schema_to_db_type_token_maps_live_spellings`
+Expected: all PASS.
+
+- [ ] **Step 6: Run the full crate suite (no regressions)**
+
+Run: `cargo test -p ferro-ddl-lowering`
+Expected: PASS (all existing drift/equivalence fixtures still green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ferro-ddl-lowering/src/lib.rs
+git commit -m "fix(ir-p8.6): normalize live SQLite BLOB to the canonical blob token (#165)"
+```
+
+---
+
+## Task 2: Python auto-migrate gate tests (SQLite false positive + genuine-diff + Postgres control)
+
+**Files:**
+- Modify: `tests/test_auto_migrate.py` — add three tests; reuse existing helpers `_sqlite_columns` (`:225`), `_pg_live_type` (`:385`), and the `clean_registry` fixture (`:212`). Top-of-file already imports `Annotated`, `pytest`, `ferro`, `Model`, `FerroField`, and (`:209`) `execute`.
+
+**Interfaces:**
+- Consumes: `ferro.connect`, `ferro.reset_engine`, the Rust behavior from Task 1, and the conftest fixtures `db_url`, `postgres_base_url`, `db_schema_name`.
+
+- [ ] **Step 1: Rebuild the core so Python sees the fix**
+
+Run: `uv run maturin develop`
+Expected: builds cleanly (exit 0).
+
+- [ ] **Step 2: Write the three gate tests**
+
+Add to `tests/test_auto_migrate.py` (after `test_sqlite_type_drift_warns_and_leaves_column_untouched` `:383`; `import warnings` and `from uuid import UUID` are already available — `UUID` via `:2`):
+
+```python
+@pytest.mark.asyncio
+@pytest.mark.sqlite_only
+async def test_sqlite_bytes_field_does_not_false_positive_blob_drift(
+    db_url, clean_registry
+):
+    """A fresh model with a `bytes` field creates a BLOB column; auto-migrate must
+    NOT warn that it is 'declared text but the model expects blob'. The model and
+    the DB agree. (#165)"""
+    import warnings
+
+    class Document(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        name: str = ""
+        data: bytes = b""
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await ferro.connect(db_url, migrate_updates=True)
+
+    blob_warnings = [
+        str(w.message) for w in caught if "blob" in str(w.message).lower()
+    ]
+    assert not blob_warnings, f"spurious BLOB drift warning(s): {blob_warnings}"
+
+    # The column really is a BLOB — the fix did not mask a real difference.
+    columns = _sqlite_columns(db_url, "document")
+    assert columns["data"][2].lower() == "blob"
+
+
+@pytest.mark.asyncio
+@pytest.mark.sqlite_only
+async def test_sqlite_genuine_text_to_blob_diff_still_warns(
+    db_url, clean_registry
+):
+    """Control: a pre-existing TEXT column adopted by a `bytes` model is a REAL
+    difference and must still warn — the fix only silences blob==blob. (#165)"""
+    await ferro.connect(db_url)
+    await execute(
+        'CREATE TABLE "attachment" '
+        '("id" integer PRIMARY KEY AUTOINCREMENT, "payload" text NOT NULL)'
+    )
+    ferro.reset_engine()
+
+    class Attachment(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        payload: bytes = b""
+
+    with pytest.warns(UserWarning, match=r"attachment\.payload.*expects 'blob'"):
+        await ferro.connect(db_url, migrate_updates=True)
+
+    # No DDL runs for SQLite type drift — the column is left as declared.
+    columns = _sqlite_columns(db_url, "attachment")
+    assert columns["payload"][2].lower() == "text"
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
+async def test_pg_bytes_field_bytea_no_drift(
+    db_url, postgres_base_url, db_schema_name, clean_registry
+):
+    """Mirror-image control: on Postgres a `bytes` field maps to `bytea`, which
+    already round-trips through introspection — no warning, no drift, ever. (#165)"""
+    import warnings
+
+    class DocPg(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        name: str = ""
+        data: bytes = b""
+
+    await ferro.connect(db_url, migrate_updates=True)  # creates docpg -> bytea
+    ferro.reset_engine()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await ferro.connect(db_url, migrate_updates=True)  # reconnect: must be quiet
+    blob_warnings = [
+        str(w.message) for w in caught if "blob" in str(w.message).lower()
+    ]
+    assert not blob_warnings, f"unexpected BLOB drift warning(s): {blob_warnings}"
+
+    assert (
+        _pg_live_type(postgres_base_url, db_schema_name, "docpg", "data") == "bytea"
+    )
+```
+
+- [ ] **Step 3: Run the SQLite gate tests**
+
+Run: `uv run pytest tests/test_auto_migrate.py -k "bytes_field or genuine_text_to_blob" -p no:cacheprovider -q`
+Expected: both SQLite tests PASS (the `postgres_only` test skips without a Postgres provider).
+
+- [ ] **Step 4: Run the Postgres control**
+
+Run:
+```bash
+FERRO_POSTGRES_URL=postgres://postgres:password@localhost:5432/postgres \
+  uv run pytest tests/test_auto_migrate.py -k "test_pg_bytes_field_bytea_no_drift" \
+  -p no:cacheprovider --db-backends=postgres -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Verify no shadow-runtime mismatch (both planner paths agree)**
+
+Both the IR and legacy planners consume the same shared normalizer, so the shadow comparator must stay quiet on the BLOB case. Re-run the SQLite gate under strict shadow mode (BOTH flags — STRICT alone is a silent no-op):
+
+Run:
+```bash
+FERRO_SHADOW_RUNTIME=1 FERRO_SHADOW_RUNTIME_STRICT=1 \
+  uv run pytest tests/test_auto_migrate.py -k "bytes_field or genuine_text_to_blob" \
+  -p no:cacheprovider -q
+```
+Expected: PASS (no `Ferro shadow runtime mismatch` RuntimeError). If it fails, the legacy path diverged — stop and reconcile before continuing (do not silence the comparator).
+
+- [ ] **Step 6: Run the full SQLite suite (no regression)**
+
+Run: `uv run pytest tests/test_auto_migrate.py -p no:cacheprovider -q`
+Expected: PASS (SQLite; the `postgres_only` test skips without a provider).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/test_auto_migrate.py
+git commit -m "test(ir-p8.6): gate SQLite BLOB introspection false positive (#165)"
+```
+
+---
+
+## Final verification (before requesting whole-branch review)
+
+- [ ] `cargo test -p ferro-ddl-lowering` — green (incl. the four new/extended blob tests).
+- [ ] `cargo test --no-default-features --features testing` — workspace green.
+- [ ] `uv run maturin develop` — clean.
+- [ ] SQLite gate + full `tests/test_auto_migrate.py` — green; no 3.13/3.14 regression.
+- [ ] Postgres control (Task 2 Step 4) — green.
+- [ ] Strict shadow mode (Task 2 Step 5, `FERRO_SHADOW_RUNTIME=1 FERRO_SHADOW_RUNTIME_STRICT=1`) — green (no mismatch on the BLOB case).
+- [ ] `uv run cz check --rev-range feat/ir-p8.6-cleanups..HEAD` — all commits conventional.
+- [ ] Grep-gate: `rg '"blob"' crates/ferro-ddl-lowering/src/lib.rs` shows both new arms + the tests; the `_ => "text"` catch-all is no longer reachable by a live `blob` spelling.
+- [ ] No `CHANGELOG.md` edits; no AI attribution in commits.

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -382,6 +382,91 @@ async def test_sqlite_type_drift_warns_and_leaves_column_untouched(
     ), "no DDL may run for SQLite type drift"
 
 
+@pytest.mark.asyncio
+@pytest.mark.sqlite_only
+async def test_sqlite_bytes_field_does_not_false_positive_blob_drift(
+    db_url, clean_registry
+):
+    """A fresh model with a `bytes` field creates a BLOB column; auto-migrate must
+    NOT warn that it is 'declared text but the model expects blob'. The model and
+    the DB agree. (#165)"""
+    import warnings
+
+    class Document(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        name: str = ""
+        data: bytes = b""
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await ferro.connect(db_url, migrate_updates=True)
+
+    blob_warnings = [
+        str(w.message) for w in caught if "blob" in str(w.message).lower()
+    ]
+    assert not blob_warnings, f"spurious BLOB drift warning(s): {blob_warnings}"
+
+    # The column really is a BLOB — the fix did not mask a real difference.
+    columns = _sqlite_columns(db_url, "document")
+    assert columns["data"][2].lower() == "blob"
+
+
+@pytest.mark.asyncio
+@pytest.mark.sqlite_only
+async def test_sqlite_genuine_text_to_blob_diff_still_warns(
+    db_url, clean_registry
+):
+    """Control: a pre-existing TEXT column adopted by a `bytes` model is a REAL
+    difference and must still warn — the fix only silences blob==blob. (#165)"""
+    await ferro.connect(db_url)
+    await execute(
+        'CREATE TABLE "attachment" '
+        '("id" integer PRIMARY KEY AUTOINCREMENT, "payload" text NOT NULL)'
+    )
+    ferro.reset_engine()
+
+    class Attachment(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        payload: bytes = b""
+
+    with pytest.warns(UserWarning, match=r"attachment\.payload.*expects 'blob'"):
+        await ferro.connect(db_url, migrate_updates=True)
+
+    # No DDL runs for SQLite type drift — the column is left as declared.
+    columns = _sqlite_columns(db_url, "attachment")
+    assert columns["payload"][2].lower() == "text"
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
+async def test_pg_bytes_field_bytea_no_drift(
+    db_url, postgres_base_url, db_schema_name, clean_registry
+):
+    """Mirror-image control: on Postgres a `bytes` field maps to `bytea`, which
+    already round-trips through introspection — no warning, no drift, ever. (#165)"""
+    import warnings
+
+    class DocPg(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        name: str = ""
+        data: bytes = b""
+
+    await ferro.connect(db_url, migrate_updates=True)  # creates docpg -> bytea
+    ferro.reset_engine()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await ferro.connect(db_url, migrate_updates=True)  # reconnect: must be quiet
+    blob_warnings = [
+        str(w.message) for w in caught if "blob" in str(w.message).lower()
+    ]
+    assert not blob_warnings, f"unexpected BLOB drift warning(s): {blob_warnings}"
+
+    assert (
+        _pg_live_type(postgres_base_url, db_schema_name, "docpg", "data") == "bytea"
+    )
+
+
 def _pg_live_type(base_url: str, schema: str, table: str, column: str) -> str:
     import psycopg
 


### PR DESCRIPTION
Fixes the last open sub-issue of Epic #145 (Phase 8.6). Closes #165 (auto-close won't fire on merge into the integration branch — will be closed explicitly).

## The bug (reproduced first)

A model with a `bytes` field creates a SQLite `BLOB` column, yet auto-migrate warns on **every** connect:

```
WARN: Column 'document.data' is declared 'text' in the database but the model
      expects 'blob'. SQLite cannot change column types in place; use Alembic…
CREATE: CREATE TABLE "document" ( "data" blob NOT NULL, … )   ← emitted blob
PRAGMA: {'name': 'data', 'type': 'BLOB'}                      ← DB agrees
```

The model and the DB agree — it's a pure false positive from the schema-diff introspection. (Mirror image of #154, which was Postgres-only; this is SQLite-only. Postgres `bytea` already round-trips: verified no warning.)

## Root cause

The shared introspection normalizer `information_schema_to_db_type_token` (`crates/ferro-ddl-lowering/src/lib.rs`) had **no arm for the live `blob` spelling**, so a live SQLite BLOB fell through to the catch-all `_ => "text"`. That phantom `text` drove the warning in **both** planner paths (the IR planner via `schema_columns_storage_drift`, and the legacy planner via `plan_existing_column`'s `sqlite_type_class`).

## The fix

Two pure `match` arms in the single-source `lib.rs`:
- `information_schema_to_db_type_token`: `"blob" => "blob"`
- `db_type_token_to_canonical`: `"blob" => Some(Blob)`

Token `"blob"` (not the canonical `"bytea"`) is deliberate — it's the only token that round-trips through **both** consumers: `db_type_token_to_canonical("blob") == Some(Blob)` (IR path) **and** `sqlite_type_class("blob")` classes it the same as the model's declared blob (legacy path — `sqlite_type_class("bytea")` would return `Numeric`). Single-source, covers both planners, no emitter/planner changes.

Genuine `text`⇄`blob` diffs still warn (both directions). Postgres and all other types untouched.

## Verification

- `cargo test -p ferro-ddl-lowering`: **17/17** (incl. a cross-consumer round-trip guard + drift regression, both directions).
- Python `tests/test_auto_migrate.py`: SQLite false-positive-gone + genuine-diff control + Postgres `bytea` control.
- **IR-vs-legacy planner parity:** `FERRO_SHADOW_RUNTIME=1 FERRO_SHADOW_RUNTIME_STRICT=1` → **0 shadow mismatches** (both planners agree).
- Full SQLite `test_auto_migrate.py`: 24 passed / 5 skipped. `cz check` clean. No CHANGELOG edits.

Spec: `docs/brainstorms/2026-07-01-ir-p8.6-165-blob-introspection-false-positive-requirements.md`
Plan: `docs/plans/2026-07-01-003-fix-ir-p8.6-165-blob-introspection-plan.md`