### PR TITLE
feat(ff-a)!: reject limit/offset on mutating queries

### DIFF
--- a/docs/plans/2026-07-02-001-fable-fixes-roadmap.md
+++ b/docs/plans/2026-07-02-001-fable-fixes-roadmap.md
@@ -51,7 +51,7 @@ These are behavioral changes to the public API — they must land before 1.0.
 
 **Sub-tasks**
 
-- [ ] **A1 — Reject `limit`/`offset` on mutating queries.**
+- [x] **A1 — Reject `limit`/`offset` on mutating queries.**
       `Query.update()` / `Query.delete()` raise `ValueError` when `_limit` or
       `_offset` is set (portable SQL has no `DELETE ... LIMIT`; failing loud is
       the long-term design, not a placeholder for implementing it). Remove

--- a/docs/plans/2026-07-02-001-fable-fixes-roadmap.md
+++ b/docs/plans/2026-07-02-001-fable-fixes-roadmap.md
@@ -59,7 +59,7 @@ These are behavioral changes to the public API — they must land before 1.0.
       contract cannot regress. Tests: builder-level raise + static contract on
       the mutating payload shape. *(F1 — the review's most severe finding.)*
       Migration impact: **breaking** (previously silently ignored).
-- [ ] **A2 — Typed exception hierarchy.**
+- [x] **A2 — Typed exception hierarchy.**
       `ferro.exceptions` grows a DBAPI-shaped tree
       (`FerroError` → `OperationalError`, `IntegrityError` →
       `UniqueViolationError` / `ForeignKeyViolationError` /

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -231,6 +231,30 @@ class Query(Generic[T]):
         self._offset = value
         return self
 
+    def _mutating_query_def(self, operation: str) -> dict[str, Any]:
+        """Build the QueryIR payload for a mutating operation (update/delete).
+
+        Mutating payloads never carry ``limit``/``offset`` keys: portable SQL
+        has no ``UPDATE/DELETE ... LIMIT``, so pagination on a mutation is
+        rejected loudly instead of being silently ignored.
+
+        Raises:
+            ValueError: If ``limit()`` or ``offset()`` was set on this query.
+        """
+        if self._limit is not None or self._offset is not None:
+            raise ValueError(
+                f"{operation}() does not support limit/offset: portable SQL has "
+                f"no {operation.upper()} ... LIMIT. Remove the .limit()/.offset() "
+                f"call, or fetch primary keys first and {operation} by "
+                "primary-key set."
+            )
+        return {
+            "model_name": self.model_cls.__name__,
+            "where": [node.to_ir_dict() for node in self.where_clause],
+            "order_by": [],
+            "m2m": None,
+        }
+
     async def all(self) -> list[T]:
         """Return all model instances that match the current query
 
@@ -300,19 +324,15 @@ class Query(Generic[T]):
         Returns:
             The number of records updated.
 
+        Raises:
+            ValueError: If ``limit()`` or ``offset()`` was set on this query.
+
         Examples:
             >>> updated = await User.where(lambda user: user.id == 1).update(name="Taylor")
             >>> isinstance(updated, int)
             True
         """
-        query_def = {
-            "model_name": self.model_cls.__name__,
-            "where": [node.to_ir_dict() for node in self.where_clause],
-            "order_by": [],
-            "limit": self._limit,
-            "offset": self._offset,
-            "m2m": None,
-        }
+        query_def = self._mutating_query_def("update")
         tx_id, using, session_id = self._transaction_or_using()
         return await update_filtered(
             self.model_cls.__name__,
@@ -348,19 +368,15 @@ class Query(Generic[T]):
         Returns:
             The number of records deleted.
 
+        Raises:
+            ValueError: If ``limit()`` or ``offset()`` was set on this query.
+
         Examples:
             >>> deleted = await User.where(lambda user: user.disabled == True).delete()  # noqa: E712
             >>> isinstance(deleted, int)
             True
         """
-        query_def = {
-            "model_name": self.model_cls.__name__,
-            "where": [node.to_ir_dict() for node in self.where_clause],
-            "order_by": [],
-            "limit": self._limit,
-            "offset": self._offset,
-            "m2m": None,
-        }
+        query_def = self._mutating_query_def("delete")
         tx_id, using, session_id = self._transaction_or_using()
         return await delete_filtered(
             self.model_cls.__name__,

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -234,6 +234,21 @@ fn query_condition_for_backend(
         .map_err(pyo3::exceptions::PyValueError::new_err)
 }
 
+/// Reject `limit`/`offset` on mutating operations (FF-A A1, #171).
+///
+/// Portable SQL has no `UPDATE/DELETE ... LIMIT`. The Python builder raises
+/// before serializing and omits the keys from mutating payloads; this
+/// boundary guard keeps the contract from regressing via any other caller.
+fn reject_pagination_on_mutation(query_def: &QueryDef, operation: &str) -> PyResult<()> {
+    if query_def.limit.is_some() || query_def.offset.is_some() {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "{operation}() does not support limit/offset: portable SQL has no {} ... LIMIT",
+            operation.to_uppercase()
+        )));
+    }
+    Ok(())
+}
+
 /// Map SeaQuery `Value` variants to `EngineBindValue`.
 ///
 /// Typed `None` variants are preserved as `Null(NullKind::T)` so the bind
@@ -1929,6 +1944,7 @@ pub fn delete_filtered(
     session_id: Option<String>,
 ) -> PyResult<Bound<'_, PyAny>> {
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
+    reject_pagination_on_mutation(&query_def, "delete")?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
@@ -1994,6 +2010,7 @@ pub fn update_filtered<'py>(
     session_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
+    reject_pagination_on_mutation(&query_def, "update")?;
     let update_inputs = bind_inputs_from_py(&updates)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
@@ -3545,5 +3562,76 @@ mod engine_value_to_rust_value_tests {
         assert!(
             matches!(out, RustValue::Json(v) if v.get("k").and_then(|x| x.as_str()) == Some("v"))
         );
+    }
+}
+
+#[cfg(test)]
+mod mutation_pagination_guard_tests {
+    use super::{query_def_from_ir_json, reject_pagination_on_mutation};
+
+    fn envelope_without_pagination_keys() -> String {
+        serde_json::json!({
+            "ir_kind": "query",
+            "ir_version": 1,
+            "payload": {
+                "model_name": "Widget",
+                "where": [{
+                    "node_kind": "leaf",
+                    "operator": "==",
+                    "column": "name",
+                    "value": {"kind": "string", "value": "a"}
+                }],
+                "order_by": [],
+                "m2m": null
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn query_ir_without_pagination_keys_parses_to_none() {
+        let query_def = query_def_from_ir_json(&envelope_without_pagination_keys())
+            .expect("mutating payloads omit limit/offset keys; parsing must succeed");
+        assert_eq!(query_def.limit, None);
+        assert_eq!(query_def.offset, None);
+    }
+
+    #[test]
+    fn guard_allows_mutation_without_pagination() {
+        let query_def = query_def_from_ir_json(&envelope_without_pagination_keys()).unwrap();
+        assert!(reject_pagination_on_mutation(&query_def, "delete").is_ok());
+        assert!(reject_pagination_on_mutation(&query_def, "update").is_ok());
+    }
+
+    #[test]
+    fn guard_rejects_limit_with_pyvalueerror() {
+        let mut query_def = query_def_from_ir_json(&envelope_without_pagination_keys()).unwrap();
+        query_def.limit = Some(5);
+        pyo3::Python::attach(|py| {
+            let err = reject_pagination_on_mutation(&query_def, "delete")
+                .expect_err("limit on a mutating query must be rejected");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+            let msg = err.to_string();
+            assert!(
+                msg.contains("delete") && msg.contains("limit"),
+                "message should name the operation and limit: {msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn guard_rejects_offset_with_pyvalueerror() {
+        let mut query_def = query_def_from_ir_json(&envelope_without_pagination_keys()).unwrap();
+        query_def.offset = Some(2);
+        pyo3::Python::attach(|py| {
+            let err = reject_pagination_on_mutation(&query_def, "update")
+                .expect_err("offset on a mutating query must be rejected");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+            let msg = err.to_string();
+            assert!(
+                msg.contains("update") && msg.contains("offset"),
+                "message should name the operation and offset: {msg}"
+            );
+        });
     }
 }

--- a/tests/test_mutation_pagination_guard.py
+++ b/tests/test_mutation_pagination_guard.py
@@ -1,0 +1,97 @@
+"""FF-A A1 (#171): limit/offset on mutating queries raise instead of being ignored."""
+
+from typing import Annotated
+
+import pytest
+
+from ferro import FerroField, Model, connect
+
+
+class PaginationGuardItem(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str
+    flagged: bool = False
+
+
+@pytest.mark.asyncio
+async def test_delete_with_limit_raises_value_error():
+    with pytest.raises(ValueError, match=r"delete\(\) does not support limit/offset"):
+        await PaginationGuardItem.where(lambda item: item.flagged == True).limit(  # noqa: E712
+            5
+        ).delete()
+
+
+@pytest.mark.asyncio
+async def test_delete_with_offset_raises_value_error():
+    with pytest.raises(ValueError, match=r"delete\(\) does not support limit/offset"):
+        await PaginationGuardItem.where(lambda item: item.flagged == True).offset(  # noqa: E712
+            2
+        ).delete()
+
+
+@pytest.mark.asyncio
+async def test_update_with_limit_raises_value_error():
+    with pytest.raises(ValueError, match=r"update\(\) does not support limit/offset"):
+        await PaginationGuardItem.where(lambda item: item.flagged == True).limit(  # noqa: E712
+            5
+        ).update(name="renamed")
+
+
+@pytest.mark.asyncio
+async def test_update_with_offset_raises_value_error():
+    with pytest.raises(ValueError, match=r"update\(\) does not support limit/offset"):
+        await PaginationGuardItem.where(lambda item: item.flagged == True).offset(  # noqa: E712
+            2
+        ).update(name="renamed")
+
+
+def test_mutating_query_def_omits_pagination_keys():
+    query = PaginationGuardItem.where(lambda item: item.flagged == True)  # noqa: E712
+    for operation in ("update", "delete"):
+        payload = query._mutating_query_def(operation)
+        assert "limit" not in payload
+        assert "offset" not in payload
+        assert payload["model_name"] == "PaginationGuardItem"
+        assert payload["order_by"] == []
+        assert payload["m2m"] is None
+        assert len(payload["where"]) == 1
+
+
+@pytest.mark.backend_matrix
+@pytest.mark.asyncio
+async def test_failed_paginated_mutation_touches_no_rows(db_url):
+    class GuardedRow(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    await connect(db_url, auto_migrate=True)
+
+    for label in ("a", "b", "c"):
+        await GuardedRow(label=label).save()
+
+    with pytest.raises(ValueError):
+        await GuardedRow.where(lambda row: row.id > 0).limit(1).delete()
+    with pytest.raises(ValueError):
+        await GuardedRow.where(lambda row: row.id > 0).offset(1).update(label="x")
+
+    rows = await GuardedRow.where(lambda row: row.id > 0).order_by("label").all()
+    assert [row.label for row in rows] == ["a", "b", "c"]
+
+
+@pytest.mark.backend_matrix
+@pytest.mark.asyncio
+async def test_first_then_delete_on_same_query_still_allowed(db_url):
+    class FirstThenDelete(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    await connect(db_url, auto_migrate=True)
+
+    await FirstThenDelete(label="only").save()
+
+    query = FirstThenDelete.where(lambda row: row.label == "only")
+    found = await query.first()
+    assert found is not None
+
+    deleted = await query.delete()
+    assert deleted == 1

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -1,3 +1,4 @@
+import ast
 from pathlib import Path
 
 
@@ -6,3 +7,34 @@ def test_query_methods_use_query_ir_serializer_instead_of_raw_json_dumps():
 
     assert source.count("def _query_ir_payload_to_json(") == 1
     assert "json.dumps(query_def)" not in source
+
+
+def test_mutating_query_methods_cannot_carry_pagination():
+    source = Path("src/ferro/query/builder.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    query_cls = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Query"
+    )
+    for method_name in ("update", "delete"):
+        method = next(
+            node
+            for node in query_cls.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == method_name
+        )
+        attributes = {
+            node.attr for node in ast.walk(method) if isinstance(node, ast.Attribute)
+        }
+        assert "_limit" not in attributes, (
+            f"Query.{method_name}() must not read _limit; pagination is rejected "
+            "by _mutating_query_def (FF-A A1)"
+        )
+        assert "_offset" not in attributes, (
+            f"Query.{method_name}() must not read _offset; pagination is rejected "
+            "by _mutating_query_def (FF-A A1)"
+        )
+        assert "_mutating_query_def" in attributes, (
+            f"Query.{method_name}() must build its payload via _mutating_query_def"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -541,7 +541,7 @@ wheels = [
 
 [[package]]
 name = "ferro-orm"
-version = "0.11.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Closes #171 (Epic FF-A #170, review finding **F1** — the review's most severe finding).

## Problem

`Query.update()` / `Query.delete()` accepted `.limit(n)` / `.offset(n)` chains, put the values into the QueryIR payload, and the Rust side silently ignored them — only the `WHERE` condition was applied. So:

```python
await User.where(lambda u: u.archived == True).limit(10).delete()
```

deleted **every** matching row, not 10.

## Fix (long-term design, not a placeholder)

Portable SQL has no `DELETE ... LIMIT`; failing loud is the design. Three layers so the contract cannot regress:

1. **Builder raises** — shared `Query._mutating_query_def()` raises `ValueError` when `_limit`/`_offset` is set:
   ```
   ValueError: delete() does not support limit/offset: portable SQL has no DELETE ... LIMIT.
   Remove the .limit()/.offset() call, or fetch primary keys first and delete by primary-key set.
   ```
2. **Payload omits the keys** — mutating QueryIR payloads no longer carry `limit`/`offset` at all. `QueryIrPayload`'s fields are `Option<u64>`, and serde parses missing keys to `None` — no IR version bump, golden vectors untouched.
3. **Rust boundary guard** — `reject_pagination_on_mutation()` in `update_filtered`/`delete_filtered` rejects any payload that still carries pagination, before any SQL is built.

`first()` restores `_limit` in a `finally`, so `first()`-then-`delete()` on the same `Query` still works. Instance `model.delete()` (which routes through `Query.delete()`) is unaffected.

## Tests

- Builder-level raise ×4 (limit/offset × update/delete)
- Backend-matrix (sqlite + postgres) proof that no rows are touched when the raise fires
- `first()`-then-`delete()` on the same Query still allowed
- Payload contract: mutating payload carries no `limit`/`offset` keys
- AST static contract: `update()`/`delete()` bodies cannot reference `_limit`/`_offset` and must build via `_mutating_query_def`
- Rust: missing keys parse to `None`; guard rejects `Some(...)` with `PyValueError`

Full matrix: 941 passed; the 7 `[postgres]` failures are pre-existing on `main` and tracked in #176.

## Migration impact

**breaking** — previously silently ignored. Drop the `.limit()`/`.offset()` call, or select primary keys first and mutate by PK set. Migration-guide entry lands with A5 (#175).