### PR TITLE
chore(benchmarks): pinned async benchmark suite over the rich-type hot path

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,102 @@
+# Ferro hot-path benchmarks
+
+A small, pinned, repeatable suite that measures Ferro's Python-facing async hot
+path — **single save**, **bulk save**, and a **filtered fetch of ~10k rows** — on
+both backends, over a rich-type fixture model. It exists so the before/after of
+Epic **FF-C** (per-model codec plans, catalog cache, native Postgres decode, enum
+hydration) is quantifiable and future hot-path regressions are visible.
+
+It is **purely additive**: it imports the public Ferro API and changes no
+production code. It is **not** part of `just test`, so it never slows the
+functional matrix.
+
+## What it measures
+
+Four cases per backend, over `BenchRecord` (see `model.py`):
+
+| benchmark                 | operation                                             | rows |
+| ------------------------- | ----------------------------------------------------- | ---- |
+| `single_save`             | `record.save()` — one INSERT                          | 1    |
+| `bulk_save`               | `BenchRecord.bulk_create([...])` — one bulk INSERT    | 10k  |
+| `fetch_10k_identity_on`   | `BenchRecord.where(...).all()`, identity map **on**   | 10k  |
+| `fetch_10k_identity_off`  | `BenchRecord.where(...).all()`, identity map **off**  | 10k  |
+
+Only **wall-clock** is recorded (median / min / mean / stdev / p95, in ms).
+
+### Why the rich-type fixture is load-bearing
+
+A plain `int`/`str` model would show *nothing* from FF-C. Every `BenchRecord`
+field maps to a concrete cost C1–C4 removes, so the suite makes that work
+visible:
+
+- `created_at: datetime` (`db_type="timestamptz"`) → **C3** native typed decode
+  (today a `CAST(... AS text)` projection on Postgres — finding **F8**).
+- `balance: Decimal` → **C1/F5** per-value codec (the `pattern_looks_decimal`
+  heuristic C1 deletes).
+- `external_id: uuid.UUID` (`db_type="uuid"`) → **C3** typed decode / UUID casing.
+- `status: Status` (`str, Enum`, no `db_type`) → native Postgres enum, **C4**
+  enum hydration (removes the `_fix_types` Python post-pass).
+- `attributes: dict[str, str]` → JSON codec.
+- `name`, `score` → the plain-typed baseline columns.
+
+Catalog round-trips (**F4**) are incurred by all of the above during
+save/fetch/migrate, so they are exercised implicitly.
+
+## Running
+
+```bash
+just bench                 # SQLite always; Postgres if FERRO_POSTGRES_URL is set
+# or directly:
+uv run python -m benchmarks.run
+```
+
+Postgres is included automatically when a URL is configured (via
+`FERRO_POSTGRES_URL` or a repo-root `.env`, reusing `tests/db_backends.py`); it is
+skipped with a printed note otherwise.
+
+Useful flags: `--rows N`, `--iters N`, `--warmup N`, `--seed N`,
+`--backends sqlite,postgres`, `--out DIR`.
+
+Each run writes `baselines/<backend>.json` (per-backend, keyed by benchmark name)
+and prints a summary table.
+
+## Capturing a before/after around a change
+
+```bash
+# 1. Baseline the current code into a scratch dir
+uv run python -m benchmarks.run --out /tmp/before
+
+# 2. Make your hot-path change, rebuild the Rust core
+uv run maturin develop
+
+# 3. Re-run into a second dir
+uv run python -m benchmarks.run --out /tmp/after
+
+# 4. Diff the medians (per backend)
+uv run python -m benchmarks.compare /tmp/before/sqlite.json /tmp/after/sqlite.json
+uv run python -m benchmarks.compare /tmp/before/postgres.json /tmp/after/postgres.json
+```
+
+`compare` prints each benchmark's `old → new` median with **Δms** and **Δ%**.
+Negative % is a speed-up (green); positive is a regression (red).
+
+## Reading the deltas
+
+- Compare **same backend, same machine** only. Absolute numbers vary wildly by
+  backend and hardware; the deliverable is a stable *per-backend delta*, never a
+  SQLite-vs-Postgres comparison.
+- The checked-in `baselines/*.json` were captured on a developer machine and are
+  a reference point, not a CI gate. Re-capture your own baseline before measuring
+  a change so both sides come from the same box.
+- Watch the **median** for the headline and **stdev/p95** for noise. If stdev is
+  a large fraction of the median, raise `--warmup`/`--iters` until it settles
+  before trusting a delta.
+
+## Stability knobs
+
+Fixed row counts, deterministic seed data (`random.Random(seed)`), discarded
+warmup iterations, a fresh database per case (temp SQLite file / dropped-and-
+recreated PG schema), a pinned pool (`max_connections=5`), and a single
+persistent event loop across all cases. The fetch cases are measured with the
+identity map both on and off because that bookkeeping is real hot-path cost the
+FF-C rewrite interacts with.

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,11 @@
+"""Ferro hot-path benchmark suite (Epic FF-C, sub-task C5).
+
+A small, pinned, repeatable suite measuring the Python-facing async hot path —
+single save, bulk save, and a filtered fetch of ~10k rows — on both backends
+(SQLite always; Postgres when ``FERRO_POSTGRES_URL`` is configured), over a
+rich-type fixture model that exercises the type-decision path FF-C's C1–C4
+rewrite touches.
+
+The suite is purely additive: it imports the public Ferro API and never changes
+production code. Run it with ``just bench`` (see ``benchmarks/README.md``).
+"""

--- a/benchmarks/__main__.py
+++ b/benchmarks/__main__.py
@@ -1,0 +1,10 @@
+"""``python -m benchmarks`` → run the suite (alias for ``benchmarks.run``)."""
+
+from __future__ import annotations
+
+import sys
+
+from benchmarks.run import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/backends.py
+++ b/benchmarks/backends.py
@@ -1,0 +1,88 @@
+"""Backend selection and per-case isolation for the benchmark suite.
+
+Reuses ``tests/db_backends.py`` (``get_postgres_url`` / ``build_postgres_test_url``)
+rather than inventing a second backend-selection path, mirroring how the pytest
+matrix decides whether Postgres is available. SQLite is always present; Postgres
+is included only when a URL is configured and skipped cleanly otherwise.
+
+Each benchmark case runs against a *fresh* database so timings never depend on
+leftover state:
+
+- SQLite: a unique temp file (not ``:memory:`` — a pooled connection opens a
+  distinct in-memory database per connection, which would break multi-connection
+  pools).
+- Postgres: a random ``ferro_<hex>`` schema created up front and dropped after,
+  addressed through the ``ferro_search_path`` query param the Rust engine reads.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+# Repo root is on sys.path when run as ``python -m benchmarks.run`` from the
+# project directory, so the pytest-free helpers import cleanly.
+from tests.db_backends import build_postgres_test_url, get_postgres_url
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_ENV_FILE = _REPO_ROOT / ".env"
+
+
+def postgres_base_url() -> str | None:
+    """The externally managed Postgres URL, or ``None`` when unconfigured."""
+    return get_postgres_url(dict(os.environ), _ENV_FILE)
+
+
+def available_backends() -> list[str]:
+    """``["sqlite"]`` plus ``"postgres"`` when a Postgres URL is configured."""
+    backends = ["sqlite"]
+    if postgres_base_url():
+        backends.append("postgres")
+    return backends
+
+
+def _connect_admin(base_url: str):
+    import psycopg
+
+    return psycopg.connect(base_url, autocommit=True)
+
+
+def _create_schema(base_url: str, schema: str) -> None:
+    with _connect_admin(base_url) as conn:
+        conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        conn.execute(f'CREATE SCHEMA "{schema}"')
+
+
+def _drop_schema(base_url: str, schema: str) -> None:
+    with _connect_admin(base_url) as conn:
+        conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+
+
+@contextmanager
+def fresh_target(backend: str) -> Iterator[str]:
+    """Yield a connect URL for a fresh, isolated database of ``backend``.
+
+    Cleans up (temp dir / dropped schema) on exit regardless of outcome.
+    """
+    if backend == "sqlite":
+        with tempfile.TemporaryDirectory(prefix="ferro-bench-") as tmp:
+            yield f"sqlite:{Path(tmp) / 'bench.db'}?mode=rwc"
+        return
+
+    if backend == "postgres":
+        base_url = postgres_base_url()
+        if not base_url:  # pragma: no cover - guarded by available_backends()
+            raise RuntimeError("Postgres benchmark requested but no URL configured")
+        schema = f"ferro_{uuid.uuid4().hex[:16]}"
+        _create_schema(base_url, schema)
+        try:
+            yield build_postgres_test_url(base_url, schema)
+        finally:
+            _drop_schema(base_url, schema)
+        return
+
+    raise ValueError(f"Unknown backend: {backend!r}")

--- a/benchmarks/baselines/postgres.json
+++ b/benchmarks/baselines/postgres.json
@@ -1,0 +1,49 @@
+{
+  "benchmarks": {
+    "bulk_save": {
+      "mean_ms": 387.507312654634,
+      "median_ms": 389.5133335608989,
+      "min_ms": 364.61825005244464,
+      "n": 8,
+      "p95_ms": 399.0427920361981,
+      "rows": 10000,
+      "stdev_ms": 10.560156248841137
+    },
+    "fetch_10000_identity_off": {
+      "mean_ms": 287.3585860012099,
+      "median_ms": 285.91304150177166,
+      "min_ms": 283.37641595862806,
+      "n": 30,
+      "p95_ms": 292.72716608829796,
+      "rows": 10000,
+      "stdev_ms": 3.9899757994622176
+    },
+    "fetch_10000_identity_on": {
+      "mean_ms": 189.35828615600863,
+      "median_ms": 189.4699584809132,
+      "min_ms": 187.52899998798966,
+      "n": 30,
+      "p95_ms": 190.47379202675074,
+      "rows": 10000,
+      "stdev_ms": 0.7979450732007062
+    },
+    "single_save": {
+      "mean_ms": 1.7114295321516693,
+      "median_ms": 1.7078330274671316,
+      "min_ms": 1.2648329138755798,
+      "n": 100,
+      "p95_ms": 2.06791702657938,
+      "rows": 1,
+      "stdev_ms": 0.22644750383971446
+    }
+  },
+  "meta": {
+    "backend": "postgres",
+    "generated_at": "2026-07-02T22:29:44+00:00",
+    "note": "Wall-clock ms. Machine-specific; compare same-machine runs only.",
+    "platform": "macOS-26.5.1-arm64-arm-64bit-Mach-O",
+    "python": "3.14.5",
+    "rows": 10000,
+    "seed": 1234
+  }
+}

--- a/benchmarks/baselines/sqlite.json
+++ b/benchmarks/baselines/sqlite.json
@@ -1,0 +1,49 @@
+{
+  "benchmarks": {
+    "bulk_save": {
+      "mean_ms": 221.7548440094106,
+      "median_ms": 221.4729170082137,
+      "min_ms": 220.64062498975545,
+      "n": 8,
+      "p95_ms": 223.35558396298438,
+      "rows": 10000,
+      "stdev_ms": 0.8960294958933418
+    },
+    "fetch_10000_identity_off": {
+      "mean_ms": 271.8375902002056,
+      "median_ms": 271.24443696811795,
+      "min_ms": 266.449874965474,
+      "n": 30,
+      "p95_ms": 277.1654580719769,
+      "rows": 10000,
+      "stdev_ms": 3.047871791171487
+    },
+    "fetch_10000_identity_on": {
+      "mean_ms": 175.64869583196318,
+      "median_ms": 175.53445848170668,
+      "min_ms": 174.02187502011657,
+      "n": 30,
+      "p95_ms": 176.9996250513941,
+      "rows": 10000,
+      "stdev_ms": 0.9337145812562601
+    },
+    "single_save": {
+      "mean_ms": 0.35855210735462606,
+      "median_ms": 0.3517500008456409,
+      "min_ms": 0.31791708897799253,
+      "n": 100,
+      "p95_ms": 0.4023750079795718,
+      "rows": 1,
+      "stdev_ms": 0.03532271957579324
+    }
+  },
+  "meta": {
+    "backend": "sqlite",
+    "generated_at": "2026-07-02T22:29:44+00:00",
+    "note": "Wall-clock ms. Machine-specific; compare same-machine runs only.",
+    "platform": "macOS-26.5.1-arm64-arm-64bit-Mach-O",
+    "python": "3.14.5",
+    "rows": 10000,
+    "seed": 1234
+  }
+}

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -1,0 +1,98 @@
+"""Compare two benchmark result files and print per-benchmark deltas.
+
+    uv run python -m benchmarks.compare OLD.json NEW.json
+
+This is the "before/after C1–C3" tool: capture a baseline, make a hot-path
+change, re-run, then diff. Deltas are reported on the median (Δms and Δ%);
+negative % is a speed-up, positive is a regression. Compare only files from the
+*same backend on the same machine* — absolute numbers are not portable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _load(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if "benchmarks" not in data:
+        raise ValueError(f"{path}: not a benchmark result file (no 'benchmarks' key)")
+    return data
+
+
+def _rows(
+    old: dict, new: dict
+) -> list[tuple[str, float | None, float | None, float | None]]:
+    old_b, new_b = old["benchmarks"], new["benchmarks"]
+    out = []
+    for name in sorted(set(old_b) | set(new_b)):
+        o = old_b.get(name, {}).get("median_ms")
+        n = new_b.get(name, {}).get("median_ms")
+        pct = ((n - o) / o * 100.0) if (o and n is not None) else None
+        out.append((name, o, n, pct))
+    return out
+
+
+def _print(old: dict, new: dict, old_path: Path, new_path: Path) -> None:
+    ob, nb = old.get("meta", {}).get("backend"), new.get("meta", {}).get("backend")
+    if ob and nb and ob != nb:
+        print(f"⚠️  backend mismatch: old={ob!r} new={nb!r} — deltas are meaningless\n")
+
+    rows = _rows(old, new)
+    try:
+        from rich.console import Console
+        from rich.table import Table
+
+        title = f"{old_path.name} → {new_path.name}"
+        if ob:
+            title += f"  ({ob})"
+        table = Table(title=f"median Δ  {title}")
+        table.add_column("benchmark", justify="left")
+        table.add_column("old (ms)", justify="right")
+        table.add_column("new (ms)", justify="right")
+        table.add_column("Δ ms", justify="right")
+        table.add_column("Δ %", justify="right")
+        for name, o, n, pct in rows:
+            d_ms = f"{n - o:+.3f}" if (o is not None and n is not None) else "—"
+            if pct is None:
+                d_pct = "—"
+                style = "dim"
+            else:
+                d_pct = f"{pct:+.1f}%"
+                style = "green" if pct < 0 else ("red" if pct > 0 else None)
+            table.add_row(
+                name,
+                f"{o:.3f}" if o is not None else "—",
+                f"{n:.3f}" if n is not None else "—",
+                d_ms,
+                f"[{style}]{d_pct}[/{style}]" if style else d_pct,
+            )
+        Console().print(table)
+    except ImportError:  # pragma: no cover - rich is a dev dependency
+        print(f"{'benchmark':<26}{'old':>10}{'new':>10}{'Δ%':>9}")
+        for name, o, n, pct in rows:
+            print(
+                f"{name:<26}"
+                f"{(f'{o:.3f}' if o is not None else '—'):>10}"
+                f"{(f'{n:.3f}' if n is not None else '—'):>10}"
+                f"{(f'{pct:+.1f}%' if pct is not None else '—'):>9}"
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Diff two benchmark result files (median deltas)."
+    )
+    parser.add_argument("old", type=Path, help="baseline result JSON")
+    parser.add_argument("new", type=Path, help="new result JSON")
+    args = parser.parse_args(argv)
+
+    _print(_load(args.old), _load(args.new), args.old, args.new)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -1,0 +1,99 @@
+"""The timing core: wall-clock measurement over a persistent event loop.
+
+Deliberately not pytest / pytest-benchmark: that framework rebuilds the asyncio
+event loop per iteration (loop setup pollutes an async measurement) and the
+repo's global ``addopts = "--cov=src"`` would instrument the very hot path we
+measure. Here a single loop is created once by the runner, warmup iterations are
+discarded, and each timed unit is an already-built awaitable thunk so no
+per-iteration construction cost leaks into the number.
+
+Only wall-clock is measured (median/min/mean/stdev/p95). Absolute values are
+machine- and backend-specific; the deliverable is stable *per-backend* deltas,
+which ``compare.py`` computes.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from dataclasses import asdict, dataclass
+from typing import Awaitable, Callable
+
+# A thunk producing a fresh awaitable for one timed iteration. Building the
+# awaitable up front (outside the timed region) keeps construction cost out of
+# the measurement.
+Thunk = Callable[[], Awaitable[object]]
+
+
+@dataclass(frozen=True)
+class Timing:
+    """Wall-clock summary for one benchmark case, in milliseconds."""
+
+    name: str
+    backend: str
+    rows: int
+    n: int
+    median_ms: float
+    min_ms: float
+    mean_ms: float
+    stdev_ms: float
+    p95_ms: float
+
+    def as_record(self) -> dict[str, float | int]:
+        """The per-benchmark payload written to the baseline JSON."""
+        d = asdict(self)
+        d.pop("name")
+        d.pop("backend")
+        return d
+
+
+def _percentile(sorted_ms: list[float], pct: float) -> float:
+    """Nearest-rank percentile over an ascending list (pct in [0, 100])."""
+    if not sorted_ms:
+        return 0.0
+    if len(sorted_ms) == 1:
+        return sorted_ms[0]
+    rank = max(1, min(len(sorted_ms), round(pct / 100 * len(sorted_ms))))
+    return sorted_ms[rank - 1]
+
+
+def summarize(name: str, backend: str, rows: int, durations_s: list[float]) -> Timing:
+    """Reduce raw per-iteration seconds into a millisecond ``Timing``."""
+    ms = sorted(d * 1000.0 for d in durations_s)
+    return Timing(
+        name=name,
+        backend=backend,
+        rows=rows,
+        n=len(ms),
+        median_ms=statistics.median(ms),
+        min_ms=ms[0],
+        mean_ms=statistics.fmean(ms),
+        stdev_ms=statistics.stdev(ms) if len(ms) > 1 else 0.0,
+        p95_ms=_percentile(ms, 95),
+    )
+
+
+async def measure(
+    name: str,
+    backend: str,
+    rows: int,
+    thunks: list[Thunk],
+    warmup: int,
+) -> Timing:
+    """Time each thunk after discarding ``warmup`` leading iterations.
+
+    ``thunks`` holds ``warmup + n`` entries; the first ``warmup`` are awaited but
+    not recorded (JIT-free Python still has cold caches, first-touch pool
+    connections, and lazy imports to shake out). Each remaining thunk is timed
+    individually with ``perf_counter`` around a single ``await``.
+    """
+    for i in range(warmup):
+        await thunks[i]()
+
+    durations: list[float] = []
+    for thunk in thunks[warmup:]:
+        start = time.perf_counter()
+        await thunk()
+        durations.append(time.perf_counter() - start)
+
+    return summarize(name, backend, rows, durations)

--- a/benchmarks/model.py
+++ b/benchmarks/model.py
@@ -1,0 +1,84 @@
+"""The rich-type fixture model and deterministic row generator.
+
+The model is load-bearing: a plain ``int``/``str`` model would show nothing from
+FF-C's C1–C4 rewrite. Every field here maps to a concrete cost those sub-tasks
+remove, so the benchmark makes the codec/decode/catalog work visible:
+
+- ``created_at: datetime`` via ``db_type="timestamptz"`` — C3 native typed decode
+  (today coerced through a ``CAST(... AS text)`` projection on Postgres, F8).
+- ``balance: Decimal`` — C1/F5 per-value codec (the heuristic ``pattern_looks_decimal``
+  path C1 deletes).
+- ``external_id: uuid.UUID`` via ``db_type="uuid"`` — C3 typed decode / UUID casing.
+- ``status: Status`` (a ``str, Enum`` with no ``db_type``) — native Postgres enum,
+  C4 enum hydration (removes the ``_fix_types`` Python post-pass).
+- ``attributes: dict[str, str]`` — JSON codec.
+- ``name: str`` / ``score: int`` — the plain-typed baseline columns.
+"""
+
+from __future__ import annotations
+
+import random
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import Enum
+
+from ferro import Field, Model
+
+
+class Status(str, Enum):
+    """A native-enum column (no ``db_type``) so C4's enum hydration is exercised."""
+
+    DRAFT = "draft"
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+
+
+class BenchRecord(Model):
+    """Rich-type fixture spanning every codec/decode family C1–C4 rewrites."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    score: int
+    created_at: datetime = Field(db_type="timestamptz")
+    balance: Decimal
+    external_id: uuid.UUID = Field(db_type="uuid")
+    status: Status
+    attributes: dict[str, str]
+
+
+_STATUSES = tuple(Status)
+# A fixed UTC instant so seed data never depends on wall-clock time (which is
+# both nondeterministic and, for `new Date()`-style calls, unavailable in some
+# harnesses). The generator derives per-row offsets from the seeded RNG only.
+_EPOCH = datetime(2024, 1, 1, tzinfo=UTC)
+
+
+def make_records(n: int, seed: int) -> list[BenchRecord]:
+    """Build ``n`` deterministic ``BenchRecord`` instances.
+
+    Seeded so every run — and every backend — sees byte-identical input, which
+    is what lets the timings be compared run-to-run. The rows are *unsaved*
+    instances (no ``id``); callers persist them via ``create`` / ``bulk_create``.
+    """
+    rng = random.Random(seed)
+    records: list[BenchRecord] = []
+    for i in range(n):
+        # UUID from the seeded RNG (uuid4() would pull from os.urandom and break
+        # determinism); build a version-4-shaped value from 16 seeded bytes.
+        uid = uuid.UUID(bytes=bytes(rng.getrandbits(8) for _ in range(16)), version=4)
+        records.append(
+            BenchRecord(
+                name=f"record-{i:06d}",
+                score=rng.randint(0, 1_000_000),
+                created_at=_EPOCH.replace(microsecond=rng.randint(0, 999_999)),
+                balance=Decimal(rng.randint(0, 10_000_000)) / Decimal(100),
+                external_id=uid,
+                status=_STATUSES[rng.randrange(len(_STATUSES))],
+                attributes={
+                    "region": rng.choice(("us", "eu", "apac")),
+                    "tier": rng.choice(("free", "pro", "enterprise")),
+                },
+            )
+        )
+    return records

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,0 +1,270 @@
+"""Run the benchmark suite and write per-backend baseline JSON.
+
+    uv run python -m benchmarks.run                 # all available backends
+    uv run python -m benchmarks.run --backends sqlite
+    uv run python -m benchmarks.run --rows 10000 --out /tmp/before
+
+Runs four cases per backend over the rich-type ``BenchRecord`` fixture:
+``single_save``, ``bulk_save`` (``--rows``), and the filtered fetch of ~``--rows``
+rows with the identity map both on (``fetch_10k_identity_on``) and off
+(``fetch_10k_identity_off``). Postgres is included only when a URL is configured
+(``FERRO_POSTGRES_URL`` / ``.env``); otherwise it is skipped with a printed note.
+
+All cases share one persistent asyncio event loop. Each case runs against a fresh
+isolated database (temp SQLite file / dropped-and-recreated PG schema), so a run
+never depends on leftover state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import platform
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ferro import PoolConfig, connect, engines, reset_engine
+
+from benchmarks.backends import available_backends, fresh_target
+from benchmarks.harness import Timing, measure
+from benchmarks.model import BenchRecord, make_records
+
+# Pinned so pool warmth and connection count are not a hidden variable.
+_POOL = PoolConfig(max_connections=5, min_connections=0)
+_DEFAULT_SEED = 1234
+
+# Rows per bulk INSERT statement. A single statement of `rows` × 8 columns blows
+# past SQLite's bound-parameter cap (and Postgres' 65535), so a "bulk save N"
+# realistically chunks. 1000 rows × 8 cols = 8000 binds — safely under both
+# backends' limits — and the timed unit inserts all `rows` across these chunks.
+_BULK_CHUNK = 1000
+
+
+def _chunks(items, size):
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+async def _insert_chunked(records) -> None:
+    for chunk in _chunks(records, _BULK_CHUNK):
+        await BenchRecord.bulk_create(chunk)
+
+
+# Per-case iteration counts. Single save and fetch are cheap enough for a large
+# sample; bulk save inserts --rows per iteration, so it uses a smaller sample to
+# bound both wall-clock and the prebuilt-instance memory footprint. A global
+# --iters/--warmup overrides these when supplied.
+_CASE_ITERS = {
+    "single_save": (100, 10),
+    "bulk_save": (8, 2),
+    "fetch": (30, 5),
+}
+
+
+def _counts(case: str, iters: int | None, warmup: int | None) -> tuple[int, int]:
+    default_iters, default_warmup = _CASE_ITERS[case]
+    return (
+        iters if iters is not None else default_iters,
+        warmup if warmup is not None else default_warmup,
+    )
+
+
+async def _bench_single_save(backend, url, rows, seed, iters, warmup) -> Timing:
+    n, w = _counts("single_save", iters, warmup)
+    await connect(url, auto_migrate=True, pool=_POOL)
+    # An unnamed session binds the default connection so operations use the
+    # supported routing path (not the v0.14-deprecated implicit-default path).
+    async with engines.session():
+        # One distinct unsaved instance per iteration; ``save()`` inserts a new
+        # row (autoincrement PK), so iterations never collide or become UPDATEs.
+        records = make_records(n + w, seed)
+        thunks = [(lambda r=r: r.save()) for r in records]
+        return await measure("single_save", backend, 1, thunks, w)
+
+
+async def _bench_bulk_save(backend, url, rows, seed, iters, warmup) -> Timing:
+    n, w = _counts("bulk_save", iters, warmup)
+    await connect(url, auto_migrate=True, pool=_POOL)
+    async with engines.session():
+        # Distinct batch per iteration (different seed) so re-inserting never
+        # hits a PK conflict and each iteration writes genuinely fresh rows. Each
+        # timed unit inserts all `rows` via chunked bulk_create (see _BULK_CHUNK).
+        batches = [make_records(rows, seed + i + 1) for i in range(n + w)]
+        thunks = [(lambda b=b: _insert_chunked(b)) for b in batches]
+        return await measure("bulk_save", backend, rows, thunks, w)
+
+
+async def _bench_fetch(
+    backend, url, rows, seed, iters, warmup, *, identity_map
+) -> Timing:
+    n, w = _counts("fetch", iters, warmup)
+    await connect(url, auto_migrate=True, pool=_POOL, identity_map=identity_map)
+    async with engines.session():
+        await _insert_chunked(make_records(rows, seed))  # untimed seed
+        # A filter matching every seeded row: a real WHERE clause returning ~rows
+        # rows to hydrate each iteration. Repeated identical query exercises the
+        # identity-map reconcile path (on) vs. fresh-instance hydration (off).
+        name = f"fetch_{rows}_identity_{'on' if identity_map else 'off'}"
+        thunks = [(lambda: BenchRecord.where(lambda r: r.score >= 0).all())] * (n + w)
+        return await measure(name, backend, rows, thunks, w)
+
+
+# (case-key, coroutine factory) in report order.
+_CASES = [
+    ("single_save", lambda **kw: _bench_single_save(**kw)),
+    ("bulk_save", lambda **kw: _bench_bulk_save(**kw)),
+    ("fetch", lambda **kw: _bench_fetch(**kw, identity_map=True)),
+    ("fetch", lambda **kw: _bench_fetch(**kw, identity_map=False)),
+]
+
+
+def _run_backend(loop, backend, rows, seed, iters, warmup) -> list[Timing]:
+    timings: list[Timing] = []
+    for _case_key, factory in _CASES:
+        with fresh_target(backend) as url:
+            try:
+                timings.append(
+                    loop.run_until_complete(
+                        factory(
+                            backend=backend,
+                            url=url,
+                            rows=rows,
+                            seed=seed,
+                            iters=iters,
+                            warmup=warmup,
+                        )
+                    )
+                )
+            finally:
+                reset_engine()
+    return timings
+
+
+def _write_baseline(
+    out_dir: Path, backend: str, timings: list[Timing], meta: dict
+) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "meta": {**meta, "backend": backend},
+        "benchmarks": {t.name: t.as_record() for t in timings},
+    }
+    path = out_dir / f"{backend}.json"
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return path
+
+
+def _print_table(all_timings: list[Timing]) -> None:
+    try:
+        from rich.console import Console
+        from rich.table import Table
+
+        table = Table(title="Ferro hot-path benchmarks (wall-clock, ms)")
+        for col in (
+            "backend",
+            "benchmark",
+            "rows",
+            "n",
+            "median",
+            "min",
+            "mean",
+            "stdev",
+            "p95",
+        ):
+            table.add_column(
+                col, justify="right" if col not in ("backend", "benchmark") else "left"
+            )
+        for t in all_timings:
+            table.add_row(
+                t.backend,
+                t.name,
+                str(t.rows),
+                str(t.n),
+                f"{t.median_ms:.3f}",
+                f"{t.min_ms:.3f}",
+                f"{t.mean_ms:.3f}",
+                f"{t.stdev_ms:.3f}",
+                f"{t.p95_ms:.3f}",
+            )
+        Console().print(table)
+    except ImportError:  # pragma: no cover - rich is a dev dependency
+        header = f"{'backend':<9}{'benchmark':<26}{'rows':>7}{'n':>5}{'median':>10}{'p95':>10}"
+        print(header)
+        for t in all_timings:
+            print(
+                f"{t.backend:<9}{t.name:<26}{t.rows:>7}{t.n:>5}"
+                f"{t.median_ms:>10.3f}{t.p95_ms:>10.3f}"
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the Ferro hot-path benchmark suite."
+    )
+    parser.add_argument(
+        "--rows", type=int, default=10_000, help="rows for bulk save / fetch"
+    )
+    parser.add_argument(
+        "--iters", type=int, default=None, help="override per-case timed iterations"
+    )
+    parser.add_argument(
+        "--warmup", type=int, default=None, help="override per-case warmup iterations"
+    )
+    parser.add_argument(
+        "--seed", type=int, default=_DEFAULT_SEED, help="deterministic data seed"
+    )
+    parser.add_argument(
+        "--backends", type=str, default=None, help="comma list; default all available"
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path(__file__).resolve().parent / "baselines",
+        help="directory for <backend>.json baselines",
+    )
+    args = parser.parse_args(argv)
+
+    backends = available_backends()
+    if args.backends:
+        requested = [b.strip() for b in args.backends.split(",") if b.strip()]
+        skipped = [b for b in requested if b not in backends]
+        for b in skipped:
+            print(f"note: backend {b!r} not available (no URL configured?) — skipping")
+        backends = [b for b in requested if b in backends]
+    if "postgres" not in backends:
+        print(
+            "note: Postgres not configured (set FERRO_POSTGRES_URL) — running SQLite only"
+        )
+
+    meta = {
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "rows": args.rows,
+        "seed": args.seed,
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "note": "Wall-clock ms. Machine-specific; compare same-machine runs only.",
+    }
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    all_timings: list[Timing] = []
+    try:
+        for backend in backends:
+            timings = _run_backend(
+                loop, backend, args.rows, args.seed, args.iters, args.warmup
+            )
+            path = _write_baseline(args.out, backend, timings, meta)
+            print(f"wrote {path}")
+            all_timings.extend(timings)
+    finally:
+        loop.close()
+
+    _print_table(all_timings)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/plans/2026-07-02-001-fable-fixes-roadmap.md
+++ b/docs/plans/2026-07-02-001-fable-fixes-roadmap.md
@@ -205,10 +205,13 @@ finally gets its runtime consumer.
       directly (registry holds the enum class or Python converts via a single
       plan-driven hook). Removes the partial-coverage, `except Exception: pass`
       Python post-pass from every fetch (I-6).
-- [ ] **C5 — Benchmarks.**
+- [x] **C5 — Benchmarks.**
       A small pinned benchmark suite (save, filtered fetch ×10k rows, both
       backends) run before/after C1–C3 so the "high-performance core" claim is
       measured, and future regressions on the hot path are visible.
+      Landed in `benchmarks/` (single/bulk save + filtered fetch ×10k, SQLite +
+      Postgres, rich-type fixture; `just bench` runner, checked-in per-backend
+      baselines, `benchmarks/compare.py` for before/after deltas).
 
 **Exit gate**
 

--- a/justfile
+++ b/justfile
@@ -9,3 +9,6 @@ docs:
 
 test *ARGS:
     uv run pytest --db-backends=sqlite,postgres {{ARGS}}
+
+bench *ARGS:
+    uv run python -m benchmarks.run {{ARGS}}


### PR DESCRIPTION
## What this is

**Epic FF-C, sub-task C5 (#195).** A small, pinned, repeatable benchmark suite for Ferro's Python-facing async hot path. It lands **first** in FF-C so the before/after of the C1–C3 rewrite (per-model codec plans, catalog cache, native Postgres decode) is quantifiable and future hot-path regressions are visible.

**Purely additive — no production code changes.** Not wired into `just test`, so the functional matrix is unaffected (verified: `1022 passed, 11 skipped, 1 xfailed` with `FERRO_POSTGRES_URL=… just test`, ~45s, unchanged).

## What it measures

Four cases per backend over the rich-type `BenchRecord` fixture, wall-clock only (median/min/mean/stdev/p95):

| benchmark                 | operation                                            | rows |
| ------------------------- | ---------------------------------------------------- | ---- |
| `single_save`             | `record.save()` — one INSERT                         | 1    |
| `bulk_save`               | chunked `bulk_create` of `--rows`                    | 10k  |
| `fetch_10000_identity_on` | `where(...).all()`, identity map **on**              | 10k  |
| `fetch_10000_identity_off`| `where(...).all()`, identity map **off**             | 10k  |

SQLite always runs; Postgres runs when `FERRO_POSTGRES_URL` (or `.env`) is set and is **skipped cleanly** otherwise — reusing `tests/db_backends.py` rather than inventing backend selection.

## Why the rich-type fixture (load-bearing)

A plain `int`/`str` model would show **nothing** from C1–C4. Every `BenchRecord` field maps to a concrete cost those sub-tasks remove, so the suite makes that work visible:

- `created_at: datetime` (`db_type="timestamptz"`) → **C3** native decode (today a `CAST(... AS text)` projection on PG — **F8**)
- `balance: Decimal` → **C1/F5** per-value codec (the `pattern_looks_decimal` heuristic C1 deletes)
- `external_id: uuid.UUID` (`db_type="uuid"`) → **C3** typed decode / UUID casing
- `status: Status` (`str, Enum`, no `db_type`) → native PG enum, **C4** enum hydration (removes the `_fix_types` post-pass)
- `attributes: dict[str, str]` → JSON codec
- `name`, `score` → plain-typed baseline columns

Catalog round-trips (**F4**) are incurred implicitly by all of the above.

## Framework choice

A custom `time.perf_counter` harness over a single persistent event loop with explicit warmup, run as `python -m benchmarks.run` — **not** pytest-benchmark (rebuilds the loop per iteration; the repo's global `--cov=src` would instrument the hot path) and not asv (heavyweight for four cases). Matches the existing `scripts/` style.

## Sample baseline (this machine — macOS arm64, Python 3.14; medians, ms)

| benchmark                  | SQLite | Postgres |
| -------------------------- | -----: | -------: |
| `single_save`              |  0.352 |    1.708 |
| `bulk_save` (10k)          | 221.5  |  389.5   |
| `fetch_10000_identity_on`  | 175.5  |  189.5   |
| `fetch_10000_identity_off` | 271.2  |  285.9   |

Numbers are **machine-specific** — the deliverable is stable *per-backend* deltas, never a SQLite-vs-Postgres comparison. Observed run-to-run median spread here: **<1.5%** on the heavy cases (3× SQLite, 2× Postgres); `single_save` ~4% (sub-millisecond, expected). Note `fetch` is *faster* with the identity map on — the map absorbs repeated hydration; C1–C3 will move that needle.

## How C1–C3 will use it

```
uv run python -m benchmarks.run --out /tmp/before   # baseline current code
# … make the C1/C2/C3 change, uv run maturin develop …
uv run python -m benchmarks.run --out /tmp/after
uv run python -m benchmarks.compare /tmp/before/sqlite.json /tmp/after/sqlite.json
```

`compare` prints each benchmark's `old → new` median with Δms and Δ% (green = speed-up, red = regression). Checked-in `benchmarks/baselines/*.json` are a reference point, not a CI gate.

## Verification done

- SQLite ×3 and Postgres ×2 full runs — spread reported above.
- Clean Postgres skip with no URL configured (only `sqlite.json` written, note printed).
- `compare` demoed on two identical runs (≈0–1% on heavy cases — the noise floor).
- Full matrix green and not slowed; benchmarks excluded from `just test`.

Roadmap: `docs/plans/2026-07-02-001-fable-fixes-roadmap.md` — Epic FF-C (L164–219), C5 at L208. Epic: #190.
