### PR TITLE
feat(ff-a): typed DBAPI-shaped exception hierarchy mapped from sqlx errors

### DIFF
--- a/docs/pages/api/exceptions.md
+++ b/docs/pages/api/exceptions.md
@@ -1,5 +1,55 @@
 # Exceptions
 
-Exceptions raised by Ferro's public API. `ModelDoesNotExist` is raised by primary-key lookups like `Model.get(pk)` when no row matches; use `Model.get_or_none(pk)` if you prefer `None` over an exception.
+Every database failure Ferro raises is catchable by type. The tree is
+DBAPI-shaped, rooted at `FerroError`:
+
+```
+FerroError
+├── InterfaceError          the database interface was misused
+├── OperationalError        the database or its environment failed
+├── DataError               a value could not be decoded or converted
+├── IntegrityError          a constraint rejected the statement
+│   ├── UniqueViolationError
+│   ├── ForeignKeyViolationError
+│   ├── NotNullViolationError
+│   └── CheckViolationError
+└── ModelDoesNotExist       (also a LookupError)
+```
+
+Catch a duplicate insert without matching driver text:
+
+```python
+from ferro import UniqueViolationError
+
+try:
+    await User(email="taylor@example.com").save()
+except UniqueViolationError as exc:
+    print(exc.sqlstate)      # "23505" on Postgres, None on SQLite
+    print(exc.constraint)    # violated constraint name (Postgres only)
+    print(exc.driver_message)  # original driver text, for logs
+```
+
+`ModelDoesNotExist` is raised by primary-key lookups like `Model.get(pk)` when
+no row matches; use `Model.get_or_none(pk)` if you prefer `None` over an
+exception. It remains a `LookupError`, so pre-existing `except LookupError`
+handlers keep working.
+
+::: ferro.FerroError
+
+::: ferro.InterfaceError
+
+::: ferro.OperationalError
+
+::: ferro.DataError
+
+::: ferro.IntegrityError
+
+::: ferro.UniqueViolationError
+
+::: ferro.ForeignKeyViolationError
+
+::: ferro.NotNullViolationError
+
+::: ferro.CheckViolationError
 
 ::: ferro.ModelDoesNotExist

--- a/docs/plans/2026-07-02-002-feat-ff-a-172-typed-exceptions-plan.md
+++ b/docs/plans/2026-07-02-002-feat-ff-a-172-typed-exceptions-plan.md
@@ -1,0 +1,37 @@
+---
+title: "feat: Typed exception hierarchy mapped from sqlx (#172)"
+date: 2026-07-02
+issue: 172
+epic: 170
+branch: feat/ff-a-172-typed-exceptions
+origin: docs/plans/2026-07-02-001-fable-fixes-roadmap.md (Epic FF-A, sub-task A2)
+---
+
+# Typed exception hierarchy Implementation Plan
+
+**Goal:** Every database failure raised by the Rust core is catchable by type from Python. `ferro.exceptions` grows a DBAPI-shaped tree; a new `src/errors.rs` maps `sqlx::Error` (via `DatabaseError::kind()`) onto it, preserving the original driver message plus structured `sqlstate`/`constraint` attributes. No user-facing string matching required, ever.
+
+**Architecture:** Exceptions are defined in pure Python (`src/ferro/exceptions.py`) so `__module__`, pickling, and mkdocstrings behave; Rust raises them through a `GILOnceCell`-cached lookup of `ferro.exceptions` at first raise (cold path — no import cycle, `_core` never imports `ferro` at init). One conversion function, `map_db_error(context, sqlx::Error) -> PyErr`, with a pure `exception_name_for(&sqlx::Error) -> &'static str` classifier that cargo unit tests pin. All engine-execution `map_err` sites in `operations.rs`, the DDL-execution sites in `migrate.rs`, and connect/routing failures in `connection.rs` convert; internal invariants (lock poisoning, registry misses) stay `RuntimeError`.
+
+**Tree:** `FerroError` → `InterfaceError`, `OperationalError`, `DataError`, `IntegrityError` (→ `UniqueViolationError`, `ForeignKeyViolationError`, `NotNullViolationError`, `CheckViolationError`). `ModelDoesNotExist` re-parents to `(FerroError, LookupError)` — existing `except LookupError` callers keep working.
+
+**Mapping:** `Database(e).kind()` Unique/ForeignKey/NotNull/CheckViolation → the four violations; `Database` Other → `OperationalError` (sqlstate kept); `Io`/`Tls`/`PoolTimedOut`/`PoolClosed`/`WorkerCrashed`/`RowNotFound`/catch-all → `OperationalError`; `Configuration`/`Protocol`/`ColumnNotFound`/`ColumnIndexOutOfBounds` → `InterfaceError`; `Decode`/`ColumnDecode`/`TypeNotFound` → `DataError`. Message: `"{context}: {driver message}"`.
+
+**Closes:** [#172](https://github.com/syn54x/ferro-orm/issues/172)
+**Base branch:** `main`
+
+## Constraints
+
+- AGENTS.md I-3 (PyResult, never panic across FFI), I-6 (no partial conversion — every *database* failure typed), I-10 (no CHANGELOG edits), conventional commits, no AI attribution.
+- Exit-gate rule (epic #170): tests assert exception **types**, zero driver-message string matching.
+
+## Tasks
+
+- [ ] RED: `tests/test_exceptions.py` — hierarchy `issubclass` chains, `ModelDoesNotExist` still `LookupError`, structured attr defaults, pickle round-trip.
+- [ ] GREEN: `src/ferro/exceptions.py` tree + `src/ferro/__init__.py` exports.
+- [ ] RED: `tests/test_exception_mapping.py` (`backend_matrix`) — unique violation → `UniqueViolationError` (+ `sqlstate == "23505"` postgres-only), not-null via `Query.update(col=None)` → `NotNullViolationError`, FK violation → `ForeignKeyViolationError`, bad connect → `OperationalError`, unknown `using` → `InterfaceError`; all currently `RuntimeError`.
+- [ ] Verify SQLite FK enforcement (`PRAGMA foreign_keys`) before writing the FK test; if sqlx defaults it off, enabling it is a deliberate scoped change in this PR.
+- [ ] GREEN: new `src/errors.rs` (`map_db_error`, `exception_name_for`, cached class lookup) + `mod errors;` in `lib.rs`; swap engine-execution `map_err` sites in `operations.rs`, `migrate.rs`, `connection.rs`; routing misses → `InterfaceError`.
+- [ ] Rust unit tests for `exception_name_for` over constructed sqlx variants.
+- [ ] Docs: `docs/pages/api/exceptions.md` `:::` blocks; migration-guide row under new `### Fable Fixes — FF-A` section (minor; broad `except RuntimeError` → `except ferro.FerroError`).
+- [ ] Full matrix green; `cargo test` green; PR with `Closes #172`.

--- a/docs/plans/ir-first-migration-guide.md
+++ b/docs/plans/ir-first-migration-guide.md
@@ -151,6 +151,14 @@ Runtime migration IR cutover (target: `v0.13.0`).
 - **Internal change:** `auto_migrate` executes `ferro-migrate` `SchemaIR(old,new)` plans as the primary path. The legacy enriched-JSON diff walk in `src/migrate.rs` is **deprecated** and kept for shadow comparison until Phase 9 removal.
 - **Parity requirement:** IR planner output must match the legacy planner, `create_tables`, and Alembic for the `auto_migrate` capability matrix (AGENTS.md I-1).
 
+### Fable Fixes — FF-A (mutation-surface correctness & typed errors)
+
+Roadmap: `docs/plans/2026-07-02-001-fable-fixes-roadmap.md`, epic [#170](https://github.com/syn54x/ferro-orm/issues/170).
+
+| Issue | Change | Impact | User action | Notes |
+| --- | --- | --- | --- | --- |
+| [#172](https://github.com/syn54x/ferro-orm/issues/172) | Database failures now raise a typed DBAPI-shaped hierarchy from `ferro.exceptions` (`FerroError` → `InterfaceError` / `OperationalError` / `DataError` / `IntegrityError` → `UniqueViolationError` / `ForeignKeyViolationError` / `NotNullViolationError` / `CheckViolationError`) instead of bare `RuntimeError` / `ValueError` / `ConnectionError`; driver message, SQLSTATE, and constraint name preserved as attributes | minor | Broad `except RuntimeError` handlers around ORM/raw operations move to `except ferro.FerroError` (or a specific subclass); `connect()` failure handlers move from `except ConnectionError` to `except ferro.OperationalError` (server/environment) / `ferro.InterfaceError` (bad scheme or configuration); routing errors (unknown connection name, no default selected, engine not initialized) are now `ferro.InterfaceError` | `ModelDoesNotExist` is unchanged for callers: it joins the tree as `FerroError` + `LookupError`. Internal invariants (lock poisoning, unregistered models) remain `RuntimeError` |
+
 ### Phase 9
 
 Compatibility cutover and shim removal (target: `v0.14.0`).

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -197,7 +197,7 @@ pub fn connect(
     let (connection_url, search_path) = split_search_path(&url);
     let redacted_url = redact_connection_url(&connection_url);
     let backend = dialect_from_url(&connection_url).map_err(|e| {
-        pyo3::exceptions::PyConnectionError::new_err(format!(
+        crate::errors::interface_error(format!(
             "DB Connection failed for {}: {}",
             redacted_url, e
         ))
@@ -240,10 +240,7 @@ pub fn connect(
         )
         .await
         .map_err(|e| {
-            pyo3::exceptions::PyConnectionError::new_err(format!(
-                "DB Connection failed for {}: {}",
-                redacted_url, e
-            ))
+            crate::errors::map_db_error(&format!("DB Connection failed for {}", redacted_url), e)
         })?
         .with_identity_map_enabled(identity_map)
         .with_shadow_runtime_enabled(shadow_runtime_enabled_from_env());

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,181 @@
+//! Mapping from `sqlx` failures to Ferro's typed Python exceptions.
+//!
+//! The exception classes live in `ferro.exceptions` (pure Python, so
+//! `__module__`, pickling, and docs behave); this module looks them up
+//! lazily at first raise and caches the module handle. `_core` never
+//! imports `ferro` at module init, so there is no circular import — by
+//! the time an error is raised, `ferro` is fully imported.
+//!
+//! Classification policy (DBAPI-shaped):
+//! - Constraint violations map to the `IntegrityError` subclasses.
+//! - Environment/runtime failures (I/O, TLS, pool exhaustion) map to
+//!   `OperationalError`.
+//! - Client-side misuse of the interface (configuration, protocol,
+//!   unknown columns) maps to `InterfaceError`.
+//! - Value decode/conversion failures map to `DataError`.
+
+use pyo3::prelude::*;
+use pyo3::sync::GILOnceCell;
+use pyo3::types::PyDict;
+
+static EXCEPTIONS_MODULE: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+
+/// Python exception class name in `ferro.exceptions` for a `sqlx::Error`.
+///
+/// Pure classifier so the mapping table is unit-testable without a live
+/// database or the GIL.
+pub(crate) fn exception_name_for(err: &sqlx::Error) -> &'static str {
+    use sqlx::error::ErrorKind;
+
+    match err {
+        sqlx::Error::Database(db) => match db.kind() {
+            ErrorKind::UniqueViolation => "UniqueViolationError",
+            ErrorKind::ForeignKeyViolation => "ForeignKeyViolationError",
+            ErrorKind::NotNullViolation => "NotNullViolationError",
+            ErrorKind::CheckViolation => "CheckViolationError",
+            _ => "OperationalError",
+        },
+        sqlx::Error::Io(_)
+        | sqlx::Error::Tls(_)
+        | sqlx::Error::PoolTimedOut
+        | sqlx::Error::PoolClosed
+        | sqlx::Error::WorkerCrashed
+        | sqlx::Error::RowNotFound => "OperationalError",
+        sqlx::Error::Configuration(_)
+        | sqlx::Error::Protocol(_)
+        | sqlx::Error::ColumnNotFound(_)
+        | sqlx::Error::ColumnIndexOutOfBounds { .. } => "InterfaceError",
+        sqlx::Error::Decode(_)
+        | sqlx::Error::ColumnDecode { .. }
+        | sqlx::Error::TypeNotFound { .. } => "DataError",
+        _ => "OperationalError",
+    }
+}
+
+fn ferro_exception<'py>(py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+    let module = EXCEPTIONS_MODULE.get_or_try_init(py, || {
+        PyResult::Ok(py.import("ferro.exceptions")?.into_any().unbind())
+    })?;
+    module.bind(py).getattr(name)
+}
+
+fn build_exception(
+    py: Python<'_>,
+    name: &str,
+    message: &str,
+    driver_message: Option<String>,
+    sqlstate: Option<String>,
+    constraint: Option<String>,
+) -> PyResult<PyErr> {
+    let cls = ferro_exception(py, name)?;
+    let kwargs = PyDict::new(py);
+    kwargs.set_item("driver_message", driver_message)?;
+    kwargs.set_item("sqlstate", sqlstate)?;
+    kwargs.set_item("constraint", constraint)?;
+    let instance = cls.call((message,), Some(&kwargs))?;
+    Ok(PyErr::from_value(instance))
+}
+
+/// Convert a database failure into the matching typed Ferro exception.
+///
+/// The message is `"{context}: {driver error}"`; the original driver
+/// message, SQLSTATE code, and violated constraint name (when the backend
+/// reports them) are preserved as structured attributes on the exception.
+pub(crate) fn map_db_error(context: &str, err: sqlx::Error) -> PyErr {
+    let name = exception_name_for(&err);
+    let (driver_message, sqlstate, constraint) = match &err {
+        sqlx::Error::Database(db) => (
+            Some(db.message().to_string()),
+            db.code().map(|code| code.to_string()),
+            db.constraint().map(|constraint| constraint.to_string()),
+        ),
+        _ => (None, None, None),
+    };
+    let message = format!("{}: {}", context, err);
+
+    Python::attach(|py| {
+        build_exception(py, name, &message, driver_message, sqlstate, constraint)
+            .unwrap_or_else(|lookup_err| lookup_err)
+    })
+}
+
+/// Raise `ferro.exceptions.InterfaceError` for client-side interface misuse
+/// that does not originate in a `sqlx::Error` (e.g. routing to an unknown
+/// connection name, unsupported connection URL schemes).
+pub(crate) fn interface_error(message: impl Into<String>) -> PyErr {
+    let message = message.into();
+    Python::attach(|py| {
+        build_exception(py, "InterfaceError", &message, None, None, None)
+            .unwrap_or_else(|lookup_err| lookup_err)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::exception_name_for;
+
+    #[test]
+    fn pool_and_io_failures_are_operational() {
+        assert_eq!(
+            exception_name_for(&sqlx::Error::PoolTimedOut),
+            "OperationalError"
+        );
+        assert_eq!(
+            exception_name_for(&sqlx::Error::PoolClosed),
+            "OperationalError"
+        );
+        assert_eq!(
+            exception_name_for(&sqlx::Error::WorkerCrashed),
+            "OperationalError"
+        );
+        assert_eq!(
+            exception_name_for(&sqlx::Error::Io(std::io::Error::other("boom"))),
+            "OperationalError"
+        );
+    }
+
+    #[test]
+    fn row_not_found_is_operational() {
+        assert_eq!(
+            exception_name_for(&sqlx::Error::RowNotFound),
+            "OperationalError"
+        );
+    }
+
+    #[test]
+    fn configuration_and_protocol_are_interface_errors() {
+        assert_eq!(
+            exception_name_for(&sqlx::Error::Configuration("bad".into())),
+            "InterfaceError"
+        );
+        assert_eq!(
+            exception_name_for(&sqlx::Error::Protocol("bad".into())),
+            "InterfaceError"
+        );
+        assert_eq!(
+            exception_name_for(&sqlx::Error::ColumnNotFound("missing".into())),
+            "InterfaceError"
+        );
+    }
+
+    #[test]
+    fn decode_failures_are_data_errors() {
+        assert_eq!(
+            exception_name_for(&sqlx::Error::Decode("bad value".into())),
+            "DataError"
+        );
+        assert_eq!(
+            exception_name_for(&sqlx::Error::ColumnDecode {
+                index: "0".into(),
+                source: "bad value".into(),
+            }),
+            "DataError"
+        );
+        assert_eq!(
+            exception_name_for(&sqlx::Error::TypeNotFound {
+                type_name: "ghost".into(),
+            }),
+            "DataError"
+        );
+    }
+}

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -26,7 +26,18 @@ from ._core import (
     connect as _core_connect,
 )
 from .base import DbType, DbTypeToken, FerroField, FerroNullable, ForeignKey, varchar
-from .exceptions import ModelDoesNotExist
+from .exceptions import (
+    CheckViolationError,
+    DataError,
+    FerroError,
+    ForeignKeyViolationError,
+    IntegrityError,
+    InterfaceError,
+    ModelDoesNotExist,
+    NotNullViolationError,
+    OperationalError,
+    UniqueViolationError,
+)
 from .fields import BackRef, Field, ManyToMany
 from .models import Model, transaction
 from .query import Relation
@@ -205,6 +216,15 @@ __all__ = [
     "connect",
     "PoolConfig",
     "Model",
+    "FerroError",
+    "InterfaceError",
+    "OperationalError",
+    "DataError",
+    "IntegrityError",
+    "UniqueViolationError",
+    "ForeignKeyViolationError",
+    "NotNullViolationError",
+    "CheckViolationError",
     "ModelDoesNotExist",
     "DbType",
     "DbTypeToken",

--- a/src/ferro/exceptions.py
+++ b/src/ferro/exceptions.py
@@ -1,9 +1,119 @@
-"""ORM-specific exceptions."""
+"""ORM-specific exceptions.
+
+The tree is DBAPI-shaped so callers can catch database failures by type
+instead of string-matching driver messages:
+
+- :class:`FerroError` — root of everything Ferro raises for database work.
+    - :class:`InterfaceError` — the database interface was misused
+      (unknown connection name, protocol/configuration problems).
+    - :class:`OperationalError` — the database or its environment failed
+      (connection refused, pool timeout, I/O or TLS errors).
+    - :class:`DataError` — a value could not be decoded or converted.
+    - :class:`IntegrityError` — a constraint rejected the statement.
+        - :class:`UniqueViolationError`
+        - :class:`ForeignKeyViolationError`
+        - :class:`NotNullViolationError`
+        - :class:`CheckViolationError`
+    - :class:`ModelDoesNotExist` — lookup by primary key found no row
+      (also a :class:`LookupError` for backwards compatibility).
+
+Exceptions raised from the Rust core preserve the original driver
+message and, where the backend provides them, the SQLSTATE code and the
+violated constraint name as structured attributes.
+"""
 
 from typing import Any
 
 
-class ModelDoesNotExist(LookupError):
+class FerroError(Exception):
+    """Root of Ferro's database exception hierarchy.
+
+    Attributes:
+        driver_message: Original message from the database driver, when the
+            error originated in the database. ``None`` otherwise.
+        sqlstate: Five-character SQLSTATE code (e.g. ``"23505"``) when the
+            backend reports one. ``None`` otherwise (SQLite reports extended
+            result codes for some errors, Postgres reports SQLSTATE).
+        constraint: Name of the violated constraint when the backend reports
+            it (Postgres does; SQLite does not). ``None`` otherwise.
+    """
+
+    driver_message: str | None
+    sqlstate: str | None
+    constraint: str | None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        driver_message: str | None = None,
+        sqlstate: str | None = None,
+        constraint: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.driver_message = driver_message
+        self.sqlstate = sqlstate
+        self.constraint = constraint
+
+    def __reduce__(self):
+        return (
+            self.__class__,
+            (str(self),),
+            {
+                "driver_message": self.driver_message,
+                "sqlstate": self.sqlstate,
+                "constraint": self.constraint,
+            },
+        )
+
+
+class InterfaceError(FerroError):
+    """The database interface was misused.
+
+    Raised for problems on the client side of the conversation: operating on
+    an unknown or uninitialized connection name, driver protocol errors, or
+    invalid connection configuration.
+    """
+
+
+class OperationalError(FerroError):
+    """The database or its environment failed.
+
+    Raised for failures outside the program's control: the server is
+    unreachable, a connection pool timed out or is closed, or an I/O or TLS
+    error interrupted the conversation.
+    """
+
+
+class DataError(FerroError):
+    """A value could not be decoded or converted.
+
+    Raised when a fetched value cannot be decoded into the expected Python
+    type or a bound value cannot be represented for the column type.
+    """
+
+
+class IntegrityError(FerroError):
+    """A database constraint rejected the statement."""
+
+
+class UniqueViolationError(IntegrityError):
+    """A UNIQUE or PRIMARY KEY constraint rejected the statement."""
+
+
+class ForeignKeyViolationError(IntegrityError):
+    """A FOREIGN KEY constraint rejected the statement."""
+
+
+class NotNullViolationError(IntegrityError):
+    """A NOT NULL constraint rejected the statement."""
+
+
+class CheckViolationError(IntegrityError):
+    """A CHECK constraint rejected the statement."""
+
+
+class ModelDoesNotExist(FerroError, LookupError):
     """Raised when :meth:`~ferro.models.Model.get` finds no row for the primary key."""
 
     model: type
@@ -15,3 +125,6 @@ class ModelDoesNotExist(LookupError):
         super().__init__(
             f"No {model_cls.__name__} record found for primary key {pk!r}"
         )
+
+    def __reduce__(self):
+        return (self.__class__, (self.model, self.pk))

--- a/src/introspect.rs
+++ b/src/introspect.rs
@@ -105,9 +105,10 @@ pub(crate) fn quote_ident(name: &str) -> String {
 }
 
 fn introspection_error(context: &str, table: &str, err: sqlx::Error) -> PyErr {
-    pyo3::exceptions::PyRuntimeError::new_err(format!(
-        "Schema introspection failed ({context} for table '{table}'): {err}"
-    ))
+    crate::errors::map_db_error(
+        &format!("Schema introspection failed ({context} for table '{table}')"),
+        err,
+    )
 }
 
 /// Read the live columns of `table`. Returns `None` when the table does not

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 mod backend;
 mod codec;
 mod connection;
+mod errors;
 mod hydration;
 mod introspect;
 mod migrate;

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -834,11 +834,14 @@ async fn execute_drop_column(
         for index in &indexes {
             let sql = format!("DROP INDEX IF EXISTS {}", quote_ident(&index.name));
             engine.execute_sql_unprepared(&sql).await.map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!(
-                    "Auto-migrate failed dropping index '{}' (required to drop column \
-                     '{}.{}'): {}",
-                    index.name, table_lower, col_name, e
-                ))
+                crate::errors::map_db_error(
+                    &format!(
+                        "Auto-migrate failed dropping index '{}' (required to drop column \
+                         '{}.{}')",
+                        index.name, table_lower, col_name
+                    ),
+                    e,
+                )
             })?;
         }
     }
@@ -849,11 +852,14 @@ async fn execute_drop_column(
         quote_ident(col_name)
     );
     engine.execute_sql_unprepared(&sql).await.map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!(
-            "Cannot drop column '{}.{}': {}. Columns referenced by constraints, foreign \
-             keys, triggers, or views must be migrated with Alembic.",
-            table_lower, col_name, e
-        ))
+        crate::errors::map_db_error(
+            &format!(
+                "Cannot drop column '{}.{}' (columns referenced by constraints, foreign \
+                 keys, triggers, or views must be migrated with Alembic)",
+                table_lower, col_name
+            ),
+            e,
+        )
     })?;
     Ok(())
 }
@@ -921,10 +927,13 @@ pub async fn internal_migrate(engine: Arc<EngineHandle>, opts: MigrateOptions) -
 
         for sql in &plan.statements {
             engine.execute_sql_unprepared(sql).await.map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!(
-                    "Auto-migrate DDL failed for table '{}': {} (statement: {})",
-                    table_lower, e, sql
-                ))
+                crate::errors::map_db_error(
+                    &format!(
+                        "Auto-migrate DDL failed for table '{}' (statement: {})",
+                        table_lower, sql
+                    ),
+                    e,
+                )
             })?;
             ddl_ran = true;
         }
@@ -944,10 +953,10 @@ pub async fn internal_migrate(engine: Arc<EngineHandle>, opts: MigrateOptions) -
 
     if ddl_ran {
         engine.refresh_pool().await.map_err(|e| {
-            pyo3::exceptions::PyRuntimeError::new_err(format!(
-                "Auto-migrate applied DDL but failed to refresh the connection pool: {}",
-                e
-            ))
+            crate::errors::map_db_error(
+                "Auto-migrate applied DDL but failed to refresh the connection pool",
+                e,
+            )
         })?;
         // Identity-mapped instances were hydrated against the pre-migration
         // schema (e.g. a row loaded before a column add lacks the new field).

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -380,20 +380,20 @@ async fn postgres_catalog_rows(
             conn.fetch_all_sql_with_binds(sql, &values)
                 .await
                 .map_err(|e| {
-                    pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "Failed to inspect {} for '{}': {}",
-                        label, table_name, e
-                    ))
+                    crate::errors::map_db_error(
+                        &format!("Failed to inspect {} for '{}'", label, table_name),
+                        e,
+                    )
                 })?
         }
         None => engine
             .fetch_all_sql_with_binds(sql, &values)
             .await
             .map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!(
-                    "Failed to inspect {} for '{}': {}",
-                    label, table_name, e
-                ))
+                crate::errors::map_db_error(
+                    &format!("Failed to inspect {} for '{}'", label, table_name),
+                    e,
+                )
             })?,
     };
 
@@ -714,12 +714,7 @@ pub fn begin_transaction(
             let savepoint_name = format!("sp_{}", tx_id.replace('-', "_"));
             execute_transaction_sql(&conn, &format!("SAVEPOINT {savepoint_name}"))
                 .await
-                .map_err(|e| {
-                    pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "Failed to create SAVEPOINT: {}",
-                        e
-                    ))
-                })?;
+                .map_err(|e| crate::errors::map_db_error("Failed to create SAVEPOINT", e))?;
 
             tx_insert(
                 session_id.as_deref(),
@@ -733,9 +728,10 @@ pub fn begin_transaction(
                 session_id.clone(),
             )
             .map(|(name, engine, _, _)| (name, engine))?;
-            let conn = engine.begin_transaction_connection().await.map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to BEGIN: {}", e))
-            })?;
+            let conn = engine
+                .begin_transaction_connection()
+                .await
+                .map_err(|e| crate::errors::map_db_error("Failed to BEGIN", e))?;
 
             tx_insert(
                 session_id.as_deref(),
@@ -776,18 +772,11 @@ pub fn commit_transaction(
                 &format!("RELEASE SAVEPOINT {savepoint_name}"),
             )
             .await
-            .map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!(
-                    "Failed to RELEASE SAVEPOINT: {}",
-                    e
-                ))
-            })?;
+            .map_err(|e| crate::errors::map_db_error("Failed to RELEASE SAVEPOINT", e))?;
         } else {
             execute_transaction_sql(&tx_handle.conn, "COMMIT")
                 .await
-                .map_err(|e| {
-                    pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to COMMIT: {}", e))
-                })?;
+                .map_err(|e| crate::errors::map_db_error("Failed to COMMIT", e))?;
         }
 
         Ok(())
@@ -841,29 +830,17 @@ pub fn rollback_transaction(
                 &format!("ROLLBACK TO SAVEPOINT {savepoint_name}"),
             )
             .await
-            .map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!(
-                    "Failed to ROLLBACK TO SAVEPOINT: {}",
-                    e
-                ))
-            })?;
+            .map_err(|e| crate::errors::map_db_error("Failed to ROLLBACK TO SAVEPOINT", e))?;
             execute_transaction_sql(
                 &tx_handle.conn,
                 &format!("RELEASE SAVEPOINT {savepoint_name}"),
             )
             .await
-            .map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!(
-                    "Failed to RELEASE SAVEPOINT: {}",
-                    e
-                ))
-            })?;
+            .map_err(|e| crate::errors::map_db_error("Failed to RELEASE SAVEPOINT", e))?;
         } else {
             execute_transaction_sql(&tx_handle.conn, "ROLLBACK")
                 .await
-                .map_err(|e| {
-                    pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to ROLLBACK: {}", e))
-                })?;
+                .map_err(|e| crate::errors::map_db_error("Failed to ROLLBACK", e))?;
         }
 
         identity_map_clear(session_id.as_deref())?;
@@ -984,18 +961,14 @@ pub fn fetch_all<'py>(
                 let rows = conn
                     .fetch_all_sql_with_binds(&sql, &[])
                     .await
-                    .map_err(|e| {
-                        pyo3::exceptions::PyRuntimeError::new_err(format!("Fetch failed: {}", e))
-                    })?;
+                    .map_err(|e| crate::errors::map_db_error("Fetch failed", e))?;
                 typed_rows_to_parsed_data(rows, &schema_for_decode, pk_col.as_deref())
             }
             None => {
                 let rows = engine
                     .fetch_all_sql_with_binds(&sql, &[])
                     .await
-                    .map_err(|e| {
-                        pyo3::exceptions::PyRuntimeError::new_err(format!("Fetch failed: {}", e))
-                    })?;
+                    .map_err(|e| crate::errors::map_db_error("Fetch failed", e))?;
                 typed_rows_to_parsed_data(rows, &schema_for_decode, pk_col.as_deref())
             }
         };
@@ -1156,9 +1129,7 @@ pub fn fetch_one<'py>(
                 let rows = conn
                     .fetch_all_sql_with_binds(&sql, &engine_bind_values)
                     .await
-                    .map_err(|e| {
-                        pyo3::exceptions::PyRuntimeError::new_err(format!("Fetch failed: {}", e))
-                    })?;
+                    .map_err(|e| crate::errors::map_db_error("Fetch failed", e))?;
                 typed_rows_to_parsed_data(rows, &schema_for_decode, None)
                     .into_iter()
                     .next()
@@ -1169,9 +1140,7 @@ pub fn fetch_one<'py>(
                 let rows = engine
                     .fetch_all_sql_with_binds(&sql, &engine_bind_values)
                     .await
-                    .map_err(|e| {
-                        pyo3::exceptions::PyRuntimeError::new_err(format!("Fetch failed: {}", e))
-                    })?;
+                    .map_err(|e| crate::errors::map_db_error("Fetch failed", e))?;
                 typed_rows_to_parsed_data(rows, &schema_for_decode, None)
                     .into_iter()
                     .next()
@@ -1332,9 +1301,7 @@ pub fn save_record<'py>(
                     let rows = conn
                         .fetch_all_sql_with_binds(&sql, &engine_bind_values)
                         .await
-                        .map_err(|e| {
-                            pyo3::exceptions::PyRuntimeError::new_err(format!("Save failed: {}", e))
-                        })?;
+                        .map_err(|e| crate::errors::map_db_error("Save failed", e))?;
                     let id = rows
                         .first()
                         .and_then(|row| row.values.first())
@@ -1345,9 +1312,7 @@ pub fn save_record<'py>(
                     let exec_res = conn
                         .execute_sql_with_binds_result(&sql, &engine_bind_values)
                         .await
-                        .map_err(|e| {
-                            pyo3::exceptions::PyRuntimeError::new_err(format!("Save failed: {}", e))
-                        })?;
+                        .map_err(|e| crate::errors::map_db_error("Save failed", e))?;
                     Ok(exec_res.last_insert_id)
                 }
             }
@@ -1357,9 +1322,7 @@ pub fn save_record<'py>(
                     let rows = engine
                         .fetch_all_sql_with_binds(&sql, &engine_bind_values)
                         .await
-                        .map_err(|e| {
-                            pyo3::exceptions::PyRuntimeError::new_err(format!("Save failed: {}", e))
-                        })?;
+                        .map_err(|e| crate::errors::map_db_error("Save failed", e))?;
                     let id = rows
                         .first()
                         .and_then(|row| row.values.first())
@@ -1370,9 +1333,7 @@ pub fn save_record<'py>(
                     let exec_res = engine
                         .execute_sql_with_binds_result(&sql, &engine_bind_values)
                         .await
-                        .map_err(|e| {
-                            pyo3::exceptions::PyRuntimeError::new_err(format!("Save failed: {}", e))
-                        })?;
+                        .map_err(|e| crate::errors::map_db_error("Save failed", e))?;
                     Ok(exec_res.last_insert_id)
                 }
             }
@@ -1499,10 +1460,7 @@ pub fn save_bulk_records<'py>(
             execute_statement_with_optional_tx(&engine, tx_conn, &sql, &bind_values.0)
                 .await
                 .map_err(|e| {
-                    pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "Bulk save failed for '{}': {}",
-                        name, e
-                    ))
+                    crate::errors::map_db_error(&format!("Bulk save failed for '{}'", name), e)
                 })?;
 
         Ok(rows_affected)
@@ -1631,9 +1589,7 @@ pub fn fetch_filtered<'py>(
                 let rows = conn
                     .fetch_all_sql_with_binds(&sql, &engine_bind_values)
                     .await
-                    .map_err(|e| {
-                        pyo3::exceptions::PyRuntimeError::new_err(format!("Fetch failed: {}", e))
-                    })?;
+                    .map_err(|e| crate::errors::map_db_error("Fetch failed", e))?;
                 typed_rows_to_parsed_data(rows, &schema_for_decode, pk_col.as_deref())
             }
             None => {
@@ -1641,9 +1597,7 @@ pub fn fetch_filtered<'py>(
                 let rows = engine
                     .fetch_all_sql_with_binds(&sql, &engine_bind_values)
                     .await
-                    .map_err(|e| {
-                        pyo3::exceptions::PyRuntimeError::new_err(format!("Fetch failed: {}", e))
-                    })?;
+                    .map_err(|e| crate::errors::map_db_error("Fetch failed", e))?;
                 typed_rows_to_parsed_data(rows, &schema_for_decode, pk_col.as_deref())
             }
         };
@@ -1797,9 +1751,7 @@ pub fn count_filtered(
                 let rows = conn
                     .fetch_all_sql_with_binds(&sql, &engine_bind_values)
                     .await
-                    .map_err(|e| {
-                        pyo3::exceptions::PyRuntimeError::new_err(format!("Count failed: {}", e))
-                    })?;
+                    .map_err(|e| crate::errors::map_db_error("Count failed", e))?;
                 rows.first()
                     .and_then(|row| row.values.first())
                     .and_then(|(_, value)| value.as_i64())
@@ -1809,9 +1761,7 @@ pub fn count_filtered(
                 let rows = engine
                     .fetch_all_sql_with_binds(&sql, &engine_bind_values)
                     .await
-                    .map_err(|e| {
-                        pyo3::exceptions::PyRuntimeError::new_err(format!("Count failed: {}", e))
-                    })?;
+                    .map_err(|e| crate::errors::map_db_error("Count failed", e))?;
                 rows.first()
                     .and_then(|row| row.values.first())
                     .and_then(|(_, value)| value.as_i64())
@@ -1948,9 +1898,7 @@ pub fn delete_record(
 
         execute_statement_with_optional_tx(&engine, tx_conn, &sql, &bind_values.0)
             .await
-            .map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!("Delete failed: {}", e))
-            })?;
+            .map_err(|e| crate::errors::map_db_error("Delete failed", e))?;
 
         Ok(true)
     })
@@ -2006,9 +1954,7 @@ pub fn delete_filtered(
         let rows_affected =
             execute_statement_with_optional_tx(&engine, tx_conn, &sql, &bind_values.0)
                 .await
-                .map_err(|e| {
-                    pyo3::exceptions::PyRuntimeError::new_err(format!("Delete failed: {}", e))
-                })?;
+                .map_err(|e| crate::errors::map_db_error("Delete failed", e))?;
 
         // After bulk delete, we MUST clear the Identity Map for this model to avoid stale objects
         if engine.is_identity_map_enabled() {
@@ -2099,9 +2045,7 @@ pub fn update_filtered<'py>(
         let rows_affected =
             execute_statement_with_optional_tx(&engine, tx_conn, &sql, &bind_values.0)
                 .await
-                .map_err(|e| {
-                    pyo3::exceptions::PyRuntimeError::new_err(format!("Update failed: {}", e))
-                })?;
+                .map_err(|e| crate::errors::map_db_error("Update failed", e))?;
 
         // After bulk update, we MUST clear the Identity Map for this model to avoid stale objects
         if engine.is_identity_map_enabled() {
@@ -2182,9 +2126,7 @@ pub fn add_m2m_links<'py>(
 
         execute_statement_with_optional_tx(&engine, tx_conn, &sql, &bind_values.0)
             .await
-            .map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!("Add M2M links failed: {}", e))
-            })?;
+            .map_err(|e| crate::errors::map_db_error("Add M2M links failed", e))?;
 
         Ok(())
     })
@@ -2258,9 +2200,7 @@ pub fn remove_m2m_links<'py>(
 
         execute_statement_with_optional_tx(&engine, tx_conn, &sql, &bind_values.0)
             .await
-            .map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!("Remove M2M links failed: {}", e))
-            })?;
+            .map_err(|e| crate::errors::map_db_error("Remove M2M links failed", e))?;
 
         Ok(())
     })
@@ -2320,9 +2260,7 @@ pub fn clear_m2m_links<'py>(
 
         execute_statement_with_optional_tx(&engine, tx_conn, &sql, &bind_values.0)
             .await
-            .map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!("Clear M2M links failed: {}", e))
-            })?;
+            .map_err(|e| crate::errors::map_db_error("Clear M2M links failed", e))?;
 
         Ok(())
     })
@@ -2597,9 +2535,7 @@ pub fn raw_execute<'py>(
                 engine.execute_sql_with_binds(&sql, &bind_values).await
             }
         }
-        .map_err(|e| {
-            pyo3::exceptions::PyRuntimeError::new_err(format!("Raw SQL execute failed: {e}"))
-        })?;
+        .map_err(|e| crate::errors::map_db_error("Raw SQL execute failed", e))?;
 
         Ok(rows_affected as i64)
     })
@@ -2637,9 +2573,7 @@ pub fn raw_fetch_all<'py>(
                 engine.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
         }
-        .map_err(|e| {
-            pyo3::exceptions::PyRuntimeError::new_err(format!("Raw SQL fetch_all failed: {e}"))
-        })?;
+        .map_err(|e| crate::errors::map_db_error("Raw SQL fetch_all failed", e))?;
 
         Python::attach(|py| {
             let out = pyo3::types::PyList::empty(py);
@@ -2692,9 +2626,7 @@ pub fn raw_fetch_one<'py>(
                 engine.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
         }
-        .map_err(|e| {
-            pyo3::exceptions::PyRuntimeError::new_err(format!("Raw SQL fetch_one failed: {e}"))
-        })?;
+        .map_err(|e| crate::errors::map_db_error("Raw SQL fetch_one failed", e))?;
 
         Python::attach(|py| match rows.into_iter().next() {
             Some(row) => Ok(engine_row_to_pydict(py, row)?.into_any().unbind()),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -367,18 +367,18 @@ pub async fn internal_create_tables(engine: Arc<EngineHandle>) -> PyResult<()> {
         })?;
 
         engine.execute_sql(&emission.create_sql).await.map_err(|e| {
-            pyo3::exceptions::PyRuntimeError::new_err(format!(
-                "SQL Execution failed for '{}' table: {}",
-                model.table_name, e
-            ))
+            crate::errors::map_db_error(
+                &format!("SQL Execution failed for '{}' table", model.table_name),
+                e,
+            )
         })?;
 
         for post_sql in &emission.post_create_sqls {
             engine.execute_sql(post_sql).await.map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!(
-                    "SQL Execution failed for '{}' index: {}",
-                    model.table_name, e
-                ))
+                crate::errors::map_db_error(
+                    &format!("SQL Execution failed for '{}' index", model.table_name),
+                    e,
+                )
             })?;
         }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -65,7 +65,7 @@ pub fn connection_for_route(using: Option<String>) -> PyResult<(String, Arc<Engi
                 .get(&connection_name)
                 .cloned()
                 .ok_or_else(|| {
-                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                    crate::errors::interface_error(format!(
                         "Default connection '{}' is not registered",
                         connection_name
                     ))
@@ -87,14 +87,12 @@ pub fn connection_for_route(using: Option<String>) -> PyResult<(String, Arc<Engi
             .is_some();
 
         if has_connections && !has_default {
-            return Err(pyo3::exceptions::PyRuntimeError::new_err(
+            return Err(crate::errors::interface_error(
                 "No default connection selected",
             ));
         }
 
-        return Err(pyo3::exceptions::PyRuntimeError::new_err(
-            "Engine not initialized",
-        ));
+        return Err(crate::errors::interface_error("Engine not initialized"));
     };
 
     if connection_name.is_empty()
@@ -117,7 +115,7 @@ pub fn connection_for_route(using: Option<String>) -> PyResult<(String, Arc<Engi
         .cloned()
         .map(|engine| (connection_name.clone(), engine))
         .ok_or_else(|| {
-            pyo3::exceptions::PyValueError::new_err(format!(
+            crate::errors::interface_error(format!(
                 "Connection '{}' is not registered",
                 connection_name
             ))

--- a/tests/test_composite_unique.py
+++ b/tests/test_composite_unique.py
@@ -12,6 +12,7 @@ from ferro import (
     ManyToMany,
     Model,
     Relation,
+    UniqueViolationError,
     clear_registry,
     connect,
     reset_engine,
@@ -81,11 +82,8 @@ async def test_composite_unique_enforced_on_user_model(db_url):
     await connect(db_url, auto_migrate=True)
 
     await PairRow(alpha_id=1, beta_id=2).save()
-    with pytest.raises(RuntimeError, match="Save failed") as excinfo:
+    with pytest.raises(UniqueViolationError, match="Save failed"):
         await PairRow(alpha_id=1, beta_id=2).save()
-
-    msg = str(excinfo.value)
-    assert "unique" in msg.lower()
 
 
 @pytest.mark.asyncio
@@ -107,10 +105,8 @@ async def test_m2m_duplicate_link_rejected(db_url):
     actor = await Actor.create(name="Alice")
     movie = await Movie.create(title="Matrix")
     await actor.movies.add(movie)
-    with pytest.raises(RuntimeError, match="Add M2M links failed") as excinfo:
+    with pytest.raises(UniqueViolationError, match="Add M2M links failed"):
         await actor.movies.add(movie)
-    msg = str(excinfo.value)
-    assert "unique" in msg.lower()
 
 
 def test_alembic_metadata_has_unique_constraints():

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -496,7 +496,7 @@ async def test_unqualified_operation_requires_default_connection(tmp_path):
 
     await ferro.connect(f"sqlite:{db_file}?mode=rwc", name="app")
 
-    with pytest.raises(RuntimeError, match="No default connection selected"):
+    with pytest.raises(ferro.InterfaceError, match="No default connection selected"):
         await ferro.execute("SELECT 1")
 
 

--- a/tests/test_connection_redaction.py
+++ b/tests/test_connection_redaction.py
@@ -8,7 +8,7 @@ import ferro
 async def test_connection_error_redacts_secret_query_params(tmp_path):
     """Connection errors should give context without exposing secret query values."""
     db_file = tmp_path / "app.db"
-    with pytest.raises(ConnectionError) as excinfo:
+    with pytest.raises(ferro.InterfaceError) as excinfo:
         await ferro.connect(
             f"sqlite:{db_file}?mode=rwc&password=supersecret&apikey=topsecret",
             name="app",
@@ -25,7 +25,7 @@ async def test_connection_error_redacts_secret_query_params(tmp_path):
 @pytest.mark.asyncio
 async def test_connection_error_redacts_postgres_userinfo_and_tokens():
     """Postgres-style DSNs should redact password userinfo and token query params."""
-    with pytest.raises(ConnectionError) as excinfo:
+    with pytest.raises(ferro.InterfaceError) as excinfo:
         await ferro.connect(
             "postgres+srv://app_user:supersecret@example.invalid/app?access_token=topsecret",
             name="app",

--- a/tests/test_exception_mapping.py
+++ b/tests/test_exception_mapping.py
@@ -1,0 +1,152 @@
+"""Database failures raised from the Rust core are catchable by type (FF-A / A2, #172).
+
+Exit-gate rule: exception *types* (and structured attributes) are asserted —
+never driver message text.
+"""
+
+from typing import Annotated
+
+import pytest
+
+from ferro import (
+    BackRef,
+    FerroField,
+    ForeignKey,
+    InterfaceError,
+    IntegrityError,
+    Model,
+    NotNullViolationError,
+    OperationalError,
+    Relation,
+    UniqueViolationError,
+    connect,
+)
+from ferro import Field
+from ferro.exceptions import CheckViolationError, ForeignKeyViolationError
+
+
+@pytest.mark.backend_matrix
+@pytest.mark.asyncio
+async def test_unique_violation_is_typed(db_url, db_backend):
+    class UniqueUser(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        email: Annotated[str, FerroField(unique=True)]
+
+    await connect(db_url, auto_migrate=True)
+    await UniqueUser(email="a@b.com").save()
+
+    with pytest.raises(UniqueViolationError) as excinfo:
+        await UniqueUser(email="a@b.com").save()
+
+    exc = excinfo.value
+    assert isinstance(exc, IntegrityError)
+    assert exc.driver_message is not None
+    if db_backend == "postgres":
+        assert exc.sqlstate == "23505"
+        assert exc.constraint is not None
+
+
+@pytest.mark.backend_matrix
+@pytest.mark.asyncio
+async def test_not_null_violation_is_typed(db_url, db_backend):
+    class NotNullNote(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        body: str
+
+    await connect(db_url, auto_migrate=True)
+    note = NotNullNote(body="text")
+    await note.save()
+    pk = note.id
+
+    with pytest.raises(NotNullViolationError) as excinfo:
+        await NotNullNote.where(lambda note: note.id == pk).update(body=None)
+
+    exc = excinfo.value
+    assert isinstance(exc, IntegrityError)
+    assert exc.driver_message is not None
+    if db_backend == "postgres":
+        assert exc.sqlstate == "23502"
+
+
+# db_check constraints are emitted on Postgres only (SQLite would need a
+# table rebuild; ferro-ddl-lowering elides them there with a warning), so a
+# CheckViolationError can only originate on Postgres.
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_check_violation_is_typed(db_url, db_backend):
+    import enum
+
+    class DocFormat(str, enum.Enum):
+        MARKDOWN = "markdown"
+        HTML = "html"
+
+    class CheckedDoc(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        format: Annotated[DocFormat, Field(db_type="text", db_check=True)]
+
+    await connect(db_url, auto_migrate=True)
+    doc = CheckedDoc(format=DocFormat.MARKDOWN)
+    await doc.save()
+    pk = doc.id
+
+    # Pydantic validation is bypassed on the bulk-update path by design;
+    # the DB CHECK constraint is the enforcement of record.
+    with pytest.raises(CheckViolationError) as excinfo:
+        await CheckedDoc.where(lambda doc: doc.id == pk).update(format="bogus")
+
+    exc = excinfo.value
+    assert isinstance(exc, IntegrityError)
+    if db_backend == "postgres":
+        assert exc.sqlstate == "23514"
+
+
+@pytest.mark.backend_matrix
+@pytest.mark.asyncio
+async def test_foreign_key_violation_is_typed(db_url, db_backend):
+    class FkAuthor(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+        books: Relation[list["FkBook"]] = BackRef()
+
+    class FkBook(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        title: str
+        author: Annotated[FkAuthor, ForeignKey(related_name="books")]
+
+    await connect(db_url, auto_migrate=True)
+
+    with pytest.raises(ForeignKeyViolationError) as excinfo:
+        await FkBook(title="Ghost", author_id=99999).save()
+
+    exc = excinfo.value
+    assert isinstance(exc, IntegrityError)
+    if db_backend == "postgres":
+        assert exc.sqlstate == "23503"
+
+
+@pytest.mark.asyncio
+async def test_unopenable_database_is_operational_error(tmp_path):
+    # No mode=rwc: SQLite refuses to open a missing file, which surfaces as a
+    # connect-time database error.
+    with pytest.raises(OperationalError):
+        await connect(f"sqlite://{tmp_path}/missing/nope.db", auto_migrate=False)
+
+
+@pytest.mark.asyncio
+async def test_unsupported_scheme_is_interface_error():
+    with pytest.raises(InterfaceError):
+        await connect("mysql://root@localhost/nope", auto_migrate=False)
+
+
+@pytest.mark.asyncio
+async def test_unknown_connection_name_is_interface_error(tmp_path):
+    class RoutedItem(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    await connect(f"sqlite://{tmp_path}/routed.db?mode=rwc", auto_migrate=True)
+
+    from ferro.query.builder import Query
+
+    with pytest.raises(InterfaceError):
+        await Query(RoutedItem, using="no_such_connection").all()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,126 @@
+"""Contract tests for the ferro.exceptions hierarchy (FF-A / A2, #172)."""
+
+import pickle
+
+import pytest
+
+import ferro
+from ferro.exceptions import (
+    CheckViolationError,
+    DataError,
+    FerroError,
+    ForeignKeyViolationError,
+    IntegrityError,
+    InterfaceError,
+    ModelDoesNotExist,
+    NotNullViolationError,
+    OperationalError,
+    UniqueViolationError,
+)
+
+
+class TestHierarchy:
+    def test_ferro_error_is_the_root(self):
+        for exc in (
+            InterfaceError,
+            OperationalError,
+            DataError,
+            IntegrityError,
+            ModelDoesNotExist,
+        ):
+            assert issubclass(exc, FerroError)
+
+    def test_violations_are_integrity_errors(self):
+        for exc in (
+            UniqueViolationError,
+            ForeignKeyViolationError,
+            NotNullViolationError,
+            CheckViolationError,
+        ):
+            assert issubclass(exc, IntegrityError)
+            assert issubclass(exc, FerroError)
+
+    def test_branches_are_disjoint(self):
+        assert not issubclass(IntegrityError, OperationalError)
+        assert not issubclass(OperationalError, IntegrityError)
+        assert not issubclass(DataError, IntegrityError)
+        assert not issubclass(InterfaceError, OperationalError)
+
+    def test_model_does_not_exist_remains_lookup_error(self):
+        """Pre-FF-A callers catching LookupError must keep working."""
+        assert issubclass(ModelDoesNotExist, LookupError)
+
+        class Dummy:
+            pass
+
+        with pytest.raises(LookupError):
+            raise ModelDoesNotExist(Dummy, 1)
+        with pytest.raises(FerroError):
+            raise ModelDoesNotExist(Dummy, 1)
+
+
+class TestStructuredAttributes:
+    def test_defaults_are_none(self):
+        exc = OperationalError("connect failed")
+        assert exc.driver_message is None
+        assert exc.sqlstate is None
+        assert exc.constraint is None
+        assert str(exc) == "connect failed"
+
+    def test_attributes_are_kept(self):
+        exc = UniqueViolationError(
+            "Save failed: duplicate key",
+            driver_message="duplicate key value violates unique constraint",
+            sqlstate="23505",
+            constraint="uq_user_email",
+        )
+        assert exc.driver_message == (
+            "duplicate key value violates unique constraint"
+        )
+        assert exc.sqlstate == "23505"
+        assert exc.constraint == "uq_user_email"
+        assert str(exc) == "Save failed: duplicate key"
+
+    def test_pickle_round_trip(self):
+        exc = UniqueViolationError(
+            "boom", driver_message="dup", sqlstate="23505", constraint="uq_x"
+        )
+        clone = pickle.loads(pickle.dumps(exc))
+        assert type(clone) is UniqueViolationError
+        assert str(clone) == "boom"
+        assert clone.driver_message == "dup"
+        assert clone.sqlstate == "23505"
+        assert clone.constraint == "uq_x"
+
+    def test_model_does_not_exist_keeps_bespoke_init(self):
+        class Dummy:
+            pass
+
+        exc = ModelDoesNotExist(Dummy, 42)
+        assert exc.model is Dummy
+        assert exc.pk == 42
+        assert "Dummy" in str(exc)
+        assert "42" in str(exc)
+
+
+class TestPublicSurface:
+    def test_exported_from_ferro(self):
+        for name in (
+            "FerroError",
+            "InterfaceError",
+            "OperationalError",
+            "DataError",
+            "IntegrityError",
+            "UniqueViolationError",
+            "ForeignKeyViolationError",
+            "NotNullViolationError",
+            "CheckViolationError",
+            "ModelDoesNotExist",
+        ):
+            assert hasattr(ferro, name), f"ferro.{name} missing"
+            assert name in ferro.__all__
+
+    def test_module_is_ferro_exceptions(self):
+        """Classes must not leak a private module path into tracebacks."""
+        assert UniqueViolationError.__module__ == "ferro.exceptions"
+        assert FerroError.__module__ == "ferro.exceptions"

--- a/tests/test_raw_sql.py
+++ b/tests/test_raw_sql.py
@@ -433,13 +433,14 @@ async def test_marshal_bool_before_int_order(db_url):
 
 
 @pytest.mark.asyncio
-async def test_invalid_sql_raises_runtimeerror_with_db_message(db_url):
+async def test_invalid_sql_raises_operational_error_with_db_message(db_url):
     """T8.1: driver error text appears in the surfaced exception."""
-    from ferro import execute
+    from ferro import OperationalError, execute
 
     await connect(db_url)
-    with pytest.raises(RuntimeError, match="Raw SQL execute failed"):
+    with pytest.raises(OperationalError, match="Raw SQL execute failed") as excinfo:
         await execute("THIS IS NOT VALID SQL")
+    assert excinfo.value.driver_message is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -35,7 +35,7 @@ async def test_create_tables_success(db_url):
 async def test_create_tables_no_connection():
     """Test that create_tables raises an error if no connection exists."""
     ferro.reset_engine()
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(ferro.InterfaceError) as excinfo:
         await ferro.create_tables()
     assert "Engine not initialized" in str(excinfo.value)
 


### PR DESCRIPTION
## What

Every database failure Ferro raises is now catchable by type. `ferro.exceptions` grows a DBAPI-shaped tree, and the Rust core maps `sqlx` failures onto it instead of formatting everything into `RuntimeError`.

```
FerroError
├── InterfaceError          interface misuse (unknown connection, bad scheme/config)
├── OperationalError        server/environment failures (unreachable, pool, I/O, TLS)
├── DataError               decode/conversion failures
├── IntegrityError
│   ├── UniqueViolationError
│   ├── ForeignKeyViolationError
│   ├── NotNullViolationError
│   └── CheckViolationError
└── ModelDoesNotExist       (unchanged for callers — also still a LookupError)
```

Before / after, on both backends:

```python
# before
try:
    await User(email="a@b.com").save()
except RuntimeError as e:
    if "unique" in str(e).lower():   # string matching on driver text
        ...

# after
try:
    await User(email="a@b.com").save()
except ferro.UniqueViolationError as e:
    e.sqlstate         # "23505" on Postgres
    e.constraint       # violated constraint name (Postgres)
    e.driver_message   # original driver text, preserved for logs
```

## How

- Exceptions are **pure Python** (`src/ferro/exceptions.py`) so `__module__`, pickling, and mkdocstrings behave; a new `src/errors.rs` looks the classes up lazily at first raise (`GILOnceCell`-cached — no import cycle, cold path).
- One conversion point: `map_db_error(context, sqlx::Error)` with a pure `exception_name_for` classifier pinned by cargo unit tests. Classification: `DatabaseError::kind()` → the four violations; `Io`/`Tls`/`Pool*`/`WorkerCrashed`/`RowNotFound` → `OperationalError`; `Configuration`/`Protocol`/`ColumnNotFound` → `InterfaceError`; `Decode`/`TypeNotFound` → `DataError`.
- Converted sites: all engine executions in `operations.rs` (save, fetch, count, delete, update, m2m, raw SQL, BEGIN/COMMIT/ROLLBACK/SAVEPOINT), `migrate.rs` DDL + pool refresh, `schema.rs` CREATE TABLE, `introspect.rs`, `connection.rs` connect failures, and routing errors in `state.rs` (unknown connection name, no default selected, engine not initialized → `InterfaceError`). Internal invariants (lock poisoning, unregistered models, unknown transaction ids) deliberately stay `RuntimeError`.

## Behavioral changes (migration impact: minor)

| Before | After |
|---|---|
| `RuntimeError` on any DB failure | typed `FerroError` subclass |
| `ConnectionError` on `connect()` failure | `OperationalError` (server/env) or `InterfaceError` (bad scheme/config) |
| `ValueError`/`RuntimeError` on routing misuse | `InterfaceError` |

Documented in `docs/plans/ir-first-migration-guide.md` (new FF-A section) and `docs/pages/api/exceptions.md`.

## Tests

- `tests/test_exceptions.py` — hierarchy contract, LookupError back-compat, structured attrs, pickle round-trip.
- `tests/test_exception_mapping.py` — unique / not-null / FK violations on the sqlite+postgres matrix, check violation on Postgres (`db_check` is Postgres-only by design), unopenable DB → `OperationalError`, unsupported scheme + unknown `using` → `InterfaceError`. SQLSTATE and constraint asserted on Postgres. **Zero string matching on driver messages** (epic exit-gate rule).
- Rust: `errors::tests` pin the classifier over constructed `sqlx::Error` variants.
- Existing tests that pinned untyped errors (`test_composite_unique`, `test_raw_sql`, `test_connection`, `test_connection_redaction`, `test_schema`) rewritten to the typed contract — the two composite-unique tests also lose their `"unique" in msg` string matching.

Full matrix: 931 passed; the 7 remaining `[postgres]` failures pre-exist on `main` and are tracked in #176 (non-idempotent `db_check` ADD CONSTRAINT — discovered while validating this PR, filed separately).

## Exit steps

- [x] Sub-issue closure encoded: Closes #172
- [x] Migration-guide entry added (FF-A section)
- [x] `cargo test --no-default-features --features testing` green (117 tests)
- [x] `uv run pytest --db-backends=sqlite,postgres` green except pre-existing #176 set

Part of Epic FF-A (#170). Plan: `docs/plans/2026-07-02-002-feat-ff-a-172-typed-exceptions-plan.md`.

Closes #172
