### PR TITLE
feat(ff-a)!: create() is a real INSERT; save() distinguishes INSERT from UPDATE (A3+A4)

### DIFF
--- a/docs/plans/2026-07-02-001-fable-fixes-roadmap.md
+++ b/docs/plans/2026-07-02-001-fable-fixes-roadmap.md
@@ -68,11 +68,11 @@ These are behavioral changes to the public API — they must land before 1.0.
       instead of `PyRuntimeError(format!(...))` across all of `operations.rs` /
       `migrate.rs`. Original driver message preserved on the exception.
       Migration impact: **minor** (RuntimeError → subclass; document).
-- [ ] **A3 — `create()` is a real INSERT.**
+- [x] **A3 — `create()` is a real INSERT.**
       Drop `ON CONFLICT DO UPDATE` from the `create()` path; a duplicate PK or
       unique violation raises `UniqueViolationError` (depends on A2).
       Migration impact: **breaking** (previously clobbered the existing row).
-- [ ] **A4 — `save()` distinguishes INSERT from UPDATE; upsert becomes explicit.**
+- [x] **A4 — `save()` distinguishes INSERT from UPDATE; upsert becomes explicit.**
       Track persistence state explicitly on the instance (today it is implicit
       in the identity map / `__ferro_connection_name`): transient → INSERT,
       persistent → `UPDATE ... WHERE pk = ?`. Add a named upsert surface
@@ -88,7 +88,7 @@ These are behavioral changes to the public API — they must land before 1.0.
 
 - [ ] `Query.limit(...).delete()` / `.update()` raise; no mutating payload
       carries limit/offset.
-- [ ] `create()` on an existing PK raises `UniqueViolationError` on both
+- [x] `create()` on an existing PK raises `UniqueViolationError` on both
       backends; upsert path exists and is tested.
 - [ ] Full matrix green with exception types asserted (no string matching on
       driver messages anywhere in tests).

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -119,7 +119,15 @@ async def save_record(
     tx_id: Optional[str] = None,
     using: Optional[str] = None,
     session_id: Optional[str] = None,
+    mode: str = "insert",
 ) -> int | None: ...
+async def update_record(
+    name: str,
+    data: dict[str, Any],
+    tx_id: Optional[str] = None,
+    using: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> int: ...
 async def save_bulk_records(
     name: str,
     rows: list[dict[str, Any]],

--- a/src/ferro/exceptions.py
+++ b/src/ferro/exceptions.py
@@ -114,7 +114,10 @@ class CheckViolationError(IntegrityError):
 
 
 class ModelDoesNotExist(FerroError, LookupError):
-    """Raised when :meth:`~ferro.models.Model.get` finds no row for the primary key."""
+    """Raised when :meth:`~ferro.models.Model.get` finds no row for the primary
+    key, and when :meth:`~ferro.models.Model.save` on a persisted instance
+    matches no row (the row was deleted underneath, or the primary key was
+    mutated before saving)."""
 
     model: type
     pk: Any

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -241,6 +241,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             tx_id,
             operation_using,
             session_id=session_id,
+            mode="upsert",
         )
 
         pk_val = None

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -7,6 +7,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
+    Literal,
     Self,
     overload,
 )
@@ -28,6 +29,7 @@ from ._core import (
     save_bulk_records,
     save_record,
     transaction_connection_name,
+    update_record,
 )
 from .base import ForeignKey, foreign_key_allows_none
 from .exceptions import ModelDoesNotExist
@@ -42,6 +44,20 @@ from .state import (
 
 
 _FERRO_CONNECTION_ATTR = "__ferro_connection_name"
+_FERRO_PERSISTED_ATTR = "__ferro_persisted"
+
+
+def _is_persisted(instance: object) -> bool:
+    """True when the instance is known to have a row in the database.
+
+    Set by Rust hydration (`hydrate_model_instance`) and by a successful
+    ``save()``; cleared by ``delete()``. Absent means transient (FF-A A4).
+    """
+    return bool(instance.__dict__.get(_FERRO_PERSISTED_ATTR, False))
+
+
+def _set_persisted(instance: object, value: bool) -> None:
+    object.__setattr__(instance, _FERRO_PERSISTED_ATTR, value)
 
 
 def _field_eq(field_name: str, value: Any) -> Predicate[Any]:
@@ -221,28 +237,89 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         return self
 
     async def save(
-        self, *, using: str | None = None, session: "Session | None" = None
+        self,
+        *,
+        using: str | None = None,
+        session: "Session | None" = None,
+        on_conflict: Literal["update"] | None = None,
     ) -> None:
-        """Persist the current model instance
+        """Persist the current model instance.
 
-        Returns:
-            None
+        A transient instance (constructed with ``Model(...)`` and never saved)
+        is INSERTed — a duplicate primary key or unique value raises
+        :class:`~ferro.exceptions.UniqueViolationError`. A persistent instance
+        (fetched from the database, or previously saved) is UPDATEd by primary
+        key. Pass ``on_conflict="update"`` for insert-or-update semantics
+        regardless of persistence state (the primitive behind
+        :meth:`upsert`).
+
+        Note that ``model_copy()`` copies persistence state: saving a copy of
+        a persisted instance updates the same row. The UPDATE targets the
+        instance's *current* primary-key value, so mutating the PK of a
+        persisted instance before ``save()`` matches no row and raises. A row
+        inserted inside a rolled-back transaction leaves the instance marked
+        persisted; a later ``save()`` raises ``ModelDoesNotExist``.
+
+        Args:
+            using: Connection name override.
+            session: Session scope for the operation.
+            on_conflict: ``None`` (default) or ``"update"`` to upsert.
+
+        Raises:
+            UniqueViolationError: A duplicate primary key or unique value on
+                INSERT.
+            ModelDoesNotExist: The row behind a persisted instance no longer
+                exists (deleted underneath, or the PK was mutated).
+            ValueError: ``on_conflict`` is not ``None`` or ``"update"``, or a
+                persisted instance has no primary-key value.
 
         Examples:
             >>> user = User(name="Taylor")
             >>> await user.save()
         """
+        if on_conflict not in (None, "update"):
+            raise ValueError(
+                f'on_conflict must be None or "update", got {on_conflict!r}'
+            )
         tx_id, operation_using, identity_using, session_id = _instance_transaction_route(
             self, using, session
         )
-        new_id = await save_record(
-            self.__class__.__name__,
-            save_bind_payload(self),
-            tx_id,
-            operation_using,
-            session_id=session_id,
-            mode="upsert",
-        )
+        new_id = None
+        if on_conflict == "update":
+            new_id = await save_record(
+                self.__class__.__name__,
+                save_bind_payload(self),
+                tx_id,
+                operation_using,
+                session_id=session_id,
+                mode="upsert",
+            )
+        elif _is_persisted(self):
+            pk_field_name = self.__class__._primary_key_field_name()
+            pk_val = getattr(self, pk_field_name) if pk_field_name is not None else None
+            if pk_val is None:
+                raise ValueError(
+                    f"Cannot UPDATE a persisted {self.__class__.__name__} "
+                    "without a primary key value"
+                )
+            rows_affected = await update_record(
+                self.__class__.__name__,
+                save_bind_payload(self),
+                tx_id,
+                operation_using,
+                session_id=session_id,
+            )
+            if rows_affected == 0:
+                raise ModelDoesNotExist(self.__class__, pk_val)
+        else:
+            new_id = await save_record(
+                self.__class__.__name__,
+                save_bind_payload(self),
+                tx_id,
+                operation_using,
+                session_id=session_id,
+                mode="insert",
+            )
 
         pk_val = None
         pk_field_name = None
@@ -274,6 +351,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                 session_id=session_id,
             )
             _set_instance_origin(self, identity_using)
+        _set_persisted(self, True)
 
     async def delete(
         self, *, using: str | None = None, session: "Session | None" = None
@@ -305,6 +383,8 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             evict_instance(
                 name, str(pk_val), identity_using, session_id=session_id
             )
+            # The instance is transient again: a later save() re-INSERTs.
+            _set_persisted(self, False)
 
     @classmethod
     def _primary_key_field_name(cls) -> str | None:
@@ -445,6 +525,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             name, str(pk_val), self, identity_using, session_id=session_id
         )
         _set_instance_origin(self, identity_using)
+        _set_persisted(self, True)
         self.__class__._fix_types(self)
 
     @overload
@@ -516,11 +597,18 @@ class Model(BaseModel, metaclass=ModelMetaclass):
     async def create(cls, *, session: "Session | None" = None, **fields) -> Self:
         """Create and persist a new model instance
 
+        ``create()`` is a plain INSERT: it never updates an existing row.
+
         Args:
             **fields: Field values to construct the model.
 
         Returns:
             The newly created and persisted model instance.
+
+        Raises:
+            UniqueViolationError: A row with the same primary key or unique
+                value already exists — use :meth:`upsert` for
+                insert-or-update semantics.
 
         Examples:
             >>> user = await User.create(name="Taylor")
@@ -529,6 +617,29 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         """
         instance = cls(**fields)
         await instance.save(session=session)
+        return instance
+
+    @classmethod
+    async def upsert(cls, *, session: "Session | None" = None, **fields) -> Self:
+        """Insert the row, or update the existing row on primary-key conflict.
+
+        Equivalent to ``cls(**fields).save(on_conflict="update")``. With an
+        autoincrement primary key left unset there is no conflict target, so
+        this degrades to a plain INSERT.
+
+        Args:
+            **fields: Field values to construct the model.
+
+        Returns:
+            The persisted model instance.
+
+        Examples:
+            >>> user = await User.upsert(id=1, name="Taylor")
+            >>> isinstance(user, User)
+            True
+        """
+        instance = cls(**fields)
+        await instance.save(session=session, on_conflict="update")
         return instance
 
     @classmethod
@@ -638,8 +749,20 @@ class ModelConnection[M: Model]:
         self._connection_name: str = connection_name
 
     async def create(self, **fields: Any) -> M:
+        """Create and persist a new instance on this connection.
+
+        A plain INSERT — a duplicate primary key or unique value raises
+        :class:`~ferro.exceptions.UniqueViolationError`; use :meth:`upsert`
+        for insert-or-update semantics.
+        """
         instance = self.model_cls(**fields)
         await instance.save(using=self._connection_name)
+        return instance
+
+    async def upsert(self, **fields: Any) -> M:
+        """Insert the row on this connection, or update it on PK conflict."""
+        instance = self.model_cls(**fields)
+        await instance.save(using=self._connection_name, on_conflict="update")
         return instance
 
     async def all(self) -> list[M]:

--- a/src/hydration.rs
+++ b/src/hydration.rs
@@ -36,7 +36,8 @@ fn set_pydantic_hydration_slots<'py>(
 /// Hydrate a model instance from pre-decoded column values.
 ///
 /// Allocates via `cls.__new__(cls)`, writes fields into `__dict__`, sets
-/// `__ferro_connection_name`, and initializes Pydantic tracking slots.
+/// `__ferro_connection_name` and the `__ferro_persisted` marker, and
+/// initializes Pydantic tracking slots.
 ///
 /// # Arguments
 /// * `py` — Active Python interpreter token.
@@ -64,6 +65,9 @@ pub fn hydrate_model_instance<'py>(
         pyo3::intern!(py, "__ferro_connection_name"),
         connection_name,
     )?;
+    // Hydrated instances are persistent by definition: `Model.save()` reads
+    // this marker to choose UPDATE ... WHERE pk = ? over INSERT (FF-A A4).
+    dict.set_item(pyo3::intern!(py, "__ferro_persisted"), true)?;
     let fields_set = pyo3::types::PySet::empty(py)?;
 
     for (col_name, val) in fields {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(operations::register_instance, m)?)?;
     m.add_function(wrap_pyfunction!(operations::evict_instance, m)?)?;
     m.add_function(wrap_pyfunction!(operations::save_record, m)?)?;
+    m.add_function(wrap_pyfunction!(operations::update_record, m)?)?;
     m.add_function(wrap_pyfunction!(operations::save_bulk_records, m)?)?;
     m.add_function(wrap_pyfunction!(operations::delete_record, m)?)?;
     m.add_function(wrap_pyfunction!(operations::delete_filtered, m)?)?;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -249,6 +249,28 @@ fn reject_pagination_on_mutation(query_def: &QueryDef, operation: &str) -> PyRes
     Ok(())
 }
 
+/// Persistence strategy for `save_record` (FF-A A3/A4).
+///
+/// `Insert` renders a plain INSERT — a duplicate primary key or unique value
+/// surfaces as a database error (mapped to `UniqueViolationError`). `Upsert`
+/// renders `INSERT ... ON CONFLICT (pk) DO UPDATE` and is only reachable from
+/// the explicit upsert surface (`Model.upsert()` / `save(on_conflict="update")`).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum SaveMode {
+    Insert,
+    Upsert,
+}
+
+fn parse_save_mode(mode: &str) -> PyResult<SaveMode> {
+    match mode {
+        "insert" => Ok(SaveMode::Insert),
+        "upsert" => Ok(SaveMode::Upsert),
+        other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "save_record mode must be 'insert' or 'upsert', got {other:?}"
+        ))),
+    }
+}
+
 /// Map SeaQuery `Value` variants to `EngineBindValue`.
 ///
 /// Typed `None` variants are preserved as `Null(NullKind::T)` so the bind
@@ -1188,21 +1210,185 @@ pub fn fetch_one<'py>(
     })
 }
 
+/// Render the INSERT statement for `save_record`.
+///
+/// `SaveMode::Insert` renders a plain INSERT; `SaveMode::Upsert` adds
+/// `ON CONFLICT (pk) DO UPDATE` over the non-PK columns when a conflict
+/// target exists (an explicit PK value, or a non-autoincrement PK). An
+/// autoincrement PK left null is omitted from the column list either way.
+///
+/// Returns `(sql, bind_values, needs_postgres_returning)`.
+#[allow(clippy::too_many_arguments)]
+fn build_save_sql(
+    schema: &serde_json::Value,
+    table_name: &str,
+    bind_inputs: &[(String, BindInput)],
+    pk_col: Option<&str>,
+    pk_is_auto: bool,
+    mode: SaveMode,
+    backend: Dialect,
+    enum_udt: &HashMap<String, String>,
+    uuid_columns: &HashSet<String>,
+    ts_cast: &HashMap<String, String>,
+) -> PyResult<(String, sea_query::Values, bool)> {
+    let mut columns = Vec::new();
+    let mut values = Vec::new();
+    let mut pk_provided = false;
+    for (key, input) in bind_inputs {
+        let is_pk = pk_col == Some(key.as_str());
+        if is_pk && pk_is_auto && input.is_json_null() {
+            continue;
+        }
+        if is_pk && !input.is_json_null() {
+            pk_provided = true;
+        }
+        columns.push(Alias::new(key));
+        values.push(bind_input_to_expr(
+            schema,
+            table_name,
+            key,
+            input,
+            enum_udt,
+            uuid_columns,
+            ts_cast,
+            backend,
+        )?);
+    }
+    let mut insert_stmt = InsertStatement::new()
+        .into_table(Alias::new(table_name))
+        .columns(columns.clone())
+        .values(values)
+        .map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid INSERT values: {e}"))
+        })?
+        .to_owned();
+    if mode == SaveMode::Upsert
+        && let Some(pk) = pk_col
+        && (pk_provided || !pk_is_auto)
+    {
+        let mut on_conflict = OnConflict::column(Alias::new(pk));
+        let mut update_cols = Vec::new();
+        for col in &columns {
+            if col.to_string() != pk {
+                update_cols.push(col.clone());
+            }
+        }
+        if !update_cols.is_empty() {
+            on_conflict.update_columns(update_cols);
+            insert_stmt.on_conflict(on_conflict);
+        }
+    }
+    let needs_postgres_returning =
+        backend == Dialect::Postgres && pk_col.is_some() && pk_is_auto && !pk_provided;
+    let (mut sql, values) = sea_query_build_for_backend!(insert_stmt, backend);
+    if needs_postgres_returning && let Some(pk) = pk_col {
+        sql.push_str(&format!(" RETURNING \"{}\"", pk));
+    }
+    Ok((sql, values, needs_postgres_returning))
+}
+
+/// SQL plan for `update_record`: either a real UPDATE, or — for models whose
+/// only column is the primary key — an existence check that preserves the
+/// rows-matched contract (0 means the row is gone) without rendering an
+/// `UPDATE ... SET` with an empty assignment list, which is invalid SQL.
+#[derive(Debug)]
+enum UpdateByPkSql {
+    Update(String, sea_query::Values),
+    ExistenceCheck(String, sea_query::Values),
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_update_by_pk_sql(
+    schema: &serde_json::Value,
+    table_name: &str,
+    bind_inputs: &[(String, BindInput)],
+    pk_col: Option<&str>,
+    backend: Dialect,
+    enum_udt: &HashMap<String, String>,
+    uuid_columns: &HashSet<String>,
+    ts_cast: &HashMap<String, String>,
+) -> PyResult<UpdateByPkSql> {
+    let pk = pk_col.ok_or_else(|| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "Model for table '{table_name}' has no primary key; cannot UPDATE by primary key"
+        ))
+    })?;
+    let pk_input = bind_inputs
+        .iter()
+        .find(|(key, _)| key.as_str() == pk)
+        .filter(|(_, input)| !input.is_json_null())
+        .ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "Cannot UPDATE '{table_name}' without a primary key value"
+            ))
+        })?;
+    let pk_expr = bind_input_to_expr(
+        schema,
+        table_name,
+        pk,
+        &pk_input.1,
+        enum_udt,
+        uuid_columns,
+        ts_cast,
+        backend,
+    )?;
+
+    let mut update_stmt = UpdateStatement::new()
+        .table(Alias::new(table_name))
+        .to_owned();
+    let mut set_count = 0usize;
+    for (key, input) in bind_inputs {
+        if key.as_str() == pk {
+            continue;
+        }
+        update_stmt.value(
+            Alias::new(key),
+            bind_input_to_expr(
+                schema,
+                table_name,
+                key,
+                input,
+                enum_udt,
+                uuid_columns,
+                ts_cast,
+                backend,
+            )?,
+        );
+        set_count += 1;
+    }
+    if set_count == 0 {
+        let select = Query::select()
+            .expr(Expr::cust("COUNT(*)"))
+            .from(Alias::new(table_name))
+            .and_where(Expr::col(Alias::new(pk)).eq(pk_expr))
+            .to_owned();
+        let (sql, values) = sea_query_build_for_backend!(select, backend);
+        return Ok(UpdateByPkSql::ExistenceCheck(sql, values));
+    }
+    update_stmt.and_where(Expr::col(Alias::new(pk)).eq(pk_expr));
+    let (sql, values) = sea_query_build_for_backend!(update_stmt, backend);
+    Ok(UpdateByPkSql::Update(sql, values))
+}
+
 /// Persists a model's data to the database.
 ///
-/// Implements an upsert (INSERT ... ON CONFLICT DO UPDATE) strategy.
+/// `mode` selects the persistence strategy: `"insert"` (default) renders a
+/// plain INSERT — a duplicate primary key or unique value raises
+/// `UniqueViolationError` — while `"upsert"` renders
+/// `INSERT ... ON CONFLICT (pk) DO UPDATE` for the explicit upsert surface.
 ///
 /// Args:
 ///     name (str): The model name.
 ///     data (dict[str, Any]): Per-column value map for the model instance.
 ///         ``bytes``/``bytearray`` values are preserved verbatim; all other
 ///         values are routed through the schema-guided casting authority.
+///     mode (str): `"insert"` or `"upsert"`.
 ///
 /// # Errors
 /// Returns a `PyErr` if the engine is not initialized, the model is not
-/// registered, or a column value cannot be bound.
+/// registered, the mode is unknown, or a column value cannot be bound.
 #[pyfunction]
-#[pyo3(signature = (name, data, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (name, data, tx_id=None, using=None, session_id=None, mode="insert"))]
 pub fn save_record<'py>(
     py: Python<'py>,
     name: String,
@@ -1210,8 +1396,10 @@ pub fn save_record<'py>(
     tx_id: Option<String>,
     using: Option<String>,
     session_id: Option<String>,
+    mode: &str,
 ) -> PyResult<Bound<'py, PyAny>> {
     let bind_inputs = bind_inputs_from_py(&data)?; // GIL held here, before the async move
+    let mode = parse_save_mode(mode)?;
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (_connection_name, engine, tx_conn, backend) =
             active_route_for_operation(tx_id, using, session_id.clone())?;
@@ -1250,63 +1438,18 @@ pub fn save_record<'py>(
             postgres_uuid_column_names(&table_name, &engine, &tx_conn, backend).await?;
         let ts_cast =
             postgres_temporal_cast_by_column(&table_name, &engine, &tx_conn, backend).await?;
-        let (sql, bind_values, needs_postgres_returning) = {
-            let mut columns = Vec::new();
-            let mut values = Vec::new();
-            let mut pk_provided = false;
-            for (key, input) in &bind_inputs {
-                let is_pk = pk_col.as_deref() == Some(key.as_str());
-                if is_pk && pk_is_auto && input.is_json_null() {
-                    continue;
-                }
-                if is_pk && !input.is_json_null() {
-                    pk_provided = true;
-                }
-                columns.push(Alias::new(key));
-                values.push(bind_input_to_expr(
-                    &schema,
-                    &table_name,
-                    key,
-                    input,
-                    &enum_udt,
-                    &uuid_columns,
-                    &ts_cast,
-                    backend,
-                )?);
-            }
-            let mut insert_stmt = InsertStatement::new()
-                .into_table(Alias::new(&table_name))
-                .columns(columns.clone())
-                .values(values)
-                .map_err(|e| {
-                    pyo3::exceptions::PyValueError::new_err(format!("invalid INSERT values: {e}"))
-                })?
-                .to_owned();
-            if let Some(pk) = pk_col.as_ref()
-                && (pk_provided || !pk_is_auto)
-            {
-                let mut on_conflict = OnConflict::column(Alias::new(pk));
-                let mut update_cols = Vec::new();
-                for col in &columns {
-                    if col.to_string() != *pk {
-                        update_cols.push(col.clone());
-                    }
-                }
-                if !update_cols.is_empty() {
-                    on_conflict.update_columns(update_cols);
-                    insert_stmt.on_conflict(on_conflict);
-                }
-            }
-            let needs_postgres_returning = backend == crate::state::Dialect::Postgres
-                && pk_col.is_some()
-                && pk_is_auto
-                && !pk_provided;
-            let (mut sql, values) = sea_query_build_for_backend!(insert_stmt, backend);
-            if needs_postgres_returning && let Some(pk) = pk_col.as_ref() {
-                sql.push_str(&format!(" RETURNING \"{}\"", pk));
-            }
-            (sql, values, needs_postgres_returning)
-        };
+        let (sql, bind_values, needs_postgres_returning) = build_save_sql(
+            &schema,
+            &table_name,
+            &bind_inputs,
+            pk_col.as_deref(),
+            pk_is_auto,
+            mode,
+            backend,
+            &enum_udt,
+            &uuid_columns,
+            &ts_cast,
+        )?;
 
         match tx_conn {
             Some(conn_arc) => {
@@ -1351,6 +1494,112 @@ pub fn save_record<'py>(
                         .map_err(|e| crate::errors::map_db_error("Save failed", e))?;
                     Ok(exec_res.last_insert_id)
                 }
+            }
+        }
+    })
+}
+
+/// UPDATE one row by primary key: `UPDATE <table> SET <non-pk cols> WHERE <pk> = ?`.
+///
+/// Args:
+///     name (str): The model name.
+///     data (dict[str, Any]): Per-column value map for the model instance,
+///         including the primary key (used for the WHERE filter, never SET).
+///
+/// Returns:
+///     int: Rows matched. 0 means no row with that primary key exists any
+///     more — the Python layer raises `ModelDoesNotExist`. For models whose
+///     only column is the primary key there is nothing to SET; an existence
+///     check runs instead so the 0-means-gone contract holds.
+///
+/// # Errors
+/// `PyValueError` when the model has no primary key or the primary-key value
+/// is missing/null; `PyRuntimeError` on registry failures; typed
+/// `ferro.exceptions` subclasses on database errors.
+#[pyfunction]
+#[pyo3(signature = (name, data, tx_id=None, using=None, session_id=None))]
+pub fn update_record<'py>(
+    py: Python<'py>,
+    name: String,
+    data: Bound<'py, pyo3::types::PyDict>,
+    tx_id: Option<String>,
+    using: Option<String>,
+    session_id: Option<String>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let bind_inputs = bind_inputs_from_py(&data)?; // GIL held here, before the async move
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let (_connection_name, engine, tx_conn, backend) =
+            active_route_for_operation(tx_id, using, session_id.clone())?;
+
+        let schema = {
+            let registry = MODEL_REGISTRY.read().map_err(|_| {
+                pyo3::exceptions::PyRuntimeError::new_err("Failed to lock registry")
+            })?;
+            registry.get(&name).cloned().ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!("Model '{}' not found", name))
+            })?
+        };
+
+        let mut pk_col = None;
+        if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
+            for (col_name, col_info) in properties {
+                if col_info
+                    .get("primary_key")
+                    .and_then(|pk| pk.as_bool())
+                    .unwrap_or(false)
+                {
+                    pk_col = Some(col_name.clone());
+                    break;
+                }
+            }
+        }
+
+        let table_name = name.to_lowercase();
+        let enum_udt = postgres_enum_udt_by_column(&table_name, &engine, &tx_conn, backend).await?;
+        let uuid_columns =
+            postgres_uuid_column_names(&table_name, &engine, &tx_conn, backend).await?;
+        let ts_cast =
+            postgres_temporal_cast_by_column(&table_name, &engine, &tx_conn, backend).await?;
+
+        let plan = build_update_by_pk_sql(
+            &schema,
+            &table_name,
+            &bind_inputs,
+            pk_col.as_deref(),
+            backend,
+            &enum_udt,
+            &uuid_columns,
+            &ts_cast,
+        )?;
+
+        match plan {
+            UpdateByPkSql::Update(sql, bind_values) => {
+                let rows_affected =
+                    execute_statement_with_optional_tx(&engine, tx_conn, &sql, &bind_values.0)
+                        .await
+                        .map_err(|e| crate::errors::map_db_error("Update failed", e))?;
+                Ok(rows_affected)
+            }
+            UpdateByPkSql::ExistenceCheck(sql, bind_values) => {
+                let engine_bind_values = engine_bind_values_from_sea(&bind_values.0);
+                let rows = match tx_conn {
+                    Some(conn_arc) => {
+                        let mut conn = conn_arc.lock().await;
+                        conn.fetch_all_sql_with_binds(&sql, &engine_bind_values)
+                            .await
+                            .map_err(|e| crate::errors::map_db_error("Update failed", e))?
+                    }
+                    None => engine
+                        .fetch_all_sql_with_binds(&sql, &engine_bind_values)
+                        .await
+                        .map_err(|e| crate::errors::map_db_error("Update failed", e))?,
+                };
+                let count = rows
+                    .first()
+                    .and_then(|row| row.values.first())
+                    .and_then(|(_, value)| value.as_i64())
+                    .unwrap_or(0);
+                Ok(count.max(0) as u64)
             }
         }
     })
@@ -3632,6 +3881,244 @@ mod mutation_pagination_guard_tests {
                 msg.contains("update") && msg.contains("offset"),
                 "message should name the operation and offset: {msg}"
             );
+        });
+    }
+}
+
+#[cfg(test)]
+mod save_mode_sql_tests {
+    use super::{
+        build_save_sql, build_update_by_pk_sql, parse_save_mode, BindInput, SaveMode,
+        UpdateByPkSql,
+    };
+    use crate::state::Dialect;
+    use std::collections::{HashMap, HashSet};
+
+    fn widget_schema() -> serde_json::Value {
+        serde_json::json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true, "autoincrement": true},
+                "name": {"type": "string"}
+            }
+        })
+    }
+
+    fn widget_inputs(id: serde_json::Value, name: &str) -> Vec<(String, BindInput)> {
+        vec![
+            ("id".to_string(), BindInput::Json(id)),
+            ("name".to_string(), BindInput::Json(serde_json::json!(name))),
+        ]
+    }
+
+    fn build_save(
+        inputs: &[(String, BindInput)],
+        pk_is_auto: bool,
+        mode: SaveMode,
+        backend: Dialect,
+    ) -> (String, sea_query::Values, bool) {
+        build_save_sql(
+            &widget_schema(),
+            "widget",
+            inputs,
+            Some("id"),
+            pk_is_auto,
+            mode,
+            backend,
+            &HashMap::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        )
+        .expect("build_save_sql should succeed")
+    }
+
+    fn build_update(
+        schema: &serde_json::Value,
+        inputs: &[(String, BindInput)],
+        pk_col: Option<&str>,
+        backend: Dialect,
+    ) -> super::PyResult<UpdateByPkSql> {
+        build_update_by_pk_sql(
+            schema,
+            "widget",
+            inputs,
+            pk_col,
+            backend,
+            &HashMap::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        )
+    }
+
+    #[test]
+    fn parse_save_mode_accepts_insert_and_upsert() {
+        assert_eq!(parse_save_mode("insert").unwrap(), SaveMode::Insert);
+        assert_eq!(parse_save_mode("upsert").unwrap(), SaveMode::Upsert);
+    }
+
+    #[test]
+    fn parse_save_mode_rejects_unknown_mode_with_pyvalueerror() {
+        pyo3::Python::attach(|py| {
+            let err = parse_save_mode("update").expect_err("unknown mode must be rejected");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+            let msg = err.to_string();
+            assert!(
+                msg.contains("insert") && msg.contains("upsert") && msg.contains("update"),
+                "message should name the accepted modes and the offender: {msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn insert_mode_renders_no_on_conflict_even_with_pk_provided() {
+        for backend in [Dialect::Sqlite, Dialect::Postgres] {
+            let (sql, _, _) = build_save(
+                &widget_inputs(serde_json::json!(1), "a"),
+                true,
+                SaveMode::Insert,
+                backend,
+            );
+            assert!(
+                !sql.contains("ON CONFLICT"),
+                "insert mode must render a plain INSERT on {backend:?}: {sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn upsert_mode_renders_on_conflict_do_update_when_pk_provided() {
+        for backend in [Dialect::Sqlite, Dialect::Postgres] {
+            let (sql, _, _) = build_save(
+                &widget_inputs(serde_json::json!(1), "a"),
+                true,
+                SaveMode::Upsert,
+                backend,
+            );
+            let conflict_clause = sql
+                .split("ON CONFLICT")
+                .nth(1)
+                .unwrap_or_else(|| panic!("upsert with provided PK must ON CONFLICT on {backend:?}: {sql}"));
+            assert!(
+                conflict_clause.contains("\"name\""),
+                "non-PK column must be in the update list on {backend:?}: {sql}"
+            );
+            assert!(
+                !conflict_clause.contains("\"id\" ="),
+                "PK must not be reassigned in the update list on {backend:?}: {sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn upsert_mode_without_pk_on_auto_pk_is_plain_insert() {
+        let (sql, _, _) = build_save(
+            &widget_inputs(serde_json::Value::Null, "a"),
+            true,
+            SaveMode::Upsert,
+            Dialect::Sqlite,
+        );
+        assert!(
+            !sql.contains("ON CONFLICT"),
+            "unset auto PK has nothing to conflict on: {sql}"
+        );
+        assert!(
+            !sql.contains("\"id\""),
+            "unset auto PK must be omitted from the column list: {sql}"
+        );
+    }
+
+    #[test]
+    fn insert_mode_preserves_postgres_returning_for_auto_pk() {
+        let (sql, _, needs_returning) = build_save(
+            &widget_inputs(serde_json::Value::Null, "a"),
+            true,
+            SaveMode::Insert,
+            Dialect::Postgres,
+        );
+        assert!(needs_returning, "auto PK left unset needs RETURNING on postgres");
+        assert!(sql.contains("RETURNING \"id\""), "sql: {sql}");
+
+        let (sql, _, needs_returning) = build_save(
+            &widget_inputs(serde_json::Value::Null, "a"),
+            true,
+            SaveMode::Insert,
+            Dialect::Sqlite,
+        );
+        assert!(!needs_returning, "sqlite uses last_insert_id, not RETURNING");
+        assert!(!sql.contains("RETURNING"), "sql: {sql}");
+    }
+
+    #[test]
+    fn update_by_pk_sets_non_pk_columns_and_filters_on_pk() {
+        let result = build_update(
+            &widget_schema(),
+            &widget_inputs(serde_json::json!(1), "a"),
+            Some("id"),
+            Dialect::Sqlite,
+        )
+        .expect("update build should succeed");
+        let UpdateByPkSql::Update(sql, values) = result else {
+            panic!("expected an UPDATE statement");
+        };
+        assert_eq!(sql, "UPDATE \"widget\" SET \"name\" = ? WHERE \"id\" = ?");
+        assert_eq!(values.0.len(), 2, "one SET bind + one WHERE bind");
+
+        let result = build_update(
+            &widget_schema(),
+            &widget_inputs(serde_json::json!(1), "a"),
+            Some("id"),
+            Dialect::Postgres,
+        )
+        .expect("update build should succeed");
+        let UpdateByPkSql::Update(sql, _) = result else {
+            panic!("expected an UPDATE statement");
+        };
+        assert_eq!(sql, "UPDATE \"widget\" SET \"name\" = $1 WHERE \"id\" = $2");
+    }
+
+    #[test]
+    fn update_by_pk_requires_pk_value() {
+        pyo3::Python::attach(|py| {
+            let err = build_update(
+                &widget_schema(),
+                &widget_inputs(serde_json::Value::Null, "a"),
+                Some("id"),
+                Dialect::Sqlite,
+            )
+            .expect_err("null PK value must be rejected");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+            assert!(err.to_string().contains("primary key"), "msg: {err}");
+        });
+    }
+
+    #[test]
+    fn update_by_pk_on_pk_only_model_renders_existence_check() {
+        let schema = serde_json::json!({
+            "properties": {
+                "id": {"type": "integer", "primary_key": true, "autoincrement": false}
+            }
+        });
+        let inputs = vec![("id".to_string(), BindInput::Json(serde_json::json!(7)))];
+        let result = build_update(&schema, &inputs, Some("id"), Dialect::Sqlite)
+            .expect("pk-only build should succeed");
+        let UpdateByPkSql::ExistenceCheck(sql, values) = result else {
+            panic!("expected an existence check for a PK-only model");
+        };
+        assert!(
+            sql.starts_with("SELECT COUNT(") && sql.contains("WHERE \"id\" = ?"),
+            "sql: {sql}"
+        );
+        assert_eq!(values.0.len(), 1);
+    }
+
+    #[test]
+    fn update_by_pk_without_pk_column_errors() {
+        pyo3::Python::attach(|py| {
+            let schema = serde_json::json!({"properties": {"name": {"type": "string"}}});
+            let inputs = vec![("name".to_string(), BindInput::Json(serde_json::json!("a")))];
+            let err = build_update(&schema, &inputs, None, Dialect::Sqlite)
+                .expect_err("a model without a PK cannot be updated by PK");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+            assert!(err.to_string().contains("primary key"), "msg: {err}");
         });
     }
 }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -3888,8 +3888,7 @@ mod mutation_pagination_guard_tests {
 #[cfg(test)]
 mod save_mode_sql_tests {
     use super::{
-        build_save_sql, build_update_by_pk_sql, parse_save_mode, BindInput, SaveMode,
-        UpdateByPkSql,
+        BindInput, SaveMode, UpdateByPkSql, build_save_sql, build_update_by_pk_sql, parse_save_mode,
     };
     use crate::state::Dialect;
     use std::collections::{HashMap, HashSet};
@@ -3993,10 +3992,9 @@ mod save_mode_sql_tests {
                 SaveMode::Upsert,
                 backend,
             );
-            let conflict_clause = sql
-                .split("ON CONFLICT")
-                .nth(1)
-                .unwrap_or_else(|| panic!("upsert with provided PK must ON CONFLICT on {backend:?}: {sql}"));
+            let conflict_clause = sql.split("ON CONFLICT").nth(1).unwrap_or_else(|| {
+                panic!("upsert with provided PK must ON CONFLICT on {backend:?}: {sql}")
+            });
             assert!(
                 conflict_clause.contains("\"name\""),
                 "non-PK column must be in the update list on {backend:?}: {sql}"
@@ -4034,7 +4032,10 @@ mod save_mode_sql_tests {
             SaveMode::Insert,
             Dialect::Postgres,
         );
-        assert!(needs_returning, "auto PK left unset needs RETURNING on postgres");
+        assert!(
+            needs_returning,
+            "auto PK left unset needs RETURNING on postgres"
+        );
         assert!(sql.contains("RETURNING \"id\""), "sql: {sql}");
 
         let (sql, _, needs_returning) = build_save(
@@ -4043,7 +4044,10 @@ mod save_mode_sql_tests {
             SaveMode::Insert,
             Dialect::Sqlite,
         );
-        assert!(!needs_returning, "sqlite uses last_insert_id, not RETURNING");
+        assert!(
+            !needs_returning,
+            "sqlite uses last_insert_id, not RETURNING"
+        );
         assert!(!sql.contains("RETURNING"), "sql: {sql}");
     }
 

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -35,7 +35,10 @@ async def test_model_save_update_record(db_url):
     await user.save()
     user.username = "updated_name"
     await user.save()
-    assert True
+
+    users = await CrudUser.all()
+    assert len(users) == 1
+    assert users[0].username == "updated_name"
 
 
 @pytest.mark.asyncio
@@ -59,8 +62,8 @@ async def test_model_all_fetching(db_url):
 
 
 @pytest.mark.asyncio
-async def test_upsert_does_not_duplicate(db_url):
-    """Test that saving a model with an existing ID updates it rather than inserting a new one."""
+async def test_upsert_updates_existing_row_without_duplicate(db_url):
+    """Plain save() of a duplicate PK raises; the explicit upsert() updates (FF-A A3/A4)."""
 
     class CrudUser(Model):
         id: int = Field(default=None, json_schema_extra={"primary_key": True})
@@ -72,13 +75,17 @@ async def test_upsert_does_not_duplicate(db_url):
     await user.save()
     users_before = await CrudUser.all()
     assert len(users_before) == 1
-    user_dup = CrudUser(id=42, username="updated", email="original@example.com")
-    await user_dup.save()
+
+    with pytest.raises(ferro.UniqueViolationError):
+        await CrudUser(id=42, username="updated", email="original@example.com").save()
+
+    await CrudUser.upsert(id=42, username="updated", email="original@example.com")
     ferro.reset_engine()
     await ferro.connect(db_url, auto_migrate=True)
     fetched = await CrudUser.get(42)
     assert fetched is not None
     assert fetched.username == "updated"
+    assert len(await CrudUser.all()) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_save_semantics.py
+++ b/tests/test_save_semantics.py
@@ -1,0 +1,334 @@
+"""create() is a real INSERT; save() distinguishes INSERT from UPDATE (FF-A A3/A4, #173/#174).
+
+Exit-gate rule: exception *types* (and structured attributes) are asserted —
+never driver message text.
+"""
+
+from typing import Annotated
+from uuid import UUID, uuid4
+
+import pytest
+
+import ferro
+from ferro import (
+    FerroField,
+    IntegrityError,
+    Model,
+    ModelDoesNotExist,
+    UniqueViolationError,
+    connect,
+)
+
+pytestmark = [pytest.mark.backend_matrix, pytest.mark.asyncio]
+
+
+async def test_create_duplicate_pk_raises_unique_violation(db_url, db_backend):
+    """Exit gate: create() on an existing PK raises UniqueViolationError, no clobber."""
+
+    class CreateInsertUser(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    await CreateInsertUser.create(id=1, name="first")
+
+    with pytest.raises(UniqueViolationError) as excinfo:
+        await CreateInsertUser.create(id=1, name="second")
+
+    exc = excinfo.value
+    assert isinstance(exc, IntegrityError)
+    if db_backend == "postgres":
+        assert exc.sqlstate == "23505"
+
+    rows = await CreateInsertUser.all()
+    assert len(rows) == 1
+    assert rows[0].name == "first"
+
+
+async def test_save_transient_instance_with_taken_pk_raises(db_url):
+    class TransientPkUser(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    await TransientPkUser(id=1, name="original").save()
+
+    with pytest.raises(UniqueViolationError):
+        await TransientPkUser(id=1, name="intruder").save()
+
+    rows = await TransientPkUser.all()
+    assert len(rows) == 1
+    assert rows[0].name == "original"
+
+
+async def test_save_persisted_instance_is_update(db_url):
+    class PersistedUpdateUser(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    user = await PersistedUpdateUser.create(id=1, name="before")
+    user.name = "after"
+    await user.save()
+
+    rows = await PersistedUpdateUser.all()
+    assert len(rows) == 1
+
+    ferro.reset_engine()
+    await connect(db_url, auto_migrate=True)
+    fetched = await PersistedUpdateUser.get(1)
+    assert fetched.name == "after"
+
+
+async def test_save_twice_on_same_transient_instance_updates(db_url):
+    class DoubleSaveUser(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    user = DoubleSaveUser(name="a")
+    await user.save()
+    assert user.id is not None
+    user.name = "b"
+    await user.save()
+
+    rows = await DoubleSaveUser.all()
+    assert len(rows) == 1
+    assert rows[0].name == "b"
+
+
+async def test_fetched_instance_save_is_update(db_url):
+    """A hydrated instance carries persistence state from the Rust core."""
+
+    class HydratedSaveUser(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    await HydratedSaveUser.create(id=7, name="cold")
+
+    ferro.reset_engine()
+    await connect(db_url, auto_migrate=True)
+    fetched = await HydratedSaveUser.get(7)
+    fetched.name = "warm"
+    await fetched.save()
+
+    rows = await HydratedSaveUser.all()
+    assert len(rows) == 1
+    assert rows[0].name == "warm"
+
+
+async def test_save_after_row_deleted_raises_model_does_not_exist(db_url):
+    class StaleRowUser(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    user = await StaleRowUser.create(id=3, name="here")
+    await StaleRowUser.where(lambda u: u.id == 3).delete()
+
+    user.name = "gone"
+    with pytest.raises(ModelDoesNotExist) as excinfo:
+        await user.save()
+
+    assert excinfo.value.model is StaleRowUser
+    assert excinfo.value.pk == 3
+
+
+async def test_pk_mutation_on_persisted_instance_targets_current_pk(db_url):
+    """Documented limitation: UPDATE targets the current PK value; a mutated
+    PK matches no row and raises instead of silently inserting (FF-D will add
+    real PK-change tracking)."""
+
+    class PkMutationUser(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    user = await PkMutationUser.create(id=1, name="a")
+    user.id = 999
+
+    with pytest.raises(ModelDoesNotExist) as excinfo:
+        await user.save()
+    assert excinfo.value.pk == 999
+
+    # Assert durable state across a reconnect: the identity map would
+    # otherwise hand back the same live object whose PK the test mutated.
+    ferro.reset_engine()
+    await connect(db_url, auto_migrate=True)
+    rows = await PkMutationUser.all()
+    assert len(rows) == 1
+    assert rows[0].id == 1
+    assert rows[0].name == "a"
+
+
+async def test_upsert_inserts_when_row_missing(db_url):
+    class UpsertInsertDoc(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    await connect(db_url, auto_migrate=True)
+    doc = await UpsertInsertDoc.upsert(id=7, label="a")
+
+    rows = await UpsertInsertDoc.all()
+    assert len(rows) == 1
+    assert rows[0].label == "a"
+
+    # The returned instance is persisted: a follow-up save() is an UPDATE.
+    doc.label = "b"
+    await doc.save()
+    rows = await UpsertInsertDoc.all()
+    assert len(rows) == 1
+    assert rows[0].label == "b"
+
+
+async def test_upsert_updates_existing_row(db_url):
+    class UpsertUpdateDoc(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    await connect(db_url, auto_migrate=True)
+    await UpsertUpdateDoc.create(id=7, label="a")
+    await UpsertUpdateDoc.upsert(id=7, label="b")
+
+    rows = await UpsertUpdateDoc.all()
+    assert len(rows) == 1
+    assert rows[0].label == "b"
+
+
+async def test_save_on_conflict_update_primitive(db_url):
+    """save(on_conflict="update") is the primitive behind Model.upsert()."""
+
+    class OnConflictDoc(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    await connect(db_url, auto_migrate=True)
+    await OnConflictDoc.create(id=1, label="a")
+
+    await OnConflictDoc(id=1, label="b").save(on_conflict="update")
+
+    rows = await OnConflictDoc.all()
+    assert len(rows) == 1
+    assert rows[0].label == "b"
+
+
+async def test_save_rejects_unknown_on_conflict_value(db_url):
+    class BadOnConflictDoc(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    await connect(db_url, auto_migrate=True)
+
+    with pytest.raises(ValueError):
+        await BadOnConflictDoc(id=1, label="a").save(on_conflict="ignore")
+
+    rows = await BadOnConflictDoc.all()
+    assert len(rows) == 0
+
+
+async def test_upsert_with_unset_auto_pk_inserts(db_url):
+    """An autoincrement PK left unset has no conflict target: plain INSERT."""
+
+    class AutoPkUpsertDoc(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    await connect(db_url, auto_migrate=True)
+    doc = await AutoPkUpsertDoc.upsert(label="x")
+
+    assert doc.id is not None
+    rows = await AutoPkUpsertDoc.all()
+    assert len(rows) == 1
+
+
+async def test_delete_returns_instance_to_transient(db_url):
+    class DeleteResaveDoc(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    await connect(db_url, auto_migrate=True)
+    doc = await DeleteResaveDoc.create(id=4, label="v1")
+    await doc.delete()
+    assert len(await DeleteResaveDoc.all()) == 0
+
+    # A deleted instance is transient again: save() re-INSERTs.
+    await doc.save()
+    rows = await DeleteResaveDoc.all()
+    assert len(rows) == 1
+    assert rows[0].id == 4
+
+
+async def test_refresh_keeps_instance_persisted(db_url):
+    class RefreshDoc(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    await connect(db_url, auto_migrate=True)
+    doc = await RefreshDoc.create(id=5, label="a")
+    await doc.refresh()
+    doc.label = "b"
+    await doc.save()
+
+    rows = await RefreshDoc.all()
+    assert len(rows) == 1
+    assert rows[0].label == "b"
+
+
+async def test_model_copy_of_persisted_instance_updates_same_row(db_url):
+    class CopySaveDoc(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    await connect(db_url, auto_migrate=True)
+    doc = await CopySaveDoc.create(id=6, label="a")
+
+    copy = doc.model_copy()
+    copy.label = "b"
+    await copy.save()
+
+    rows = await CopySaveDoc.all()
+    assert len(rows) == 1
+    assert rows[0].label == "b"
+
+
+async def test_nonauto_pk_insert_then_duplicate_raises(db_url):
+    class UuidPkDoc(Model):
+        id: Annotated[UUID | None, FerroField(primary_key=True)] = None
+        label: str
+
+    await connect(db_url, auto_migrate=True)
+    pk = uuid4()
+    await UuidPkDoc(id=pk, label="first").save()
+
+    with pytest.raises(UniqueViolationError):
+        await UuidPkDoc(id=pk, label="dup").save()
+
+    await UuidPkDoc.upsert(id=pk, label="second")
+    rows = await UuidPkDoc.all()
+    assert len(rows) == 1
+    assert rows[0].label == "second"
+
+
+@pytest.mark.sqlite_only
+async def test_model_connection_upsert(tmp_path):
+    class ConnUpsertMarker(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    app_db = tmp_path / "app.db"
+    service_db = tmp_path / "service.db"
+    await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
+    await ferro.connect(f"sqlite:{service_db}?mode=rwc", name="service")
+    await ferro.create_tables()
+    await ferro.create_tables(using="service")
+
+    await ConnUpsertMarker.create(id=1, label="app")
+    await ConnUpsertMarker.using("service").create(id=1, label="service")
+
+    await ConnUpsertMarker.using("service").upsert(id=1, label="service-v2")
+
+    app_row = await ConnUpsertMarker.get(1)
+    service_row = await ConnUpsertMarker.using("service").get(1)
+    assert app_row.label == "app"
+    assert service_row.label == "service-v2"

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -38,3 +38,94 @@ def test_mutating_query_methods_cannot_carry_pagination():
         assert "_mutating_query_def" in attributes, (
             f"Query.{method_name}() must build its payload via _mutating_query_def"
         )
+
+
+def _models_module_tree() -> ast.Module:
+    source = Path("src/ferro/models.py").read_text(encoding="utf-8")
+    return ast.parse(source)
+
+
+def _class_def(tree: ast.Module, class_name: str) -> ast.ClassDef:
+    return next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+
+
+def _method_def(cls: ast.ClassDef, method_name: str) -> ast.AsyncFunctionDef:
+    return next(
+        node
+        for node in cls.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == method_name
+    )
+
+
+def _called_name(call: ast.Call) -> str | None:
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    return None
+
+
+def test_create_paths_never_pass_on_conflict():
+    """create() stays a plain INSERT: no create-family path may reach the
+    upsert surface (FF-A A3)."""
+    tree = _models_module_tree()
+    model_cls = _class_def(tree, "Model")
+    connection_cls = _class_def(tree, "ModelConnection")
+    methods = [
+        _method_def(model_cls, "create"),
+        _method_def(model_cls, "get_or_create"),
+        _method_def(model_cls, "update_or_create"),
+        _method_def(connection_cls, "create"),
+    ]
+    for method in methods:
+        for node in ast.walk(method):
+            if not isinstance(node, ast.Call):
+                continue
+            if _called_name(node) not in ("save", "create"):
+                continue
+            keywords = {kw.arg for kw in node.keywords}
+            assert "on_conflict" not in keywords, (
+                f"{method.name}() must not pass on_conflict; create paths are "
+                "plain INSERTs (FF-A A3)"
+            )
+
+
+def test_save_dispatches_by_persistence_state():
+    """save() routes transient instances to INSERT, persisted ones to UPDATE,
+    and only the explicit on_conflict surface to upsert (FF-A A4)."""
+    tree = _models_module_tree()
+    save = _method_def(_class_def(tree, "Model"), "save")
+    called = {
+        _called_name(node) for node in ast.walk(save) if isinstance(node, ast.Call)
+    }
+    assert "update_record" in called, "save() must UPDATE persisted instances"
+    assert "save_record" in called
+    assert "_is_persisted" in called, "save() must dispatch on persistence state"
+
+    for node in ast.walk(save):
+        if not (isinstance(node, ast.Call) and _called_name(node) == "save_record"):
+            continue
+        mode_kw = next((kw for kw in node.keywords if kw.arg == "mode"), None)
+        assert mode_kw is not None, "save_record calls must pass an explicit mode"
+        assert isinstance(mode_kw.value, ast.Constant)
+        assert mode_kw.value.value in ("insert", "upsert")
+
+
+def test_bulk_create_payload_has_no_conflict_handling():
+    """bulk_create stays a plain multi-row INSERT."""
+    tree = _models_module_tree()
+    bulk_create = _method_def(_class_def(tree, "Model"), "bulk_create")
+    for node in ast.walk(bulk_create):
+        if not (
+            isinstance(node, ast.Call) and _called_name(node) == "save_bulk_records"
+        ):
+            continue
+        keywords = {kw.arg for kw in node.keywords}
+        assert (
+            "mode" not in keywords and "on_conflict" not in keywords
+        ), "bulk_create must not grow conflict handling implicitly"


### PR DESCRIPTION
Implements FF-A sub-tasks A3 and A4 from the [Fable Fixes roadmap](docs/plans/2026-07-02-001-fable-fixes-roadmap.md), landed together because they share one root cause: `save_record()` unconditionally rendered `INSERT ... ON CONFLICT (pk) DO UPDATE` whenever a primary-key value was present, so `create()` and `save()` silently clobbered existing rows.

Closes #173, closes #174

## What changes

**`create()` is a plain INSERT (A3).** A duplicate primary key or unique value now raises `UniqueViolationError` (typed by #177/A2) instead of silently updating the existing row, on both backends.

**`save()` dispatches on persistence state (A4).** Instances now carry an explicit persistence marker (`__ferro_persisted` in instance `__dict__`, following the `__ferro_connection_name` pattern), stamped by Rust hydration and by a successful `save()`, cleared by `delete()`:

- transient instance → plain INSERT (duplicate → `UniqueViolationError`)
- persistent instance → `UPDATE ... WHERE pk = ?` via a new `update_record` pyfunction; 0 matched rows → `ModelDoesNotExist` (row deleted underneath, or PK mutated before saving — documented limitation until FF-D adds PK-change tracking)

**Upsert becomes explicit.** `save(on_conflict="update")` is the primitive; `Model.upsert(**fields)` / `ModelConnection.upsert(**fields)` mirror `create()`. With an autoincrement PK left unset, upsert degrades to a plain INSERT (no conflict target). `bulk_create()` is untouched (already a plain INSERT).

## Migration

```python
# Before: silent insert-or-update
await User(id=1, name="new").save()

# After: raises UniqueViolationError if row 1 exists. For the old behavior:
await User.upsert(id=1, name="new")
# or, holding an instance:
await user.save(on_conflict="update")
```

Docs and the migration-guide entry land with A5 (#175).

## Enforcement layers (A1/#178 precedent)

- Rust: `save_record` takes `mode: "insert" | "upsert"` (unknown → `ValueError`); SQL rendering factored into pure `build_save_sql` / `build_update_by_pk_sql` helpers with 10 cargo unit tests (no `ON CONFLICT` in insert mode, PK excluded from the upsert update list, `UPDATE ... WHERE pk` shape, PK-only models run an existence check instead of an empty `SET`).
- Python: 17 backend-matrix tests in `tests/test_save_semantics.py` asserting exception types only (postgres additionally asserts `sqlstate == "23505"`), plus 3 static AST contracts pinning create paths to plain INSERT and the `save()` dispatch shape.

## Verification

- `cargo test --no-default-features --features testing`: 131 passed
- Full matrix `--db-backends=sqlite,postgres`: 977 passed; the only failures are the 7 pre-existing `[postgres]` failures tracked in #176 (identical set on `main`)
- Exit gate: `test_create_duplicate_pk_raises_unique_violation` green on `[sqlite]` and `[postgres]`