### PR TITLE
fix(ff-g): make Postgres db_check ADD CONSTRAINT idempotent (G6, #176)

### DIFF
--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -391,13 +391,28 @@ pub struct CheckEmission {
 
 /// Single source for db_check emission: wrapper + dialect decision + body.
 /// Postgres emits the ALTER; SQLite elides with a warning (no silent drop).
+///
+/// The Postgres emission is idempotent: the `ALTER TABLE ... ADD CONSTRAINT` is
+/// guarded by a `DO $$ ... IF NOT EXISTS (pg_constraint) ...` block so a second
+/// `connect(auto_migrate=True)` against an already-migrated schema is a no-op
+/// rather than a hard `constraint "..." already exists` failure. Postgres has no
+/// `ADD CONSTRAINT IF NOT EXISTS`, so the guard checks `pg_constraint` first — it
+/// only *adds when absent* (it does not swallow an "already exists" error). The
+/// CHECK body from [`render_check_body`] is embedded byte-identically inside the
+/// guard, preserving the cross-emitter parity the Alembic mirror depends on.
 pub fn render_db_check(table: &str, check: &ferro_schema_ir::SchemaCheck, dialect: Dialect) -> CheckEmission {
     match dialect {
         Dialect::Postgres => CheckEmission {
             statement: Some(format!(
-                "ALTER TABLE \"{table}\" ADD CONSTRAINT \"{}\" CHECK ({})",
-                check.name,
-                render_check_body(check),
+                "DO $$ BEGIN \
+                 IF NOT EXISTS (SELECT 1 FROM pg_constraint \
+                 WHERE conname = '{conname}' AND conrelid = '\"{table}\"'::regclass) THEN \
+                 ALTER TABLE \"{table}\" ADD CONSTRAINT \"{name}\" CHECK ({body}); \
+                 END IF; END $$",
+                conname = check.name.replace('\'', "''"),
+                table = table,
+                name = check.name,
+                body = render_check_body(check),
             )),
             warning: None,
         },
@@ -871,5 +886,44 @@ mod tests {
         assert!(!is_timestamp_tz_conversion(TimestampTz, TimestampTz));
         assert!(!is_timestamp_tz_conversion(Date, TimestampTz));
         assert!(!is_timestamp_tz_conversion(Timestamp, Date));
+    }
+
+    fn sample_check() -> ferro_schema_ir::SchemaCheck {
+        ferro_schema_ir::SchemaCheck {
+            name: "ck_account_role".to_string(),
+            column: "role".to_string(),
+            values: vec!["'admin'".to_string(), "'user'".to_string()],
+        }
+    }
+
+    #[test]
+    fn render_db_check_postgres_is_idempotent_and_wraps_the_bare_alter() {
+        let e = render_db_check("account", &sample_check(), Dialect::Postgres);
+        // The idempotent guard: only ADD CONSTRAINT when pg_constraint lacks it,
+        // so a re-run against an already-migrated schema is a no-op (G6, #176).
+        assert_eq!(
+            e.statement.as_deref(),
+            Some(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint \
+                 WHERE conname = 'ck_account_role' AND conrelid = '\"account\"'::regclass) THEN \
+                 ALTER TABLE \"account\" ADD CONSTRAINT \"ck_account_role\" \
+                 CHECK (\"role\" IN ('admin', 'user')); END IF; END $$"
+            )
+        );
+        assert!(e.warning.is_none());
+        // The CHECK body is embedded byte-identically (cross-emitter parity).
+        assert!(
+            e.statement
+                .as_deref()
+                .unwrap()
+                .contains(&render_check_body(&sample_check()))
+        );
+    }
+
+    #[test]
+    fn render_db_check_sqlite_still_elides_with_warning() {
+        let e = render_db_check("account", &sample_check(), Dialect::Sqlite);
+        assert!(e.statement.is_none());
+        assert!(e.warning.as_deref().unwrap().contains("ck_account_role"));
     }
 }

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -9,6 +9,15 @@ use ferro_schema_ir::{
     SchemaCheck, SchemaColumn, SchemaForeignKey, SchemaIndex, SchemaUnique,
 };
 
+/// The single expected Postgres db_check emission for `account.role IN ('admin','user')`.
+/// The bare `ALTER TABLE ... ADD CONSTRAINT` is wrapped in an idempotent DO-block
+/// guard (G6, #176) so a re-run against an already-migrated schema is a no-op; the
+/// CHECK body stays byte-identical to what the Alembic emitter mirrors.
+const PG_DB_CHECK_ACCOUNT_ROLE: &str = "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint \
+     WHERE conname = 'ck_account_role' AND conrelid = '\"account\"'::regclass) THEN \
+     ALTER TABLE \"account\" ADD CONSTRAINT \"ck_account_role\" \
+     CHECK (\"role\" IN ('admin', 'user')); END IF; END $$";
+
 fn envelope(models: Vec<SchemaModel>) -> IrEnvelope<SchemaIrPayload> {
     IrEnvelope {
         ir_kind: "schema".to_string(),
@@ -1010,18 +1019,19 @@ fn render_create_table_golden_postgres() {
     got.sort();
     let mut want = vec![
         "CREATE INDEX IF NOT EXISTS \"idx_account_email\" ON \"account\" (\"email\")".to_string(),
-        "ALTER TABLE \"account\" ADD CONSTRAINT \"ck_account_role\" CHECK (\"role\" IN ('admin', 'user'))".to_string(),
+        PG_DB_CHECK_ACCOUNT_ROLE.to_string(),
         "CREATE UNIQUE INDEX IF NOT EXISTS \"uq_account_username_email\" ON \"account\" (\"username\", \"email\")".to_string(),
         "CREATE INDEX IF NOT EXISTS \"idx_account_created_at_birth_date\" ON \"account\" (\"created_at\", \"birth_date\")".to_string(),
     ];
     want.sort();
     assert_eq!(got, want);
 
-    // Postgres emits the db_check ALTER (quoted column, byte-matching runtime).
+    // Postgres emits the db_check ALTER (quoted column, byte-matching runtime),
+    // wrapped in the idempotent DO-block guard (G6, #176).
     assert!(acct
         .post_create_sqls
         .iter()
-        .any(|s| s == "ALTER TABLE \"account\" ADD CONSTRAINT \"ck_account_role\" CHECK (\"role\" IN ('admin', 'user'))"));
+        .any(|s| s == PG_DB_CHECK_ACCOUNT_ROLE));
     assert!(acct.warnings.is_empty(), "unexpected warnings: {:?}", acct.warnings);
 
     // FKs inline, not in post-create.
@@ -1151,10 +1161,7 @@ fn render_db_check_postgres_emits_quoted_alter_no_warning() {
         values: vec!["'admin'".to_string(), "'user'".to_string()],
     };
     let e = ferro_ddl_lowering::render_db_check("account", &check, Dialect::Postgres);
-    assert_eq!(
-        e.statement.as_deref(),
-        Some("ALTER TABLE \"account\" ADD CONSTRAINT \"ck_account_role\" CHECK (\"role\" IN ('admin', 'user'))")
-    );
+    assert_eq!(e.statement.as_deref(), Some(PG_DB_CHECK_ACCOUNT_ROLE));
     assert!(e.warning.is_none());
 }
 
@@ -1195,9 +1202,8 @@ fn emit_sql_with_ir_add_column_db_check_postgres_quoted_and_sqlite_warns() {
 
     let pg = emit_sql_with_ir(&plan, &old_ir, &new_ir, Dialect::Postgres).unwrap();
     assert!(
-        pg.statements.iter().any(|s| s
-            == "ALTER TABLE \"account\" ADD CONSTRAINT \"ck_account_role\" CHECK (\"role\" IN ('admin', 'user'))"),
-        "Postgres ALTER path must emit quoted CHECK; got: {:?}",
+        pg.statements.iter().any(|s| s == PG_DB_CHECK_ACCOUNT_ROLE),
+        "Postgres ALTER path must emit idempotent, quoted CHECK; got: {:?}",
         pg.statements
     );
 

--- a/docs/plans/2026-07-02-001-fable-fixes-roadmap.md
+++ b/docs/plans/2026-07-02-001-fable-fixes-roadmap.md
@@ -380,7 +380,7 @@ fold into whichever epic touches the same file when convenient.
 - [ ] **G5 — `RustValue::into_py_any` module-handle caching.**
       Intern `datetime`/`uuid`/`decimal`/`json` handles instead of
       `py.import` per value. Micro; measure under FF-C's benchmarks.
-- [ ] **G6 — Idempotent check-constraint emission in Postgres auto_migrate.**
+- [x] **G6 — Idempotent check-constraint emission in Postgres auto_migrate.**
       `db_check=True` fields emit their check constraint via a non-idempotent
       `ALTER TABLE ... ADD CONSTRAINT` in `post_create_sqls`
       (`ferro_ddl_lowering::render_db_check`, Postgres arm), sitting alongside
@@ -400,7 +400,7 @@ fold into whichever epic touches the same file when convenient.
 - [ ] Slot-guard test that fails when a fake slot is injected; `cargo llvm-lines`
       (or LOC) shows `operations.rs` duplication removed; PG migration
       interrupted mid-plan leaves the schema unchanged.
-- [ ] Second `connect(auto_migrate=True)` against an already-migrated Postgres
+- [x] Second `connect(auto_migrate=True)` against an already-migrated Postgres
       schema with a `db_check` model succeeds.
 
 ---

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -5,7 +5,8 @@
 
 use crate::backend::EngineHandle;
 use crate::state::{Dialect, MODEL_REGISTRY, engine_for_connection};
-use ferro_ddl_lowering::{CanonicalType, canonical_from_parts};
+use ferro_ddl_lowering::{CanonicalType, canonical_from_parts, render_db_check};
+use ferro_schema_ir::SchemaCheck;
 use pyo3::prelude::*;
 use sea_query::{
     Alias, ForeignKeyAction, Index, PostgresQueryBuilder,
@@ -183,7 +184,10 @@ pub(crate) fn canonical_column_type(
         .unwrap_or(CanonicalType::Varchar(None))
 }
 
-fn render_check_values(col_info: &serde_json::Value) -> Option<String> {
+/// Pre-rendered SQL literal tokens for a db_check column's allowed values,
+/// e.g. `["'admin'", "'user'"]`. Shape matches [`SchemaCheck::values`] so this
+/// legacy JSON path can feed the same emitter as the IR path.
+fn render_check_values(col_info: &serde_json::Value) -> Option<Vec<String>> {
     let values = col_info.get("enum").and_then(|v| v.as_array())?;
     if values.is_empty() {
         return None;
@@ -197,7 +201,7 @@ fn render_check_values(col_info: &serde_json::Value) -> Option<String> {
             other => format!("'{}'", other.to_string().replace('\'', "''")),
         })
         .collect();
-    Some(rendered.join(", "))
+    Some(rendered)
 }
 
 fn build_check_constraint_sql(
@@ -210,18 +214,18 @@ fn build_check_constraint_sql(
     // requires CREATE TABLE rebuild. db_check is a Postgres-first feature in
     // Phase 1; SQLite users opting in just see the constraint elided at
     // runtime. The parity test (U5) compares Postgres-side rendering.
-    if backend != Dialect::Postgres {
-        return None;
-    }
+    //
+    // Delegate the actual wrapper to `render_db_check` — the single source
+    // shared with the IR emitter — so this legacy JSON path stays byte-identical
+    // (including the idempotent DO-block guard) and the shadow comparator sees
+    // matching plans.
     let values = render_check_values(col_info)?;
-    let ck_name = db_check_constraint_name(table_lower, col_name);
-    Some(format!(
-        "ALTER TABLE \"{table}\" ADD CONSTRAINT \"{name}\" CHECK (\"{col}\" IN ({values}))",
-        table = table_lower,
-        name = ck_name,
-        col = col_name,
-        values = values,
-    ))
+    let check = SchemaCheck {
+        name: db_check_constraint_name(table_lower, col_name),
+        column: col_name.to_string(),
+        values,
+    };
+    render_db_check(table_lower, &check, backend).statement
 }
 
 /// Foreign-key metadata for a column, resolved from the model schema.
@@ -283,9 +287,11 @@ pub(crate) fn build_column_plan(
     }
 
     // db_check=True -> single-column CHECK constraint named ck_<table>_<col>.
-    // Emitted as a post-create ALTER TABLE so the name flows through
-    // identically on both backends. SQLite cannot execute ADD CONSTRAINT;
-    // users opting in to db_check are expected to be on Postgres for Phase 1.
+    // Emitted (via the shared `render_db_check`) as a post-create ALTER TABLE
+    // wrapped in an idempotent DO-block guard, so the name flows through
+    // identically on both backends and a re-run is a no-op. SQLite cannot
+    // execute ADD CONSTRAINT; users opting in to db_check are expected to be on
+    // Postgres for Phase 1.
     let db_check = column_bool_metadata(raw_col_info, col_info, "db_check").unwrap_or(false);
     if db_check
         && let Some(ck_sql) = build_check_constraint_sql(table_lower, col_name, col_info, backend)

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -1186,3 +1186,46 @@ async def test_create_tables_fails_loud_when_modelset_cleared(db_url, clean_regi
 
     with pytest.raises(RuntimeError, match="modelset not set"):
         await _raw_create_tables()
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres_only
+async def test_db_check_reconnect_is_idempotent(db_url):
+    """G6 (#176): a `db_check=True` column emits a Postgres CHECK via a
+    post-create `ALTER TABLE ... ADD CONSTRAINT`. That ALTER used to be
+    non-idempotent, so a second `connect(auto_migrate=True)` against an
+    already-migrated schema failed with `constraint "ck_..." already exists`.
+
+    The emission is now guarded by an idempotent DO-block, so re-connecting
+    is a no-op. Connect twice against the same schema; the second call must
+    succeed and the constraint must exist exactly once.
+    """
+    from enum import StrEnum
+
+    from ferro import Field as FerroField
+    from ferro import clear_registry, connect, reset_engine
+    from ferro.raw import fetch_all
+    from ferro.state import _MODEL_REGISTRY_PY
+
+    reset_engine()
+    clear_registry()
+    _MODEL_REGISTRY_PY.clear()
+
+    class DocStatus(StrEnum):
+        PENDING = "pending"
+        APPROVED = "approved"
+
+    class ReconnectDoc(Model):
+        id: int | None = FerroField(default=None, primary_key=True)
+        status: DocStatus = FerroField(db_type="text", db_check=True)
+
+    # First connect creates the table + CHECK constraint.
+    await connect(db_url, auto_migrate=True)
+    # Second connect re-runs the create path against the existing schema —
+    # this raised OperationalError before the idempotency fix.
+    await connect(db_url, auto_migrate=True)
+
+    rows = await fetch_all(
+        "SELECT conname FROM pg_constraint WHERE conname = 'ck_reconnectdoc_status'"
+    )
+    assert len(rows) == 1, f"expected exactly one CHECK constraint, got: {rows}"


### PR DESCRIPTION
## FF-G G6 — Idempotent check-constraint emission in Postgres `auto_migrate`

Closes #176.

### The bug
A `db_check=True` field emits its CHECK via a post-create `ALTER TABLE ... ADD CONSTRAINT` in `post_create_sqls`, sitting next to an idempotent `CREATE TABLE IF NOT EXISTS`. The ALTER was **not** idempotent, so a second `connect(auto_migrate=True)` against an already-migrated Postgres schema (app restart, or a later test in the same pytest process re-creating accumulated registry models) failed:

```
OperationalError: constraint "ck_<table>_<col>" for relation "<table>" already exists
```

Reproduced locally by connecting twice against the same schema — connect #2 raised the error, from the create path's `post_create_sqls` execution.

### The fix
Wrap the Postgres emission in an idempotent `DO $$ ... IF NOT EXISTS (pg_constraint) ...` guard in `render_db_check` — the single source consumed by **both** the CREATE path (`ferro-migrate::post_create_artifacts`) and the migrate/ALTER path (`emit_add_column`):

```sql
DO $$ BEGIN
  IF NOT EXISTS (SELECT 1 FROM pg_constraint
                 WHERE conname = 'ck_account_role' AND conrelid = '"account"'::regclass) THEN
    ALTER TABLE "account" ADD CONSTRAINT "ck_account_role" CHECK ("role" IN ('admin', 'user'));
  END IF;
END $$
```

Postgres has no `ADD CONSTRAINT IF NOT EXISTS`, so the guard checks `pg_constraint` and only adds when absent — it does **not** swallow an "already exists" error (I-6). The CHECK body from `render_check_body` is embedded byte-identically, preserving the cross-emitter parity the Alembic mirror depends on (I-1).

### Traps respected
- **Cross-emitter parity (I-1):** the legacy JSON-path emitter (`build_check_constraint_sql`, src/schema.rs) is folded into `render_db_check`, so the two emitters can no longer drift and the shadow comparator continues to see matching plans. Body stays byte-identical; the Alembic emitter (which mirrors only the body) is unaffected. Parity tests in `crates/ferro-migrate/src/tests.rs` updated in lockstep via a shared constant.
- **Shadow comparator:** verified with `FERRO_SHADOW_RUNTIME=1 FERRO_SHADOW_RUNTIME_STRICT=1` — parity holds.
- Registry accumulation (FF-E) left out of scope; the idempotency fix alone clears the failures.

### Result
Clears the 7 pre-existing `[postgres]` failures in a full `--db-backends=sqlite,postgres` run (test_hydration ×5, test_enum_cold_hydration, test_documentation_features::test_basic_model_definition) — shared root cause was this non-idempotent ALTER re-running against accumulated registry models.

### Tests
- `ferro-ddl-lowering`: idempotent-guard + SQLite-elision unit tests.
- `ferro-migrate`: parity tests updated (shared `PG_DB_CHECK_ACCOUNT_ROLE` constant).
- **Python regression** (`test_db_check_reconnect_is_idempotent`, postgres-only): db_check model, `connect(auto_migrate=True)` twice against the same schema — second call succeeds, constraint exists exactly once (roadmap G6 exit-gate line).

### Verification
- `cargo test -p ferro-schema-ir -p ferro-ddl-lowering -p ferro-migrate` ✅
- `cargo test --no-default-features --features testing` ✅ (131 passed)
- Full matrix `FERRO_POSTGRES_URL=... just test` → **993 passed, 8 skipped, 1 xfailed, 0 failed** ✅
- Shadow-strict parity ✅

Roadmap: ticked **G6** and its exit-gate line in `docs/plans/2026-07-02-001-fable-fixes-roadmap.md`. Scope is G6 only (the broader FF-G exit-gate items — slot-guard, operations.rs dedup, mid-plan interruption — are left unchecked).