### PR TITLE
feat(ff-d)!: session-scoped weak identity map with refresh-on-load; single-handle routing

### DIFF
--- a/docs/examples/multiple_databases.py
+++ b/docs/examples/multiple_databases.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from ferro import Field, Model, connect, transaction
+from ferro import Field, Model, connect, engines, transaction
 
 
 class Metric(Model):
@@ -18,14 +18,15 @@ async def main() -> None:
     # --8<-- [end:connect]
 
     # --8<-- [start:routing]
-    # Writes go to the default ("app") connection unless routed
-    await Metric.create(name="signups", value=1)
+    async with engines.session():
+        # Writes go to the default ("app") connection unless routed
+        await Metric.create(name="signups", value=1)
 
-    # Route reads and writes to a named connection with .using()
-    await Metric.using("analytics").create(name="page_views", value=100)
+        # Route reads and writes to a named connection with .using()
+        await Metric.using("analytics").create(name="page_views", value=100)
 
-    app_metrics = await Metric.all()
-    analytics_metrics = await Metric.using("analytics").all()
+        app_metrics = await Metric.all()
+        analytics_metrics = await Metric.using("analytics").all()
     # --8<-- [end:routing]
     assert len(app_metrics) == 1
     assert len(analytics_metrics) == 1
@@ -36,7 +37,8 @@ async def main() -> None:
         await Metric.using("analytics").create(name="clicks", value=42)
     # --8<-- [end:transaction]
     assert len(await Metric.using("analytics").all()) == 2
-    assert len(await Metric.all()) == 1
+    async with engines.session():
+        assert len(await Metric.all()) == 1
 
     print("multiple_databases example ran successfully")
 

--- a/docs/examples/multiple_databases.py
+++ b/docs/examples/multiple_databases.py
@@ -21,12 +21,12 @@ async def main() -> None:
     async with engines.session():
         # Writes go to the default ("app") connection unless routed
         await Metric.create(name="signups", value=1)
-
-        # Route reads and writes to a named connection with .using()
-        await Metric.using("analytics").create(name="page_views", value=100)
-
         app_metrics = await Metric.all()
-        analytics_metrics = await Metric.using("analytics").all()
+
+    # Route reads and writes to a named connection with .using() — this
+    # doesn't need a session; a `using=` call is its own explicit route
+    await Metric.using("analytics").create(name="page_views", value=100)
+    analytics_metrics = await Metric.using("analytics").all()
     # --8<-- [end:routing]
     assert len(app_metrics) == 1
     assert len(analytics_metrics) == 1

--- a/docs/examples/mutations.py
+++ b/docs/examples/mutations.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from ferro import Field, Model, UniqueViolationError, connect
+from ferro import Field, Model, UniqueViolationError, connect, engines
 
 
 class Customer(Model):
@@ -15,94 +15,95 @@ class Customer(Model):
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
 
-    # --8<-- [start:get-or-create]
-    customer, created = await Customer.get_or_create(
-        email="alice@example.com",
-        defaults={"name": "Alice"},
-    )
-    assert created is True
+    async with engines.session():
+        # --8<-- [start:get-or-create]
+        customer, created = await Customer.get_or_create(
+            email="alice@example.com",
+            defaults={"name": "Alice"},
+        )
+        assert created is True
 
-    # Second call finds the existing row instead of inserting
-    same, created = await Customer.get_or_create(email="alice@example.com")
-    assert created is False and same.id == customer.id
-    # --8<-- [end:get-or-create]
+        # Second call finds the existing row instead of inserting
+        same, created = await Customer.get_or_create(email="alice@example.com")
+        assert created is False and same.id == customer.id
+        # --8<-- [end:get-or-create]
 
-    # --8<-- [start:update-or-create]
-    customer, created = await Customer.update_or_create(
-        email="alice@example.com",
-        defaults={"plan": "pro"},
-    )
-    assert created is False and customer.plan == "pro"
-    # --8<-- [end:update-or-create]
+        # --8<-- [start:update-or-create]
+        customer, created = await Customer.update_or_create(
+            email="alice@example.com",
+            defaults={"plan": "pro"},
+        )
+        assert created is False and customer.plan == "pro"
+        # --8<-- [end:update-or-create]
 
-    # --8<-- [start:refresh]
-    # Reload an instance from the database, discarding local state
-    await Customer.where(lambda customer: customer.email == "alice@example.com").update(
-        name="Alice L."
-    )
-    await customer.refresh()
-    assert customer.name == "Alice L."
-    # --8<-- [end:refresh]
+        # --8<-- [start:refresh]
+        # Reload an instance from the database, discarding local state
+        await Customer.where(lambda customer: customer.email == "alice@example.com").update(
+            name="Alice L."
+        )
+        await customer.refresh()
+        assert customer.name == "Alice L."
+        # --8<-- [end:refresh]
 
-    # --8<-- [start:create-strict]
-    alice = await Customer.get(customer.id)
+        # --8<-- [start:create-strict]
+        alice = await Customer.get(customer.id)
 
-    # create() never updates an existing row — a duplicate is an error
-    try:
-        await Customer.create(id=alice.id, email="alice.2@example.com")
-    except UniqueViolationError:
-        ...  # the existing row is untouched
-    # --8<-- [end:create-strict]
+        # create() never updates an existing row — a duplicate is an error
+        try:
+            await Customer.create(id=alice.id, email="alice.2@example.com")
+        except UniqueViolationError:
+            ...  # the existing row is untouched
+        # --8<-- [end:create-strict]
 
-    # --8<-- [start:save-insert-update]
-    bob = Customer(email="bob@example.com", name="Bob")
-    await bob.save()  # never persisted: INSERT (bob.id is now set)
+        # --8<-- [start:save-insert-update]
+        bob = Customer(email="bob@example.com", name="Bob")
+        await bob.save()  # never persisted: INSERT (bob.id is now set)
 
-    bob.plan = "pro"
-    await bob.save()  # persisted: UPDATE ... WHERE id = ?
+        bob.plan = "pro"
+        await bob.save()  # persisted: UPDATE ... WHERE id = ?
 
-    bobs = await Customer.where(lambda customer: customer.name == "Bob").count()
-    assert bobs == 1  # two saves, one row
-    # --8<-- [end:save-insert-update]
+        bobs = await Customer.where(lambda customer: customer.name == "Bob").count()
+        assert bobs == 1  # two saves, one row
+        # --8<-- [end:save-insert-update]
 
-    # --8<-- [start:upsert]
-    # No row with this primary key: INSERT
-    carol = await Customer.upsert(id=100, email="carol@example.com", name="Carol")
+        # --8<-- [start:upsert]
+        # No row with this primary key: INSERT
+        carol = await Customer.upsert(id=100, email="carol@example.com", name="Carol")
 
-    # Same primary key again: UPDATE of the existing row
-    carol = await Customer.upsert(id=100, email="carol@example.com", plan="pro")
-    assert carol.plan == "pro"
-    assert await Customer.where(lambda customer: customer.id == 100).count() == 1
+        # Same primary key again: UPDATE of the existing row
+        carol = await Customer.upsert(id=100, email="carol@example.com", plan="pro")
+        assert carol.plan == "pro"
+        assert await Customer.where(lambda customer: customer.id == 100).count() == 1
 
-    # The whole row is written: `name` was left unset above, so the stored
-    # "Carol" reverted to the field default — pass every field you care about.
-    stored = await Customer.get(100)
-    assert stored.name == ""
-    # --8<-- [end:upsert]
+        # The whole row is written: `name` was left unset above, so the stored
+        # "Carol" reverted to the field default — pass every field you care about.
+        stored = await Customer.get(100)
+        assert stored.name == ""
+        # --8<-- [end:upsert]
 
-    # --8<-- [start:handling-errors]
-    try:
-        await Customer.create(email="alice@example.com")  # email already taken
-    except UniqueViolationError as exc:
-        print(exc.sqlstate)  # "23505" (SQLSTATE) on Postgres, "2067" on SQLite
-        print(exc.constraint)  # violated constraint name (Postgres only)
-        print(exc.driver_message)  # original driver text, for logs
-    # --8<-- [end:handling-errors]
+        # --8<-- [start:handling-errors]
+        try:
+            await Customer.create(email="alice@example.com")  # email already taken
+        except UniqueViolationError as exc:
+            print(exc.sqlstate)  # "23505" (SQLSTATE) on Postgres, "2067" on SQLite
+            print(exc.constraint)  # violated constraint name (Postgres only)
+            print(exc.driver_message)  # original driver text, for logs
+        # --8<-- [end:handling-errors]
 
-    await Customer.create(email="dora@example.com")  # plan defaults to "free"
+        await Customer.create(email="dora@example.com")  # plan defaults to "free"
 
-    # --8<-- [start:mutation-guard]
-    free = Customer.where(lambda customer: customer.plan == "free")
-    try:
-        await free.limit(10).delete()
-    except ValueError:
-        # Portable SQL has no DELETE ... LIMIT. Fetch primary keys first,
-        # then mutate by primary-key set:
-        doomed = await free.limit(10).all()
-        ids = [customer.id for customer in doomed]
-        removed = await Customer.where(lambda customer: customer.id.in_(ids)).delete()
-        assert removed == 1
-    # --8<-- [end:mutation-guard]
+        # --8<-- [start:mutation-guard]
+        free = Customer.where(lambda customer: customer.plan == "free")
+        try:
+            await free.limit(10).delete()
+        except ValueError:
+            # Portable SQL has no DELETE ... LIMIT. Fetch primary keys first,
+            # then mutate by primary-key set:
+            doomed = await free.limit(10).all()
+            ids = [customer.id for customer in doomed]
+            removed = await Customer.where(lambda customer: customer.id.in_(ids)).delete()
+            assert removed == 1
+        # --8<-- [end:mutation-guard]
 
     print("mutations example ran successfully")
 

--- a/docs/examples/pagination.py
+++ b/docs/examples/pagination.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from ferro import Field, Model, connect
+from ferro import Field, Model, connect, engines
 
 
 class Article(Model):
@@ -31,14 +31,16 @@ async def get_after(after_id: int | None, limit: int = 20) -> list[Article]:
 
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
-    await Article.bulk_create([Article(title=f"Article {i}") for i in range(1, 51)])
 
-    page_two = await get_page(page=2, per_page=10)
-    assert [a.title for a in page_two][:2] == ["Article 11", "Article 12"]
+    async with engines.session():
+        await Article.bulk_create([Article(title=f"Article {i}") for i in range(1, 51)])
 
-    first_batch = await get_after(after_id=None, limit=10)
-    next_batch = await get_after(after_id=first_batch[-1].id, limit=10)
-    assert next_batch[0].title == "Article 11"
+        page_two = await get_page(page=2, per_page=10)
+        assert [a.title for a in page_two][:2] == ["Article 11", "Article 12"]
+
+        first_batch = await get_after(after_id=None, limit=10)
+        next_batch = await get_after(after_id=first_batch[-1].id, limit=10)
+        assert next_batch[0].title == "Article 11"
 
     print("pagination example ran successfully")
 

--- a/docs/examples/predicates.py
+++ b/docs/examples/predicates.py
@@ -3,7 +3,7 @@
 import asyncio
 
 # --8<-- [start:setup]
-from ferro import Field, Model, connect
+from ferro import Field, Model, connect, engines
 from ferro.query import col
 
 
@@ -18,72 +18,74 @@ class User(Model):
 
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
-    await User.bulk_create(
-        [
-            User(name="alice", age=34, role="admin"),
-            User(name="bob", age=19),
-            User(name="carol", age=42, archived=True),
-            User(name="dave", age=17),
-        ]
-    )
 
-    # --8<-- [start:filtering]
-    adults = await User.where(lambda user: user.age >= 18).all()
-    # --8<-- [end:filtering]
-    assert len(adults) == 3
+    async with engines.session():
+        await User.bulk_create(
+            [
+                User(name="alice", age=34, role="admin"),
+                User(name="bob", age=19),
+                User(name="carol", age=42, archived=True),
+                User(name="dave", age=17),
+            ]
+        )
 
-    # --8<-- [start:operator-style]
-    # Deprecated path (planned removal: v0.14.0).
-    adults = await User.where(User.age >= 18).all()
-    # --8<-- [end:operator-style]
-    assert len(adults) == 3
+        # --8<-- [start:filtering]
+        adults = await User.where(lambda user: user.age >= 18).all()
+        # --8<-- [end:filtering]
+        assert len(adults) == 3
 
-    # --8<-- [start:col-style]
-    active = await User.where(col(User.archived) == False).all()  # noqa: E712
-    # --8<-- [end:col-style]
-    assert len(active) == 3
+        # --8<-- [start:operator-style]
+        # Deprecated path (planned removal: v0.14.0).
+        adults = await User.where(User.age >= 18).all()
+        # --8<-- [end:operator-style]
+        assert len(adults) == 3
 
-    # --8<-- [start:lambda-style]
-    admins = await User.where(lambda user: (user.role == "admin") & (user.archived == False)).all()  # noqa: E712
-    # --8<-- [end:lambda-style]
-    assert len(admins) == 1
+        # --8<-- [start:col-style]
+        active = await User.where(col(User.archived) == False).all()  # noqa: E712
+        # --8<-- [end:col-style]
+        assert len(active) == 3
 
-    # --8<-- [start:operators]
-    teens = await User.where(lambda user: (user.age >= 13) & (user.age <= 19)).all()
-    a_names = await User.where(lambda user: user.name.like("a%")).all()
-    staff = await User.where(lambda user: user.role.in_(["admin", "moderator"])).all()
-    # --8<-- [end:operators]
-    assert len(teens) == 2
-    assert len(a_names) == 1
-    assert len(staff) == 1
+        # --8<-- [start:lambda-style]
+        admins = await User.where(lambda user: (user.role == "admin") & (user.archived == False)).all()  # noqa: E712
+        # --8<-- [end:lambda-style]
+        assert len(admins) == 1
 
-    # --8<-- [start:combining]
-    # & is AND, | is OR — parenthesize each side
-    flagged = await User.where(lambda user: (user.age < 18) | (user.archived == True)).all()  # noqa: E712
+        # --8<-- [start:operators]
+        teens = await User.where(lambda user: (user.age >= 13) & (user.age <= 19)).all()
+        a_names = await User.where(lambda user: user.name.like("a%")).all()
+        staff = await User.where(lambda user: user.role.in_(["admin", "moderator"])).all()
+        # --8<-- [end:operators]
+        assert len(teens) == 2
+        assert len(a_names) == 1
+        assert len(staff) == 1
 
-    # Chained .where() calls also AND together
-    young_members = await User.where(lambda user: user.role == "member").where(lambda user: user.age < 21).all()
-    # --8<-- [end:combining]
-    assert len(flagged) == 2
-    assert len(young_members) == 2
+        # --8<-- [start:combining]
+        # & is AND, | is OR — parenthesize each side
+        flagged = await User.where(lambda user: (user.age < 18) | (user.archived == True)).all()  # noqa: E712
 
-    # --8<-- [start:ordering-slicing]
-    oldest_first = await User.select().order_by(User.age, "desc").all()
-    second_page = await User.select().order_by(User.id).limit(2).offset(2).all()
-    # --8<-- [end:ordering-slicing]
-    assert oldest_first[0].name == "carol"
-    assert len(second_page) == 2
+        # Chained .where() calls also AND together
+        young_members = await User.where(lambda user: user.role == "member").where(lambda user: user.age < 21).all()
+        # --8<-- [end:combining]
+        assert len(flagged) == 2
+        assert len(young_members) == 2
 
-    # --8<-- [start:terminals]
-    everyone = await User.all()
-    first_admin = await User.where(lambda user: user.role == "admin").first()
-    headcount = await User.select().count()
-    any_minors = await User.where(lambda user: user.age < 18).exists()
-    # --8<-- [end:terminals]
-    assert len(everyone) == 4
-    assert first_admin is not None
-    assert headcount == 4
-    assert any_minors
+        # --8<-- [start:ordering-slicing]
+        oldest_first = await User.select().order_by(User.age, "desc").all()
+        second_page = await User.select().order_by(User.id).limit(2).offset(2).all()
+        # --8<-- [end:ordering-slicing]
+        assert oldest_first[0].name == "carol"
+        assert len(second_page) == 2
+
+        # --8<-- [start:terminals]
+        everyone = await User.all()
+        first_admin = await User.where(lambda user: user.role == "admin").first()
+        headcount = await User.select().count()
+        any_minors = await User.where(lambda user: user.age < 18).exists()
+        # --8<-- [end:terminals]
+        assert len(everyone) == 4
+        assert first_admin is not None
+        assert headcount == 4
+        assert any_minors
 
     print("predicates example ran successfully")
 

--- a/docs/examples/predicates_annotated.py
+++ b/docs/examples/predicates_annotated.py
@@ -5,7 +5,7 @@ import asyncio
 # --8<-- [start:setup]
 from typing import Annotated
 
-from ferro import Field, Model, connect
+from ferro import Field, Model, connect, engines
 
 
 class User(Model):
@@ -19,15 +19,17 @@ class User(Model):
 
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
-    await User.bulk_create(
-        [
-            User(name="alice", age=34, role="admin"),
-            User(name="bob", age=19),
-        ]
-    )
 
-    adults = await User.where(lambda user: user.age >= 18).all()
-    assert len(adults) == 2
+    async with engines.session():
+        await User.bulk_create(
+            [
+                User(name="alice", age=34, role="admin"),
+                User(name="bob", age=19),
+            ]
+        )
+
+        adults = await User.where(lambda user: user.age >= 18).all()
+        assert len(adults) == 2
 
     print("predicates_annotated example ran successfully")
 

--- a/docs/examples/quickstart.py
+++ b/docs/examples/quickstart.py
@@ -6,7 +6,7 @@ import asyncio
 from datetime import datetime
 from typing import Annotated
 
-from ferro import BackRef, Field, ForeignKey, Model, Relation, connect, transaction
+from ferro import BackRef, Field, ForeignKey, Model, Relation, connect, engines, transaction
 
 
 class Author(Model):
@@ -31,78 +31,79 @@ async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
     # --8<-- [end:connect]
 
-    # --8<-- [start:create]
-    alice = await Author.create(name="Alice", email="alice@example.com")
+    async with engines.session():
+        # --8<-- [start:create]
+        alice = await Author.create(name="Alice", email="alice@example.com")
 
-    post = await Post.create(
-        title="Why Ferro is Fast",
-        body="Ferro hands SQL generation and row hydration to a Rust engine...",
-        published=True,
-        author=alice,
-    )
+        post = await Post.create(
+            title="Why Ferro is Fast",
+            body="Ferro hands SQL generation and row hydration to a Rust engine...",
+            published=True,
+            author=alice,
+        )
 
-    # Insert many rows in a single statement
-    await Post.bulk_create(
-        [
-            Post(title="Async Patterns", body="...", published=True, author_id=alice.id),
-            Post(title="Unfinished Draft", body="...", author_id=alice.id),
-        ]
-    )
-    # --8<-- [end:create]
-    assert post.id is not None
+        # Insert many rows in a single statement
+        await Post.bulk_create(
+            [
+                Post(title="Async Patterns", body="...", published=True, author_id=alice.id),
+                Post(title="Unfinished Draft", body="...", author_id=alice.id),
+            ]
+        )
+        # --8<-- [end:create]
+        assert post.id is not None
 
-    # --8<-- [start:query]
-    # Fetch by primary key
-    same_post = await Post.get(post.id)
+        # --8<-- [start:query]
+        # Fetch by primary key
+        same_post = await Post.get(post.id)
 
-    # Filter, order, and slice
-    published = (
-        await Post.where(lambda post: post.published == True)  # noqa: E712
-        .order_by(Post.created_at, "desc")
-        .limit(10)
-        .all()
-    )
+        # Filter, order, and slice
+        published = (
+            await Post.where(lambda post: post.published == True)  # noqa: E712
+            .order_by(Post.created_at, "desc")
+            .limit(10)
+            .all()
+        )
 
-    # Aggregate terminals
-    total = await Post.select().count()
-    has_drafts = await Post.where(lambda post: post.published == False).exists()  # noqa: E712
-    # --8<-- [end:query]
-    assert same_post is post  # identity map: same Python object
-    assert len(published) == 2
-    assert total == 3
-    assert has_drafts
+        # Aggregate terminals
+        total = await Post.select().count()
+        has_drafts = await Post.where(lambda post: post.published == False).exists()  # noqa: E712
+        # --8<-- [end:query]
+        assert same_post is post  # identity map: same Python object
+        assert len(published) == 2
+        assert total == 3
+        assert has_drafts
 
-    # --8<-- [start:relationships]
-    # Forward access: awaiting the foreign key loads the related instance
-    author = await same_post.author
+        # --8<-- [start:relationships]
+        # Forward access: awaiting the foreign key loads the related instance
+        author = await same_post.author
 
-    # Reverse access: the BackRef is a chainable query
-    alice_posts = await author.posts.where(lambda post: post.published == True).all()  # noqa: E712
-    # --8<-- [end:relationships]
-    assert author.name == "Alice"
-    assert len(alice_posts) == 2
+        # Reverse access: the BackRef is a chainable query
+        alice_posts = await author.posts.where(lambda post: post.published == True).all()  # noqa: E712
+        # --8<-- [end:relationships]
+        assert author.name == "Alice"
+        assert len(alice_posts) == 2
 
-    # --8<-- [start:update-delete]
-    # Update one instance
-    post.title = "Why Ferro is *Really* Fast"
-    await post.save()
+        # --8<-- [start:update-delete]
+        # Update one instance
+        post.title = "Why Ferro is *Really* Fast"
+        await post.save()
 
-    # Update many rows at once
-    updated = await Post.where(lambda post: post.published == False).update(published=True)  # noqa: E712
+        # Update many rows at once
+        updated = await Post.where(lambda post: post.published == False).update(published=True)  # noqa: E712
 
-    # Delete
-    deleted = await Post.where(lambda post: post.title == "Unfinished Draft").delete()
-    # --8<-- [end:update-delete]
-    assert updated == 1
-    assert deleted == 1
+        # Delete
+        deleted = await Post.where(lambda post: post.title == "Unfinished Draft").delete()
+        # --8<-- [end:update-delete]
+        assert updated == 1
+        assert deleted == 1
 
-    # --8<-- [start:transaction]
-    async with transaction():
-        bob = await Author.create(name="Bob", email="bob@example.com")
-        await Post.create(title="Hello", body="...", author=bob)
-    # Commits on success, rolls back if the block raises
-    # --8<-- [end:transaction]
-    assert await Author.select().count() == 2
+        # --8<-- [start:transaction]
+        async with transaction():
+            bob = await Author.create(name="Bob", email="bob@example.com")
+            await Post.create(title="Hello", body="...", author=bob)
+        # Commits on success, rolls back if the block raises
+        # --8<-- [end:transaction]
+        assert await Author.select().count() == 2
 
     print("quickstart example ran successfully")
 

--- a/docs/examples/quickstart_annotated.py
+++ b/docs/examples/quickstart_annotated.py
@@ -11,7 +11,7 @@ import asyncio
 from datetime import datetime
 from typing import Annotated
 
-from ferro import BackRef, Field, ForeignKey, Model, Relation, connect
+from ferro import BackRef, Field, ForeignKey, Model, Relation, connect, engines
 
 
 class Author(Model):
@@ -34,12 +34,13 @@ class Post(Model):
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
 
-    alice = await Author.create(name="Alice", email="alice@example.com")
-    post = await Post.create(title="Hello", body="...", published=True, author=alice)
+    async with engines.session():
+        alice = await Author.create(name="Alice", email="alice@example.com")
+        post = await Post.create(title="Hello", body="...", published=True, author=alice)
 
-    assert post.id is not None
-    assert (await post.author).email == "alice@example.com"
-    assert len(await alice.posts.where(lambda post: post.published == True).all()) == 1  # noqa: E712
+        assert post.id is not None
+        assert (await post.author).email == "alice@example.com"
+        assert len(await alice.posts.where(lambda post: post.published == True).all()) == 1  # noqa: E712
 
     print("quickstart_annotated example ran successfully")
 

--- a/docs/examples/raw_sql.py
+++ b/docs/examples/raw_sql.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from ferro import Field, Model, connect, execute, fetch_all, fetch_one, transaction
+from ferro import Field, Model, connect, engines, execute, fetch_all, fetch_one, transaction
 
 
 class Event(Model):
@@ -13,28 +13,30 @@ class Event(Model):
 
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
-    await Event.bulk_create(
-        [Event(kind="click"), Event(kind="click"), Event(kind="signup")]
-    )
 
-    # --8<-- [start:execute]
-    affected = await execute("UPDATE event SET payload = ? WHERE kind = ?", "{}", "click")
-    # --8<-- [end:execute]
-    assert affected == 2
+    async with engines.session():
+        await Event.bulk_create(
+            [Event(kind="click"), Event(kind="click"), Event(kind="signup")]
+        )
 
-    # --8<-- [start:fetch]
-    rows = await fetch_all("SELECT kind, COUNT(*) AS n FROM event GROUP BY kind ORDER BY n DESC")
-    top = await fetch_one("SELECT kind FROM event GROUP BY kind ORDER BY COUNT(*) DESC LIMIT 1")
-    # --8<-- [end:fetch]
-    assert rows[0]["n"] == 2
-    assert top is not None and top["kind"] == "click"
+        # --8<-- [start:execute]
+        affected = await execute("UPDATE event SET payload = ? WHERE kind = ?", "{}", "click")
+        # --8<-- [end:execute]
+        assert affected == 2
 
-    # --8<-- [start:in-transaction]
-    async with transaction() as tx:
-        await tx.execute("DELETE FROM event WHERE kind = ?", "click")
-        remaining = await tx.fetch_all("SELECT * FROM event")
-    # --8<-- [end:in-transaction]
-    assert len(remaining) == 1
+        # --8<-- [start:fetch]
+        rows = await fetch_all("SELECT kind, COUNT(*) AS n FROM event GROUP BY kind ORDER BY n DESC")
+        top = await fetch_one("SELECT kind FROM event GROUP BY kind ORDER BY COUNT(*) DESC LIMIT 1")
+        # --8<-- [end:fetch]
+        assert rows[0]["n"] == 2
+        assert top is not None and top["kind"] == "click"
+
+        # --8<-- [start:in-transaction]
+        async with transaction() as tx:
+            await tx.execute("DELETE FROM event WHERE kind = ?", "click")
+            remaining = await tx.fetch_all("SELECT * FROM event")
+        # --8<-- [end:in-transaction]
+        assert len(remaining) == 1
 
     print("raw_sql example ran successfully")
 

--- a/docs/examples/relationships.py
+++ b/docs/examples/relationships.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import Annotated
 
-from ferro import BackRef, Field, ForeignKey, ManyToMany, Model, Relation, connect
+from ferro import BackRef, Field, ForeignKey, ManyToMany, Model, Relation, connect, engines
 
 
 # --8<-- [start:one-to-many]
@@ -74,52 +74,53 @@ class Document(Model):
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
 
-    # --8<-- [start:one-to-many-usage]
-    team = await Team.create(name="Rustaceans")
-    crab = await Player.create(name="Ferris", team=team)
+    async with engines.session():
+        # --8<-- [start:one-to-many-usage]
+        team = await Team.create(name="Rustaceans")
+        crab = await Player.create(name="Ferris", team=team)
 
-    # Forward: awaiting the FK field loads the related instance
-    assert (await crab.team).name == "Rustaceans"
+        # Forward: awaiting the FK field loads the related instance
+        assert (await crab.team).name == "Rustaceans"
 
-    # The shadow column is available for direct reads and filters
-    assert crab.team_id == team.id
+        # The shadow column is available for direct reads and filters
+        assert crab.team_id == team.id
 
-    # Reverse: the BackRef is a chainable query
-    roster = await team.members.order_by(Player.name).all()
-    # --8<-- [end:one-to-many-usage]
-    assert len(roster) == 1
+        # Reverse: the BackRef is a chainable query
+        roster = await team.members.order_by(Player.name).all()
+        # --8<-- [end:one-to-many-usage]
+        assert len(roster) == 1
 
-    # --8<-- [start:one-to-one-usage]
-    user = await User.create(username="alice")
-    await Profile.create(bio="Pythonista", user=user)
+        # --8<-- [start:one-to-one-usage]
+        user = await User.create(username="alice")
+        await Profile.create(bio="Pythonista", user=user)
 
-    profile = await user.profile  # single instance, not a list
-    # --8<-- [end:one-to-one-usage]
-    assert profile.bio == "Pythonista"
+        profile = await user.profile  # single instance, not a list
+        # --8<-- [end:one-to-one-usage]
+        assert profile.bio == "Pythonista"
 
-    # --8<-- [start:m2m-usage]
-    sam = await Student.create(name="Sam")
-    rust101 = await Course.create(title="Rust 101")
-    python201 = await Course.create(title="Python 201")
+        # --8<-- [start:m2m-usage]
+        sam = await Student.create(name="Sam")
+        rust101 = await Course.create(title="Rust 101")
+        python201 = await Course.create(title="Python 201")
 
-    await sam.courses.add(rust101, python201)
-    assert len(await sam.courses.all()) == 2
+        await sam.courses.add(rust101, python201)
+        assert len(await sam.courses.all()) == 2
 
-    # The reverse side works the same way
-    assert len(await rust101.students.all()) == 1
+        # The reverse side works the same way
+        assert len(await rust101.students.all()) == 1
 
-    await sam.courses.remove(python201)
-    await sam.courses.clear()
-    # --8<-- [end:m2m-usage]
-    assert len(await sam.courses.all()) == 0
+        await sam.courses.remove(python201)
+        await sam.courses.clear()
+        # --8<-- [end:m2m-usage]
+        assert len(await sam.courses.all()) == 0
 
-    # --8<-- [start:self-referential-usage]
-    boss = await Employee.create(name="Grace")
-    dev = await Employee.create(name="Linus", manager=boss)
+        # --8<-- [start:self-referential-usage]
+        boss = await Employee.create(name="Grace")
+        dev = await Employee.create(name="Linus", manager=boss)
 
-    assert (await dev.manager).name == "Grace"
-    assert len(await boss.reports.all()) == 1
-    # --8<-- [end:self-referential-usage]
+        assert (await dev.manager).name == "Grace"
+        assert len(await boss.reports.all()) == 1
+        # --8<-- [end:self-referential-usage]
 
     print("relationships example ran successfully")
 

--- a/docs/examples/relationships_annotated.py
+++ b/docs/examples/relationships_annotated.py
@@ -9,7 +9,7 @@ are always assignments.
 import asyncio
 from typing import Annotated
 
-from ferro import BackRef, Field, ForeignKey, ManyToMany, Model, Relation, connect
+from ferro import BackRef, Field, ForeignKey, ManyToMany, Model, Relation, connect, engines
 
 
 # --8<-- [start:one-to-many]
@@ -80,26 +80,27 @@ class Document(Model):
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
 
-    team = await Team.create(name="Rustaceans")
-    player = await Player.create(name="Ferris", team=team)
-    assert (await player.team).id == team.id
+    async with engines.session():
+        team = await Team.create(name="Rustaceans")
+        player = await Player.create(name="Ferris", team=team)
+        assert (await player.team).id == team.id
 
-    user = await User.create(username="alice")
-    await Profile.create(bio="Pythonista", user=user)
-    assert (await user.profile).bio == "Pythonista"
+        user = await User.create(username="alice")
+        await Profile.create(bio="Pythonista", user=user)
+        assert (await user.profile).bio == "Pythonista"
 
-    sam = await Student.create(name="Sam")
-    rust101 = await Course.create(title="Rust 101")
-    await sam.courses.add(rust101)
-    assert len(await sam.courses.all()) == 1
+        sam = await Student.create(name="Sam")
+        rust101 = await Course.create(title="Rust 101")
+        await sam.courses.add(rust101)
+        assert len(await sam.courses.all()) == 1
 
-    boss = await Employee.create(name="Grace")
-    dev = await Employee.create(name="Linus", manager=boss)
-    assert (await dev.manager).name == "Grace"
+        boss = await Employee.create(name="Grace")
+        dev = await Employee.create(name="Linus", manager=boss)
+        assert (await dev.manager).name == "Grace"
 
-    lib = await Library.create(name="Main")
-    await Document.create(title="Charter", library=lib)
-    assert len(await lib.documents.all()) == 1
+        lib = await Library.create(name="Main")
+        await Document.create(title="Charter", library=lib)
+        assert len(await lib.documents.all()) == 1
 
     print("relationships_annotated example ran successfully")
 

--- a/docs/examples/soft_deletes.py
+++ b/docs/examples/soft_deletes.py
@@ -5,7 +5,7 @@ import asyncio
 # --8<-- [start:model]
 from datetime import UTC, datetime
 
-from ferro import Field, Model, connect
+from ferro import Field, Model, connect, engines
 from ferro.query import Query
 
 
@@ -42,17 +42,18 @@ class Invoice(SoftDeleteMixin, Model):
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
 
-    # --8<-- [start:usage]
-    invoice = await Invoice.create(number="INV-001")
-    await Invoice.create(number="INV-002")
+    async with engines.session():
+        # --8<-- [start:usage]
+        invoice = await Invoice.create(number="INV-001")
+        await Invoice.create(number="INV-002")
 
-    await invoice.soft_delete()
-    assert await Invoice.active().count() == 1
-    assert await Invoice.select().count() == 2  # row still exists
+        await invoice.soft_delete()
+        assert await Invoice.active().count() == 1
+        assert await Invoice.select().count() == 2  # row still exists
 
-    await invoice.restore()
-    assert await Invoice.active().count() == 2
-    # --8<-- [end:usage]
+        await invoice.restore()
+        assert await Invoice.active().count() == 2
+        # --8<-- [end:usage]
 
     print("soft_deletes example ran successfully")
 

--- a/docs/examples/soft_deletes_annotated.py
+++ b/docs/examples/soft_deletes_annotated.py
@@ -6,7 +6,7 @@ import asyncio
 from datetime import UTC, datetime
 from typing import Annotated
 
-from ferro import Field, Model, connect
+from ferro import Field, Model, connect, engines
 from ferro.query import Query
 
 
@@ -43,13 +43,14 @@ class Invoice(SoftDeleteMixin, Model):
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
 
-    invoice = await Invoice.create(number="INV-001")
-    await invoice.soft_delete()
-    assert await Invoice.active().count() == 0
-    assert await Invoice.select().count() == 1
+    async with engines.session():
+        invoice = await Invoice.create(number="INV-001")
+        await invoice.soft_delete()
+        assert await Invoice.active().count() == 0
+        assert await Invoice.select().count() == 1
 
-    await invoice.restore()
-    assert await Invoice.active().count() == 1
+        await invoice.restore()
+        assert await Invoice.active().count() == 1
 
     print("soft_deletes_annotated example ran successfully")
 

--- a/docs/examples/testing_conftest.py
+++ b/docs/examples/testing_conftest.py
@@ -6,14 +6,15 @@ This file is snippeted into the docs; it is not meant to be executed directly.
 # --8<-- [start:fixtures]
 import pytest
 
-from ferro import connect, reset_engine, transaction
+from ferro import connect, engines, reset_engine, transaction
 
 
 @pytest.fixture
 async def db():
     """Fresh in-memory database per test."""
     await connect("sqlite::memory:", auto_migrate=True)
-    yield
+    async with engines.session():
+        yield
     reset_engine()
 
 

--- a/docs/examples/timestamps.py
+++ b/docs/examples/timestamps.py
@@ -5,7 +5,7 @@ import asyncio
 # --8<-- [start:model]
 from datetime import UTC, datetime
 
-from ferro import Field, Model, connect
+from ferro import Field, Model, connect, engines
 
 
 def utcnow() -> datetime:
@@ -35,16 +35,17 @@ class Note(TimestampMixin, Model):
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
 
-    # --8<-- [start:usage]
-    note = await Note.create(text="first draft")
-    original = note.updated_at
+    async with engines.session():
+        # --8<-- [start:usage]
+        note = await Note.create(text="first draft")
+        original = note.updated_at
 
-    note.text = "second draft"
-    await note.save()
+        note.text = "second draft"
+        await note.save()
 
-    assert note.updated_at > original
-    assert note.created_at <= note.updated_at
-    # --8<-- [end:usage]
+        assert note.updated_at > original
+        assert note.created_at <= note.updated_at
+        # --8<-- [end:usage]
 
     print("timestamps example ran successfully")
 

--- a/docs/examples/timestamps_annotated.py
+++ b/docs/examples/timestamps_annotated.py
@@ -6,7 +6,7 @@ import asyncio
 from datetime import UTC, datetime
 from typing import Annotated
 
-from ferro import Field, Model, connect
+from ferro import Field, Model, connect, engines
 
 
 def utcnow() -> datetime:
@@ -36,12 +36,13 @@ class Note(TimestampMixin, Model):
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
 
-    note = await Note.create(text="first draft")
-    original = note.updated_at
+    async with engines.session():
+        note = await Note.create(text="first draft")
+        original = note.updated_at
 
-    note.text = "second draft"
-    await note.save()
-    assert note.updated_at > original
+        note.text = "second draft"
+        await note.save()
+        assert note.updated_at > original
 
     print("timestamps_annotated example ran successfully")
 

--- a/docs/examples/transactions.py
+++ b/docs/examples/transactions.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from ferro import Field, Model, connect, transaction
+from ferro import Field, Model, connect, engines, transaction
 
 
 class Account(Model):
@@ -14,42 +14,43 @@ class Account(Model):
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
 
-    checking = await Account.create(owner="alice", balance=100)
-    savings = await Account.create(owner="alice", balance=0)
+    async with engines.session():
+        checking = await Account.create(owner="alice", balance=100)
+        savings = await Account.create(owner="alice", balance=0)
 
-    # --8<-- [start:basic]
-    async with transaction():
-        checking.balance -= 25
-        await checking.save()
-
-        savings.balance += 25
-        await savings.save()
-    # Both writes commit together when the block exits cleanly
-    # --8<-- [end:basic]
-    await checking.refresh()
-    assert checking.balance == 75
-
-    # --8<-- [start:rollback]
-    try:
+        # --8<-- [start:basic]
         async with transaction():
-            checking.balance -= 1000
+            checking.balance -= 25
             await checking.save()
-            raise RuntimeError("insufficient funds")
-    except RuntimeError:
-        pass
 
-    await checking.refresh()
-    # The failed write was rolled back
-    assert checking.balance == 75
-    # --8<-- [end:rollback]
+            savings.balance += 25
+            await savings.save()
+        # Both writes commit together when the block exits cleanly
+        # --8<-- [end:basic]
+        await checking.refresh()
+        assert checking.balance == 75
 
-    # --8<-- [start:handle]
-    async with transaction() as tx:
-        await Account.create(owner="bob")
-        # Raw SQL on the same connection, inside the same transaction
-        rows = await tx.fetch_all("SELECT COUNT(*) AS n FROM account")
-    # --8<-- [end:handle]
-    assert rows[0]["n"] == 3
+        # --8<-- [start:rollback]
+        try:
+            async with transaction():
+                checking.balance -= 1000
+                await checking.save()
+                raise RuntimeError("insufficient funds")
+        except RuntimeError:
+            pass
+
+        await checking.refresh()
+        # The failed write was rolled back
+        assert checking.balance == 75
+        # --8<-- [end:rollback]
+
+        # --8<-- [start:handle]
+        async with transaction() as tx:
+            await Account.create(owner="bob")
+            # Raw SQL on the same connection, inside the same transaction
+            rows = await tx.fetch_all("SELECT COUNT(*) AS n FROM account")
+        # --8<-- [end:handle]
+        assert rows[0]["n"] == 3
 
     print("transactions example ran successfully")
 

--- a/docs/pages/concepts/identity-map.md
+++ b/docs/pages/concepts/identity-map.md
@@ -1,10 +1,10 @@
 # Identity Map
 
-Ferro keeps an identity map: within a single session and connection, the same database row resolves to the same Python object.
+Ferro keeps an identity map: within a single session, the same database row resolves to the same Python object. The map holds weak references only, so it never keeps an instance alive on its own, and it never serves a stale row — a re-fetch always reflects the database's current values.
 
 ## What It Is
 
-The identity map is a session-scoped cache in the Rust engine, keyed by `(connection, model name, primary key)`. When a query hydrates a row whose primary key is already in the session map, Ferro returns the existing instance instead of building a duplicate.
+The identity map is a session-scoped table in the Rust engine, keyed by `(connection, model name, primary key)`. Each entry is a **weak reference** to a Python instance, not the instance itself.
 
 ```mermaid
 graph LR
@@ -13,16 +13,21 @@ graph LR
     IM --> Same[Same Python instance]
 ```
 
-Each active session keeps its own map. Within a session, connection routing is deterministic and tracked independently from other concurrent sessions.
+Two consequences follow directly from "weak reference":
 
-## Why It Matters
+- **The map never keeps an instance alive.** When your code drops the last reference to an instance, it is released like any other Python object — the map's entry becomes a tombstone that is cleaned up (either on the next lookup that hits it, or by a periodic sweep) rather than a leak. The next fetch for that row hydrates a brand-new instance.
+- **Dedup only holds while you hold a reference.** `a is b` across two fetches is guaranteed only as long as something in your code still references the first instance.
 
-Without an identity map, two queries that return the same row give you two disconnected copies; an update to one is invisible through the other. With it, "row 1" means one object everywhere in your process:
+Each active session has its own map, so instances from one session are never returned by a fetch in another. There is no process-global map: **`Model.get()` and every other fetch always execute a query against the database** — the identity map decides whether that query's result is returned as a new instance or as the instance you already hold; it is a deduplication table, not a query cache.
+
+## The Guarantee: Refresh-on-Load
+
+Within a session, fetching a row you already hold returns the same object, updated in place to the database's current values. Unsaved local mutations are overwritten by a re-fetch — the database wins.
 
 === "Assignment"
 
     ```python
-    from ferro import Field, Model, connect, engines
+    from ferro import Field, Model, connect, engines, execute
 
 
     class User(Model):
@@ -34,18 +39,21 @@ Without an identity map, two queries that return the same row give you two disco
     await connect("sqlite::memory:", auto_migrate=True)
 
     async with engines.session():
+        user = await User.create(username="alice", email="alice@example.com")
 
-        created = await User.create(username="alice", email="alice@example.com")
-        fetched = await User.get(created.id)
-        filtered = await User.where(lambda t: t.username == "alice").first()
+        # Something else — another request, a script, a raw SQL statement —
+        # changes this row without going through `user`.
+        await execute("UPDATE user SET email = ? WHERE id = ?", "new@example.com", user.id)
 
-        # One row, one instance.
-        assert fetched is created
-        assert filtered is created
+        refetched = await User.get(user.id)
+        assert refetched is user               # same object
+        assert user.email == "new@example.com"  # refreshed in place
 
-        # A change made through any reference is visible through all of them.
-        fetched.email = "new@example.com"
-        assert created.email == "new@example.com"
+        # An unsaved local edit does not survive a re-fetch: the database wins.
+        user.email = "unsaved edit"
+        again = await User.get(user.id)
+        assert again is user
+        assert user.email == "new@example.com"
     ```
 
 === "Annotated"
@@ -53,7 +61,7 @@ Without an identity map, two queries that return the same row give you two disco
     ```python
     from typing import Annotated
 
-    from ferro import Field, Model, connect, engines
+    from ferro import Field, Model, connect, engines, execute
 
 
     class User(Model):
@@ -65,25 +73,74 @@ Without an identity map, two queries that return the same row give you two disco
     await connect("sqlite::memory:", auto_migrate=True)
 
     async with engines.session():
+        user = await User.create(username="alice", email="alice@example.com")
 
-        created = await User.create(username="alice", email="alice@example.com")
-        fetched = await User.get(created.id)
-        filtered = await User.where(lambda t: t.username == "alice").first()
+        # Something else — another request, a script, a raw SQL statement —
+        # changes this row without going through `user`.
+        await execute("UPDATE user SET email = ? WHERE id = ?", "new@example.com", user.id)
 
-        # One row, one instance.
-        assert fetched is created
-        assert filtered is created
+        refetched = await User.get(user.id)
+        assert refetched is user               # same object
+        assert user.email == "new@example.com"  # refreshed in place
 
-        # A change made through any reference is visible through all of them.
-        fetched.email = "new@example.com"
-        assert created.email == "new@example.com"
+        # An unsaved local edit does not survive a re-fetch: the database wins.
+        user.email = "unsaved edit"
+        again = await User.get(user.id)
+        assert again is user
+        assert user.email == "new@example.com"
     ```
 
-This guarantee holds within one process and one connection. It does **not** synchronize across processes — if another process (or another tool entirely) updates the database, your cached instance is stale until you refresh or evict it.
+Merging old and new field values was considered and rejected: a merge policy is exactly how stale-read bugs survive. If you have local changes you care about, `save()` them before the next fetch touches that row — or don't hold onto a mutated-but-unsaved instance across an `await` that could re-fetch it.
+
+## Why It Matters
+
+Without an identity map, two queries that return the same row give you two disconnected copies; an update to one is invisible through the other:
+
+```python
+async with engines.session():
+    created = await User.create(username="alice", email="alice@example.com")
+    fetched = await User.get(created.id)
+    filtered = await User.where(lambda t: t.username == "alice").first()
+
+    # One row, one instance.
+    assert fetched is created
+    assert filtered is created
+
+    # A change made through any reference is visible through all of them.
+    fetched.email = "new@example.com"
+    assert created.email == "new@example.com"
+```
+
+This holds within one session on one connection. It does not synchronize across processes or across sessions in the same process — each session has its own map, by design (see below).
+
+## No Session, No Identity
+
+Identity is a session feature, because the session is what bounds the map's lifetime. Ferro resolves the connection for every operation exactly once, and that resolution has three outcomes:
+
+- **A session is active** (ambient `async with engines.session():`, or an explicit `session=`) — full identity semantics: dedup, weak-value map, refresh-on-load, all scoped to that session.
+- **`using="name"` alone, no session** — the operation runs normally against that connection, but with **no identity map at all**: every load returns a fresh instance, nothing is cached, and therefore nothing can go stale.
+- **No session and no `using=`** — Ferro raises `RuntimeError("No database route for this operation...")` rather than guessing a connection.
+
+```python
+await connect("sqlite::memory:", auto_migrate=True)
+
+# `using=` alone: no session, so no identity map. Every load is a fresh
+# instance — correct data, no `a is b` guarantee.
+created = await User.using("default").create(username="bob", email="bob@example.com")
+first = await User.using("default").get(created.id)
+second = await User.using("default").get(created.id)
+assert first is not second
+assert first.email == second.email  # same row, different objects
+
+# No session, no `using=`: nothing to route through. Raises RuntimeError.
+await User.get(created.id)
+```
+
+An explicit `using=` that names a *different* connection than the session you're ambiently inside of is also an error (`ValueError`) rather than a silent sessionless fallback — Ferro never routes an operation around the session you opened without telling you.
 
 ## What Gets Cached
 
-Instances enter the identity map whenever Ferro hydrates or persists a full model:
+Instances enter the session's identity map whenever Ferro hydrates or persists a full model, inside a session:
 
 - `Model.get(pk)` and `Model.get_or_none(pk)`
 - `.first()` and `.all()` query results
@@ -92,32 +149,46 @@ Instances enter the identity map whenever Ferro hydrates or persists a full mode
 
 What does **not** populate the map:
 
+- Any of the above run outside a session via `using=` alone — sessionless operations never touch a map, by design (see above).
 - `Model.bulk_create([...])` — bulk inserts return a row count, not instances, and deliberately skip the map for memory efficiency. Re-query if you need tracked instances afterward.
 - Raw SQL (`fetch_all` / `fetch_one`) — raw rows are plain dicts and never touch the map.
 
-## Eviction and Refresh
+## Eviction and Invalidation
 
-When you know the database has changed underneath you, you have two tools.
+Because refresh-on-load already keeps a held instance current, you rarely need to force anything by hand. Two situations still call for it: forcing a *different* instance while you hold the old one, and letting Ferro invalidate on your behalf.
 
-**Refresh** reloads an instance you hold, in place:
+**Refresh** reloads an instance you hold, in place — this is the same mechanism as an ordinary re-fetch, exposed as a method:
 
 ```python
-user = await User.get(1)
-# ... something external updates the row ...
-await user.refresh()
+async with engines.session():
+    user = await User.create(username="bob", email="bob@example.com")
+    # ... something external updates the row ...
+    await user.refresh()
 ```
 
-**Evict** removes an entry from the map so the *next* fetch hydrates fresh from the database. The primary key is passed as a string:
+**Evict** removes an entry from the session's map so the *next* fetch hydrates a fresh instance instead of the one you're currently holding — useful when you want to detach from an instance you still have a reference to, rather than wait for it to go out of scope:
 
 ```python
 from ferro import evict_instance
 
-evict_instance("User", str(user.id))
+async with engines.session():
+    user = await User.create(username="bob", email="bob@example.com")
 
-fresh = await User.get(user.id)  # hits the database, new instance
+    evict_instance("User", str(user.id))
+    fresh = await User.get(user.id)  # a new instance, not `user`
+    assert fresh is not user
 ```
 
-Eviction is also the lever for long-running batch jobs: cached instances live until evicted or until the engine is reset, so evict processed records if you sweep millions of rows in one process.
+`evict_instance` resolves the same session/`using=` scope as any other operation (pass `using=` or `session=` explicitly if you're not inside the ambient session you want to target).
+
+Ferro also evicts automatically, scoped to the session, so a batch job's cache never grows past what a memory-bounded weak-value map already keeps in check:
+
+- **Rolling back a transaction** evicts that session's entire map — a rollback means every instance created or modified inside it may no longer reflect the database, so Ferro clears the slate rather than leave you to guess which ones.
+- **Bulk `update()` / `delete()`** evict only that model's entries within the session — an unrelated model's cached instances are untouched.
+
+Because eviction is scoped to `(connection, session)` or `(connection, model)`, one session's rollback or bulk write never disturbs another session's cache.
+
+One case is intentionally *not* covered: running `ferro.migrate()` while a session is open does not evict that session's identity map. Schema changes and live sessions are your own responsibility to sequence — this is unchanged from before weak-valued maps and refresh-on-load existed.
 
 ## Opting Out
 
@@ -129,11 +200,11 @@ from ferro import connect
 await connect("sqlite::memory:", auto_migrate=True, identity_map=False)
 ```
 
-With `identity_map=False`, every load returns a fresh instance and the map is never consulted. You give up the `a is b` guarantee across loads in exchange for lower memory use — appropriate for read-heavy ETL-style workloads where instance identity carries no meaning.
+With `identity_map=False`, sessions opened on this connection never keep an identity map: every load returns a fresh instance, and there is no `a is b` guarantee even inside a session. Since the map is already weak-valued and memory-bounded, this option is about giving up dedup semantics you don't need — not about memory pressure — and suits read-heavy, ETL-style workloads where instance identity carries no meaning.
 
 ## Identity Map in Tests
 
-Because the map persists for the lifetime of a connection, tests that share a process must reset state between cases or earlier tests' instances will leak into later ones. `reset_engine()` tears down all connections and their identity maps:
+Because a session's map lives for the session's lifetime, tests that share a process should still reset connection state between cases so one test's connections and sessions never leak into the next. `reset_engine()` tears down all connections and any sessions still open on them:
 
 ```python
 import pytest

--- a/docs/pages/concepts/identity-map.md
+++ b/docs/pages/concepts/identity-map.md
@@ -22,7 +22,7 @@ Without an identity map, two queries that return the same row give you two disco
 === "Assignment"
 
     ```python
-    from ferro import Field, Model, connect
+    from ferro import Field, Model, connect, engines
 
 
     class User(Model):
@@ -33,17 +33,19 @@ Without an identity map, two queries that return the same row give you two disco
 
     await connect("sqlite::memory:", auto_migrate=True)
 
-    created = await User.create(username="alice", email="alice@example.com")
-    fetched = await User.get(created.id)
-    filtered = await User.where(lambda t: t.username == "alice").first()
+    async with engines.session():
 
-    # One row, one instance.
-    assert fetched is created
-    assert filtered is created
+        created = await User.create(username="alice", email="alice@example.com")
+        fetched = await User.get(created.id)
+        filtered = await User.where(lambda t: t.username == "alice").first()
 
-    # A change made through any reference is visible through all of them.
-    fetched.email = "new@example.com"
-    assert created.email == "new@example.com"
+        # One row, one instance.
+        assert fetched is created
+        assert filtered is created
+
+        # A change made through any reference is visible through all of them.
+        fetched.email = "new@example.com"
+        assert created.email == "new@example.com"
     ```
 
 === "Annotated"
@@ -51,7 +53,7 @@ Without an identity map, two queries that return the same row give you two disco
     ```python
     from typing import Annotated
 
-    from ferro import Field, Model, connect
+    from ferro import Field, Model, connect, engines
 
 
     class User(Model):
@@ -62,17 +64,19 @@ Without an identity map, two queries that return the same row give you two disco
 
     await connect("sqlite::memory:", auto_migrate=True)
 
-    created = await User.create(username="alice", email="alice@example.com")
-    fetched = await User.get(created.id)
-    filtered = await User.where(lambda t: t.username == "alice").first()
+    async with engines.session():
 
-    # One row, one instance.
-    assert fetched is created
-    assert filtered is created
+        created = await User.create(username="alice", email="alice@example.com")
+        fetched = await User.get(created.id)
+        filtered = await User.where(lambda t: t.username == "alice").first()
 
-    # A change made through any reference is visible through all of them.
-    fetched.email = "new@example.com"
-    assert created.email == "new@example.com"
+        # One row, one instance.
+        assert fetched is created
+        assert filtered is created
+
+        # A change made through any reference is visible through all of them.
+        fetched.email = "new@example.com"
+        assert created.email == "new@example.com"
     ```
 
 This guarantee holds within one process and one connection. It does **not** synchronize across processes — if another process (or another tool entirely) updates the database, your cached instance is stale until you refresh or evict it.
@@ -134,13 +138,14 @@ Because the map persists for the lifetime of a connection, tests that share a pr
 ```python
 import pytest
 
-from ferro import connect, reset_engine
+from ferro import connect, engines, reset_engine
 
 
 @pytest.fixture
 async def db():
     await connect("sqlite::memory:", auto_migrate=True)
-    yield
+    async with engines.session():
+        yield
     reset_engine()
 ```
 

--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -53,7 +53,9 @@ import ferro
 await ferro.connect(APP_DATABASE_URL, name="app", default=True)
 await ferro.connect(SERVICE_DATABASE_URL, name="service")
 
-users = await User.all()                    # default connection
+async with ferro.engines.session():
+    users = await User.all()                # default connection
+
 jobs = await Job.using("service").all()     # explicit routing
 ```
 

--- a/docs/pages/howto/migrating-to-v0-12-0.md
+++ b/docs/pages/howto/migrating-to-v0-12-0.md
@@ -110,6 +110,30 @@ argument) binds to that default connection — you do not need to pass
 Need to target a specific connection from inside another session? Pass
 `session=` explicitly — it overrides the ambient session.
 
+!!! warning "v0.13 update: this removal already landed"
+    The deprecation window above described a `v0.14.0` removal. It actually
+    shipped one minor early, in `v0.13.0`, as part of the identity-map and
+    routing redesign (FF-D). If you are on `v0.13.0` or later:
+
+    - Unqualified operations with no active session and no `using=` no
+      longer warn — they raise `RuntimeError` immediately.
+    - An explicit `using=` that names a connection different from the
+      session you're ambiently inside of no longer runs silently on that
+      connection — it raises `ValueError`. Pass an explicit `session=` for
+      that connection instead, or open a session on the connection you
+      named.
+    - `using=`-only operations (no session at all) still run, but now with
+      **no identity map**: every load returns a fresh instance and nothing
+      is cached across calls. This is a behavior change, not just a
+      deprecation — the data returned is still correct and current, but
+      `a is b` across two `using=`-only fetches of the same row is no
+      longer guaranteed. Wrap the code in a session if you need that
+      guarantee back.
+
+    See [Identity Map](../concepts/identity-map.md) for the full guarantee
+    session-scoped identity now provides (weak-valued map, refresh-on-load,
+    scoped invalidation).
+
 ### 3. Build Alembic metadata from `get_metadata()`
 
 The private JSON-derivation helpers `ferro.migrations.alembic._build_sa_table`
@@ -136,7 +160,7 @@ directly in your Alembic `env.py`.
 | Deprecated surface | Replacement | Removed in |
 | --- | --- | --- |
 | `Model.where(Model.field OP value)` | `where(lambda t: ...)` or `col(Model.field)` | `v0.14.0` |
-| Unqualified ORM/raw operations outside an active session | `async with ferro.engines.session("name")` or explicit `session=` | `v0.14.0` |
+| Unqualified ORM/raw operations outside an active session | `async with ferro.engines.session("name")` or explicit `session=` | `v0.13.0` (landed early — see note above) |
 | `ferro.migrations.alembic._build_sa_table` | `ferro.migrations.get_metadata()` | `v0.14.0` |
 | `ferro.migrations.alembic._map_to_sa_type` | `ferro.migrations.get_metadata()` | `v0.14.0` |
 

--- a/docs/pages/howto/multiple-databases.md
+++ b/docs/pages/howto/multiple-databases.md
@@ -14,13 +14,15 @@ Each `connect()` call creates an independent pool, configurable per connection w
 
 ## Routing Queries
 
-Everything runs on the default connection unless routed. `Model.using(name)` returns a handle exposing the same API (`create`, `all`, `select`, `where`, `get`, `get_or_none`, `bulk_create`, `get_or_create`, `update_or_create`) pinned to the named connection:
+Operations need a route: either an open session (ambient or explicit `session=`) or an explicit `using=`. Inside `async with engines.session():`, unqualified calls resolve to that session's connection — the default connection if you opened the session with no name. `Model.using(name)` returns a handle exposing the same API (`create`, `all`, `select`, `where`, `get`, `get_or_none`, `bulk_create`, `get_or_create`, `update_or_create`) pinned to the named connection, and it runs on its own — no session required:
 
 ```python
 --8<-- "docs/examples/multiple_databases.py:routing"
 ```
 
-Routing is per-call: `using()` doesn't change any global state, so two coroutines can talk to different databases concurrently without interfering.
+Routing is per-call: `using()` doesn't change any global state, so two coroutines can talk to different databases concurrently without interfering. A `using()` call made without a session, as `analytics_metrics` is above, runs with no identity map — every load is a fresh instance, with no `a is b` guarantee across calls. See [Identity Map](../concepts/identity-map.md#no-session-no-identity) for what that trades away.
+
+An explicit `using=` that names a connection different from the session you're ambiently inside of raises `ValueError` rather than silently running outside the session — and an operation with no session and no `using=` at all raises `RuntimeError`. There is no implicit default-connection fallback.
 
 For session-first workflows, use `engines.session(name)` to pin a full block:
 
@@ -62,7 +64,7 @@ Don't run schema creation concurrently through multiple names that point at the 
 - **Keep credentials server-side.** Elevated service-role connections belong in configuration, not source control — and never make a service-role connection the default in a user-facing runtime.
 - **Never route from untrusted input.** Don't pick the `using` name from request data.
 - **Pools isolate roles, not request context.** A named connection isolates credentials and pooling; it does not provide per-request RLS/JWT context inside one shared pool. Objects loaded through an elevated connection can contain elevated data — filter before returning them to users.
-- **No automatic routing.** Read/write splitting, cross-connection joins, and two-phase commit are not features; routing is always an explicit `using` call.
+- **No automatic routing.** Read/write splitting, cross-connection joins, and two-phase commit are not features; routing is always an explicit `using=`, `session=`, or `engines.session(name)` you name yourself — never inferred from query shape or request data.
 
 ## See Also
 

--- a/docs/pages/howto/testing.md
+++ b/docs/pages/howto/testing.md
@@ -12,7 +12,7 @@ Put two fixtures in your `conftest.py`:
 
 How this works:
 
-- **`db`** connects to a fresh in-memory SQLite database for each test. `auto_migrate=True` creates tables for every registered model, so there is no schema setup to maintain. On teardown, [`reset_engine()`](../api/connection.md) closes the pool and clears the identity map, guaranteeing no state leaks between tests.
+- **`db`** connects to a fresh in-memory SQLite database for each test and holds an [`engines.session()`](../guide/connections.md#sessions-recommended) open around the test body, so ORM calls inside the test resolve against that session without extra boilerplate. `auto_migrate=True` creates tables for every registered model, so there is no schema setup to maintain. On teardown, [`reset_engine()`](../api/connection.md) closes the pool and clears the identity map, guaranteeing no state leaks between tests.
 - **`db_transaction`** layers a [`transaction()`](../guide/transactions.md) on top. Everything inside the test shares one connection, which gives you connection affinity for the duration of the test. Use it when a test mixes ORM calls with raw SQL that must observe the same uncommitted state.
 
 Since each test gets its own database, most tests only need `db`.
@@ -138,7 +138,7 @@ import uuid
 
 import pytest
 
-from ferro import connect, execute, reset_engine
+from ferro import connect, engines, execute, reset_engine
 
 POSTGRES_URL = "postgresql://localhost:5432/app_test"
 
@@ -149,14 +149,16 @@ async def pg_db():
 
     # Create the schema with a throwaway connection
     await connect(POSTGRES_URL)
-    await execute(f'CREATE SCHEMA "{schema}"')
+    async with engines.session():
+        await execute(f'CREATE SCHEMA "{schema}"')
     reset_engine()
 
     # Reconnect with the schema as the search path
     await connect(f"{POSTGRES_URL}?ferro_search_path={schema}", auto_migrate=True)
-    yield
+    async with engines.session():
+        yield
 
-    await execute(f'DROP SCHEMA "{schema}" CASCADE')
+        await execute(f'DROP SCHEMA "{schema}" CASCADE')
     reset_engine()
 ```
 

--- a/docs/plans/2026-07-02-001-fable-fixes-roadmap.md
+++ b/docs/plans/2026-07-02-001-fable-fixes-roadmap.md
@@ -29,14 +29,15 @@ state.
 | 1 | **FF-A** Mutation-surface correctness & typed errors | Public *behavior* changes — breaking after 1.0, cheap now. No dependencies. |
 | 2 | **FF-B** Structural I-1 on Postgres | Completes the IR-first program's own promise; blocks trustworthy 1.0 migrations. |
 | 3 | **FF-C** Compiled hot path | Largest epic; makes the performance pitch honest. Unblocks FF-D. |
-| 4 | **FF-D** Identity map & routing redesign | Rides the v0.14 shim-removal cutover (IR-P9); depends on FF-C's codec plan for refresh-on-load. |
+| 4 | **FF-D** Identity map & routing redesign | Landed v0.13, one minor ahead of the v0.14 shim-removal cutover (IR-P9) originally targeted; depended on FF-C's codec plan for refresh-on-load. |
 | ∥ | **FF-E** Registry & model identity | Independent; can run parallel to FF-B/FF-C. |
 | ∥ | **FF-F** Query builder 1.0 shape | Independent of FF-A–FF-D; gates the public roadmap features (aggregations, partial selects). |
 | ∥ | **FF-G** Hardening & hygiene | Small parallel items; fold into whichever epic touches the same file. |
 
 Interaction with the IR-first program: FF-B extends IR-P8.5's consolidation to
-the *derived*-type domain; FF-D's global-map removal belongs in the IR-P9 /
-v0.14 cutover. Neither replaces those phases — they sharpen their exit gates.
+the *derived*-type domain; FF-D's global-map removal landed in v0.13, ahead of
+the IR-P9 / v0.14 cutover it was originally scoped to ride. Neither replaces
+those phases — they sharpen their exit gates.
 
 ---
 
@@ -232,7 +233,7 @@ finally gets its runtime consumer.
 
 ---
 
-## Epic FF-D — Identity map & routing redesign (v0.14 cutover)
+## Epic FF-D — Identity map & routing redesign (landed v0.13)
 
 Findings: **F3** (unbounded strong refs, stale reads, global-clear
 invalidation), **F13** (triple stringly-typed route resolved twice; `using=`
@@ -240,43 +241,45 @@ silently bypasses ambient session; `Model.__init__` reads target PK by the
 *source* model's PK name).
 
 **Objective:** identity is session-scoped, memory-bounded, and never returns
-stale data; routing is resolved exactly once through one handle. Lands with
-the IR-P9 / v0.14 shim removal, which already deletes the ambient-global path.
+stale data; routing is resolved exactly once through one handle. Landed in
+v0.13, one minor ahead of the IR-P9 / v0.14 shim removal originally announced
+for the ambient-global path.
 
 **Sub-tasks**
 
-- [ ] **D1 — Weak-value identity map with refresh-on-load.**
+- [x] **D1 — Weak-value identity map with refresh-on-load.**
       Map holds weak references (instances are released when user code drops
       them). On fetch-hit, update the cached instance's `__dict__` from the
       freshly fetched row (the decoded fields are already in hand — today they
       are discarded), preserving `a is b` while eliminating the stale-read
       class. Document the guarantee precisely in
       `docs/pages/concepts/identity-map.md`.
-- [ ] **D2 — Scoped invalidation.**
+- [x] **D2 — Scoped invalidation.**
       Rollback evicts per `(connection, session)` — not the global
       everything-clear in `rollback_transaction`; bulk update/delete evict per
-      `(connection, model)`. Global `IDENTITY_MAP` is deleted with the v0.14
-      ambient-session removal (IR-P9), not kept as a fallback.
-- [ ] **D3 — One route handle.**
+      `(connection, model)`. Global `IDENTITY_MAP` is deleted in v0.13 along
+      with the ambient-session removal, not kept as a fallback.
+- [x] **D3 — One route handle.**
       Replace the `(tx_id, using, session_id)` triple threaded through every
       FFI call with a single opaque route resolved once (in
       `resolve_operation_scope`) and passed through. Rust stops re-deriving
       the connection per operation (`active_route_for_operation` collapses).
-- [ ] **D4 — `using=` vs ambient session is an error.**
+- [x] **D4 — `using=` vs ambient session is an error.**
       The silent session-bypass in `resolve_operation_scope` (explicit `using`
       different from ambient session → runs sessionless on the global map)
-      becomes a `ValueError` at the v0.14 boundary. Migration impact:
-      **breaking**; deprecation warning lands ahead of the cutover.
-- [ ] **D5 — Fix `Model.__init__` FK extraction.**
+      becomes a `ValueError`. Migration impact: **breaking**; shipped directly
+      in v0.13 with no deprecation phase — one minor ahead of the v0.14 notice
+      originally announced.
+- [x] **D5 — Fix `Model.__init__` FK extraction.**
       Relationship inputs read the *target* model's PK field name, not the
       source's (`models.py:197–204`). Correct today only because every model's
       PK is named `id`. Test with a target model whose PK is not `id`.
 
 **Exit gate**
 
-- [ ] A loop loading 1M rows shows bounded RSS after GC (memory test).
-- [ ] External UPDATE + re-fetch returns fresh values with identity preserved.
-- [ ] Exactly one route-resolution site per operation (grep-verified);
+- [x] A loop loading 1M rows shows bounded RSS after GC (memory test).
+- [x] External UPDATE + re-fetch returns fresh values with identity preserved.
+- [x] Exactly one route-resolution site per operation (grep-verified);
       v0.14 matrix green with the global map gone.
 
 ---

--- a/docs/plans/2026-07-02-005-ff-d-identity-routing-design.md
+++ b/docs/plans/2026-07-02-005-ff-d-identity-routing-design.md
@@ -1,0 +1,207 @@
+# FF-D — Identity map & routing redesign (design)
+
+**Status:** approved (design review 2026-07-02)
+**Epic:** FF-D (`docs/plans/2026-07-02-001-fable-fixes-roadmap.md` L235–281)
+**Findings closed:** F3 (unbounded strong-ref identity map, stale reads,
+global-clear invalidation), F13 (stringly-typed route triple resolved twice;
+`using=` silently bypasses ambient session; `Model.__init__` reads target PK
+by the source model's PK name).
+**Ships in:** v0.13, one PR, no deprecation staging. This lands the
+ambient-default-connection removal one minor ahead of the shipped v0.14
+deprecation notice — deliberate, accepted, and stated in the PR.
+
+**Objective:** identity is session-scoped, memory-bounded, and never returns
+stale data; routing is resolved exactly once through one handle.
+
+---
+
+## Central decision — the sessionless path (Option B)
+
+Sessions are never created implicitly. Today, an operation with
+`session_id=None` routes identity through the process-global `IDENTITY_MAP`
+(`src/state.rs:212`) — one strong-ref map shared by every sessionless op for
+the life of the process. That map is F3.
+
+**Decision: sessionless operations still run, but with no identity map.**
+
+- **Session-bound** (ambient `async with ferro.engines.session(...)` or
+  explicit `session=`): full identity semantics — dedup (`a is b`),
+  weak-value map, refresh-on-load — in `SessionState.identity_map`.
+- **Sessionless with explicit route** (`using="name"`, no session): runs
+  normally against that connection. No identity map: no dedup, no cache,
+  therefore no stale-read surface. Identity primitives' `None` arm becomes a
+  no-op (get → miss, insert → nothing).
+- **No route at all** (no session, no `using`): **error.** The
+  legacy default-connection path (deprecated since v0.12, removal announced
+  for v0.14) is removed now. Structurally unrepresentable — see RouteHandle.
+
+Rejected alternatives:
+
+- **A — sessions mandatory:** breaks legitimate, non-deprecated
+  `using=`-only code; the v0.14 notice never announced universal sessions.
+- **C — implicit per-operation session:** a per-op session's map dies with
+  the op, so it never dedupes across calls — behaviorally identical to B
+  plus a `register_session`/`close_session` round-trip per query. Giving the
+  implicit session a longer lifetime has no natural boundary and
+  reintroduces F3.
+
+Identity is a feature you opt into by naming a scope, because the scope is
+the only honest bound on the map's lifetime.
+
+**User-observable breakage (v0.13):**
+
+1. No-session, no-`using` operations raise instead of warning (was: v0.14).
+2. Explicit `using=` conflicting with the ambient session raises
+   `ValueError` instead of silently running sessionless (D4).
+3. `using=`-only code loses cross-call `a is b` (the data is fresh; only
+   object identity is gone — wrap in a session to get it back).
+
+---
+
+## D1a — Weak-value identity map
+
+**Representation.** Map value changes from a strong `Py<PyAny>` (the
+instance) to a `Py<PyAny>` holding a **`weakref.ref(instance)`** created at
+insert time via PyO3's weakref API. Key shape unchanged:
+`(connection_name, model_name, pk_string)`. Lives only on
+`SessionState.identity_map` (`src/state.rs:225`); the global map is deleted
+(D2). The map owns the weakref object strongly; the instance is kept alive
+only by user code.
+
+- **get:** fetch entry → **upgrade** (call the weakref) → live strong ref =
+  hit; dead referent = remove tombstone, report miss. Hit-vs-miss is decided
+  on the upgraded strong ref, never the raw entry, so the instance cannot
+  die between "hit" and "use".
+- **insert:** create the weakref; if the class cannot be weakly referenced,
+  raise a clear `TypeError` — **never** silently fall back to a strong ref.
+  First red test proves pydantic v2 `BaseModel` supports `weakref.ref`; the
+  Ferro metaclass gains a class-definition-time guard so a user-added
+  `__slots__` fails loudly there, not at runtime.
+
+**Pruning — amortized sweep, no weakref callbacks.**
+
+- get-side: any lookup hitting a dead ref removes that entry immediately;
+- sweep: per-map atomic op counter triggers `retain(alive)` every ~1024 ops
+  — O(map) per sweep, amortized O(1)/op.
+
+Weakref callbacks (exact delete-on-death) are rejected: a callback fires
+during refcount-drop/GC at unpredictable points and would re-enter the
+`DashMap` — possibly on a shard lock already held by the same thread across
+the FFI boundary (deadlock; AGENTS.md I-3). The sweep is lock-safe and
+bounds memory at *live instances + ≤N tombstones* (tombstones are a key +
+dead weakref, ~tens of bytes). Session close drops the whole map, as today.
+
+## D1b — Refresh-on-load
+
+On fetch-hit the decoded row is currently discarded
+(`src/operations.rs:991–997`, ~`:1824`, single-get ~`:1054`). Instead:
+write the fresh values into the cached live instance and return it —
+`a is b` preserved, values current.
+
+- **One materialization path.** Extract the field-materialization step of
+  `hydrate_model_instance` (decoded values → Python objects, including FK
+  columns and FF-C plan-driven enum hydration) into a helper shared by fresh
+  hydration and refresh. Refresh: upgrade weakref → overwrite
+  `instance.__dict__[field]` for **every** decoded field → reset
+  `__pydantic_fields_set__` to the full decoded-field set (identical to a
+  freshly hydrated instance) → preserve `_ferro_persisted`/origin internals.
+  Shared path = refresh cannot drift from hydration; partial writes are
+  structurally impossible.
+- **Guarantee** (documented in `docs/pages/concepts/identity-map.md`):
+  *within a session, fetching a row you already hold returns the same
+  object, updated in place to the database's current values.* Corollary,
+  stated explicitly: **unsaved local mutations are overwritten by a
+  re-fetch — the database wins.** Merging is how stale-read bugs survive.
+
+## D2 — Scoped invalidation + global-map deletion
+
+- `rollback_transaction` (`src/operations.rs:825`) stops calling the global
+  everything-clear; it evicts the affected `(connection, session)` scope:
+  the session's map when `session_id` is set — and under Option B the
+  sessionless arm has no map, so nothing to clear.
+- Bulk update/delete evict per `(connection, model)` via the existing
+  `identity_map_retain_model` shape (`src/operations.rs:148`), scoped to the
+  session map.
+- Delete `static IDENTITY_MAP` (`src/state.rs:212`) and its clear sites
+  (`src/connection.rs:315`, `src/migrate.rs:886`). Not kept as a fallback;
+  the identity primitives' `None` arm is a no-op, not a global.
+- Session/transaction isolation semantics of `SessionState` are unchanged.
+
+## D3 — One route handle
+
+**Shape: frozen `#[pyclass]` passed by value — not a token into a registry**
+(a registry adds allocation, an eviction policy, and a lifetime bug surface
+for three small fields).
+
+```rust
+#[pyclass(frozen)]
+pub struct RouteHandle {
+    tx_id: Option<String>,      // Some → route through this tx's pinned conn
+    connection_name: String,    // always resolved, never None
+    session_id: Option<String>, // Some → session identity map; None → none
+}
+```
+
+- **Resolved exactly once** in `resolve_operation_scope`
+  (`src/ferro/state.py:65`; `resolve_transaction_scope` at `:122` likewise):
+  Python reads the ambient contextvars (session, tx) and makes one FFI call
+  that validates and returns the handle. Every operation signature collapses
+  from `(tx_id=None, using=None, session_id=None)` (~22 signatures) to
+  `(route)`. `active_route_for_operation` (`src/operations.rs:75`, 18
+  callers) reduces to reading the handle's fields; engine lookup by
+  `connection_name` stays a cheap map hit inside Rust (`Arc<EngineHandle>`
+  does not cross the boundary).
+- **`connection_name` is non-optional** — the ambient-default path is not an
+  error branch to maintain; a routeless handle is unrepresentable.
+- Rollout: change the Rust signatures first and let the compiler enumerate
+  call sites; Python follows the new `resolve_operation_scope` return type
+  through `models.py` / `raw.py` / `query/builder.py`. Grep-verified
+  "one route-resolution site per operation" is the backstop.
+
+## D4 — `using=` vs ambient session is an error
+
+In the same single resolution site: explicit `using` ≠ ambient session's
+connection → `ValueError` (replaces the silent `effective_session = None`
+bypass at `src/ferro/state.py:86–87`). Explicit `using` ≠ explicit
+`session=` already raises and continues to. No deprecation phase.
+
+## D5 — `Model.__init__` FK extraction
+
+`src/ferro/models.py:214–220` scans the **source** class's `ferro_fields`
+for the PK name, then reads that name off the **target** instance — correct
+today only because every PK is named `id`. Fix: resolve the PK field from
+`val.__class__` (the target model). Test with a target whose PK ≠ `id`.
+
+---
+
+## Build order & commits
+
+D5 (isolated warm-up) → D1 (weak map + refresh-on-load) → D4 + D3 (remove
+ambient path, collapse routing) → D2 (scoped eviction, delete global map).
+Separate conventional commits, scope `ff-d`, `!` on the user-observable
+breaking commits (D4 error, ambient-path removal). Branch
+`ff-d/identity-and-routing`.
+
+## Testing (exit gates, written first, red before implementation)
+
+1. **Memory bound:** loop loading ~1M rows in a session → bounded RSS after
+   GC (strong-ref map fails today).
+2. **Stale read:** external `UPDATE` + re-fetch → fresh values with
+   `a is b` preserved (fails today).
+3. **D5:** relationship input whose target model's PK ≠ `id` extracts the
+   right value.
+4. **Scoped invalidation:** rollback evicts only the affected
+   `(connection, session)`; bulk update/delete only `(connection, model)`;
+   an unrelated cached instance survives.
+5. **One route site:** grep-verifiable single route-resolution per
+   operation.
+6. **`using` conflict:** explicit `using` ≠ ambient session raises
+   `ValueError`; no-session no-`using` raises.
+7. **Weakref support:** `weakref.ref(instance)` works on Ferro models;
+   a weakref-suppressing class fails loudly at class definition.
+
+Verification matrix: `cargo test` (crates + root
+`--no-default-features --features testing`); full
+`FERRO_POSTGRES_URL=... just test` green with the global map gone;
+shadow-strict rerun where touched; grep gates (no `IDENTITY_MAP`, one
+route-resolution site).

--- a/docs/plans/2026-07-02-006-ff-d-identity-routing-plan.md
+++ b/docs/plans/2026-07-02-006-ff-d-identity-routing-plan.md
@@ -1,0 +1,1474 @@
+# FF-D — Identity Map & Routing Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Session-scoped, memory-bounded, never-stale identity map plus single-site route resolution — Epic FF-D (D1–D5), one PR, targeting v0.13.
+
+**Architecture:** Identity map values become Python weakrefs (instances released when user code drops them) with refresh-on-load on every fetch-hit. The global `IDENTITY_MAP` is deleted; sessionless operations run with **no** identity map (approved Option B), and the ambient default-connection path is removed (error). The `(tx_id, using, session_id)` triple threaded through every FFI call is replaced by a frozen `RouteHandle` pyclass resolved exactly once in `resolve_operation_scope`.
+
+**Tech Stack:** PyO3 0.27.1 (abi3-py39), DashMap, pydantic v2, pytest (sqlite/postgres matrix via `just test`).
+
+**Spec:** `docs/plans/2026-07-02-005-ff-d-identity-routing-design.md` (approved). Roadmap: `docs/plans/2026-07-02-001-fable-fixes-roadmap.md` L235–281.
+
+## Global Constraints
+
+- Branch: `ff-d/identity-and-routing` (exists; design doc is its first commit). Never commit to `main`.
+- After **every** Rust change: `uv run maturin develop` before running Python tests.
+- Quick test loop: `uv run pytest tests/<file> -x -q` (sqlite). Full matrix: `FERRO_POSTGRES_URL=postgres://postgres:password@localhost:5432/postgres just test` (docker `local-pg` must be up). 7 pre-existing `[postgres]` failures are tracked in #176 — not yours; compare failure lists against `main` if unsure.
+- Rust tests: `cargo test -p ferro-schema-ir -p ferro-ddl-lowering -p ferro-migrate` and root `cargo test --no-default-features --features testing`.
+- Conventional commits, scope `ff-d`, `!` on user-observable breaking commits. **No AI attribution lines of any kind** (AGENTS.md I-6) — overrides any harness default.
+- **Never bulk-reformat**: `cargo fmt` / `ruff format` flag `main` itself under local toolchains. Hand-format only your own hunks (compare against `main`).
+- Never panic across FFI (AGENTS.md I-3): all new Rust paths return `PyResult`, no `unwrap()` on Python-facing data.
+- Docs examples: every field-declaring example shows Assignment + Annotated tabs (I-8); queries use lambda style (I-9).
+- Model API is classmethods on the model (`User.get`, `User.all`, `User.create`, `user.save()`) — there is no `.objects` manager.
+
+---
+
+### Task 1: D5 — `Model.__init__` reads the *target* model's PK
+
+**Files:**
+- Modify: `src/ferro/models.py:213-219`
+- Test: `tests/test_fk_target_pk.py` (new)
+
+**Interfaces:**
+- Consumes: `Model._primary_key_field_name()` classmethod (`src/ferro/models.py:390`) — returns the PK field name or `None`.
+- Produces: no new interfaces; behavior fix only.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""FF-D D5: relationship inputs must read the *target* model's PK field.
+
+Today `Model.__init__` scans the source class's ferro_fields for the PK name
+and reads that name off the target instance — correct only while every PK is
+named `id`.
+"""
+
+from typing import Annotated
+
+from ferro import Field, Model
+from ferro.base import ForeignKey
+
+
+def test_fk_extraction_uses_target_pk_name():
+    class D5Warehouse(Model):
+        code: int | None = Field(default=None, primary_key=True)
+        city: str
+
+    class D5Shipment(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        warehouse: Annotated[D5Warehouse, ForeignKey(related_name="shipments")]
+
+    wh = D5Warehouse(code=7, city="Reno")
+    shipment = D5Shipment(warehouse=wh)
+    assert shipment.warehouse_id == 7
+
+
+def test_fk_extraction_with_target_pk_named_id_still_works():
+    class D5Author(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    class D5Book(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        author: Annotated[D5Author, ForeignKey(related_name="books")]
+
+    a = D5Author(id=3, name="x")
+    b = D5Book(author=a)
+    assert b.author_id == 3
+```
+
+(No `connect()` needed — this exercises pure `__init__` normalization. Class names are prefixed `D5` because the registry keys on bare class names.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_fk_target_pk.py -x -q`
+Expected: first test FAILS with `assert None == 7` (source-model PK name `id` read off a target that has no `id`).
+
+- [ ] **Step 3: Fix `Model.__init__`**
+
+Replace the PK-scan loop in `src/ferro/models.py` (currently lines 213–219, scanning `self.__class__.ferro_fields`):
+
+```python
+                # If it's a Model instance, extract the ID
+                if isinstance(val, Model):
+                    # Read the *target* model's PK (FF-D D5) — the source
+                    # model's PK name is irrelevant to the related instance.
+                    pk_field = val.__class__._primary_key_field_name() or "id"
+                    id_val = getattr(val, pk_field, None)
+                    data[f"{field_name}_id"] = id_val
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/test_fk_target_pk.py -q` → both PASS.
+Run: `uv run pytest tests/test_crud.py tests/test_relationship_engine.py -q` → no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_fk_target_pk.py src/ferro/models.py
+git commit -m "fix(ff-d): D5 — extract FK value via the target model's PK field"
+```
+
+---
+
+### Task 2: Weakref foundation — pinning tests + metaclass guard
+
+**Files:**
+- Modify: `src/ferro/metaclass.py` (guard in `ModelMetaclass.__new__`, `src/ferro/metaclass.py:35-40`)
+- Test: `tests/test_identity_weakref.py` (new)
+
+**Interfaces:**
+- Produces: `ferro.metaclass._assert_weakref_support(cls) -> None` — raises `TypeError` if instances of `cls` cannot be weakly referenced. Called from `ModelMetaclass.__new__` on every model class. Task 3's Rust insert path is the runtime backstop.
+
+- [ ] **Step 1: Probe the assumption (the trap check)**
+
+Run:
+```bash
+uv run python -c "
+import weakref
+from ferro import Field, Model
+class P(Model):
+    id: int | None = Field(default=None, primary_key=True)
+u = P(id=1)
+r = weakref.ref(u)
+assert r() is u
+del u
+import gc; gc.collect()
+assert r() is None
+print('pydantic v2 Model instances are weakref-able: OK')
+"
+```
+Expected: prints OK. If this fails, STOP — the whole D1 design needs revisiting; report back before proceeding.
+
+- [ ] **Step 2: Write the pinning tests + guard test**
+
+`tests/test_identity_weakref.py`:
+
+```python
+"""FF-D D1: Ferro identity mapping requires weakly referenceable instances."""
+
+import gc
+import weakref
+
+import pytest
+
+from ferro import Field, Model
+from ferro.metaclass import _assert_weakref_support
+
+
+def test_model_instances_support_weakref():
+    class WRUser(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    u = WRUser(id=1, name="a")
+    r = weakref.ref(u)
+    assert r() is u
+    del u
+    gc.collect()
+    assert r() is None
+
+
+def test_weakref_guard_rejects_unweakrefable_class():
+    class NoWeakref:
+        __slots__ = ()  # no __dict__, no __weakref__ anywhere in MRO
+
+    with pytest.raises(TypeError, match="weak"):
+        _assert_weakref_support(NoWeakref)
+
+
+def test_weakref_guard_accepts_model_classes():
+    class WRGuarded(Model):
+        id: int | None = Field(default=None, primary_key=True)
+
+    _assert_weakref_support(WRGuarded)  # must not raise
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `uv run pytest tests/test_identity_weakref.py -x -q`
+Expected: FAIL with `ImportError: cannot import name '_assert_weakref_support'`.
+
+- [ ] **Step 4: Implement the guard**
+
+In `src/ferro/metaclass.py`, add near the top (module level):
+
+```python
+def _assert_weakref_support(cls: type) -> None:
+    """Reject model classes whose instances cannot be weakly referenced.
+
+    The identity map holds weak references to instances (FF-D D1). A class
+    that suppresses ``__weakref__`` would force a silent strong-ref fallback,
+    which is exactly the unbounded-memory failure F3 removed — so it fails
+    loudly at class definition time instead.
+    """
+    if not any("__weakref__" in getattr(base, "__dict__", {}) for base in cls.__mro__):
+        raise TypeError(
+            f"{cls.__name__} instances do not support weak references "
+            "(no __weakref__ slot in the MRO). Ferro model instances must be "
+            "weakly referenceable for identity mapping; remove __slots__ "
+            "declarations that suppress __weakref__."
+        )
+```
+
+In `ModelMetaclass.__new__`, after the class object is created (the `cls = super().__new__(...)` result) and before it is returned, add:
+
+```python
+        _assert_weakref_support(cls)
+```
+
+(Read the actual `__new__` body first; insert after class creation, before return. Do not guard `Model` itself out — the base class passes the check via pydantic's `__weakref__`.)
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `uv run pytest tests/test_identity_weakref.py -q` → 3 PASS.
+Run: `uv run pytest tests/test_crud.py tests/test_field_wrapper.py -q` → model creation unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_identity_weakref.py src/ferro/metaclass.py
+git commit -m "feat(ff-d): D1 groundwork — weakref pinning tests and metaclass guard"
+```
+
+---
+
+### Task 3: D1a — Weak-value identity map (Rust)
+
+**Files:**
+- Modify: `src/state.rs` (SessionState gets a sweep counter; global map stays *transitionally*, now holding weakrefs — deleted in Task 8)
+- Modify: `src/operations.rs:106-165` (primitives), plus every primitive call site: `:853, :991, :1010, :1054, :1154, :1824, :1843, :2010, :2039, :2169, :2258`
+- Modify: `src/lib.rs` (register `identity_map_len`)
+- Test: `tests/test_identity_memory.py` (new)
+
+**Interfaces:**
+- Produces (Rust, private): `identity_map_get(py, session_id, key) -> PyResult<Option<Py<PyAny>>>` — returns an **upgraded strong ref** or `None` (dead entries pruned on sight); `identity_map_insert(py, session_id, key, value: &Bound<PyAny>) -> PyResult<()>` — stores a weakref, `TypeError` if the value can't be weakly referenced; `maybe_sweep(py, map, ops)`.
+- Produces (FFI, test diagnostic): `_core.identity_map_len(session_id: str | None = None) -> int` — count of **live** entries.
+- Rule established here: **every identity primitive takes `py: Python<'_>` first** — GIL before shard lock, always. No map access without the GIL in scope.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_identity_memory.py`:
+
+```python
+"""FF-D D1a exit gate: the identity map is memory-bounded.
+
+The map holds weak references: instances are released when user code drops
+them; a dead entry is a miss. This is the deterministic form of the roadmap's
+"bounded RSS after GC" gate — live-entry count and weakref death prove the
+bound without RSS flakiness. (Strong-ref map fails both tests today.)
+"""
+
+import gc
+import weakref
+
+import pytest
+
+from ferro import Field, Model, connect, engines
+from ferro._core import identity_map_len
+
+
+@pytest.mark.asyncio
+async def test_dropped_instances_are_released_by_the_map(db_url):
+    class MemItem(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        payload: str
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session() as s:
+        created = await MemItem.create(payload="x")
+        pk = created.id
+        ref = weakref.ref(created)
+
+        del created
+        gc.collect()
+        # The map must not keep the instance alive.
+        assert ref() is None
+
+        # A dead entry is a miss: re-fetch hydrates a fresh, correct instance.
+        fresh = await MemItem.get(pk)
+        assert fresh.id == pk
+        assert fresh.payload == "x"
+
+
+@pytest.mark.asyncio
+async def test_identity_map_is_bounded_under_bulk_scanning(db_url):
+    class MemScan(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        n: int
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session() as s:
+        await MemScan.bulk_create([MemScan(n=i) for i in range(20_000)])
+        for _ in range(3):
+            rows = await MemScan.all()
+            assert len(rows) == 20_000
+            del rows
+            gc.collect()
+            # Live entries collapse once user refs are gone — the map is
+            # bounded by *live* instances, not by rows ever loaded.
+            assert identity_map_len(s.session_id) < 100
+
+
+@pytest.mark.asyncio
+async def test_identity_dedup_still_works_for_live_instances(db_url):
+    class MemLive(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        n: int
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        a = await MemLive.create(n=1)
+        b = await MemLive.get(a.id)
+        assert b is a  # weak map still dedupes while the instance is alive
+```
+
+(Check how existing async tests are marked — if the suite uses `asyncio_mode = auto`, drop the explicit `@pytest.mark.asyncio`; mirror `tests/test_session.py`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_identity_memory.py -x -q`
+Expected: FAIL — first test at `assert ref() is None` (map holds strong ref today); also `ImportError` for `identity_map_len` (add the import failure note: that alone confirms red).
+
+- [ ] **Step 3: Add sweep counters to `src/state.rs`**
+
+Add `use std::sync::atomic::AtomicUsize;` to imports. Change:
+
+```rust
+/// Identity Map used for object tracking and deduplication.
+///
+/// Values are Python `weakref.ref` objects (FF-D D1) — the map never keeps an
+/// instance alive. Transitional: deleted with the ambient path (FF-D D2).
+pub static IDENTITY_MAP: Lazy<DashMap<(String, String, String), Py<PyAny>>> =
+    Lazy::new(DashMap::new);
+
+/// Amortized-sweep op counter for [`IDENTITY_MAP`] (see `maybe_sweep`).
+pub static IDENTITY_MAP_OPS: Lazy<AtomicUsize> = Lazy::new(AtomicUsize::default);
+```
+
+In `SessionState`, add the field and initialize it in `new`:
+
+```rust
+    /// Session-local identity map; values are `weakref.ref` objects (FF-D D1).
+    pub identity_map: DashMap<(String, String, String), Py<PyAny>>,
+    /// Amortized-sweep op counter for `identity_map`.
+    pub identity_ops: AtomicUsize,
+```
+
+- [ ] **Step 4: Rewrite the primitives in `src/operations.rs`**
+
+Replace `identity_map_get` / `identity_map_insert` (lines 106–133) with:
+
+```rust
+/// Sweep the map for dead weakrefs every N tracked operations (FF-D D1).
+///
+/// Amortized O(1)/op; memory is bounded by live instances plus at most one
+/// interval of tombstones. Callback-based eviction is deliberately avoided:
+/// a weakref callback fires mid-GC and would re-enter the DashMap, risking a
+/// shard-lock deadlock across the FFI boundary (AGENTS.md I-3).
+const IDENTITY_SWEEP_INTERVAL: usize = 1024;
+
+fn weakref_is_live(py: Python<'_>, weak: &Py<PyAny>) -> bool {
+    weak.bind(py)
+        .call0()
+        .map(|obj| !obj.is_none())
+        .unwrap_or(false)
+}
+
+fn maybe_sweep(
+    py: Python<'_>,
+    map: &DashMap<(String, String, String), Py<PyAny>>,
+    ops: &std::sync::atomic::AtomicUsize,
+) {
+    use std::sync::atomic::Ordering;
+    if ops.fetch_add(1, Ordering::Relaxed) % IDENTITY_SWEEP_INTERVAL
+        == IDENTITY_SWEEP_INTERVAL - 1
+    {
+        map.retain(|_, weak| weakref_is_live(py, weak));
+    }
+}
+
+fn identity_map_get(
+    py: Python<'_>,
+    session_id: Option<&str>,
+    key: &(String, String, String),
+) -> PyResult<Option<Py<PyAny>>> {
+    // Clone the weakref out of the shard guard before touching Python:
+    // GIL-before-shard ordering is the invariant (see maybe_sweep).
+    let weak = if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        session.identity_map.get(key).map(|e| e.value().clone_ref(py))
+    } else {
+        IDENTITY_MAP.get(key).map(|e| e.value().clone_ref(py))
+    };
+    let Some(weak) = weak else { return Ok(None) };
+    // Upgrade to a strong ref; hit-vs-miss is decided on the upgraded ref so
+    // the instance cannot die between the check and use.
+    let obj = weak.bind(py).call0()?;
+    if obj.is_none() {
+        // Dead entry: prune the tombstone, report a miss.
+        if let Some(session_id) = session_id {
+            session_state(session_id)?.identity_map.remove(key);
+        } else {
+            IDENTITY_MAP.remove(key);
+        }
+        return Ok(None);
+    }
+    Ok(Some(obj.unbind()))
+}
+
+fn identity_map_insert(
+    py: Python<'_>,
+    session_id: Option<&str>,
+    key: (String, String, String),
+    value: &Bound<'_, PyAny>,
+) -> PyResult<()> {
+    // Weak by design: the map must never keep an instance alive (FF-D D1).
+    // A class that can't be weakly referenced is a loud error, never a
+    // silent strong-ref fallback.
+    let weak = pyo3::types::PyWeakrefReference::new(value)
+        .map_err(|err| {
+            pyo3::exceptions::PyTypeError::new_err(format!(
+                "Cannot track instance in the identity map: the class does not \
+                 support weak references ({err}). Ferro model instances must be \
+                 weakly referenceable."
+            ))
+        })?
+        .into_any()
+        .unbind();
+    if let Some(session_id) = session_id {
+        let session = session_state(session_id)?;
+        session.identity_map.insert(key, weak);
+        maybe_sweep(py, &session.identity_map, &session.identity_ops);
+        return Ok(());
+    }
+    IDENTITY_MAP.insert(key, weak);
+    maybe_sweep(py, &IDENTITY_MAP, &crate::state::IDENTITY_MAP_OPS);
+    Ok(())
+}
+```
+
+`identity_map_remove`, `identity_map_retain_model`, `identity_map_clear` keep their shapes (they don't dereference values). Add the FFI diagnostic and register it in `src/lib.rs` next to the other operation functions:
+
+```rust
+/// Count *live* identity-map entries (test diagnostic for FF-D D1).
+#[pyfunction]
+#[pyo3(signature = (session_id=None))]
+pub fn identity_map_len(py: Python<'_>, session_id: Option<String>) -> PyResult<usize> {
+    let count = |map: &DashMap<(String, String, String), Py<PyAny>>| {
+        map.iter().filter(|e| weakref_is_live(py, e.value())).count()
+    };
+    if let Some(session_id) = session_id {
+        return Ok(count(&session_state(&session_id)?.identity_map));
+    }
+    Ok(count(&IDENTITY_MAP))
+}
+```
+
+- [ ] **Step 5: Update every primitive call site**
+
+The compiler enumerates them; the known list — `:853` (rollback, Task 8 revisits), `:991/:1010` (fetch_all), `:1054/:1154` (fetch_one), `:1824/:1843` (fetch_where), `:2010` (register_instance), `:2039` (evict_instance), `:2169/:2258` (bulk update/delete). Pattern:
+  - Sites inside `Python::attach(|py| ...)` closures: pass that `py`.
+  - Sync pyfunctions (`register_instance`, `evict_instance`): add `py: Python<'_>` as first parameter (pyo3 injects it) and bind `obj` for insert: `identity_map_insert(py, session_id.as_deref(), key, obj.bind(py))?`.
+  - Insert call sites that currently pass `instance.clone().unbind()` now pass `&instance` (the bound value).
+  - `fetch_one`'s **sync pre-check** at `:1053-1061` keeps working for now (it has `py`); it is deleted in Task 4.
+
+- [ ] **Step 6: Build and verify**
+
+```bash
+cargo check
+uv run maturin develop
+uv run pytest tests/test_identity_memory.py tests/test_identity_weakref.py -q
+uv run pytest tests/test_crud.py tests/test_session.py tests/test_bulk_update.py tests/test_deletion.py tests/test_transactions.py -q
+cargo test --no-default-features --features testing
+```
+Expected: all PASS (dedup-while-alive keeps existing identity tests green — they hold refs in local variables).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/state.rs src/operations.rs src/lib.rs tests/test_identity_memory.py
+git commit -m "feat(ff-d): D1a — weak-value identity map with amortized dead-entry sweep"
+```
+
+---
+
+### Task 4: D1b — Refresh-on-load
+
+**Files:**
+- Modify: `src/hydration.rs` (extract shared field-write path; add `refresh_model_instance`)
+- Modify: `src/operations.rs` — three hit sites: fetch_all (`:988-998`), fetch_one (delete sync pre-check `:1052-1061`; refresh in async body near `:1154`), fetch_where (`:1824` region)
+- Test: `tests/test_identity_refresh.py` (new)
+
+**Interfaces:**
+- Consumes: `identity_map_get` from Task 3 (returns upgraded strong ref).
+- Produces: `crate::hydration::refresh_model_instance(py, cls, instance, fields, py_col_names, enum_classes) -> PyResult<()>` — overwrites **every** decoded field in `instance.__dict__`, resets `__pydantic_fields_set__` to exactly the decoded columns, preserves `__ferro_connection_name`/`__ferro_persisted` and pydantic extra/private slots. Same materialization code as fresh hydration (shared `apply_decoded_fields`).
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_identity_refresh.py`:
+
+```python
+"""FF-D D1b exit gate: fetch-hits refresh the cached instance in place.
+
+Guarantee: within a session, fetching a row you already hold returns the same
+object, updated to the database's current values. The database wins over
+unsaved local mutations. (Today the freshly decoded row is discarded.)
+"""
+
+import pytest
+
+from ferro import Field, Model, connect, engines, execute
+
+
+@pytest.mark.asyncio
+async def test_refetch_returns_fresh_values_with_identity_preserved(db_url):
+    class RefUser(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+        score: int
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        u = await RefUser.create(name="old", score=1)
+
+        # External write the ORM cache knows nothing about.
+        await execute(
+            "UPDATE refuser SET name = ?, score = ? WHERE id = ?", "new", 2, u.id
+        )
+
+        again = await RefUser.get(u.id)
+        assert again is u          # identity preserved
+        assert u.name == "new"     # FAILS today: stale "old"
+        assert u.score == 2
+
+
+@pytest.mark.asyncio
+async def test_database_wins_over_unsaved_local_mutation(db_url):
+    class RefDoc(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        body: str
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        d = await RefDoc.create(body="persisted")
+        d.body = "unsaved local edit"
+
+        again = await RefDoc.get(d.id)
+        assert again is d
+        assert d.body == "persisted"  # documented: re-fetch overwrites
+
+
+@pytest.mark.asyncio
+async def test_refresh_resets_fields_set_like_fresh_hydration(db_url):
+    class RefFlag(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        a: str
+        b: str
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        f = await RefFlag.create(a="1", b="2")
+        first_fetch = await RefFlag.get(f.id)
+        expected_fields_set = set(first_fetch.__pydantic_fields_set__)
+
+        f.a = "mutated"
+        again = await RefFlag.get(f.id)
+        assert again is f
+        assert set(f.__pydantic_fields_set__) == expected_fields_set
+        assert f.a == "1"
+```
+
+(Note: Postgres uses `$1` placeholders — check how other raw-SQL tests handle the dialect; follow `tests/test_raw*.py`/`tests/test_crud.py` conventions. If raw placeholders differ per backend, mark the external-update test to build SQL per `db_backend` fixture.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_identity_refresh.py -x -q`
+Expected: FAIL at `assert u.name == "new"` — cached instance returned with stale values.
+
+- [ ] **Step 3: Extract the shared write path in `src/hydration.rs`**
+
+Split the field loop out of `hydrate_model_instance` (its lines 100–127) into:
+
+```rust
+/// Write decoded column values into `dict` and record them in `fields_set`.
+///
+/// The single materialization path for both fresh hydration and fetch-hit
+/// refresh (FF-D D1b) — refresh cannot drift from hydration, and a partial
+/// write is structurally impossible.
+fn apply_decoded_fields<'py>(
+    py: Python<'py>,
+    cls: &Bound<'py, PyAny>,
+    dict: &Bound<'py, pyo3::types::PyDict>,
+    fields_set: &Bound<'py, pyo3::types::PySet>,
+    fields: Vec<(String, RustValue)>,
+    py_col_names: &HashMap<String, pyo3::Py<pyo3::types::PyString>>,
+    enum_classes: &HashMap<String, Bound<'py, PyAny>>,
+) -> PyResult<()> {
+    for (col_name, val) in fields {
+        let mut py_val = val.into_py_any(py)?;
+        if let Some(enum_cls) = enum_classes.get(&col_name)
+            && !py_val.is_none()
+        {
+            py_val = enum_cls.call1((py_val,)).map_err(|err| {
+                let model = cls
+                    .getattr(pyo3::intern!(py, "__name__"))
+                    .and_then(|n| n.extract::<String>())
+                    .unwrap_or_else(|_| "<model>".to_string());
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "Failed to hydrate enum field {model}.{col_name}: {err}"
+                ))
+            })?;
+        }
+        if let Some(py_name) = py_col_names.get(&col_name) {
+            let py_name = py_name.bind(py);
+            dict.set_item(py_name, py_val)?;
+            fields_set.add(py_name)?;
+        } else {
+            let py_name = pyo3::types::PyString::new(py, &col_name);
+            dict.set_item(&py_name, py_val)?;
+            fields_set.add(&py_name)?;
+        }
+    }
+    Ok(())
+}
+```
+
+`hydrate_model_instance` calls it after setting the ferro markers; then keeps its existing `__pydantic_fields_set__` + slot initialization. Add:
+
+```rust
+/// Refresh a live cached instance from a freshly decoded row (FF-D D1b).
+///
+/// Overwrites every decoded field and resets `__pydantic_fields_set__` to
+/// match a fresh hydration. Ferro markers (`__ferro_connection_name`,
+/// `__ferro_persisted`) and pydantic extra/private slots are already present
+/// on the instance and are left untouched.
+pub fn refresh_model_instance<'py>(
+    py: Python<'py>,
+    cls: &Bound<'py, PyAny>,
+    instance: &Bound<'py, PyAny>,
+    fields: Vec<(String, RustValue)>,
+    py_col_names: &HashMap<String, pyo3::Py<pyo3::types::PyString>>,
+    enum_classes: &HashMap<String, Bound<'py, PyAny>>,
+) -> PyResult<()> {
+    let dict_attr = instance.getattr(pyo3::intern!(py, "__dict__"))?;
+    let dict = dict_attr.cast::<pyo3::types::PyDict>()?;
+    let fields_set = pyo3::types::PySet::empty(py)?;
+    apply_decoded_fields(py, cls, dict, &fields_set, fields, py_col_names, enum_classes)?;
+    instance.setattr(pyo3::intern!(py, "__pydantic_fields_set__"), fields_set)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Rewire the three hit sites in `src/operations.rs`**
+
+fetch_all (`:988`) — the hit arm stops discarding the row:
+
+```rust
+                if use_identity_map
+                    && let Some(ref pk_val) = row_pk_val
+                    && let Some(existing_obj) = identity_map_get(
+                        py,
+                        session_id.as_deref(),
+                        &(connection_name.clone(), name.clone(), pk_val.clone()),
+                    )?
+                {
+                    let existing = existing_obj.bind(py);
+                    crate::hydration::refresh_model_instance(
+                        py, cls, existing, fields, &py_col_names, &enum_classes,
+                    )?;
+                    results.append(existing)?;
+                    continue;
+                }
+```
+
+fetch_where (`:1824` region): identical transformation.
+
+fetch_one: **delete** the pre-query sync short-circuit (`:1052-1061`) — it returns cached state without touching the database, which is exactly the stale-read class being removed. In the async body's hydration section (`:1150` region), apply the same hit-arm pattern: map hit → refresh → return the existing instance; miss → hydrate + insert as today. Add a comment at the deletion site:
+
+```rust
+    // No identity-map short-circuit before the query (FF-D D1b): the map is
+    // an identity/dedup structure, not a query cache — every fetch reads the
+    // database and refreshes the cached instance in place.
+```
+
+- [ ] **Step 5: Build, verify red→green, no regressions**
+
+```bash
+uv run maturin develop
+uv run pytest tests/test_identity_refresh.py tests/test_identity_memory.py -q
+uv run pytest tests/test_crud.py tests/test_hydration.py tests/test_hydration_equivalence.py tests/test_enum_cold_hydration.py -q
+```
+Expected: all PASS. If a test asserted the old fetch-one-skips-DB behavior, update it — the new semantics are the spec.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hydration.rs src/operations.rs tests/test_identity_refresh.py
+git commit -m "feat(ff-d): D1b — refresh-on-load; fetch-hits update the cached instance in place"
+```
+
+---
+
+### Task 5: Migrate test suite and docs examples to explicit sessions
+
+Sessions work today — this migration lands **before** the Task 6 flip so every commit stays green. This is the largest mechanical chunk (~60 test files + docs pages); it is parallelizable per-file across subagents.
+
+**Files:**
+- Modify: nearly every file in `tests/` that runs ORM/raw ops after `await connect(...)` without a session
+- Modify: docs pages whose examples run sessionless ops (enumerated via `tests/test_docs_examples.py`)
+
+**Interfaces:**
+- Consumes: `ferro.engines.session(name: str | None = None)` async context manager (`src/ferro/session.py:124`); `session=` kwargs on model classmethods and query entry points.
+- Produces: a suite where **no test relies on ambient default-connection routing** — the invariant Task 6 enforces.
+
+- [ ] **Step 1: Enumerate offenders**
+
+The deprecation warning marks the exact path being removed. Run:
+
+```bash
+uv run python -c "from ferro._deprecations import enable_deprecation_warnings; enable_deprecation_warnings()" # confirm helper exists
+uv run pytest tests/ -q -W "error::DeprecationWarning" 2>&1 | tail -30
+```
+If the ferro deprecation uses a custom category, error on that category instead (check `src/ferro/_deprecations.py` for the warning class). Capture the failing-file list — that is the migration work-list. (If warning-as-error doesn't isolate cleanly, defer enumeration to Task 6's flip and migrate against real errors — but keep the migration edits in **this** commit.)
+
+- [ ] **Step 2: Migrate test files — the pattern**
+
+For a typical test:
+
+```python
+# BEFORE
+await connect(db_url, auto_migrate=True)
+u = await User.create(name="a")
+
+# AFTER
+await connect(db_url, auto_migrate=True)
+async with engines.session():
+    u = await User.create(name="a")
+```
+
+Rules:
+- `from ferro import engines` (already exported).
+- The session block starts **after** `connect(...)`/`create_tables()`/`migrate()` (DDL entry points route by name, not by operation scope — they stay outside).
+- Tests already using `transaction()` ambient blocks: wrap the transaction block inside the session (`async with engines.session():` outer, `async with transaction():` inner) — transactions inherit fine.
+- Tests using **named connections + `using=`** (`tests/test_connection.py`, `tests/test_exception_mapping.py`, `tests/test_named_connections_integration.py`, `tests/test_save_semantics.py`, `tests/test_session.py`, `tests/test_transactions.py`): `using="X"` alone still works after the flip (sessionless, no identity map). Leave pure `using=` call sites as-is **unless** the test asserts `a is b` identity — identity assertions must move inside `engines.session("X")` for that connection (they lose the map otherwise; Task 8 deletes the global map they lean on).
+- Identity-assertion tests (`test_crud.py:92,112`, `test_connection.py:221`, `test_bulk_update.py:39`, `test_deletion.py:67`, `test_transactions.py:143`): must run inside sessions — flag these as done explicitly.
+- Do NOT add an autouse session fixture: `connect()` happens inside test bodies, and a blanket ambient session would collide with every named-connection test under D4. Explicit blocks only.
+
+- [ ] **Step 3: Migrate docs examples**
+
+Wrap ORM/raw operation snippets in `async with engines.session():` in every docs page whose examples run sessionless (find them via `uv run pytest tests/test_docs_examples.py -q` plus grep for `await connect` in `docs/pages/`). Keep I-8 (both declaration tabs) and I-9 (lambda predicates) intact. `docs/pages/concepts/identity-map.md` gets only the mechanical session wrapper here — its full rewrite is Task 9.
+
+- [ ] **Step 4: Verify green on CURRENT code**
+
+```bash
+uv run pytest tests/ -q -x --db-backends=sqlite
+FERRO_POSTGRES_URL=postgres://postgres:password@localhost:5432/postgres just test
+```
+Expected: green (modulo the 7 pre-existing #176 postgres failures).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/ docs/pages/
+git commit -m "test(ff-d): migrate suite and docs examples to explicit sessions ahead of ambient-path removal"
+```
+
+---
+
+### Task 6: D4 + ambient-default removal — the breaking flip
+
+**Files:**
+- Modify: `src/ferro/state.py:65-166` (both resolvers), `src/ferro/models.py:68-89` (`_transaction_or_using`, `_instance_transaction_route`), `src/ferro/models.py:128` (transaction), `src/ferro/raw.py:71-76`, `src/ferro/query/builder.py:112-117`
+- Test: `tests/test_routing_errors.py` (new)
+
+**Interfaces:**
+- Produces: `resolve_operation_scope(*, using, session)` and `resolve_transaction_scope(*, using, session)` — `allow_legacy_default` parameter **deleted**. New errors: `RuntimeError` (no route at all), `ValueError` (explicit `using` conflicts with ambient session — D4). Return type still the triple (D3 changes it in Task 7).
+- Instance ops: origin acts as the effective `using` (`using or origin` passed to the resolver), so an origin conflicting with the ambient session raises the same D4 `ValueError`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_routing_errors.py`:
+
+```python
+"""FF-D D4 + ambient-default removal (v0.13, one minor ahead of the notice).
+
+Every operation needs an explicit route: a session (ambient or session=) or
+using=. The silent using-bypasses-session path is a ValueError.
+"""
+
+import pytest
+
+from ferro import Field, Model, connect, engines, execute
+
+
+@pytest.mark.asyncio
+async def test_operation_with_no_route_raises(db_url):
+    class RtA(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    with pytest.raises(RuntimeError, match="No database route"):
+        await RtA.all()
+
+
+@pytest.mark.asyncio
+async def test_raw_with_no_route_raises(db_url):
+    await connect(db_url, auto_migrate=True)
+    with pytest.raises(RuntimeError, match="No database route"):
+        await execute("SELECT 1")
+
+
+@pytest.mark.asyncio
+async def test_using_matching_ambient_session_is_allowed(db_url):
+    class RtB(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session() as s:
+        a = await RtB.create(name="x")
+        b = await RtB.all(using=s.connection_name)
+        assert b[0] is a  # same connection: session-scoped, not a bypass
+
+
+@pytest.mark.asyncio
+async def test_using_conflicting_with_ambient_session_raises(db_url, tmp_path):
+    class RtC(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    await connect(f"sqlite:{tmp_path}/other.db?mode=rwc", auto_migrate=True, name="other")
+    async with engines.session():
+        with pytest.raises(ValueError, match="conflicts with the ambient session"):
+            await RtC.all(using="other")
+
+
+@pytest.mark.asyncio
+async def test_using_alone_still_works_without_identity(db_url, tmp_path):
+    class RtD(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    await connect(f"sqlite:{tmp_path}/named.db?mode=rwc", auto_migrate=True, name="named")
+    rows = await RtD.all(using="named")
+    assert rows == []  # runs fine sessionless; no identity map involved
+```
+
+(Follow `tests/test_connection.py` for the exact multi-connection setup idiom — adjust `connect(name=...)` usage to match.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_routing_errors.py -x -q`
+Expected: no-route tests FAIL (deprecation warning today, no raise); conflict test FAILS (silent bypass today).
+
+- [ ] **Step 3: Rewrite the resolvers in `src/ferro/state.py`**
+
+Replace `resolve_operation_scope` and `resolve_transaction_scope` bodies; delete `_LEGACY_DEFAULT_CONNECTION_REASON` and the `_deprecations` imports if now unused:
+
+```python
+_NO_ROUTE_MESSAGE = (
+    "No database route for this operation. Open a session "
+    "(`async with ferro.engines.session(...)`) or pass `using=`/`session=` "
+    "explicitly. Implicit default-connection routing was removed in v0.13 "
+    "(deprecated since v0.12); see the sessions migration guide."
+)
+
+
+def _using_conflict_message(using: str, session_connection: str) -> str:
+    return (
+        f"Explicit `using={using!r}` conflicts with the ambient session bound "
+        f"to connection {session_connection!r}. Pass an explicit `session=` "
+        f"for that connection, or open a session on {using!r}."
+    )
+
+
+def resolve_operation_scope(
+    *,
+    using: str | None,
+    session: SessionLike | None,
+) -> tuple[str | None, str | None, str | None]:
+    """Resolve the route for ORM/raw operations.
+
+    Exactly one resolution site per operation (FF-D D3/D4): a session
+    (ambient or explicit), an explicit `using=`, or an active transaction.
+    No route is an error; `using=` conflicting with the ambient session is
+    an error (the silent sessionless bypass was removed in v0.13).
+    """
+    tx_id = _CURRENT_TRANSACTION.get()
+    tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
+
+    ambient_session = _CURRENT_SESSION.get()
+    explicit_session = session
+    effective_session = explicit_session or ambient_session
+
+    if effective_session is not None and using is not None:
+        if using != effective_session.connection_name:
+            if explicit_session is not None:
+                raise ValueError(
+                    "Explicit `using` conflicts with explicit `session` connection"
+                )
+            raise ValueError(  # FF-D D4
+                _using_conflict_message(using, effective_session.connection_name)
+            )
+
+    if explicit_session is None and ambient_session is not None:
+        _ensure_active_session(ambient_session)
+    _ensure_active_session(effective_session)
+
+    session_id = effective_session.session_id if effective_session is not None else None
+
+    if tx_id is not None:
+        if using is not None and using != tx_connection:
+            raise ValueError(
+                "Operations inside a transaction inherit the transaction connection"
+            )
+        if effective_session is not None and tx_connection is not None:
+            if effective_session.connection_name != tx_connection:
+                raise ValueError(
+                    "Active transaction is bound to a different connection than session"
+                )
+        return tx_id, None, session_id
+
+    effective_using = using or (
+        effective_session.connection_name if effective_session is not None else None
+    )
+    if effective_using is None:
+        raise RuntimeError(_NO_ROUTE_MESSAGE)
+    return None, effective_using, session_id
+```
+
+`resolve_transaction_scope`: same transformation — drop `allow_legacy_default`, same D4 conflict error, same `RuntimeError(_NO_ROUTE_MESSAGE)` when `effective_using is None` and no parent transaction.
+
+- [ ] **Step 4: Update the four callers**
+
+`models.py:71`, `models.py:128`, `raw.py:74`, `builder.py:115`: delete `allow_legacy_default=True` argument. In `models.py` `_instance_transaction_route` (`:76-89`): pass origin through the resolver so D4 sees it:
+
+```python
+def _instance_transaction_route(
+    instance: object, using: str | None, session: "Session | None"
+) -> tuple[str | None, str | None, str | None, str | None]:
+    origin = _instance_origin(instance)
+    if using is not None and origin is not None and using != origin:
+        raise ValueError("Instance is already bound to a different connection")
+
+    # Origin is the instance's implicit route (FF-D D4): it participates in
+    # session-conflict checks instead of silently bypassing the session.
+    tx_id, route_using, session_id = _transaction_or_using(using or origin, session)
+    if tx_id is not None:
+        tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
+        return tx_id, route_using, origin or tx_connection, session_id
+
+    return None, route_using, route_using, session_id
+```
+
+- [ ] **Step 5: Run the full suite; fix stragglers**
+
+```bash
+uv run pytest tests/test_routing_errors.py -q          # new tests green
+uv run pytest tests/ -q --db-backends=sqlite            # Task 5 migration holds
+```
+Any residual failures are tests still on the ambient path that Step 1's enumeration missed — migrate them now (same pattern as Task 5). Also run `uv run pytest tests/test_docs_examples.py -q`.
+
+- [ ] **Step 6: Commit (breaking)**
+
+```bash
+git add src/ferro/state.py src/ferro/models.py src/ferro/raw.py src/ferro/query/builder.py tests/
+git commit -m "feat(ff-d)!: D4 — explicit route required; using= vs ambient session is an error
+
+Removes implicit default-connection routing (deprecated since v0.12,
+announced for v0.14 — lands one minor early, accepted). Explicit using=
+that conflicts with the ambient session now raises ValueError instead of
+silently running sessionless. Instance origin participates in the same
+conflict check."
+```
+
+---
+
+### Task 7: D3 — One `RouteHandle`, resolved once
+
+**Files:**
+- Modify: `src/state.rs` (add `RouteHandle` pyclass), `src/lib.rs` (register class)
+- Modify: `src/operations.rs` — delete `active_route_for_operation` (`:75`), `active_engine_for_connection` (`:63`), `get_transaction_route`; add `route_engine`; collapse all ~20 operation signatures (list from `grep -n "session_id=None" src/operations.rs`)
+- Modify: `src/ferro/state.py` (resolvers return `RouteHandle`), `src/ferro/models.py`, `src/ferro/raw.py`, `src/ferro/query/builder.py`, `src/ferro/__init__.py` (public `evict_instance` wrapper)
+- Test: `tests/test_route_single_site.py` (new)
+
+**Interfaces:**
+- Produces (Rust + FFI): frozen pyclass
+
+  ```rust
+  #[pyclass(frozen, module = "ferro._core")]
+  pub struct RouteHandle {
+      pub tx_id: Option<String>,
+      pub connection_name: String,   // never None — a routeless handle is unrepresentable
+      pub session_id: Option<String>,
+  }
+  ```
+
+  with `#[new] fn new(connection_name: String, tx_id: Option<String>, session_id: Option<String>)` and `#[getter]`s for all three fields.
+- Produces (Rust, private): `route_engine(route: &RouteHandle) -> PyResult<(String, Arc<EngineHandle>, Option<TransactionConnection>, Dialect)>` — the only place engine/tx-conn are derived, a cheap map lookup.
+- Produces (Python): `resolve_operation_scope(*, using, session) -> RouteHandle`; `resolve_transaction_scope(*, using, session) -> RouteHandle` (its `tx_id` is the *parent* tx). `raw.Transaction` stores one `RouteHandle`.
+- Every `_core` operation signature becomes `(..., route)` — `tx_id`/`using`/`session_id` parameters deleted.
+
+- [ ] **Step 1: Write the grep-gate test**
+
+`tests/test_route_single_site.py`:
+
+```python
+"""FF-D D3 exit gate: exactly one route-resolution site per operation.
+
+RouteHandle may only be constructed inside src/ferro/state.py (the two
+resolvers). Rust must not re-derive routes per operation.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _grep(root: Path, pattern: str, suffix: str) -> list[str]:
+    hits = []
+    for path in root.rglob(f"*{suffix}"):
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if pattern in line and not line.lstrip().startswith(("#", "//", "///")):
+                hits.append(f"{path.relative_to(ROOT)}:{lineno}")
+    return hits
+
+
+def test_route_handle_constructed_only_in_state_py():
+    hits = _grep(ROOT / "src" / "ferro", "RouteHandle(", ".py")
+    assert hits, "expected RouteHandle construction in src/ferro/state.py"
+    assert all(h.startswith("src/ferro/state.py") for h in hits), hits
+
+
+def test_rust_route_rederivation_is_gone():
+    assert _grep(ROOT / "src", "active_route_for_operation", ".rs") == []
+    assert _grep(ROOT / "src", "active_engine_for_connection", ".rs") == []
+```
+
+Run: `uv run pytest tests/test_route_single_site.py -x -q` → FAILS (both symbols exist; no RouteHandle yet).
+
+- [ ] **Step 2: Add `RouteHandle` + `route_engine` in Rust**
+
+In `src/state.rs` (near the registries):
+
+```rust
+/// Opaque, immutable route for one operation (FF-D D3).
+///
+/// Resolved exactly once in Python's `resolve_operation_scope` and passed by
+/// value through every FFI operation. `connection_name` is non-optional: the
+/// removed ambient-default path is unrepresentable, not an error branch.
+#[pyclass(frozen, module = "ferro._core")]
+pub struct RouteHandle {
+    pub tx_id: Option<String>,
+    pub connection_name: String,
+    pub session_id: Option<String>,
+}
+
+#[pymethods]
+impl RouteHandle {
+    #[new]
+    #[pyo3(signature = (connection_name, tx_id=None, session_id=None))]
+    fn new(
+        connection_name: String,
+        tx_id: Option<String>,
+        session_id: Option<String>,
+    ) -> Self {
+        Self { tx_id, connection_name, session_id }
+    }
+
+    #[getter]
+    fn connection_name(&self) -> &str {
+        &self.connection_name
+    }
+
+    #[getter]
+    fn tx_id(&self) -> Option<&str> {
+        self.tx_id.as_deref()
+    }
+
+    #[getter]
+    fn session_id(&self) -> Option<&str> {
+        self.session_id.as_deref()
+    }
+}
+```
+
+Register in `src/lib.rs`: `m.add_class::<state::RouteHandle>()?;`
+
+In `src/operations.rs`, replace `active_route_for_operation` / `active_engine_for_connection` / `get_transaction_route` with:
+
+```rust
+/// Derive engine + transaction connection from an already-resolved route.
+///
+/// The only route-consumption site (FF-D D3): a map lookup, never a
+/// re-derivation of `using`/session precedence.
+fn route_engine(
+    route: &crate::state::RouteHandle,
+) -> PyResult<(String, Arc<EngineHandle>, Option<TransactionConnection>, Dialect)> {
+    let engine = engine_for_connection(Some(route.connection_name.clone()))?;
+    let tx_conn = match &route.tx_id {
+        Some(tx_id) => Some(
+            tx_get(route.session_id.as_deref(), tx_id)?
+                .ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err("Transaction not found")
+                })?
+                .conn,
+        ),
+        None => None,
+    };
+    let backend = engine.backend();
+    Ok((route.connection_name.clone(), engine, tx_conn, backend))
+}
+```
+
+(Confirm `TransactionHandle.conn` is the `TransactionConnection` field name — see `src/state.rs:195-203`.)
+
+- [ ] **Step 3: Collapse the operation signatures**
+
+For every `#[pyfunction]` in `operations.rs` carrying `(tx_id=None, using=None, session_id=None)` (the grep list in this plan's Task 3 references; ~20 functions: `fetch_all`, `fetch_one`, `save_record`, `update_record`, `save_bulk_records`, `fetch_where`, `fetch_where_raw`, `register_instance`, `evict_instance`, `delete_record`, `delete_where`, `update_where`, m2m add/remove/clear, `raw_execute`, `raw_fetch_all`, `raw_fetch_one`, `begin_transaction`):
+
+```rust
+// BEFORE
+#[pyo3(signature = (cls, tx_id=None, using=None, session_id=None))]
+pub fn fetch_all<'py>(py: Python<'py>, cls: Bound<'py, PyAny>, tx_id: Option<String>, using: Option<String>, session_id: Option<String>) -> ...
+
+// AFTER
+#[pyo3(signature = (cls, route))]
+pub fn fetch_all<'py>(py: Python<'py>, cls: Bound<'py, PyAny>, route: Py<crate::state::RouteHandle>) -> ...
+```
+
+Inside each function: `let r = route.get();` (frozen + fields are `String`/`Option<String>` → `Sync`, so `.get()` works without the GIL), clone the three fields before any `future_into_py` move, and replace `active_route_for_operation(...)` calls with `route_engine(r)`. `session_id.as_deref()` for identity primitives becomes `r.session_id.as_deref()`. `begin_transaction`'s `parent_tx_id` is `r.tx_id`. `commit_transaction`, `rollback_transaction`, `transaction_connection_name` keep `(tx_id, session_id=None)` — they act on a specific transaction, not an operation route.
+
+Build with `cargo check` and let the compiler enumerate every missed site until clean. **D3 is wide, not deep — the compiler is the checklist.**
+
+- [ ] **Step 4: Update the Python side**
+
+`src/ferro/state.py` — resolvers return handles (import at top: `from ._core import RouteHandle`):
+
+```python
+    # resolve_operation_scope tail (replacing the triple returns):
+    if tx_id is not None:
+        ...  # conflict checks unchanged
+        return RouteHandle(
+            connection_name=tx_connection, tx_id=tx_id, session_id=session_id
+        )
+
+    effective_using = using or (
+        effective_session.connection_name if effective_session is not None else None
+    )
+    if effective_using is None:
+        raise RuntimeError(_NO_ROUTE_MESSAGE)
+    return RouteHandle(connection_name=effective_using, session_id=session_id)
+```
+
+Same for `resolve_transaction_scope` (handle's `tx_id` = parent tx). Then:
+- `models.py` `_transaction_or_using` returns the handle; every call site `tx_id, using, session_id = ...` becomes `route = ...` and FFI calls pass `route`. `_instance_transaction_route` returns `(route, effective_connection)` — read `route.connection_name`/`route.tx_id` instead of the unpacked triple; the origin check logic from Task 6 is unchanged.
+- `transaction()` (`models.py:128-143`): `route = resolve_transaction_scope(...)`; `tx_id = await begin_transaction(route)`; `connection_name = transaction_connection_name(tx_id, session_id=route.session_id)`; the yielded `Transaction` gets `RouteHandle(connection_name=connection_name, tx_id=tx_id, session_id=route.session_id)`.
+- `raw.py`: `_transaction_or_using` returns the handle; module functions pass it; `Transaction.__slots__ = ("_route",)`, methods pass `self._route`.
+- `builder.py`: `_transaction_or_using` returns the handle; all seven call sites pass it.
+- `__init__.py`: `evict_instance` must stay public with a Python signature — add to `models.py`:
+
+```python
+def evict_instance(
+    model_name: str,
+    pk: str,
+    *,
+    using: str | None = None,
+    session: "Session | None" = None,
+) -> None:
+    """Remove one instance from the active scope's identity map."""
+    route = resolve_operation_scope(using=using, session=session)
+    _core_evict_instance(model_name, pk, route)
+```
+
+(import `evict_instance as _core_evict_instance` from `._core`; re-export the wrapper from `__init__.py` instead of the raw FFI symbol). Update `_core.pyi` for changed signatures + `RouteHandle`.
+
+- [ ] **Step 5: Build and verify**
+
+```bash
+uv run maturin develop
+uv run pytest tests/test_route_single_site.py -q       # grep gate green
+uv run pytest tests/ -q --db-backends=sqlite            # full sqlite pass
+cargo test --no-default-features --features testing
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/state.rs src/operations.rs src/lib.rs src/ferro/ tests/test_route_single_site.py
+git commit -m "refactor(ff-d): D3 — single RouteHandle resolved once; delete per-op route re-derivation"
+```
+
+---
+
+### Task 8: D2 — Scoped invalidation; delete the global map
+
+**Files:**
+- Modify: `src/operations.rs` (rollback eviction `:853`; primitives lose their global arm; bulk-op retain sites `:2169/:2258` keep session-only semantics)
+- Modify: `src/state.rs` (delete `IDENTITY_MAP`, `IDENTITY_MAP_OPS`)
+- Modify: `src/connection.rs:9,315` and `src/migrate.rs:37,886` (delete import + `IDENTITY_MAP.clear()`)
+- Test: `tests/test_identity_scoped_invalidation.py` (new)
+
+**Interfaces:**
+- Changes: all identity primitives become **session-only** — `session_id: None` arm is a no-op (`get` → `Ok(None)`, `insert`/`remove`/`retain`/`clear` → `Ok(())`). `identity_map_len(None)` returns `0`.
+- Invariant produced: `grep -rn "IDENTITY_MAP" src/ crates/` is empty.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_identity_scoped_invalidation.py`:
+
+```python
+"""FF-D D2 exit gate: invalidation is scoped, never a global clear.
+
+Rollback evicts only the affected (connection, session); bulk update/delete
+evict only (connection, model). Unrelated cached instances survive.
+"""
+
+import pytest
+
+from ferro import Field, Model, connect, engines, transaction
+
+
+@pytest.mark.asyncio
+async def test_rollback_evicts_only_the_affected_session(db_url):
+    class InvA(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session() as s1:
+        kept = await InvA.create(name="kept-in-s1")
+
+    async with engines.session() as s2:
+        outer = await InvA.create(name="s2-outer")
+        try:
+            async with transaction():
+                await InvA.create(name="rolled-back")
+                raise RuntimeError("force rollback")
+        except RuntimeError:
+            pass
+
+        # s2's map was evicted by the rollback: re-fetch hydrates fresh.
+        refetched = await InvA.get(outer.id)
+        assert refetched is not outer
+        assert refetched.name == "s2-outer"
+
+    # A different session was never touched (its map died with it anyway;
+    # the point is the rollback path no longer clears anything global).
+    async with engines.session():
+        still_there = await InvA.get(kept.id)
+        assert still_there.name == "kept-in-s1"
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_evicts_only_that_model(db_url):
+    class InvUser(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    class InvOrder(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        item: str
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        u = await InvUser.create(name="before")
+        o = await InvOrder.create(item="widget")
+
+        await InvUser.where(lambda t: t.id == u.id).update(name="after")
+
+        fresh_u = await InvUser.get(u.id)
+        assert fresh_u is not u          # evicted: fresh instance
+        assert fresh_u.name == "after"
+
+        same_o = await InvOrder.get(o.id)
+        assert same_o is o               # unrelated model survived
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_evicts_only_that_model(db_url):
+    class InvDelA(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        n: int
+
+    class InvDelB(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        n: int
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        a = await InvDelA.create(n=1)
+        b = await InvDelB.create(n=2)
+        await InvDelA.where(lambda t: t.n == 1).delete()
+        assert await InvDelA.get_or_none(a.id) is None
+        assert (await InvDelB.get(b.id)) is b
+```
+
+(Check the bulk-update/delete query API against `tests/test_bulk_update.py` / `tests/test_deletion.py` and adjust `.update(...)`/`.delete()` spelling to match.)
+
+Run: `uv run pytest tests/test_identity_scoped_invalidation.py -x -q`
+Expected: rollback test FAILS today at `refetched is not outer`… **verify which arm fails**: with sessions, rollback already clears the session map, so these may pass — the red assertion for D2 is the *global* behavior, which after Task 5's migration is only observable via the grep gate. If all three pass pre-change, note that and treat the grep gate (Step 4) as the red test.
+
+- [ ] **Step 2: Make the primitives session-only; delete the global map**
+
+In `src/operations.rs`, every primitive's `None` arm becomes a no-op:
+
+```rust
+fn identity_map_get(
+    py: Python<'_>,
+    session_id: Option<&str>,
+    key: &(String, String, String),
+) -> PyResult<Option<Py<PyAny>>> {
+    // Sessionless operations have no identity map (FF-D Option B): nothing
+    // is cached, so nothing can dedup — and nothing can go stale.
+    let Some(session_id) = session_id else {
+        return Ok(None);
+    };
+    let session = session_state(session_id)?;
+    let weak = session.identity_map.get(key).map(|e| e.value().clone_ref(py));
+    let Some(weak) = weak else { return Ok(None) };
+    let obj = weak.bind(py).call0()?;
+    if obj.is_none() {
+        session.identity_map.remove(key);
+        return Ok(None);
+    }
+    Ok(Some(obj.unbind()))
+}
+```
+
+Apply the same collapse to `insert` (weakref creation unchanged), `remove`, `retain_model`, `clear`, and `identity_map_len` (`None` → `Ok(0)`). Then:
+- `src/state.rs`: delete `IDENTITY_MAP` + `IDENTITY_MAP_OPS` statics and the doc reference on `SessionState.identity_map`.
+- `src/connection.rs`: drop `IDENTITY_MAP` from the `use` list (`:9`) and delete `IDENTITY_MAP.clear();` in `reset_engine` (`:315`) — `SESSION_REGISTRY.clear()` two lines later already tears down every session map.
+- `src/migrate.rs`: drop the import (`:37`) and the clear (`:886`).
+- `src/operations.rs:11`: drop `IDENTITY_MAP` from imports.
+- Rollback (`:853`): the call is already `identity_map_clear(py?, session_id.as_deref())` — with the session-only primitive this *is* the scoped `(connection, session)` eviction (a session is pinned to one connection). Update the doc comment on `rollback_transaction` ("clear the identity map" → "evict the transaction's session-scoped identity map").
+
+- [ ] **Step 3: Build and verify**
+
+```bash
+uv run maturin develop
+uv run pytest tests/test_identity_scoped_invalidation.py tests/test_identity_memory.py tests/test_identity_refresh.py tests/test_routing_errors.py -q
+uv run pytest tests/ -q --db-backends=sqlite
+cargo test --no-default-features --features testing
+```
+
+- [ ] **Step 4: Grep gate**
+
+```bash
+grep -rn "IDENTITY_MAP" src/ crates/ && echo "FAIL: global map remains" || echo "OK: global map gone"
+```
+Expected: `OK`. Add this assertion to `tests/test_route_single_site.py`:
+
+```python
+def test_global_identity_map_is_gone():
+    assert _grep(ROOT / "src", "IDENTITY_MAP", ".rs") == []
+```
+
+- [ ] **Step 5: Commit (breaking — sessionless caching is gone)**
+
+```bash
+git add src/ tests/
+git commit -m "feat(ff-d)!: D2 — session-scoped invalidation; delete the global identity map
+
+Sessionless operations run with no identity map (no dedup, no cache, no
+stale-read surface). Rollback evicts the affected session's map only; bulk
+update/delete evict per model within the session."
+```
+
+---
+
+### Task 9: Docs — identity-map concepts rewrite + migration guide
+
+**Files:**
+- Modify: `docs/pages/concepts/identity-map.md` (rewrite sections)
+- Modify: the sessions migration guide (`docs/plans/ir-first-migration-guide.md` §sessions — confirm path via `IR_FIRST_MIGRATION_GUIDE_SESSIONS` in `src/ferro/_deprecations.py`)
+- Modify: `docs/plans/2026-07-02-001-fable-fixes-roadmap.md` (tick D1–D5 + exit gates L277–280)
+
+**Interfaces:** none — documentation of the guarantees implemented in Tasks 3–8.
+
+- [ ] **Step 1: Rewrite `docs/pages/concepts/identity-map.md`**
+
+Keep the page structure; rewrite content to state the new guarantees **precisely**:
+- *What it is*: session-scoped, weak-valued — "The identity map holds weak references: it never keeps an instance alive. When your code drops the last reference, the instance is released and the next fetch hydrates fresh."
+- *The guarantee* (verbatim from the design doc): "Within a session, fetching a row you already hold returns the same object, updated in place to the database's current values. Unsaved local mutations are overwritten by a re-fetch — the database wins."
+- *Scope*: "No session, no identity: operations routed with `using=` alone run without an identity map — every load returns a fresh instance, nothing is cached, nothing can go stale. Identity is a session feature because the session bounds the map's lifetime."
+- *Invalidation*: "Rolling back a transaction evicts the session's map. Bulk `update()`/`delete()` evict that model's entries in the session."
+- Update the existing examples to run inside `async with engines.session():` (both tabs, I-8); update the batch-jobs paragraph (weak values make manual eviction unnecessary for memory; `evict_instance` remains for forcing a fresh *instance* while holding the old one); update the stale-until-refresh caveat (re-fetch now refreshes in place; `refresh()` still works).
+- The memory-bound and refresh behaviors must match `tests/test_identity_memory.py` / `tests/test_identity_refresh.py` exactly.
+
+- [ ] **Step 2: Migration guide + roadmap ticks**
+
+- Migration guide: add a v0.13 note — implicit default-connection routing removed (was announced for v0.14); `using=` vs ambient session now errors; sessionless `using=` ops no longer identity-mapped.
+- Roadmap: tick `- [x]` for D1–D5 and the three exit-gate boxes; update the epic header line `(v0.14 cutover)` → `(landed v0.13)` and the D2/D4 body text that references the v0.14 boundary.
+
+- [ ] **Step 3: Verify docs examples still execute**
+
+```bash
+uv run pytest tests/test_docs_examples.py tests/test_documentation_features.py -q
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/
+git commit -m "docs(ff-d): identity-map guarantees (weak values, refresh-on-load, scoped invalidation); v0.13 routing migration notes"
+```
+
+---
+
+### Task 10: Full verification, push, PR, project tracking
+
+**Files:** none new — verification + shipping.
+
+- [ ] **Step 1: Full matrix + crates**
+
+```bash
+uv run maturin develop
+FERRO_POSTGRES_URL=postgres://postgres:password@localhost:5432/postgres just test
+cargo test -p ferro-schema-ir -p ferro-ddl-lowering -p ferro-migrate
+cargo test --no-default-features --features testing
+```
+Expected: green modulo the 7 pre-existing `[postgres]` failures (#176) — diff the failure list against `main` to confirm no new ones.
+
+- [ ] **Step 2: Shadow-strict rerun on touched surfaces**
+
+```bash
+FERRO_SHADOW_RUNTIME=1 FERRO_SHADOW_RUNTIME_STRICT=1 uv run pytest tests/test_crud.py tests/test_transactions.py tests/test_bulk_update.py tests/test_deletion.py tests/test_identity_memory.py tests/test_identity_refresh.py tests/test_identity_scoped_invalidation.py tests/test_routing_errors.py -q
+```
+(Both flags — STRICT alone is a silent no-op.)
+
+- [ ] **Step 3: Grep gates (final)**
+
+```bash
+uv run pytest tests/test_route_single_site.py -q
+grep -rn "IDENTITY_MAP" src/ crates/ | wc -l          # expect 0
+grep -rn "allow_legacy_default" src/ | wc -l           # expect 0
+```
+
+- [ ] **Step 4: Formatter discipline check**
+
+```bash
+git diff main --stat
+```
+Confirm every touched file is intentional; no bulk reformat hunks (compare any suspicious file against `main`).
+
+- [ ] **Step 5: Push and open PR (account `0x054`)**
+
+Push with the inline-token URL and open the PR with the `0x054` token (osxkeychain serves the wrong credential — see memory). PR body leads, in order:
+1. **Memory-bound proof** — weak-value map: dropped instances are released (`test_identity_memory.py`, deterministic form of the RSS gate; state the substitution).
+2. **Stale-read-with-identity proof** — external UPDATE + re-fetch returns fresh values with `a is b` (`test_identity_refresh.py`); note `fetch_one` no longer short-circuits the DB (identity map is dedup, not a query cache).
+3. **Routing collapse** — one `RouteHandle` resolved once in `resolve_operation_scope`; grep-verified single construction site; `active_route_for_operation` deleted.
+4. **Scoped invalidation + global map deleted** — rollback evicts per session, bulk ops per model; `IDENTITY_MAP` static and all clear sites gone.
+5. **D4** — `using=` vs ambient session is now `ValueError` (was: silent sessionless bypass).
+6. **D5** — FK extraction reads the target model's PK.
+7. **State plainly:** sessionless path fate (Option B: `using=`-only ops run with no identity map; no-route ops raise) and that the ambient-default removal lands in v0.13, one minor ahead of the shipped v0.14 deprecation notice — deliberate and accepted.
+No AI attribution in the PR body.
+
+- [ ] **Step 6: Project tracking (Project #7, owner `syn54x`)**
+
+Follow the FF-C convention: tick every `[FF-D]` sub-issue checkbox, close the sub-issues, set them and the epic to Done on Project #7. (Find them: `gh issue list --repo syn54x/ferro-orm --search "FF-D" --state all`.)

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -289,7 +289,8 @@ pub fn connect(
     })
 }
 
-/// Shuts down the global engine and clears the Identity Map.
+/// Shuts down the global engine and tears down all sessions (and their
+/// session-scoped identity maps).
 ///
 /// This is useful for testing environments to ensure isolation
 /// between test runs.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -6,8 +6,7 @@
 use crate::backend::{EngineHandle, PoolSpec, dialect_from_url};
 use crate::migrate::{MigrateOptions, internal_migrate};
 use crate::state::{
-    CONNECTION_REGISTRY, DEFAULT_CONNECTION_NAME, ENGINE, IDENTITY_MAP, SESSION_REGISTRY,
-    TRANSACTION_REGISTRY,
+    CONNECTION_REGISTRY, DEFAULT_CONNECTION_NAME, ENGINE, SESSION_REGISTRY, TRANSACTION_REGISTRY,
 };
 use pyo3::prelude::*;
 use std::sync::Arc;
@@ -312,8 +311,9 @@ pub fn reset_engine() -> PyResult<()> {
     *DEFAULT_CONNECTION_NAME.write().map_err(|_| {
         pyo3::exceptions::PyRuntimeError::new_err("Failed to lock Default Connection")
     })? = None;
-    IDENTITY_MAP.clear();
     TRANSACTION_REGISTRY.clear();
+    // Tears down every session's identity map with it (FF-D D2: identity
+    // maps are session-scoped only).
     SESSION_REGISTRY.clear();
     Ok(())
 }

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -15,7 +15,6 @@ from pydantic import Field as PydanticField
 from ._core import (
     clear_registry as _core_clear_registry,
     create_tables as _core_create_tables,
-    evict_instance,
     migrate as _core_migrate,
     reset_engine,
     set_default_connection,
@@ -39,7 +38,7 @@ from .exceptions import (
     UniqueViolationError,
 )
 from .fields import BackRef, Field, ManyToMany
-from .models import Model, transaction
+from .models import Model, evict_instance, transaction
 from .query import Relation
 from .raw import Transaction, execute, fetch_all, fetch_one
 from .session import Session, engines

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -116,9 +116,11 @@ async def connect(
         name: Optional connection name. Omitted connections register as "default".
         default: If True, make this named connection the default for unqualified operations.
         pool: Optional per-connection pool configuration.
-        identity_map: If True (default), keep a per-connection identity map so the same primary
-            key maps to a single Python instance. If False, each load returns fresh instances and
-            the map is not consulted (lower memory use; no ``a is b`` guarantees across loads).
+        identity_map: If True (default), sessions opened on this connection keep an identity
+            map so the same primary key maps to a single Python instance within a session.
+            Identity maps are session-scoped: operations outside a session never cache or
+            dedup instances. If False, loads on this connection return fresh instances even
+            inside a session (lower memory use; no ``a is b`` guarantees across loads).
         migrate_updates: If True, additionally update existing tables to match the
             registered models. Implies ``auto_migrate``. What this covers is
             capability-relative per backend:

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -1,5 +1,27 @@
 from typing import Any, Optional
 
+class RouteHandle:
+    """Opaque, immutable route for one operation (FF-D D3).
+
+    Resolved exactly once by ``ferro.state.resolve_operation_scope`` /
+    ``resolve_transaction_scope`` and threaded by value through every FFI
+    operation. ``connection_name`` is never ``None`` — a routeless handle is
+    unrepresentable, not an error branch.
+    """
+
+    def __init__(
+        self,
+        connection_name: str,
+        tx_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> None: ...
+    @property
+    def connection_name(self) -> str: ...
+    @property
+    def tx_id(self) -> Optional[str]: ...
+    @property
+    def session_id(self) -> Optional[str]: ...
+
 def register_model_schema(name: str, schema: str) -> None: ...
 async def connect(
     url: str,
@@ -90,74 +112,54 @@ def _shadow_compare_query_plan_for_test(
 
 async def fetch_all(
     cls: object,
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> list[Any]: ...
 async def fetch_filtered(
     cls: object,
     query_ir_json: str,
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> list[Any]: ...
 async def count_filtered(
     name: str,
     query_ir_json: str,
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> int: ...
 async def fetch_one(
     cls: object,
     pk_val: str,
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> Any | None: ...
 async def save_record(
     name: str,
     data: dict[str, Any],
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
     mode: str = "insert",
 ) -> int | None: ...
 async def update_record(
     name: str,
     data: dict[str, Any],
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> int: ...
 async def save_bulk_records(
     name: str,
     rows: list[dict[str, Any]],
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> int: ...
 async def delete_record(
     name: str,
     pk_val: str,
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> bool: ...
 async def delete_filtered(
     name: str,
     query_ir_json: str,
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> int: ...
 async def update_filtered(
     name: str,
     query_ir_json: str,
     updates: dict[str, Any],
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> int: ...
 async def add_m2m_links(
     join_table: str,
@@ -165,9 +167,7 @@ async def add_m2m_links(
     target_col: str,
     source_id: Any,
     target_ids: list[Any],
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> None: ...
 async def remove_m2m_links(
     join_table: str,
@@ -175,23 +175,15 @@ async def remove_m2m_links(
     target_col: str,
     source_id: Any,
     target_ids: list[Any],
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> None: ...
 async def clear_m2m_links(
     join_table: str,
     source_col: str,
     source_id: Any,
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> None: ...
-async def begin_transaction(
-    parent_tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
-) -> str: ...
+async def begin_transaction(route: RouteHandle) -> str: ...
 async def commit_transaction(tx_id: str, session_id: Optional[str] = None) -> None: ...
 def transaction_connection_name(tx_id: str, session_id: Optional[str] = None) -> str: ...
 async def rollback_transaction(tx_id: str, session_id: Optional[str] = None) -> None: ...
@@ -200,34 +192,25 @@ def close_session(session_id: str) -> None: ...
 async def raw_execute(
     sql: str,
     args: list[Any],
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> int: ...
 async def raw_fetch_all(
     sql: str,
     args: list[Any],
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> list[dict[str, Any]]: ...
 async def raw_fetch_one(
     sql: str,
     args: list[Any],
-    tx_id: Optional[str] = None,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> dict[str, Any] | None: ...
 def register_instance(
     name: str,
     pk: str,
     obj: object,
-    using: Optional[str] = None,
-    session_id: Optional[str] = None,
+    route: RouteHandle,
 ) -> None: ...
-def evict_instance(
-    name: str, pk: str, using: Optional[str] = None, session_id: Optional[str] = None
-) -> None: ...
+def evict_instance(name: str, pk: str, route: RouteHandle) -> None: ...
 def reset_engine() -> None: ...
 def set_default_connection(name: str) -> None: ...
 def clear_registry() -> None: ...

--- a/src/ferro/metaclass.py
+++ b/src/ferro/metaclass.py
@@ -32,6 +32,23 @@ from .schema_metadata import _enum_subclass_from_annotation, build_model_schema
 from .state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
 
 
+def _assert_weakref_support(cls: type) -> None:
+    """Reject model classes whose instances cannot be weakly referenced.
+
+    The identity map holds weak references to instances (FF-D D1). A class
+    that suppresses ``__weakref__`` would force a silent strong-ref fallback,
+    which is exactly the unbounded-memory failure F3 removed — so it fails
+    loudly at class definition time instead.
+    """
+    if not any("__weakref__" in getattr(base, "__dict__", {}) for base in cls.__mro__):
+        raise TypeError(
+            f"{cls.__name__} instances do not support weak references "
+            "(no __weakref__ slot in the MRO). Ferro model instances must be "
+            "weakly referenceable for identity mapping; remove __slots__ "
+            "declarations that suppress __weakref__."
+        )
+
+
 class ModelMetaclass(type(BaseModel)):
     """
     Metaclass for Ferro models that automatically registers the model schema with the Rust core.
@@ -50,6 +67,9 @@ class ModelMetaclass(type(BaseModel)):
 
         # Phase 2: Class Creation
         cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+
+        # Verify weakref support for identity mapping (FF-D D1)
+        _assert_weakref_support(cls)
 
         # Phase 3: Post-Creation Setup
         if name == "Model":

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -211,11 +211,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                 val = data.pop(field_name)
                 # If it's a Model instance, extract the ID
                 if isinstance(val, Model):
-                    pk_field = "id"
-                    for f_name, f_meta in self.__class__.ferro_fields.items():
-                        if f_meta.primary_key:
-                            pk_field = f_name
-                            break
+                    # Read the *target* model's PK (FF-D D5) — the source
+                    # model's PK name is irrelevant to the related instance.
+                    pk_field = val.__class__._primary_key_field_name() or "id"
                     id_val = getattr(val, pk_field, None)
                     data[f"{field_name}_id"] = id_val
                 else:

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -68,9 +68,7 @@ def _field_eq(field_name: str, value: Any) -> Predicate[Any]:
 def _transaction_or_using(
     using: str | None, session: "Session | None"
 ) -> tuple[str | None, str | None, str | None]:
-    return resolve_operation_scope(
-        using=using, session=session, allow_legacy_default=True
-    )
+    return resolve_operation_scope(using=using, session=session)
 
 
 def _instance_transaction_route(
@@ -80,13 +78,14 @@ def _instance_transaction_route(
     if using is not None and origin is not None and using != origin:
         raise ValueError("Instance is already bound to a different connection")
 
-    tx_id, route_using, session_id = _transaction_or_using(using, session)
+    # Origin is the instance's implicit route (FF-D D4): it participates in
+    # session-conflict checks instead of silently bypassing the session.
+    tx_id, route_using, session_id = _transaction_or_using(using or origin, session)
     if tx_id is not None:
         tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
         return tx_id, route_using, origin or tx_connection, session_id
 
-    effective_using = route_using or origin
-    return None, effective_using, effective_using, session_id
+    return None, route_using, route_using, session_id
 
 
 def _instance_origin(instance: object) -> str | None:
@@ -126,7 +125,7 @@ async def transaction(using: str | None = None, *, session: "Session | None" = N
     from .raw import Transaction
 
     parent_tx_id, effective_using, session_id = resolve_transaction_scope(
-        using=using, session=session, allow_legacy_default=True
+        using=using, session=session
     )
     tx_id = await begin_transaction(parent_tx_id, effective_using, session_id=session_id)
     connection_name = transaction_connection_name(tx_id, session_id=session_id)

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -22,7 +22,7 @@ from ._bind_payload import save_bind_payload
 from ._core import (
     begin_transaction,
     commit_transaction,
-    evict_instance,
+    evict_instance as _core_evict_instance,
     fetch_all,
     register_instance,
     rollback_transaction,
@@ -36,10 +36,12 @@ from .exceptions import ModelDoesNotExist
 from .metaclass import ModelMetaclass
 from .query import Predicate, Query, QueryNode
 from .state import (
+    RouteHandle,
     _CURRENT_TRANSACTION,
     _CURRENT_TRANSACTION_CONNECTION,
     resolve_operation_scope,
     resolve_transaction_scope,
+    route_for_transaction,
 )
 
 
@@ -67,25 +69,29 @@ def _field_eq(field_name: str, value: Any) -> Predicate[Any]:
 
 def _transaction_or_using(
     using: str | None, session: "Session | None"
-) -> tuple[str | None, str | None, str | None]:
+) -> RouteHandle:
     return resolve_operation_scope(using=using, session=session)
 
 
 def _instance_transaction_route(
     instance: object, using: str | None, session: "Session | None"
-) -> tuple[str | None, str | None, str | None, str | None]:
+) -> tuple[RouteHandle, str]:
+    """Resolve the route for an instance method (`save`/`delete`/`refresh`).
+
+    Returns `(route, effective_connection)`. `effective_connection` is
+    `route.connection_name` — always the real connection the instance's
+    identity-map entry lives on, whether or not an ambient transaction is
+    active (FF-D D3/D4 folded the old `identity_using`/`operation_using`
+    split into the single resolved route).
+    """
     origin = _instance_origin(instance)
     if using is not None and origin is not None and using != origin:
         raise ValueError("Instance is already bound to a different connection")
 
     # Origin is the instance's implicit route (FF-D D4): it participates in
     # session-conflict checks instead of silently bypassing the session.
-    tx_id, route_using, session_id = _transaction_or_using(using or origin, session)
-    if tx_id is not None:
-        tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
-        return tx_id, route_using, origin or tx_connection, session_id
-
-    return None, route_using, route_using, session_id
+    route = _transaction_or_using(using or origin, session)
+    return route, route.connection_name
 
 
 def _instance_origin(instance: object) -> str | None:
@@ -96,6 +102,25 @@ def _instance_origin(instance: object) -> str | None:
 def _set_instance_origin(instance: object, using: str | None) -> None:
     if using is not None:
         object.__setattr__(instance, _FERRO_CONNECTION_ATTR, using)
+
+
+def evict_instance(
+    model_name: str,
+    pk: str,
+    *,
+    using: str | None = None,
+    session: "Session | None" = None,
+) -> None:
+    """Remove one instance from the active scope's identity map.
+
+    Public wrapper around the FFI `evict_instance` (FF-D D3): resolves the
+    route once via `resolve_operation_scope`, then passes it through. Model
+    instance methods (`save`/`delete`/`refresh`) call the FFI symbol
+    directly with their already-resolved route instead of going through this
+    wrapper, so a route is never resolved twice for one operation.
+    """
+    route = resolve_operation_scope(using=using, session=session)
+    _core_evict_instance(model_name, pk, route)
 
 
 @asynccontextmanager
@@ -124,18 +149,17 @@ async def transaction(using: str | None = None, *, session: "Session | None" = N
     """
     from .raw import Transaction
 
-    parent_tx_id, effective_using, session_id = resolve_transaction_scope(
-        using=using, session=session
-    )
-    tx_id = await begin_transaction(parent_tx_id, effective_using, session_id=session_id)
-    connection_name = transaction_connection_name(tx_id, session_id=session_id)
+    route = resolve_transaction_scope(using=using, session=session)
+    tx_id = await begin_transaction(route)
+    connection_name = transaction_connection_name(tx_id, session_id=route.session_id)
+    child_route = route_for_transaction(connection_name, tx_id, route.session_id)
     token = _CURRENT_TRANSACTION.set(tx_id)
     connection_token = _CURRENT_TRANSACTION_CONNECTION.set(connection_name)
     try:
-        yield Transaction(tx_id, session_id=session_id)
-        await commit_transaction(tx_id, session_id=session_id)
+        yield Transaction(child_route)
+        await commit_transaction(tx_id, session_id=route.session_id)
     except Exception:
-        await rollback_transaction(tx_id, session_id=session_id)
+        await rollback_transaction(tx_id, session_id=route.session_id)
         raise
     finally:
         _CURRENT_TRANSACTION.reset(token)
@@ -278,17 +302,13 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             raise ValueError(
                 f'on_conflict must be None or "update", got {on_conflict!r}'
             )
-        tx_id, operation_using, identity_using, session_id = _instance_transaction_route(
-            self, using, session
-        )
+        route, identity_using = _instance_transaction_route(self, using, session)
         new_id = None
         if on_conflict == "update":
             new_id = await save_record(
                 self.__class__.__name__,
                 save_bind_payload(self),
-                tx_id,
-                operation_using,
-                session_id=session_id,
+                route,
                 mode="upsert",
             )
         elif _is_persisted(self):
@@ -302,9 +322,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             rows_affected = await update_record(
                 self.__class__.__name__,
                 save_bind_payload(self),
-                tx_id,
-                operation_using,
-                session_id=session_id,
+                route,
             )
             if rows_affected == 0:
                 raise ModelDoesNotExist(self.__class__, pk_val)
@@ -312,9 +330,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             new_id = await save_record(
                 self.__class__.__name__,
                 save_bind_payload(self),
-                tx_id,
-                operation_using,
-                session_id=session_id,
+                route,
                 mode="insert",
             )
 
@@ -344,8 +360,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                 self.__class__.__name__,
                 str(pk_val),
                 self,
-                identity_using,
-                session_id=session_id,
+                route,
             )
             _set_instance_origin(self, identity_using)
         _set_persisted(self, True)
@@ -365,21 +380,15 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         """
         pk_field_name = self.__class__._primary_key_field_name()
         pk_val = getattr(self, pk_field_name) if pk_field_name is not None else None
-        _tx_id, operation_using, identity_using, session_id = _instance_transaction_route(
-            self, using, session
-        )
+        route, _identity_using = _instance_transaction_route(self, using, session)
 
         if pk_val is not None:
             name = self.__class__.__name__
-            query = self.__class__.where(_field_eq(pk_field_name, pk_val))
-            if operation_using is not None:
-                query = Query(self.__class__, using=operation_using).where(
-                    _field_eq(pk_field_name, pk_val)
-                )
-            await query.delete()
-            evict_instance(
-                name, str(pk_val), identity_using, session_id=session_id
+            query = Query(self.__class__, using=route.connection_name).where(
+                _field_eq(pk_field_name, pk_val)
             )
+            await query.delete()
+            _core_evict_instance(name, str(pk_val), route)
             # The instance is transient again: a later save() re-INSERTs.
             _set_persisted(self, False)
 
@@ -409,8 +418,8 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> isinstance(users, list)
             True
         """
-        tx_id, using, session_id = _transaction_or_using(using, session)
-        return await fetch_all(cls, tx_id, using, session_id=session_id)
+        route = _transaction_or_using(using, session)
+        return await fetch_all(cls, route)
 
     @classmethod
     async def get(cls, pk: Any, *, session: "Session | None" = None) -> Self:
@@ -476,25 +485,19 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             raise RuntimeError("Cannot refresh a model without a primary key")
 
         name = self.__class__.__name__
-        _tx_id, operation_using, identity_using, session_id = _instance_transaction_route(
-            self, using, session
-        )
+        route, identity_using = _instance_transaction_route(self, using, session)
 
-        evict_instance(name, str(pk_val), identity_using, session_id=session_id)
-        query = self.__class__.where(_field_eq(pk_field_name, pk_val))
-        if operation_using is not None:
-            query = Query(self.__class__, using=operation_using).where(
-                _field_eq(pk_field_name, pk_val)
-            )
+        _core_evict_instance(name, str(pk_val), route)
+        query = Query(self.__class__, using=route.connection_name).where(
+            _field_eq(pk_field_name, pk_val)
+        )
         fresh_instance = await query.first()
 
         if fresh_instance is None:
             raise RuntimeError(f"Instance not found in database: {name}({pk_val})")
 
         self.__dict__.update(fresh_instance.__dict__)
-        register_instance(
-            name, str(pk_val), self, identity_using, session_id=session_id
-        )
+        register_instance(name, str(pk_val), self, route)
         _set_instance_origin(self, identity_using)
         _set_persisted(self, True)
 
@@ -636,10 +639,8 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         if not instances:
             return 0
         data = [save_bind_payload(i) for i in instances]
-        tx_id, using, session_id = _transaction_or_using(using, session)
-        return await save_bulk_records(
-            cls.__name__, data, tx_id, using, session_id=session_id
-        )
+        route = _transaction_or_using(using, session)
+        return await save_bulk_records(cls.__name__, data, route)
 
     @classmethod
     async def get_or_create(

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -112,9 +112,7 @@ class Query(Generic[T]):
     def _transaction_or_using(self) -> tuple[str | None, str | None, str | None]:
         from ..state import resolve_operation_scope
 
-        return resolve_operation_scope(
-            using=self._using, session=self._session, allow_legacy_default=True
-        )
+        return resolve_operation_scope(using=self._using, session=self._session)
 
     def _m2m(
         self, join_table: str, source_col: str, target_col: str, source_id: Any

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -21,6 +21,7 @@ from .._core import (
 from .nodes import QueryNode, QueryProxy, _serialize_query_value
 
 if TYPE_CHECKING:
+    from .._core import RouteHandle
     from .nodes import Predicate
 
 T = TypeVar("T")
@@ -109,7 +110,7 @@ class Query(Generic[T]):
         self._offset: int | None = None
         self._m2m_context: dict[str, Any] | None = None
 
-    def _transaction_or_using(self) -> tuple[str | None, str | None, str | None]:
+    def _transaction_or_using(self) -> "RouteHandle":
         from ..state import resolve_operation_scope
 
         return resolve_operation_scope(using=self._using, session=self._session)
@@ -272,13 +273,11 @@ class Query(Generic[T]):
             "offset": self._offset,
             "m2m": self._m2m_context,
         }
-        tx_id, using, session_id = self._transaction_or_using()
+        route = self._transaction_or_using()
         return await fetch_filtered(
             self.model_cls,
             _query_ir_payload_to_json(query_def),
-            tx_id,
-            using,
-            session_id=session_id,
+            route,
         )
 
     async def count(self) -> int:
@@ -300,13 +299,11 @@ class Query(Generic[T]):
             "offset": None,
             "m2m": self._m2m_context,
         }
-        tx_id, using, session_id = self._transaction_or_using()
+        route = self._transaction_or_using()
         return await count_filtered(
             self.model_cls.__name__,
             _query_ir_payload_to_json(query_def),
-            tx_id,
-            using,
-            session_id=session_id,
+            route,
         )
 
     async def update(self, **fields) -> int:
@@ -327,14 +324,12 @@ class Query(Generic[T]):
             True
         """
         query_def = self._mutating_query_def("update")
-        tx_id, using, session_id = self._transaction_or_using()
+        route = self._transaction_or_using()
         return await update_filtered(
             self.model_cls.__name__,
             _query_ir_payload_to_json(query_def),
             update_bind_payload(fields),
-            tx_id,
-            using,
-            session_id=session_id,
+            route,
         )
 
     async def first(self) -> T | None:
@@ -371,13 +366,11 @@ class Query(Generic[T]):
             True
         """
         query_def = self._mutating_query_def("delete")
-        tx_id, using, session_id = self._transaction_or_using()
+        route = self._transaction_or_using()
         return await delete_filtered(
             self.model_cls.__name__,
             _query_ir_payload_to_json(query_def),
-            tx_id,
-            using,
-            session_id=session_id,
+            route,
         )
 
     async def exists(self) -> bool:
@@ -418,18 +411,14 @@ class Query(Generic[T]):
             # Assume 'id' for now
             ids.append(getattr(inst, "id"))
 
-        from ..state import _CURRENT_TRANSACTION
-
-        tx_id, using, session_id = self._transaction_or_using()
+        route = self._transaction_or_using()
         await add_m2m_links(
             self._m2m_context["join_table"],
             self._m2m_context["source_col"],
             self._m2m_context["target_col"],
             self._m2m_context["source_id"],
             ids,
-            tx_id,
-            using,
-            session_id=session_id,
+            route,
         )
 
     async def remove(self, *instances: Any) -> None:
@@ -455,18 +444,14 @@ class Query(Generic[T]):
         for inst in instances:
             ids.append(getattr(inst, "id"))
 
-        from ..state import _CURRENT_TRANSACTION
-
-        tx_id, using, session_id = self._transaction_or_using()
+        route = self._transaction_or_using()
         await remove_m2m_links(
             self._m2m_context["join_table"],
             self._m2m_context["source_col"],
             self._m2m_context["target_col"],
             self._m2m_context["source_id"],
             ids,
-            tx_id,
-            using,
-            session_id=session_id,
+            route,
         )
 
     async def clear(self) -> None:
@@ -484,16 +469,12 @@ class Query(Generic[T]):
                 "'.clear()' can only be used on Many-to-Many relationships"
             )
 
-        from ..state import _CURRENT_TRANSACTION
-
-        tx_id, using, session_id = self._transaction_or_using()
+        route = self._transaction_or_using()
         await clear_m2m_links(
             self._m2m_context["join_table"],
             self._m2m_context["source_col"],
             self._m2m_context["source_id"],
-            tx_id,
-            using,
-            session_id=session_id,
+            route,
         )
 
     def __repr__(self):

--- a/src/ferro/raw.py
+++ b/src/ferro/raw.py
@@ -28,6 +28,7 @@ import json
 import uuid
 from typing import Any
 
+from ._core import RouteHandle
 from ._core import raw_execute as _raw_execute
 from ._core import raw_fetch_all as _raw_fetch_all
 from ._core import raw_fetch_one as _raw_fetch_one
@@ -68,9 +69,7 @@ def _check_sql(sql: str) -> None:
         raise ValueError("sql must be a non-empty statement")
 
 
-def _transaction_or_using(
-    using: str | None, session: Any | None
-) -> tuple[str | None, str | None, str | None]:
+def _transaction_or_using(using: str | None, session: Any | None) -> RouteHandle:
     return resolve_operation_scope(using=using, session=session)
 
 
@@ -87,8 +86,8 @@ async def execute(
     """
     _check_sql(sql)
     marshalled = [_marshal(a) for a in args]
-    tx_id, using, session_id = _transaction_or_using(using, session)
-    return await _raw_execute(sql, marshalled, tx_id, using, session_id=session_id)
+    route = _transaction_or_using(using, session)
+    return await _raw_execute(sql, marshalled, route)
 
 
 async def fetch_all(
@@ -101,8 +100,8 @@ async def fetch_all(
     """
     _check_sql(sql)
     marshalled = [_marshal(a) for a in args]
-    tx_id, using, session_id = _transaction_or_using(using, session)
-    return await _raw_fetch_all(sql, marshalled, tx_id, using, session_id=session_id)
+    route = _transaction_or_using(using, session)
+    return await _raw_fetch_all(sql, marshalled, route)
 
 
 async def fetch_one(
@@ -114,8 +113,8 @@ async def fetch_one(
     """
     _check_sql(sql)
     marshalled = [_marshal(a) for a in args]
-    tx_id, using, session_id = _transaction_or_using(using, session)
-    return await _raw_fetch_one(sql, marshalled, tx_id, using, session_id=session_id)
+    route = _transaction_or_using(using, session)
+    return await _raw_fetch_one(sql, marshalled, route)
 
 
 class Transaction:
@@ -123,7 +122,8 @@ class Transaction:
 
     Obtained via ``async with transaction() as tx``. Methods delegate to the
     top-level :func:`execute` / :func:`fetch_all` / :func:`fetch_one` with this
-    transaction's ``tx_id`` set explicitly, so they don't depend on the
+    transaction's route (a :class:`RouteHandle` built by
+    ``models.transaction()``) passed explicitly, so they don't depend on the
     ContextVar state. This makes the connection-affinity invariant
     structurally impossible to violate from inside the ``async with`` block.
 
@@ -131,27 +131,22 @@ class Transaction:
     subsequent call raises :class:`RuntimeError`.
     """
 
-    __slots__ = ("_tx_id", "_session_id")
+    __slots__ = ("_route",)
 
-    def __init__(self, tx_id: str, session_id: str | None = None) -> None:
-        self._tx_id = tx_id
-        self._session_id = session_id
+    def __init__(self, route: RouteHandle) -> None:
+        self._route = route
 
     async def execute(self, sql: str, *args: Any) -> int:
         _check_sql(sql)
         marshalled = [_marshal(a) for a in args]
-        return await _raw_execute(sql, marshalled, self._tx_id, session_id=self._session_id)
+        return await _raw_execute(sql, marshalled, self._route)
 
     async def fetch_all(self, sql: str, *args: Any) -> list[dict[str, Any]]:
         _check_sql(sql)
         marshalled = [_marshal(a) for a in args]
-        return await _raw_fetch_all(
-            sql, marshalled, self._tx_id, session_id=self._session_id
-        )
+        return await _raw_fetch_all(sql, marshalled, self._route)
 
     async def fetch_one(self, sql: str, *args: Any) -> dict[str, Any] | None:
         _check_sql(sql)
         marshalled = [_marshal(a) for a in args]
-        return await _raw_fetch_one(
-            sql, marshalled, self._tx_id, session_id=self._session_id
-        )
+        return await _raw_fetch_one(sql, marshalled, self._route)

--- a/src/ferro/raw.py
+++ b/src/ferro/raw.py
@@ -71,9 +71,7 @@ def _check_sql(sql: str) -> None:
 def _transaction_or_using(
     using: str | None, session: Any | None
 ) -> tuple[str | None, str | None, str | None]:
-    return resolve_operation_scope(
-        using=using, session=session, allow_legacy_default=True
-    )
+    return resolve_operation_scope(using=using, session=session)
 
 
 async def execute(

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -2,13 +2,6 @@ from contextvars import ContextVar
 
 from typing import Any, Protocol
 
-from ._deprecations import (
-    IR_FIRST_DEPRECATION_REMOVE_IN,
-    IR_FIRST_DEPRECATION_SINCE,
-    IR_FIRST_MIGRATION_GUIDE_SESSIONS,
-    warn_deprecated,
-)
-
 # Context variable to store the active transaction ID for the current task
 _CURRENT_TRANSACTION: ContextVar[str | None] = ContextVar(
     "current_transaction", default=None
@@ -26,12 +19,6 @@ class SessionLike(Protocol):
 
 _CURRENT_SESSION: ContextVar[SessionLike | None] = ContextVar(
     "current_session", default=None
-)
-
-_LEGACY_DEFAULT_CONNECTION_REASON = (
-    "Implicit default-connection routing without an active session is deprecated; "
-    "use `async with ferro.engines.session(\"name\")` (or pass `session=...`) for "
-    "ORM/raw operations."
 )
 
 _SESSION_CLOSED_MESSAGE = (
@@ -62,13 +49,34 @@ _SCHEMA_IR_BY_MODEL: dict[str, dict[str, Any]] = {}
 _SCHEMA_IR_FINGERPRINT_BY_MODEL: dict[str, str] = {}
 
 
+_NO_ROUTE_MESSAGE = (
+    "No database route for this operation. Open a session "
+    "(`async with ferro.engines.session(...)`) or pass `using=`/`session=` "
+    "explicitly. Implicit default-connection routing was removed in v0.13 "
+    "(deprecated since v0.12); see the sessions migration guide."
+)
+
+
+def _using_conflict_message(using: str, session_connection: str) -> str:
+    return (
+        f"Explicit `using={using!r}` conflicts with the ambient session bound "
+        f"to connection {session_connection!r}. Pass an explicit `session=` "
+        f"for that connection, or open a session on {using!r}."
+    )
+
+
 def resolve_operation_scope(
     *,
     using: str | None,
     session: SessionLike | None,
-    allow_legacy_default: bool,
 ) -> tuple[str | None, str | None, str | None]:
-    """Resolve `(tx_id, using, session_id)` for ORM/raw operations."""
+    """Resolve the route for ORM/raw operations.
+
+    Exactly one resolution site per operation (FF-D D3/D4): a session
+    (ambient or explicit), an explicit `using=`, or an active transaction.
+    No route is an error; `using=` conflicting with the ambient session is
+    an error (the silent sessionless bypass was removed in v0.13).
+    """
     tx_id = _CURRENT_TRANSACTION.get()
     tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
 
@@ -76,19 +84,18 @@ def resolve_operation_scope(
     explicit_session = session
     effective_session = explicit_session or ambient_session
 
-    # Explicit `using` can override ambient sessions for compatibility, but not
-    # explicitly supplied `session=...`.
     if effective_session is not None and using is not None:
-        if explicit_session is not None and using != effective_session.connection_name:
-            raise ValueError(
-                "Explicit `using` conflicts with explicit `session` connection"
+        if using != effective_session.connection_name:
+            if explicit_session is not None:
+                raise ValueError(
+                    "Explicit `using` conflicts with explicit `session` connection"
+                )
+            raise ValueError(  # FF-D D4
+                _using_conflict_message(using, effective_session.connection_name)
             )
-        if explicit_session is None and using != effective_session.connection_name:
-            effective_session = None
 
     if explicit_session is None and ambient_session is not None:
         _ensure_active_session(ambient_session)
-
     _ensure_active_session(effective_session)
 
     session_id = effective_session.session_id if effective_session is not None else None
@@ -108,14 +115,8 @@ def resolve_operation_scope(
     effective_using = using or (
         effective_session.connection_name if effective_session is not None else None
     )
-    if effective_using is None and allow_legacy_default:
-        warn_deprecated(
-            reason=_LEGACY_DEFAULT_CONNECTION_REASON,
-            since=IR_FIRST_DEPRECATION_SINCE,
-            remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
-            reference=IR_FIRST_MIGRATION_GUIDE_SESSIONS,
-            stacklevel=2,
-        )
+    if effective_using is None:
+        raise RuntimeError(_NO_ROUTE_MESSAGE)
     return None, effective_using, session_id
 
 
@@ -123,25 +124,28 @@ def resolve_transaction_scope(
     *,
     using: str | None,
     session: SessionLike | None,
-    allow_legacy_default: bool,
 ) -> tuple[str | None, str | None, str | None]:
+    """Resolve the route for `transaction()` — same rules as
+    `resolve_operation_scope`, but nested transactions always inherit the
+    parent transaction's route.
+    """
     parent_tx_id = _CURRENT_TRANSACTION.get()
-    tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
     ambient_session = _CURRENT_SESSION.get()
     explicit_session = session
     effective_session = explicit_session or ambient_session
 
     if effective_session is not None and using is not None:
-        if explicit_session is not None and using != effective_session.connection_name:
-            raise ValueError(
-                "Explicit `using` conflicts with explicit `session` connection"
+        if using != effective_session.connection_name:
+            if explicit_session is not None:
+                raise ValueError(
+                    "Explicit `using` conflicts with explicit `session` connection"
+                )
+            raise ValueError(  # FF-D D4
+                _using_conflict_message(using, effective_session.connection_name)
             )
-        if explicit_session is None and using != effective_session.connection_name:
-            effective_session = None
 
     if explicit_session is None and ambient_session is not None:
         _ensure_active_session(ambient_session)
-
     _ensure_active_session(effective_session)
 
     if parent_tx_id is not None:
@@ -153,14 +157,8 @@ def resolve_transaction_scope(
     effective_using = using or (
         effective_session.connection_name if effective_session is not None else None
     )
-    if effective_using is None and allow_legacy_default:
-        warn_deprecated(
-            reason=_LEGACY_DEFAULT_CONNECTION_REASON,
-            since=IR_FIRST_DEPRECATION_SINCE,
-            remove_in=IR_FIRST_DEPRECATION_REMOVE_IN,
-            reference=IR_FIRST_MIGRATION_GUIDE_SESSIONS,
-            stacklevel=2,
-        )
+    if effective_using is None:
+        raise RuntimeError(_NO_ROUTE_MESSAGE)
     return None, effective_using, (
         effective_session.session_id if effective_session is not None else None
     )

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -2,6 +2,8 @@ from contextvars import ContextVar
 
 from typing import Any, Protocol
 
+from ._core import RouteHandle
+
 # Context variable to store the active transaction ID for the current task
 _CURRENT_TRANSACTION: ContextVar[str | None] = ContextVar(
     "current_transaction", default=None
@@ -69,13 +71,15 @@ def resolve_operation_scope(
     *,
     using: str | None,
     session: SessionLike | None,
-) -> tuple[str | None, str | None, str | None]:
+) -> RouteHandle:
     """Resolve the route for ORM/raw operations.
 
     Exactly one resolution site per operation (FF-D D3/D4): a session
     (ambient or explicit), an explicit `using=`, or an active transaction.
     No route is an error; `using=` conflicting with the ambient session is
-    an error (the silent sessionless bypass was removed in v0.13).
+    an error (the silent sessionless bypass was removed in v0.13). The
+    returned `RouteHandle` is resolved once and threaded by value through
+    every FFI operation — Rust never re-derives it.
     """
     tx_id = _CURRENT_TRANSACTION.get()
     tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
@@ -110,26 +114,30 @@ def resolve_operation_scope(
                 raise ValueError(
                     "Active transaction is bound to a different connection than session"
                 )
-        return tx_id, None, session_id
+        return RouteHandle(
+            connection_name=tx_connection, tx_id=tx_id, session_id=session_id
+        )
 
     effective_using = using or (
         effective_session.connection_name if effective_session is not None else None
     )
     if effective_using is None:
         raise RuntimeError(_NO_ROUTE_MESSAGE)
-    return None, effective_using, session_id
+    return RouteHandle(connection_name=effective_using, session_id=session_id)
 
 
 def resolve_transaction_scope(
     *,
     using: str | None,
     session: SessionLike | None,
-) -> tuple[str | None, str | None, str | None]:
+) -> RouteHandle:
     """Resolve the route for `transaction()` — same rules as
     `resolve_operation_scope`, but nested transactions always inherit the
-    parent transaction's route.
+    parent transaction's route. The returned handle's `tx_id` is the
+    *parent* transaction (or `None` for a root transaction).
     """
     parent_tx_id = _CURRENT_TRANSACTION.get()
+    tx_connection = _CURRENT_TRANSACTION_CONNECTION.get()
     ambient_session = _CURRENT_SESSION.get()
     explicit_session = session
     effective_session = explicit_session or ambient_session
@@ -148,10 +156,12 @@ def resolve_transaction_scope(
         _ensure_active_session(ambient_session)
     _ensure_active_session(effective_session)
 
+    session_id = effective_session.session_id if effective_session is not None else None
+
     if parent_tx_id is not None:
         # Nested tx route is always inherited from parent.
-        return parent_tx_id, None, (
-            effective_session.session_id if effective_session is not None else None
+        return RouteHandle(
+            connection_name=tx_connection, tx_id=parent_tx_id, session_id=session_id
         )
 
     effective_using = using or (
@@ -159,6 +169,18 @@ def resolve_transaction_scope(
     )
     if effective_using is None:
         raise RuntimeError(_NO_ROUTE_MESSAGE)
-    return None, effective_using, (
-        effective_session.session_id if effective_session is not None else None
-    )
+    return RouteHandle(connection_name=effective_using, session_id=session_id)
+
+
+def route_for_transaction(
+    connection_name: str, tx_id: str, session_id: str | None
+) -> RouteHandle:
+    """Build the child route for the `Transaction` handle yielded by
+    `transaction()` (FF-D D3).
+
+    Kept in `state.py` — the only module allowed to construct
+    `RouteHandle` — rather than inline in `models.py`, so the single
+    construction-site invariant holds for every route, including the one
+    handed to raw SQL inside a transaction block.
+    """
+    return RouteHandle(connection_name=connection_name, tx_id=tx_id, session_id=session_id)

--- a/src/hydration.rs
+++ b/src/hydration.rs
@@ -97,6 +97,35 @@ pub fn hydrate_model_instance<'py>(
     dict.set_item(pyo3::intern!(py, "__ferro_persisted"), true)?;
     let fields_set = pyo3::types::PySet::empty(py)?;
 
+    apply_decoded_fields(
+        py,
+        cls,
+        dict,
+        &fields_set,
+        fields,
+        py_col_names,
+        enum_classes,
+    )?;
+
+    let _ = instance.setattr(pyo3::intern!(py, "__pydantic_fields_set__"), fields_set);
+    set_pydantic_hydration_slots(py, cls, &instance)?;
+    Ok(instance)
+}
+
+/// Write decoded column values into `dict` and record them in `fields_set`.
+///
+/// The single materialization path for both fresh hydration and fetch-hit
+/// refresh (FF-D D1b) — refresh cannot drift from hydration, and a partial
+/// write is structurally impossible.
+fn apply_decoded_fields<'py>(
+    py: Python<'py>,
+    cls: &Bound<'py, PyAny>,
+    dict: &Bound<'py, pyo3::types::PyDict>,
+    fields_set: &Bound<'py, pyo3::types::PySet>,
+    fields: Vec<(String, RustValue)>,
+    py_col_names: &HashMap<String, pyo3::Py<pyo3::types::PyString>>,
+    enum_classes: &HashMap<String, Bound<'py, PyAny>>,
+) -> PyResult<()> {
     for (col_name, val) in fields {
         let mut py_val = val.into_py_any(py)?;
         if let Some(enum_cls) = enum_classes.get(&col_name)
@@ -125,8 +154,35 @@ pub fn hydrate_model_instance<'py>(
             fields_set.add(&py_name)?;
         }
     }
+    Ok(())
+}
 
-    let _ = instance.setattr(pyo3::intern!(py, "__pydantic_fields_set__"), fields_set);
-    set_pydantic_hydration_slots(py, cls, &instance)?;
-    Ok(instance)
+/// Refresh a live cached instance from a freshly decoded row (FF-D D1b).
+///
+/// Overwrites every decoded field and resets `__pydantic_fields_set__` to
+/// match a fresh hydration. Ferro markers (`__ferro_connection_name`,
+/// `__ferro_persisted`) and pydantic extra/private slots are already present
+/// on the instance and are left untouched.
+pub fn refresh_model_instance<'py>(
+    py: Python<'py>,
+    cls: &Bound<'py, PyAny>,
+    instance: &Bound<'py, PyAny>,
+    fields: Vec<(String, RustValue)>,
+    py_col_names: &HashMap<String, pyo3::Py<pyo3::types::PyString>>,
+    enum_classes: &HashMap<String, Bound<'py, PyAny>>,
+) -> PyResult<()> {
+    let dict_attr = instance.getattr(pyo3::intern!(py, "__dict__"))?;
+    let dict = dict_attr.cast::<pyo3::types::PyDict>()?;
+    let fields_set = pyo3::types::PySet::empty(py)?;
+    apply_decoded_fields(
+        py,
+        cls,
+        dict,
+        &fields_set,
+        fields,
+        py_col_names,
+        enum_classes,
+    )?;
+    instance.setattr(pyo3::intern!(py, "__pydantic_fields_set__"), fields_set)?;
+    Ok(())
 }

--- a/src/hydration.rs
+++ b/src/hydration.rs
@@ -163,6 +163,17 @@ fn apply_decoded_fields<'py>(
 /// match a fresh hydration. Ferro markers (`__ferro_connection_name`,
 /// `__ferro_persisted`) and pydantic extra/private slots are already present
 /// on the instance and are left untouched.
+///
+/// # Precondition
+/// `fields` must be a FULL row decode — every persisted column, not a
+/// projected subset. All three current callers (`fetch_all`, `fetch_one`,
+/// `fetch_filtered` in `src/operations.rs`) decode `SELECT table.*`, so this
+/// holds today. A future caller that passes a partial-column decode would
+/// silently corrupt the cached instance: columns absent from `fields` keep
+/// their stale `__dict__` values, and `__pydantic_fields_set__` is reset to
+/// only the decoded subset, understating which fields are actually set. This
+/// function has no way to detect a partial decode from its arguments alone —
+/// any partial-refresh caller must be rejected at the call site, not here.
 pub fn refresh_model_instance<'py>(
     py: Python<'py>,
     cls: &Bound<'py, PyAny>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(operations::fetch_one, m)?)?;
     m.add_function(wrap_pyfunction!(operations::register_instance, m)?)?;
     m.add_function(wrap_pyfunction!(operations::evict_instance, m)?)?;
+    m.add_function(wrap_pyfunction!(operations::identity_map_len, m)?)?;
     m.add_function(wrap_pyfunction!(operations::save_record, m)?)?;
     m.add_function(wrap_pyfunction!(operations::update_record, m)?)?;
     m.add_function(wrap_pyfunction!(operations::save_bulk_records, m)?)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ fn clear_registry() -> PyResult<()> {
 /// This module exposes the Rust-backed core functions to Python.
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<state::RouteHandle>()?;
     m.add_function(wrap_pyfunction!(schema::register_model_schema, m)?)?;
     m.add_function(wrap_pyfunction!(connection::connect, m)?)?;
     m.add_function(wrap_pyfunction!(operations::fetch_all, m)?)?;

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -34,7 +34,7 @@ use crate::schema::{
     ColumnPlan, build_column_plan, internal_create_tables,
     order_schemas_for_creation,
 };
-use crate::state::{IDENTITY_MAP, MODEL_REGISTRY, engine_for_connection};
+use crate::state::{MODEL_REGISTRY, engine_for_connection};
 use pyo3::prelude::*;
 use sea_query::{Alias, ColumnDef, Index, PostgresQueryBuilder, SqliteQueryBuilder, Table};
 use std::collections::{HashMap, HashSet};
@@ -878,12 +878,6 @@ pub async fn internal_migrate(engine: Arc<EngineHandle>, opts: MigrateOptions) -
                 e,
             )
         })?;
-        // Identity-mapped instances were hydrated against the pre-migration
-        // schema (e.g. a row loaded before a column add lacks the new field).
-        // The schema lives in the database, which any number of named
-        // connections may share, so the whole map is invalidated — eviction is
-        // always safe; instances simply re-hydrate on next load.
-        IDENTITY_MAP.clear();
     }
 
     for warning in &warnings {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -8,7 +8,7 @@ use crate::backend::{
 };
 use crate::query::{QueryDef, query_def_from_ir_payload};
 use crate::state::{
-    Dialect, IDENTITY_MAP, MODEL_REGISTRY, TRANSACTION_REGISTRY,
+    Dialect, MODEL_REGISTRY, TRANSACTION_REGISTRY,
     TransactionConnection, TransactionHandle, connection_for_route, ensure_session_idle_for_close,
     engine_for_connection, register_session, session_state, unregister_session,
 };
@@ -84,25 +84,22 @@ fn identity_map_get(
     session_id: Option<&str>,
     key: &(String, String, String),
 ) -> PyResult<Option<Py<PyAny>>> {
+    // Sessionless operations have no identity map (FF-D Option B): nothing
+    // is cached, so nothing can dedup — and nothing can go stale.
+    let Some(session_id) = session_id else {
+        return Ok(None);
+    };
+    let session = session_state(session_id)?;
     // Clone the weakref out of the shard guard before touching Python:
     // GIL-before-shard ordering is the invariant (see maybe_sweep).
-    let weak = if let Some(session_id) = session_id {
-        let session = session_state(session_id)?;
-        session.identity_map.get(key).map(|e| e.value().clone_ref(py))
-    } else {
-        IDENTITY_MAP.get(key).map(|e| e.value().clone_ref(py))
-    };
+    let weak = session.identity_map.get(key).map(|e| e.value().clone_ref(py));
     let Some(weak) = weak else { return Ok(None) };
     // Upgrade to a strong ref; hit-vs-miss is decided on the upgraded ref so
     // the instance cannot die between the check and use.
     let obj = weak.bind(py).call0()?;
     if obj.is_none() {
         // Dead entry: prune the tombstone, report a miss.
-        if let Some(session_id) = session_id {
-            session_state(session_id)?.identity_map.remove(key);
-        } else {
-            IDENTITY_MAP.remove(key);
-        }
+        session.identity_map.remove(key);
         return Ok(None);
     }
     Ok(Some(obj.unbind()))
@@ -114,6 +111,10 @@ fn identity_map_insert(
     key: (String, String, String),
     value: &Bound<'_, PyAny>,
 ) -> PyResult<()> {
+    // Sessionless operations have no identity map (FF-D Option B): no-op.
+    let Some(session_id) = session_id else {
+        return Ok(());
+    };
     // Weak by design: the map must never keep an instance alive (FF-D D1).
     // A class that can't be weakly referenced is a loud error, never a
     // silent strong-ref fallback.
@@ -127,46 +128,38 @@ fn identity_map_insert(
         })?
         .into_any()
         .unbind();
-    if let Some(session_id) = session_id {
-        let session = session_state(session_id)?;
-        session.identity_map.insert(key, weak);
-        maybe_sweep(py, &session.identity_map, &session.identity_ops);
-        return Ok(());
-    }
-    IDENTITY_MAP.insert(key, weak);
-    maybe_sweep(py, &IDENTITY_MAP, &crate::state::IDENTITY_MAP_OPS);
+    let session = session_state(session_id)?;
+    session.identity_map.insert(key, weak);
+    maybe_sweep(py, &session.identity_map, &session.identity_ops);
     Ok(())
 }
 
 fn identity_map_remove(session_id: Option<&str>, key: &(String, String, String)) -> PyResult<()> {
-    if let Some(session_id) = session_id {
-        let session = session_state(session_id)?;
-        session.identity_map.remove(key);
+    let Some(session_id) = session_id else {
         return Ok(());
-    }
-    IDENTITY_MAP.remove(key);
+    };
+    let session = session_state(session_id)?;
+    session.identity_map.remove(key);
     Ok(())
 }
 
 fn identity_map_retain_model(session_id: Option<&str>, model_name: &str) -> PyResult<()> {
-    if let Some(session_id) = session_id {
-        let session = session_state(session_id)?;
-        session
-            .identity_map
-            .retain(|(_, m_name, _), _| m_name != model_name);
+    let Some(session_id) = session_id else {
         return Ok(());
-    }
-    IDENTITY_MAP.retain(|(_, m_name, _), _| m_name != model_name);
+    };
+    let session = session_state(session_id)?;
+    session
+        .identity_map
+        .retain(|(_, m_name, _), _| m_name != model_name);
     Ok(())
 }
 
 fn identity_map_clear(session_id: Option<&str>) -> PyResult<()> {
-    if let Some(session_id) = session_id {
-        let session = session_state(session_id)?;
-        session.identity_map.clear();
+    let Some(session_id) = session_id else {
         return Ok(());
-    }
-    IDENTITY_MAP.clear();
+    };
+    let session = session_state(session_id)?;
+    session.identity_map.clear();
     Ok(())
 }
 
@@ -174,13 +167,12 @@ fn identity_map_clear(session_id: Option<&str>) -> PyResult<()> {
 #[pyfunction]
 #[pyo3(signature = (session_id=None))]
 pub fn identity_map_len(py: Python<'_>, session_id: Option<String>) -> PyResult<usize> {
-    let count = |map: &DashMap<(String, String, String), Py<PyAny>>| {
-        map.iter().filter(|e| weakref_is_live(py, e.value())).count()
+    // Sessionless operations have no identity map (FF-D Option B): always 0.
+    let Some(session_id) = session_id else {
+        return Ok(0);
     };
-    if let Some(session_id) = session_id {
-        return Ok(count(&session_state(&session_id)?.identity_map));
-    }
-    Ok(count(&IDENTITY_MAP))
+    let map = &session_state(&session_id)?.identity_map;
+    Ok(map.iter().filter(|e| weakref_is_live(py, e.value())).count())
 }
 
 fn tx_get(session_id: Option<&str>, tx_id: &str) -> PyResult<Option<TransactionHandle>> {
@@ -817,7 +809,10 @@ pub fn transaction_connection_name(tx_id: String, session_id: Option<String>) ->
         .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Transaction not found"))
 }
 
-/// Roll back a transaction or nested savepoint and clear the identity map.
+/// Roll back a transaction or nested savepoint and evict the transaction's
+/// session-scoped identity map (a session is pinned to one connection, so
+/// this is exactly the affected `(connection, session)` scope; sessionless
+/// rollbacks have no map to evict).
 ///
 /// Args:
 ///     tx_id (str): Id returned by `begin_transaction`.

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -12,6 +12,7 @@ use crate::state::{
     TransactionConnection, TransactionHandle, connection_for_route, ensure_session_idle_for_close,
     engine_for_connection, register_session, session_state, unregister_session,
 };
+use dashmap::DashMap;
 use ferro_schema_ir::{IrEnvelope, QueryIrPayload};
 use pyo3::prelude::*;
 use sea_query::{
@@ -103,32 +104,90 @@ fn active_connection_for_route(using: Option<String>) -> PyResult<(String, Arc<E
     connection_for_route(using)
 }
 
+/// Sweep the map for dead weakrefs every N tracked operations (FF-D D1).
+///
+/// Amortized O(1)/op; memory is bounded by live instances plus at most one
+/// interval of tombstones. Callback-based eviction is deliberately avoided:
+/// a weakref callback fires mid-GC and would re-enter the DashMap, risking a
+/// shard-lock deadlock across the FFI boundary (AGENTS.md I-3).
+const IDENTITY_SWEEP_INTERVAL: usize = 1024;
+
+fn weakref_is_live(py: Python<'_>, weak: &Py<PyAny>) -> bool {
+    weak.bind(py)
+        .call0()
+        .map(|obj| !obj.is_none())
+        .unwrap_or(false)
+}
+
+fn maybe_sweep(
+    py: Python<'_>,
+    map: &DashMap<(String, String, String), Py<PyAny>>,
+    ops: &std::sync::atomic::AtomicUsize,
+) {
+    use std::sync::atomic::Ordering;
+    if ops.fetch_add(1, Ordering::Relaxed) % IDENTITY_SWEEP_INTERVAL
+        == IDENTITY_SWEEP_INTERVAL - 1
+    {
+        map.retain(|_, weak| weakref_is_live(py, weak));
+    }
+}
+
 fn identity_map_get(
+    py: Python<'_>,
     session_id: Option<&str>,
     key: &(String, String, String),
 ) -> PyResult<Option<Py<PyAny>>> {
-    if let Some(session_id) = session_id {
+    // Clone the weakref out of the shard guard before touching Python:
+    // GIL-before-shard ordering is the invariant (see maybe_sweep).
+    let weak = if let Some(session_id) = session_id {
         let session = session_state(session_id)?;
-        return Ok(session.identity_map.get(key).map(|entry| {
-            Python::attach(|py| entry.value().clone_ref(py))
-        }));
+        session.identity_map.get(key).map(|e| e.value().clone_ref(py))
+    } else {
+        IDENTITY_MAP.get(key).map(|e| e.value().clone_ref(py))
+    };
+    let Some(weak) = weak else { return Ok(None) };
+    // Upgrade to a strong ref; hit-vs-miss is decided on the upgraded ref so
+    // the instance cannot die between the check and use.
+    let obj = weak.bind(py).call0()?;
+    if obj.is_none() {
+        // Dead entry: prune the tombstone, report a miss.
+        if let Some(session_id) = session_id {
+            session_state(session_id)?.identity_map.remove(key);
+        } else {
+            IDENTITY_MAP.remove(key);
+        }
+        return Ok(None);
     }
-    Ok(IDENTITY_MAP
-        .get(key)
-        .map(|entry| Python::attach(|py| entry.value().clone_ref(py))))
+    Ok(Some(obj.unbind()))
 }
 
 fn identity_map_insert(
+    py: Python<'_>,
     session_id: Option<&str>,
     key: (String, String, String),
-    value: Py<PyAny>,
+    value: &Bound<'_, PyAny>,
 ) -> PyResult<()> {
+    // Weak by design: the map must never keep an instance alive (FF-D D1).
+    // A class that can't be weakly referenced is a loud error, never a
+    // silent strong-ref fallback.
+    let weak = pyo3::types::PyWeakrefReference::new(value)
+        .map_err(|err| {
+            pyo3::exceptions::PyTypeError::new_err(format!(
+                "Cannot track instance in the identity map: the class does not \
+                 support weak references ({err}). Ferro model instances must be \
+                 weakly referenceable."
+            ))
+        })?
+        .into_any()
+        .unbind();
     if let Some(session_id) = session_id {
         let session = session_state(session_id)?;
-        session.identity_map.insert(key, value);
+        session.identity_map.insert(key, weak);
+        maybe_sweep(py, &session.identity_map, &session.identity_ops);
         return Ok(());
     }
-    IDENTITY_MAP.insert(key, value);
+    IDENTITY_MAP.insert(key, weak);
+    maybe_sweep(py, &IDENTITY_MAP, &crate::state::IDENTITY_MAP_OPS);
     Ok(())
 }
 
@@ -162,6 +221,19 @@ fn identity_map_clear(session_id: Option<&str>) -> PyResult<()> {
     }
     IDENTITY_MAP.clear();
     Ok(())
+}
+
+/// Count *live* identity-map entries (test diagnostic for FF-D D1).
+#[pyfunction]
+#[pyo3(signature = (session_id=None))]
+pub fn identity_map_len(py: Python<'_>, session_id: Option<String>) -> PyResult<usize> {
+    let count = |map: &DashMap<(String, String, String), Py<PyAny>>| {
+        map.iter().filter(|e| weakref_is_live(py, e.value())).count()
+    };
+    if let Some(session_id) = session_id {
+        return Ok(count(&session_state(&session_id)?.identity_map));
+    }
+    Ok(count(&IDENTITY_MAP))
 }
 
 fn tx_get(session_id: Option<&str>, tx_id: &str) -> PyResult<Option<TransactionHandle>> {
@@ -989,6 +1061,7 @@ pub fn fetch_all<'py>(
                 if use_identity_map
                     && let Some(ref pk_val) = row_pk_val
                     && let Some(existing_obj) = identity_map_get(
+                        py,
                         session_id.as_deref(),
                         &(connection_name.clone(), name.clone(), pk_val.clone()),
                     )?
@@ -1008,9 +1081,10 @@ pub fn fetch_all<'py>(
 
                 if use_identity_map && let Some(pk_val) = row_pk_val {
                     identity_map_insert(
+                        py,
                         session_id.as_deref(),
                         (connection_name.clone(), name.clone(), pk_val),
-                        instance.clone().unbind(),
+                        &instance,
                     )?;
                 }
 
@@ -1052,6 +1126,7 @@ pub fn fetch_one<'py>(
     // Check Identity Map first (if no transaction, or even with transaction, IM is usually safe)
     if engine.is_identity_map_enabled()
         && let Some(existing_obj) = identity_map_get(
+            py,
             session_id.as_deref(),
             &(connection_name.clone(), name.clone(), pk_val.clone()),
         )?
@@ -1152,9 +1227,10 @@ pub fn fetch_one<'py>(
                 )?;
                 if use_identity_map {
                     identity_map_insert(
+                        py,
                         session_id.as_deref(),
                         (connection_name.clone(), name.clone(), pk_val),
-                        instance.clone().unbind(),
+                        &instance,
                     )?;
                 }
                 Ok(instance.into_any().unbind())
@@ -1822,6 +1898,7 @@ pub fn fetch_filtered<'py>(
                 if use_identity_map
                     && let Some(ref pk_val) = row_pk_val
                     && let Some(existing_obj) = identity_map_get(
+                        py,
                         session_id.as_deref(),
                         &(connection_name.clone(), name.clone(), pk_val.clone()),
                     )?
@@ -1841,9 +1918,10 @@ pub fn fetch_filtered<'py>(
 
                 if use_identity_map && let Some(pk_val) = row_pk_val {
                     identity_map_insert(
+                        py,
                         session_id.as_deref(),
                         (connection_name.clone(), name.clone(), pk_val),
-                        instance.clone().unbind(),
+                        &instance,
                     )?;
                 }
 
@@ -1994,6 +2072,7 @@ pub fn count_filtered(
 #[pyfunction]
 #[pyo3(signature = (name, pk, obj, using=None, session_id=None))]
 pub fn register_instance(
+    py: Python<'_>,
     name: String,
     pk: String,
     obj: Py<PyAny>,
@@ -2007,7 +2086,12 @@ pub fn register_instance(
     )
     .map(|(name, engine, _, _)| (name, engine))?;
     if engine.is_identity_map_enabled() {
-        identity_map_insert(session_id.as_deref(), (connection_name, name, pk), obj)?;
+        identity_map_insert(
+            py,
+            session_id.as_deref(),
+            (connection_name, name, pk),
+            obj.bind(py),
+        )?;
     }
     Ok(())
 }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1066,7 +1066,16 @@ pub fn fetch_all<'py>(
                         &(connection_name.clone(), name.clone(), pk_val.clone()),
                     )?
                 {
-                    results.append(existing_obj.clone_ref(py))?;
+                    let existing = existing_obj.bind(py);
+                    crate::hydration::refresh_model_instance(
+                        py,
+                        cls,
+                        existing,
+                        fields,
+                        &py_col_names,
+                        &enum_classes,
+                    )?;
+                    results.append(existing)?;
                     continue;
                 }
 
@@ -1121,19 +1130,9 @@ pub fn fetch_one<'py>(
 ) -> PyResult<Bound<'py, PyAny>> {
     let name = cls.getattr("__name__")?.extract::<String>()?;
     let cls_py = cls.unbind();
-    let (connection_name, engine) = active_route_for_operation(tx_id.clone(), using.clone(), session_id.clone()).map(|(c,e,_,_)|(c,e))?;
-
-    // Check Identity Map first (if no transaction, or even with transaction, IM is usually safe)
-    if engine.is_identity_map_enabled()
-        && let Some(existing_obj) = identity_map_get(
-            py,
-            session_id.as_deref(),
-            &(connection_name.clone(), name.clone(), pk_val.clone()),
-        )?
-    {
-        let obj = existing_obj.clone_ref(py);
-        return pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(obj) });
-    }
+    // No identity-map short-circuit before the query (FF-D D1b): the map is
+    // an identity/dedup structure, not a query cache — every fetch reads the
+    // database and refreshes the cached instance in place.
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
@@ -1217,6 +1216,26 @@ pub fn fetch_one<'py>(
                 let cls = cls_py.bind(py);
                 let py_col_names = HashMap::new();
                 let enum_classes = crate::hydration::enum_classes_for(py, cls);
+
+                if use_identity_map
+                    && let Some(existing_obj) = identity_map_get(
+                        py,
+                        session_id.as_deref(),
+                        &(connection_name.clone(), name.clone(), pk_val.clone()),
+                    )?
+                {
+                    let existing = existing_obj.bind(py);
+                    crate::hydration::refresh_model_instance(
+                        py,
+                        cls,
+                        existing,
+                        fields,
+                        &py_col_names,
+                        &enum_classes,
+                    )?;
+                    return Ok(existing.clone().unbind());
+                }
+
                 let instance = crate::hydration::hydrate_model_instance(
                     py,
                     cls,
@@ -1903,7 +1922,16 @@ pub fn fetch_filtered<'py>(
                         &(connection_name.clone(), name.clone(), pk_val.clone()),
                     )?
                 {
-                    results.append(existing_obj.clone_ref(py))?;
+                    let existing = existing_obj.bind(py);
+                    crate::hydration::refresh_model_instance(
+                        py,
+                        cls,
+                        existing,
+                        fields,
+                        &py_col_names,
+                        &enum_classes,
+                    )?;
+                    results.append(existing)?;
                     continue;
                 }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -23,85 +23,32 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-fn get_transaction_connection(
-    tx_id: Option<String>,
-    session_id: Option<&str>,
-) -> PyResult<Option<TransactionConnection>> {
-    if let Some(id) = tx_id {
-        if let Some(session_id) = session_id {
-            let session = session_state(session_id)?;
-            return Ok(session
-                .transaction_registry
-                .get(&id)
-                .map(|tx| tx.value().conn.clone()));
-        }
-        return Ok(TRANSACTION_REGISTRY
-            .get(&id)
-            .map(|tx| tx.value().conn.clone()));
-    }
-    Ok(None)
-}
-
-fn get_transaction_route(
-    tx_id: Option<String>,
-    session_id: Option<&str>,
-) -> PyResult<Option<(String, TransactionConnection)>> {
-    if let Some(id) = tx_id {
-        if let Some(session_id) = session_id {
-            let session = session_state(session_id)?;
-            return Ok(session
-                .transaction_registry
-                .get(&id)
-                .map(|tx| (tx.value().connection_name.clone(), tx.value().conn.clone())));
-        }
-        return Ok(TRANSACTION_REGISTRY
-            .get(&id)
-            .map(|tx| (tx.value().connection_name.clone(), tx.value().conn.clone())));
-    }
-    Ok(None)
-}
-
-fn active_engine_for_connection(
-    using: Option<String>,
-    session_id: Option<&str>,
-) -> PyResult<Arc<EngineHandle>> {
-    if let Some(session_id) = session_id {
-        let session = session_state(session_id)?;
-        let connection_name = using.unwrap_or_else(|| session.connection_name.clone());
-        return engine_for_connection(Some(connection_name));
-    }
-    engine_for_connection(using)
-}
-
-fn active_route_for_operation(
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
-) -> PyResult<(
-    String,
-    Arc<EngineHandle>,
-    Option<TransactionConnection>,
-    Dialect,
-)> {
-    let tx_route = get_transaction_route(tx_id, session_id.as_deref())?;
-    let session_connection = if let Some(ref sid) = session_id {
-        Some(session_state(sid)?.connection_name.clone())
-    } else {
-        None
-    };
-    let route_using = tx_route
-        .as_ref()
-        .map(|(connection_name, _)| connection_name.clone())
-        .or(using)
-        .or(session_connection);
-    let (connection_name, engine) = active_connection_for_route(route_using)?;
-    let backend = engine.backend();
-    let tx_conn = tx_route.map(|(_, conn)| conn);
-    Ok((connection_name, engine, tx_conn, backend))
-}
-
 fn active_connection_for_route(using: Option<String>) -> PyResult<(String, Arc<EngineHandle>)> {
     connection_for_route(using)
+}
+
+/// Derive engine + transaction connection from an already-resolved route.
+///
+/// The only route-consumption site (FF-D D3): a map lookup, never a
+/// re-derivation of `using`/session precedence. `route.connection_name` is
+/// trusted as authoritative — Python's resolvers already folded transaction /
+/// session / explicit-`using` precedence into it.
+fn route_engine(
+    route: &crate::state::RouteHandle,
+) -> PyResult<(String, Arc<EngineHandle>, Option<TransactionConnection>, Dialect)> {
+    let engine = engine_for_connection(Some(route.connection_name.clone()))?;
+    let tx_conn = match &route.tx_id {
+        Some(tx_id) => Some(
+            tx_get(route.session_id.as_deref(), tx_id)?
+                .ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err("Transaction not found")
+                })?
+                .conn,
+        ),
+        None => None,
+    };
+    let backend = engine.backend();
+    Ok((route.connection_name.clone(), engine, tx_conn, backend))
 }
 
 /// Sweep the map for dead weakrefs every N tracked operations (FF-D D1).
@@ -759,33 +706,27 @@ fn backend_column_value_expr(
 /// `parent_tx_id` and issue `SAVEPOINT` on the parent's connection.
 ///
 /// Args:
-///     parent_tx_id (str | None): Parent transaction for nested savepoints.
-///     using (str | None): Connection name for root transactions (ignored when nested).
-///     session_id (str | None): When set, store the handle in session-local registry.
+///     route (RouteHandle): Resolved route (FF-D D3); `route.tx_id` is the
+///         *parent* transaction for nested savepoints, or `None` to open a
+///         root transaction on `route.connection_name`.
 ///
 /// Returns:
 ///     str: Opaque transaction id for `commit_transaction` / `rollback_transaction`.
 ///
 /// # Errors
-/// `PyValueError` when `using` is passed with a parent id. `PyRuntimeError` on BEGIN/SAVEPOINT failure.
+/// `PyRuntimeError` when the parent transaction id is unknown, or on
+/// BEGIN/SAVEPOINT failure.
 #[pyfunction]
-#[pyo3(signature = (parent_tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (route))]
 pub fn begin_transaction(
     py: Python<'_>,
-    parent_tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let r = route.get();
         let tx_id = uuid::Uuid::new_v4().to_string();
-        if let Some(parent_tx_id) = parent_tx_id {
-            if using.is_some() {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Nested transactions inherit the parent connection",
-                ));
-            }
-
-            let parent = tx_get(session_id.as_deref(), &parent_tx_id)?
+        if let Some(parent_tx_id) = r.tx_id.clone() {
+            let parent = tx_get(r.session_id.as_deref(), &parent_tx_id)?
                 .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Parent transaction not found"))?;
             let conn = parent.conn.clone();
             let connection_name = parent.connection_name.clone();
@@ -796,24 +737,19 @@ pub fn begin_transaction(
                 .map_err(|e| crate::errors::map_db_error("Failed to create SAVEPOINT", e))?;
 
             tx_insert(
-                session_id.as_deref(),
+                r.session_id.as_deref(),
                 tx_id.clone(),
                 TransactionHandle::nested(conn, savepoint_name, connection_name),
             )?;
         } else {
-            let (connection_name, engine) = active_route_for_operation(
-                None,
-                using,
-                session_id.clone(),
-            )
-            .map(|(name, engine, _, _)| (name, engine))?;
+            let (connection_name, engine, _, _) = route_engine(r)?;
             let conn = engine
                 .begin_transaction_connection()
                 .await
                 .map_err(|e| crate::errors::map_db_error("Failed to BEGIN", e))?;
 
             tx_insert(
-                session_id.as_deref(),
+                r.session_id.as_deref(),
                 tx_id.clone(),
                 TransactionHandle::root(conn, connection_name),
             )?;
@@ -941,7 +877,7 @@ pub fn rollback_transaction(
 #[pyo3(signature = (using=None))]
 pub fn open_session(using: Option<String>) -> PyResult<(String, String)> {
     let (connection_name, _) = active_connection_for_route(using)?;
-    let session_id = register_session(connection_name.clone());
+    let session_id = register_session();
     Ok((session_id, connection_name))
 }
 
@@ -981,19 +917,19 @@ pub fn close_session(session_id: String) -> PyResult<()> {
 /// # Errors
 /// Returns a `PyErr` if the engine is not initialized or if the query fails.
 #[pyfunction]
-#[pyo3(signature = (cls, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (cls, route))]
 pub fn fetch_all<'py>(
     py: Python<'py>,
     cls: Bound<'py, PyAny>,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let name = cls.getattr("__name__")?.extract::<String>()?;
     let cls_py = cls.unbind();
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
+        let r = route.get();
+        let (connection_name, engine, tx_conn, backend) = route_engine(r)?;
+        let session_id = r.session_id.clone();
         let use_identity_map = engine.is_identity_map_enabled();
 
         let table_name = name.to_lowercase();
@@ -1119,14 +1055,12 @@ pub fn fetch_all<'py>(
 /// # Errors
 /// Returns a `PyErr` if the engine is not initialized or if the query fails.
 #[pyfunction]
-#[pyo3(signature = (cls, pk_val, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (cls, pk_val, route))]
 pub fn fetch_one<'py>(
     py: Python<'py>,
     cls: Bound<'py, PyAny>,
     pk_val: String,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let name = cls.getattr("__name__")?.extract::<String>()?;
     let cls_py = cls.unbind();
@@ -1135,7 +1069,9 @@ pub fn fetch_one<'py>(
     // database and refreshes the cached instance in place.
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
+        let r = route.get();
+        let (connection_name, engine, tx_conn, backend) = route_engine(r)?;
+        let session_id = r.session_id.clone();
         let use_identity_map = engine.is_identity_map_enabled();
 
         let table_name = name.to_lowercase();
@@ -1437,21 +1373,19 @@ fn build_update_by_pk_sql(
 /// Returns a `PyErr` if the engine is not initialized, the model is not
 /// registered, the mode is unknown, or a column value cannot be bound.
 #[pyfunction]
-#[pyo3(signature = (name, data, tx_id=None, using=None, session_id=None, mode="insert"))]
+#[pyo3(signature = (name, data, route, mode="insert"))]
 pub fn save_record<'py>(
     py: Python<'py>,
     name: String,
     data: Bound<'py, pyo3::types::PyDict>,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
     mode: &str,
 ) -> PyResult<Bound<'py, PyAny>> {
     let bind_inputs = bind_inputs_from_py(&data)?; // GIL held here, before the async move
     let mode = parse_save_mode(mode)?;
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_connection_name, engine, tx_conn, backend) =
-            active_route_for_operation(tx_id, using, session_id.clone())?;
+        let r = route.get();
+        let (_connection_name, engine, tx_conn, backend) = route_engine(r)?;
 
         let schema = {
             let registry = MODEL_REGISTRY.read().map_err(|_| {
@@ -1563,19 +1497,17 @@ pub fn save_record<'py>(
 /// is missing/null; `PyRuntimeError` on registry failures; typed
 /// `ferro.exceptions` subclasses on database errors.
 #[pyfunction]
-#[pyo3(signature = (name, data, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (name, data, route))]
 pub fn update_record<'py>(
     py: Python<'py>,
     name: String,
     data: Bound<'py, pyo3::types::PyDict>,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let bind_inputs = bind_inputs_from_py(&data)?; // GIL held here, before the async move
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_connection_name, engine, tx_conn, backend) =
-            active_route_for_operation(tx_id, using, session_id.clone())?;
+        let r = route.get();
+        let (_connection_name, engine, tx_conn, backend) = route_engine(r)?;
 
         let schema = {
             let registry = MODEL_REGISTRY.read().map_err(|_| {
@@ -1664,22 +1596,20 @@ pub fn update_record<'py>(
 /// # Errors
 /// `PyRuntimeError` on registry/execute failures; `PyTypeError` for unbindable values.
 #[pyfunction]
-#[pyo3(signature = (name, rows, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (name, rows, route))]
 pub fn save_bulk_records<'py>(
     py: Python<'py>,
     name: String,
     rows: Vec<Bound<'py, pyo3::types::PyDict>>,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let record_inputs: Vec<Vec<(String, BindInput)>> = rows
         .iter()
         .map(bind_inputs_from_py)
         .collect::<PyResult<_>>()?;
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_connection_name, engine, tx_conn, backend) =
-            active_route_for_operation(tx_id, using, session_id.clone())?;
+        let r = route.get();
+        let (_connection_name, engine, tx_conn, backend) = route_engine(r)?;
 
         let schema = {
             let registry = MODEL_REGISTRY.read().map_err(|_| {
@@ -1780,14 +1710,12 @@ pub fn save_bulk_records<'py>(
 /// Returns:
 ///     list[PyAny]: A list of hydrated model instances.
 #[pyfunction]
-#[pyo3(signature = (cls, query_ir_json, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (cls, query_ir_json, route))]
 pub fn fetch_filtered<'py>(
     py: Python<'py>,
     cls: Bound<'py, PyAny>,
     query_ir_json: String,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let name = cls.getattr("__name__")?.extract::<String>()?;
     let cls_py = cls.unbind();
@@ -1795,7 +1723,9 @@ pub fn fetch_filtered<'py>(
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (connection_name, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
+        let r = route.get();
+        let (connection_name, engine, tx_conn, backend) = route_engine(r)?;
+        let session_id = r.session_id.clone();
         let use_identity_map = engine.is_identity_map_enabled();
 
         let table_name = name.to_lowercase();
@@ -1975,19 +1905,18 @@ pub fn fetch_filtered<'py>(
 /// # Errors
 /// `PyRuntimeError` on registry, planning, or SQL failures.
 #[pyfunction]
-#[pyo3(signature = (name, query_ir_json, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (name, query_ir_json, route))]
 pub fn count_filtered(
     py: Python<'_>,
     name: String,
     query_ir_json: String,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'_, PyAny>> {
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
+        let r = route.get();
+        let (_, engine, tx_conn, backend) = route_engine(r)?;
 
         let table_name = name.to_lowercase();
         query_def.postgres_enum_udt = postgres_table_catalog(&table_name, &engine, &tx_conn, backend)
@@ -2098,25 +2027,20 @@ pub fn count_filtered(
 /// # Errors
 /// `PyRuntimeError` when the identity map cannot be updated.
 #[pyfunction]
-#[pyo3(signature = (name, pk, obj, using=None, session_id=None))]
+#[pyo3(signature = (name, pk, obj, route))]
 pub fn register_instance(
     py: Python<'_>,
     name: String,
     pk: String,
     obj: Py<PyAny>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<()> {
-    let (connection_name, engine) = active_route_for_operation(
-        None,
-        using,
-        session_id.clone(),
-    )
-    .map(|(name, engine, _, _)| (name, engine))?;
+    let r = route.get();
+    let (connection_name, engine, _, _) = route_engine(r)?;
     if engine.is_identity_map_enabled() {
         identity_map_insert(
             py,
-            session_id.as_deref(),
+            r.session_id.as_deref(),
             (connection_name, name, pk),
             obj.bind(py),
         )?;
@@ -2134,38 +2058,32 @@ pub fn register_instance(
 /// Returns:
 ///     None
 #[pyfunction]
-#[pyo3(signature = (name, pk, using=None, session_id=None))]
+#[pyo3(signature = (name, pk, route))]
 pub fn evict_instance(
     name: String,
     pk: String,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<()> {
-    let (connection_name, engine) = active_route_for_operation(
-        None,
-        using,
-        session_id.clone(),
-    )
-    .map(|(name, engine, _, _)| (name, engine))?;
+    let r = route.get();
+    let (connection_name, engine, _, _) = route_engine(r)?;
     if engine.is_identity_map_enabled() {
-        identity_map_remove(session_id.as_deref(), &(connection_name, name, pk))?;
+        identity_map_remove(r.session_id.as_deref(), &(connection_name, name, pk))?;
     }
     Ok(())
 }
 
 /// Deletes a record by its primary key.
 #[pyfunction]
-#[pyo3(signature = (name, pk_val, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (name, pk_val, route))]
 pub fn delete_record(
     py: Python<'_>,
     name: String,
     pk_val: String,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
+        let r = route.get();
+        let (_, engine, tx_conn, backend) = route_engine(r)?;
 
         let table_name = name.to_lowercase();
         // ... sql ...
@@ -2236,20 +2154,20 @@ pub fn delete_record(
 /// # Errors
 /// `PyRuntimeError` on planning or execute failure.
 #[pyfunction]
-#[pyo3(signature = (name, query_ir_json, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (name, query_ir_json, route))]
 pub fn delete_filtered(
     py: Python<'_>,
     name: String,
     query_ir_json: String,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'_, PyAny>> {
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
     reject_pagination_on_mutation(&query_def, "delete")?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
+        let r = route.get();
+        let (_, engine, tx_conn, backend) = route_engine(r)?;
+        let session_id = r.session_id.clone();
 
         let table_name = name.to_lowercase();
         query_def.postgres_enum_udt = postgres_table_catalog(&table_name, &engine, &tx_conn, backend)
@@ -2303,22 +2221,22 @@ pub fn delete_filtered(
 /// # Errors
 /// `PyTypeError` for unbindable column values; `PyRuntimeError` on execute failure.
 #[pyfunction]
-#[pyo3(signature = (name, query_ir_json, updates, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (name, query_ir_json, updates, route))]
 pub fn update_filtered<'py>(
     py: Python<'py>,
     name: String,
     query_ir_json: String,
     updates: Bound<'py, pyo3::types::PyDict>,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let mut query_def = query_def_from_ir_json(&query_ir_json)?;
     reject_pagination_on_mutation(&query_def, "update")?;
     let update_inputs = bind_inputs_from_py(&updates)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
+        let r = route.get();
+        let (_, engine, tx_conn, backend) = route_engine(r)?;
+        let session_id = r.session_id.clone();
 
         let table_name = name.to_lowercase();
         let catalog = postgres_table_catalog(&table_name, &engine, &tx_conn, backend).await?;
@@ -2392,7 +2310,7 @@ pub fn update_filtered<'py>(
 /// # Errors
 /// `PyValueError` when an id is `None` or INSERT values are invalid; `PyRuntimeError` on execute failure.
 #[pyfunction]
-#[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, route))]
 #[allow(clippy::too_many_arguments)]
 pub fn add_m2m_links<'py>(
     py: Python<'py>,
@@ -2401,9 +2319,7 @@ pub fn add_m2m_links<'py>(
     target_col: String,
     source_id: Bound<'py, PyAny>,
     target_ids: Vec<Bound<'py, PyAny>>,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let s_id = python_to_sea_value(source_id)?;
     let t_ids: Vec<sea_query::Value> = target_ids
@@ -2412,7 +2328,8 @@ pub fn add_m2m_links<'py>(
         .collect::<PyResult<Vec<_>>>()?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
+        let r = route.get();
+        let (_, engine, tx_conn, backend) = route_engine(r)?;
         let catalog = postgres_table_catalog(&join_table, &engine, &tx_conn, backend).await?;
         let uuid_columns = &catalog.uuid_columns;
 
@@ -2468,7 +2385,7 @@ pub fn add_m2m_links<'py>(
 /// # Errors
 /// `PyRuntimeError` on execute failure.
 #[pyfunction]
-#[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (join_table, source_col, target_col, source_id, target_ids, route))]
 #[allow(clippy::too_many_arguments)]
 pub fn remove_m2m_links<'py>(
     py: Python<'py>,
@@ -2477,9 +2394,7 @@ pub fn remove_m2m_links<'py>(
     target_col: String,
     source_id: Bound<'py, PyAny>,
     target_ids: Vec<Bound<'py, PyAny>>,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let s_id = python_to_sea_value(source_id)?;
     let t_ids: Vec<sea_query::Value> = target_ids
@@ -2488,7 +2403,8 @@ pub fn remove_m2m_links<'py>(
         .collect::<PyResult<Vec<_>>>()?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (_, engine, tx_conn, backend) = active_route_for_operation(tx_id, using, session_id.clone())?;
+        let r = route.get();
+        let (_, engine, tx_conn, backend) = route_engine(r)?;
         let catalog = postgres_table_catalog(&join_table, &engine, &tx_conn, backend).await?;
         let uuid_columns = &catalog.uuid_columns;
 
@@ -2540,25 +2456,19 @@ pub fn remove_m2m_links<'py>(
 /// # Errors
 /// `PyRuntimeError` on execute failure.
 #[pyfunction]
-#[pyo3(signature = (join_table, source_col, source_id, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (join_table, source_col, source_id, route))]
 pub fn clear_m2m_links<'py>(
     py: Python<'py>,
     join_table: String,
     source_col: String,
     source_id: Bound<'py, PyAny>,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let s_id = python_to_sea_value(source_id)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (engine, tx_conn, backend) = {
-            let engine = active_engine_for_connection(using, session_id.as_deref())?;
-            let backend = engine.backend();
-            let tx_conn = get_transaction_connection(tx_id, session_id.as_deref())?;
-            (engine, tx_conn, backend)
-        };
+        let r = route.get();
+        let (_, engine, tx_conn, backend) = route_engine(r)?;
         let catalog = postgres_table_catalog(&join_table, &engine, &tx_conn, backend).await?;
         let uuid_columns = &catalog.uuid_columns;
 
@@ -2827,20 +2737,26 @@ fn get_raw_tx_conn(
 ///   not a supported primitive (the Python `_marshal` wrapper guarantees this
 ///   never trips in normal use).
 #[pyfunction]
-#[pyo3(signature = (sql, args, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (sql, args, route))]
 pub fn raw_execute<'py>(
     py: Python<'py>,
     sql: String,
     args: Vec<Bound<'py, PyAny>>,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let bind_values: Vec<EngineBindValue> = args
         .iter()
         .map(python_to_engine_bind_value)
         .collect::<PyResult<_>>()?;
-    let tx_conn = get_raw_tx_conn(tx_id, session_id.as_deref())?;
+    // Clone the route's fields before the future_into_py move (FF-D D3):
+    // `Py<RouteHandle>` itself is Send/Sync and could be moved in directly,
+    // but `get_raw_tx_conn` must run synchronously, before the async block,
+    // to preserve its sharper "transaction already closed" error surface.
+    let (route_connection_name, route_tx_id, route_session_id) = {
+        let r = route.get();
+        (r.connection_name.clone(), r.tx_id.clone(), r.session_id.clone())
+    };
+    let tx_conn = get_raw_tx_conn(route_tx_id, route_session_id.as_deref())?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let rows_affected = match tx_conn {
@@ -2849,7 +2765,7 @@ pub fn raw_execute<'py>(
                 conn.execute_sql_with_binds(&sql, &bind_values).await
             }
             None => {
-                let engine = active_engine_for_connection(using, session_id.as_deref())?;
+                let engine = engine_for_connection(Some(route_connection_name))?;
                 engine.execute_sql_with_binds(&sql, &bind_values).await
             }
         }
@@ -2865,20 +2781,22 @@ pub fn raw_execute<'py>(
 /// UUID/datetime/JSON columns come back as strings — Ferro does not decode them
 /// for raw SQL. If you want typed rows, use the ORM.
 #[pyfunction]
-#[pyo3(signature = (sql, args, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (sql, args, route))]
 pub fn raw_fetch_all<'py>(
     py: Python<'py>,
     sql: String,
     args: Vec<Bound<'py, PyAny>>,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let bind_values: Vec<EngineBindValue> = args
         .iter()
         .map(python_to_engine_bind_value)
         .collect::<PyResult<_>>()?;
-    let tx_conn = get_raw_tx_conn(tx_id, session_id.as_deref())?;
+    let (route_connection_name, route_tx_id, route_session_id) = {
+        let r = route.get();
+        (r.connection_name.clone(), r.tx_id.clone(), r.session_id.clone())
+    };
+    let tx_conn = get_raw_tx_conn(route_tx_id, route_session_id.as_deref())?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let rows = match tx_conn {
@@ -2887,7 +2805,7 @@ pub fn raw_fetch_all<'py>(
                 conn.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
             None => {
-                let engine = active_engine_for_connection(using, session_id.as_deref())?;
+                let engine = engine_for_connection(Some(route_connection_name))?;
                 engine.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
         }
@@ -2918,20 +2836,22 @@ pub fn raw_fetch_all<'py>(
 /// Values are wire-close primitives (`str | int | float | bool | bytes | None`).
 /// UUID/datetime/JSON columns come back as strings — use the ORM for typed hydration.
 #[pyfunction]
-#[pyo3(signature = (sql, args, tx_id=None, using=None, session_id=None))]
+#[pyo3(signature = (sql, args, route))]
 pub fn raw_fetch_one<'py>(
     py: Python<'py>,
     sql: String,
     args: Vec<Bound<'py, PyAny>>,
-    tx_id: Option<String>,
-    using: Option<String>,
-    session_id: Option<String>,
+    route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let bind_values: Vec<EngineBindValue> = args
         .iter()
         .map(python_to_engine_bind_value)
         .collect::<PyResult<_>>()?;
-    let tx_conn = get_raw_tx_conn(tx_id, session_id.as_deref())?;
+    let (route_connection_name, route_tx_id, route_session_id) = {
+        let r = route.get();
+        (r.connection_name.clone(), r.tx_id.clone(), r.session_id.clone())
+    };
+    let tx_conn = get_raw_tx_conn(route_tx_id, route_session_id.as_deref())?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let rows = match tx_conn {
@@ -2940,7 +2860,7 @@ pub fn raw_fetch_one<'py>(
                 conn.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
             None => {
-                let engine = active_engine_for_connection(using, session_id.as_deref())?;
+                let engine = engine_for_connection(Some(route_connection_name))?;
                 engine.fetch_all_sql_with_binds(&sql, &bind_values).await
             }
         }
@@ -2983,7 +2903,7 @@ pub fn raw_fetch_one<'py>(
 #[pyo3(name = "_catalog_query_count_for_test")]
 #[pyo3(signature = (using=None))]
 pub fn _catalog_query_count_for_test(using: Option<String>) -> PyResult<u64> {
-    let (_, engine, _, _) = active_route_for_operation(None, using, None)?;
+    let (_, engine) = active_connection_for_route(using)?;
     Ok(engine.catalog_query_count())
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -244,16 +244,6 @@ impl TransactionHandle {
 /// Maps Transaction ID -> backend connection plus optional savepoint.
 pub static TRANSACTION_REGISTRY: Lazy<DashMap<String, TransactionHandle>> = Lazy::new(DashMap::new);
 
-/// Identity Map used for object tracking and deduplication.
-///
-/// Values are Python `weakref.ref` objects (FF-D D1) — the map never keeps an
-/// instance alive. Transitional: deleted with the ambient path (FF-D D2).
-pub static IDENTITY_MAP: Lazy<DashMap<(String, String, String), Py<PyAny>>> =
-    Lazy::new(DashMap::new);
-
-/// Amortized-sweep op counter for [`IDENTITY_MAP`] (see `maybe_sweep`).
-pub static IDENTITY_MAP_OPS: Lazy<AtomicUsize> = Lazy::new(AtomicUsize::default);
-
 /// Session-scoped runtime state for Phase 6 sessionized execution.
 ///
 /// A session pins connection routing and keeps transactional/identity state local
@@ -269,7 +259,9 @@ pub static IDENTITY_MAP_OPS: Lazy<AtomicUsize> = Lazy::new(AtomicUsize::default)
 pub struct SessionState {
     /// Transactions opened within this session (isolated from global registry).
     pub transaction_registry: DashMap<String, TransactionHandle>,
-    /// Session-local identity map; values are `weakref.ref` objects (FF-D D1).
+    /// Session-local identity map — the *only* identity map (FF-D D2:
+    /// sessionless operations cache nothing); values are `weakref.ref`
+    /// objects (FF-D D1).
     pub identity_map: DashMap<(String, String, String), Py<PyAny>>,
     /// Amortized-sweep op counter for `identity_map`.
     pub identity_ops: AtomicUsize,

--- a/src/state.rs
+++ b/src/state.rs
@@ -156,6 +156,43 @@ pub fn engine_for_connection(using: Option<String>) -> PyResult<Arc<EngineHandle
     connection_for_route(using).map(|(_, engine)| engine)
 }
 
+/// Opaque, immutable route for one operation (FF-D D3).
+///
+/// Resolved exactly once in Python's `resolve_operation_scope` /
+/// `resolve_transaction_scope` and passed by value through every FFI
+/// operation. `connection_name` is non-optional: the removed ambient-default
+/// path is unrepresentable, not an error branch.
+#[pyclass(frozen, module = "ferro._core")]
+pub struct RouteHandle {
+    pub tx_id: Option<String>,
+    pub connection_name: String,
+    pub session_id: Option<String>,
+}
+
+#[pymethods]
+impl RouteHandle {
+    #[new]
+    #[pyo3(signature = (connection_name, tx_id=None, session_id=None))]
+    fn new(connection_name: String, tx_id: Option<String>, session_id: Option<String>) -> Self {
+        Self { tx_id, connection_name, session_id }
+    }
+
+    #[getter]
+    fn connection_name(&self) -> &str {
+        &self.connection_name
+    }
+
+    #[getter]
+    fn tx_id(&self) -> Option<&str> {
+        self.tx_id.as_deref()
+    }
+
+    #[getter]
+    fn session_id(&self) -> Option<&str> {
+        self.session_id.as_deref()
+    }
+}
+
 /// Active transaction handle (root `BEGIN` or nested `SAVEPOINT`).
 #[derive(Clone)]
 pub struct TransactionHandle {
@@ -221,9 +258,15 @@ pub static IDENTITY_MAP_OPS: Lazy<AtomicUsize> = Lazy::new(AtomicUsize::default)
 ///
 /// A session pins connection routing and keeps transactional/identity state local
 /// to that session so concurrent sessions do not bleed mutable runtime state.
+///
+/// The pinned connection name itself is *not* stored here: before FF-D D3 it
+/// backed an ambient ("ask the session what its connection is") fallback in
+/// `active_engine_for_connection`. That fallback is gone — Python's
+/// `resolve_operation_scope`/`resolve_transaction_scope` resolve the session's
+/// connection once and bake it into the `RouteHandle`, so Rust only ever sees
+/// an already-resolved `connection_name` and never re-derives it from the
+/// session.
 pub struct SessionState {
-    /// Connection pinned for the lifetime of this session.
-    pub connection_name: String,
     /// Transactions opened within this session (isolated from global registry).
     pub transaction_registry: DashMap<String, TransactionHandle>,
     /// Session-local identity map; values are `weakref.ref` objects (FF-D D1).
@@ -233,10 +276,9 @@ pub struct SessionState {
 }
 
 impl SessionState {
-    /// Allocate empty session state for `connection_name`.
-    pub fn new(connection_name: String) -> Self {
+    /// Allocate empty session state.
+    pub fn new() -> Self {
         Self {
-            connection_name,
             transaction_registry: DashMap::new(),
             identity_map: DashMap::new(),
             identity_ops: AtomicUsize::new(0),
@@ -247,16 +289,13 @@ impl SessionState {
 /// Global registry of active sessions.
 pub static SESSION_REGISTRY: Lazy<DashMap<String, Arc<SessionState>>> = Lazy::new(DashMap::new);
 
-/// Register a new session bound to `connection_name`.
-///
-/// # Arguments
-/// * `connection_name` — Registered connection to pin for the session.
+/// Register a new session.
 ///
 /// # Returns
 /// Opaque session UUID string for subsequent operations.
-pub fn register_session(connection_name: String) -> String {
+pub fn register_session() -> String {
     let session_id = uuid::Uuid::new_v4().to_string();
-    SESSION_REGISTRY.insert(session_id.clone(), Arc::new(SessionState::new(connection_name)));
+    SESSION_REGISTRY.insert(session_id.clone(), Arc::new(SessionState::new()));
     session_id
 }
 
@@ -404,7 +443,7 @@ mod session_close_tests {
 
     #[tokio::test]
     async fn close_guard_uses_transaction_registry_emptiness() {
-        let session_id = register_session("default".to_string());
+        let session_id = register_session();
 
         let pool = SqlitePoolOptions::new()
             .max_connections(1)

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,6 +10,7 @@ use once_cell::sync::Lazy;
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
 use std::collections::HashMap;
+use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, RwLock};
 use tokio::sync::Mutex;
 
@@ -208,9 +209,13 @@ pub static TRANSACTION_REGISTRY: Lazy<DashMap<String, TransactionHandle>> = Lazy
 
 /// Identity Map used for object tracking and deduplication.
 ///
-/// Maps `(ConnectionName, ModelName, PrimaryKeyValue)` to a live Python object.
+/// Values are Python `weakref.ref` objects (FF-D D1) — the map never keeps an
+/// instance alive. Transitional: deleted with the ambient path (FF-D D2).
 pub static IDENTITY_MAP: Lazy<DashMap<(String, String, String), Py<PyAny>>> =
     Lazy::new(DashMap::new);
+
+/// Amortized-sweep op counter for [`IDENTITY_MAP`] (see `maybe_sweep`).
+pub static IDENTITY_MAP_OPS: Lazy<AtomicUsize> = Lazy::new(AtomicUsize::default);
 
 /// Session-scoped runtime state for Phase 6 sessionized execution.
 ///
@@ -221,8 +226,10 @@ pub struct SessionState {
     pub connection_name: String,
     /// Transactions opened within this session (isolated from global registry).
     pub transaction_registry: DashMap<String, TransactionHandle>,
-    /// Session-local identity map (isolated from global [`IDENTITY_MAP`]).
+    /// Session-local identity map; values are `weakref.ref` objects (FF-D D1).
     pub identity_map: DashMap<(String, String, String), Py<PyAny>>,
+    /// Amortized-sweep op counter for `identity_map`.
+    pub identity_ops: AtomicUsize,
 }
 
 impl SessionState {
@@ -232,6 +239,7 @@ impl SessionState {
             connection_name,
             transaction_registry: DashMap::new(),
             identity_map: DashMap::new(),
+            identity_ops: AtomicUsize::new(0),
         }
     }
 }

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,6 +1,6 @@
 import pytest
 from typing import Annotated
-from ferro import Model, connect, FerroField
+from ferro import Model, connect, FerroField, engines
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -16,18 +16,19 @@ async def test_count_operation(db_url):
         category: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    await AggProduct(name="Item 1", price=10.0, category="A").save()
-    await AggProduct(name="Item 2", price=20.0, category="A").save()
-    await AggProduct(name="Item 3", price=30.0, category="B").save()
+        await AggProduct(name="Item 1", price=10.0, category="A").save()
+        await AggProduct(name="Item 2", price=20.0, category="A").save()
+        await AggProduct(name="Item 3", price=30.0, category="B").save()
 
-    # Total count
-    assert await AggProduct.where(AggProduct.id >= 0).count() == 3
+        # Total count
+        assert await AggProduct.where(AggProduct.id >= 0).count() == 3
 
-    # Filtered count
-    assert await AggProduct.where(AggProduct.category == "A").count() == 2
-    assert await AggProduct.where(AggProduct.price > 25).count() == 1
-    assert await AggProduct.where(AggProduct.category == "C").count() == 0
+        # Filtered count
+        assert await AggProduct.where(AggProduct.category == "A").count() == 2
+        assert await AggProduct.where(AggProduct.price > 25).count() == 1
+        assert await AggProduct.where(AggProduct.category == "C").count() == 0
 
 
 @pytest.mark.asyncio
@@ -41,30 +42,33 @@ async def test_order_by_operation(db_url):
         category: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    await AggProduct(name="Z", price=100.0, category="X").save()
-    await AggProduct(name="A", price=50.0, category="Y").save()
-    await AggProduct(name="M", price=75.0, category="X").save()
+        await AggProduct(name="Z", price=100.0, category="X").save()
+        await AggProduct(name="A", price=50.0, category="Y").save()
+        await AggProduct(name="M", price=75.0, category="X").save()
 
-    # Sort by price ascending
-    results = (
-        await AggProduct.where(AggProduct.id >= 0).order_by(AggProduct.price).all()
-    )
-    assert [r.name for r in results] == ["A", "M", "Z"]
+        # Sort by price ascending
+        results = (
+            await AggProduct.where(AggProduct.id >= 0)
+            .order_by(AggProduct.price)
+            .all()
+        )
+        assert [r.name for r in results] == ["A", "M", "Z"]
 
-    # Sort by name descending
-    results = (
-        await AggProduct.where(AggProduct.id >= 0)
-        .order_by(AggProduct.name, direction="desc")
-        .all()
-    )
-    assert [r.name for r in results] == ["Z", "M", "A"]
+        # Sort by name descending
+        results = (
+            await AggProduct.where(AggProduct.id >= 0)
+            .order_by(AggProduct.name, direction="desc")
+            .all()
+        )
+        assert [r.name for r in results] == ["Z", "M", "A"]
 
-    # Sort by category (asc), then price (desc)
-    results = (
-        await AggProduct.where(AggProduct.id >= 0)
-        .order_by(AggProduct.category)
-        .order_by(AggProduct.price, direction="desc")
-        .all()
-    )
-    assert [r.name for r in results] == ["Z", "M", "A"]
+        # Sort by category (asc), then price (desc)
+        results = (
+            await AggProduct.where(AggProduct.id >= 0)
+            .order_by(AggProduct.category)
+            .order_by(AggProduct.price, direction="desc")
+            .all()
+        )
+        assert [r.name for r in results] == ["Z", "M", "A"]

--- a/tests/test_alembic_bridge.py
+++ b/tests/test_alembic_bridge.py
@@ -283,7 +283,7 @@ def test_render_check_body_escapes_embedded_double_quote():
 async def test_explicit_foreign_key_shadow_id_auto_migrate_roundtrip(db_url):
     """Runtime migrate + ORM must treat explicit ``*_id`` as the single FK column."""
 
-    from ferro import connect
+    from ferro import connect, engines
 
     class TyRoundJobRole(Model):
         id: Annotated[int | None, FerroField(primary_key=True)] = None
@@ -297,17 +297,18 @@ async def test_explicit_foreign_key_shadow_id_auto_migrate_roundtrip(db_url):
         job_role_id: int | None = None
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    role = await TyRoundJobRole.create(name="ic")
-    card = await TyRoundScorecard.create(title="card-a", job_role=role)
-    assert card.job_role_id == role.id
+        role = await TyRoundJobRole.create(name="ic")
+        card = await TyRoundScorecard.create(title="card-a", job_role=role)
+        assert card.job_role_id == role.id
 
-    by_attr = await TyRoundScorecard.where(
-        TyRoundScorecard.job_role_id == role.id
-    ).first()
-    assert by_attr is not None and by_attr.id == card.id
+        by_attr = await TyRoundScorecard.where(
+            TyRoundScorecard.job_role_id == role.id
+        ).first()
+        assert by_attr is not None and by_attr.id == card.id
 
-    by_lambda = await TyRoundScorecard.where(
-        lambda s: s.job_role_id == role.id
-    ).first()
-    assert by_lambda is not None and by_lambda.id == card.id
+        by_lambda = await TyRoundScorecard.where(
+            lambda s: s.job_role_id == role.id
+        ).first()
+        assert by_lambda is not None and by_lambda.id == card.id

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -25,12 +25,13 @@ async def test_connect_with_auto_migrate(db_url):
     # Connect with auto_migrate=True
     # This should internally call the same logic as create_tables()
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    # We can verify it works by trying to call create_tables again
-    # or by just ensuring it doesn't crash.
-    # In a future step, when we have INSERT, we can verify the table exists.
-    # For now, we are verifying the API signature and that it runs without error.
-    assert True
+        # We can verify it works by trying to call create_tables again
+        # or by just ensuring it doesn't crash.
+        # In a future step, when we have INSERT, we can verify the table exists.
+        # For now, we are verifying the API signature and that it runs without error.
+        assert True
 
 
 @pytest.mark.asyncio
@@ -39,9 +40,10 @@ async def test_connect_without_auto_migrate(db_url):
     ferro.reset_engine()
 
     await ferro.connect(db_url, auto_migrate=False)
-    # Manual call still works
-    await ferro.create_tables()
-    assert True
+    async with ferro.engines.session():
+        # Manual call still works
+        await ferro.create_tables()
+        assert True
 
 
 @pytest.mark.asyncio
@@ -69,28 +71,29 @@ async def test_m2m_join_table_created_during_auto_migrate(db_url):
         actors: Relation[list["Actor"]] = BackRef()
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    actor = await Actor.create(name="Alice")
-    movie = await Movie.create(title="Matrix")
-    await actor.movies.add(movie)
+        actor = await Actor.create(name="Alice")
+        movie = await Movie.create(title="Matrix")
+        await actor.movies.add(movie)
 
-    linked = await actor.movies.all()
-    assert len(linked) == 1
-    assert linked[0].id == movie.id
-    assert linked[0].title == "Matrix"
-    assert await actor.movies.count() == 1
+        linked = await actor.movies.all()
+        assert len(linked) == 1
+        assert linked[0].id == movie.id
+        assert linked[0].title == "Matrix"
+        assert await actor.movies.count() == 1
 
-    reverse_linked = await movie.actors.all()
-    assert [row.id for row in reverse_linked] == [actor.id]
+        reverse_linked = await movie.actors.all()
+        assert [row.id for row in reverse_linked] == [actor.id]
 
-    await actor.movies.remove(movie)
-    assert await actor.movies.count() == 0
+        await actor.movies.remove(movie)
+        assert await actor.movies.count() == 0
 
-    movie_2 = await Movie.create(title="Reloaded")
-    await actor.movies.add(movie, movie_2)
-    assert await actor.movies.count() == 2
-    await actor.movies.clear()
-    assert await actor.movies.count() == 0
+        movie_2 = await Movie.create(title="Reloaded")
+        await actor.movies.add(movie, movie_2)
+        assert await actor.movies.count() == 2
+        await actor.movies.clear()
+        assert await actor.movies.count() == 0
 
 
 @pytest.mark.asyncio
@@ -117,31 +120,32 @@ async def test_uuid_m2m_join_table_columns_inherit_pk_type_and_nullability(db_ur
         actors: Relation[list["UuidActor"]] = BackRef()
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    import sqlite3
+        import sqlite3
 
-    db_path = db_url.removeprefix("sqlite:").split("?", 1)[0]
-    conn = sqlite3.connect(db_path)
-    rows = conn.execute("PRAGMA table_info(uuidactor_movies)").fetchall()
-    conn.close()
+        db_path = db_url.removeprefix("sqlite:").split("?", 1)[0]
+        conn = sqlite3.connect(db_path)
+        rows = conn.execute("PRAGMA table_info(uuidactor_movies)").fetchall()
+        conn.close()
 
-    columns = {row[1]: row for row in rows}
-    assert columns["uuidactor_id"][2].upper() in {
-        "UUID",
-        "CHAR(32)",
-        "TEXT",
-        "CHAR",
-        "VARCHAR",
-    }
-    assert columns["uuidmovie_id"][2].upper() in {
-        "UUID",
-        "CHAR(32)",
-        "TEXT",
-        "CHAR",
-        "VARCHAR",
-    }
-    assert columns["uuidactor_id"][3] == 1
-    assert columns["uuidmovie_id"][3] == 1
+        columns = {row[1]: row for row in rows}
+        assert columns["uuidactor_id"][2].upper() in {
+            "UUID",
+            "CHAR(32)",
+            "TEXT",
+            "CHAR",
+            "VARCHAR",
+        }
+        assert columns["uuidmovie_id"][2].upper() in {
+            "UUID",
+            "CHAR(32)",
+            "TEXT",
+            "CHAR",
+            "VARCHAR",
+        }
+        assert columns["uuidactor_id"][3] == 1
+        assert columns["uuidmovie_id"][3] == 1
 
 
 @pytest.mark.asyncio
@@ -169,35 +173,36 @@ async def test_uuid_m2m_relationship_query_serializes_source_id(db_url):
         tags: Relation[list[UuidTag]] = ManyToMany(related_name="posts")
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    post = await UuidPost.create(title="Hello")
-    tag = await UuidTag.create(name="python")
+        post = await UuidPost.create(title="Hello")
+        tag = await UuidTag.create(name="python")
 
-    await post.tags.add(tag)
-
-    linked = await post.tags.all()
-    assert [row.id for row in linked] == [tag.id]
-    assert await post.tags.count() == 1
-
-    reverse_linked = await tag.posts.all()
-    assert [row.id for row in reverse_linked] == [post.id]
-
-    await post.tags.remove(tag)
-    assert await post.tags.count() == 0
-
-    tag_2 = await UuidTag.create(name="orm")
-    await post.tags.add(tag, tag_2)
-    assert await post.tags.count() == 2
-    await post.tags.clear()
-    assert await post.tags.count() == 0
-
-    async with transaction():
         await post.tags.add(tag)
+
+        linked = await post.tags.all()
+        assert [row.id for row in linked] == [tag.id]
         assert await post.tags.count() == 1
+
+        reverse_linked = await tag.posts.all()
+        assert [row.id for row in reverse_linked] == [post.id]
+
         await post.tags.remove(tag)
         assert await post.tags.count() == 0
 
-    assert await post.tags.count() == 0
+        tag_2 = await UuidTag.create(name="orm")
+        await post.tags.add(tag, tag_2)
+        assert await post.tags.count() == 2
+        await post.tags.clear()
+        assert await post.tags.count() == 0
+
+        async with transaction():
+            await post.tags.add(tag)
+            assert await post.tags.count() == 1
+            await post.tags.remove(tag)
+            assert await post.tags.count() == 0
+
+        assert await post.tags.count() == 0
 
 
 # ---------------------------------------------------------------------------
@@ -264,33 +269,35 @@ async def test_migrate_updates_adds_missing_columns_and_hydrates(
 
     # Bootstrap the OLD (narrow) schema by hand, as an older release would have.
     await ferro.connect(db_url)
-    if db_backend == "sqlite":
-        await execute(
-            'CREATE TABLE "miginvoice" '
-            '("id" integer PRIMARY KEY AUTOINCREMENT, "number" varchar NOT NULL)'
-        )
-    else:
-        await execute(
-            'CREATE TABLE "miginvoice" ("id" serial PRIMARY KEY, "number" varchar NOT NULL)'
-        )
-    await execute('INSERT INTO "miginvoice" ("number") VALUES (\'INV-1\')')
+    async with ferro.engines.session():
+        if db_backend == "sqlite":
+            await execute(
+                'CREATE TABLE "miginvoice" '
+                '("id" integer PRIMARY KEY AUTOINCREMENT, "number" varchar NOT NULL)'
+            )
+        else:
+            await execute(
+                'CREATE TABLE "miginvoice" ("id" serial PRIMARY KEY, "number" varchar NOT NULL)'
+            )
+        await execute('INSERT INTO "miginvoice" ("number") VALUES (\'INV-1\')')
     ferro.reset_engine()
 
     await ferro.connect(db_url, migrate_updates=True)
+    async with ferro.engines.session():
 
-    rows = await MigInvoice.all()
-    assert len(rows) == 1
-    assert rows[0].number == "INV-1"
-    assert rows[0].paid_date is None
-    assert rows[0].memo is None
+        rows = await MigInvoice.all()
+        assert len(rows) == 1
+        assert rows[0].number == "INV-1"
+        assert rows[0].paid_date is None
+        assert rows[0].memo is None
 
-    # The new columns are usable immediately.
-    inv = await MigInvoice.create(
-        number="INV-2", paid_date=date(2026, 1, 15), memo="paid"
-    )
-    fetched = await MigInvoice.get(inv.id)
-    assert fetched.paid_date == date(2026, 1, 15)
-    assert fetched.memo == "paid"
+        # The new columns are usable immediately.
+        inv = await MigInvoice.create(
+            number="INV-2", paid_date=date(2026, 1, 15), memo="paid"
+        )
+        fetched = await MigInvoice.get(inv.id)
+        assert fetched.paid_date == date(2026, 1, 15)
+        assert fetched.memo == "paid"
 
 
 @pytest.mark.asyncio
@@ -308,29 +315,30 @@ async def test_manual_migrate_on_live_pool_refreshes_cached_statements(
         summary: str | None = None
 
     await ferro.connect(db_url)
-    if db_backend == "sqlite":
-        await execute(
-            'CREATE TABLE "migreport" '
-            '("id" integer PRIMARY KEY AUTOINCREMENT, "title" varchar NOT NULL)'
-        )
-    else:
-        await execute(
-            'CREATE TABLE "migreport" ("id" serial PRIMARY KEY, "title" varchar NOT NULL)'
-        )
-    await execute('INSERT INTO "migreport" ("title") VALUES (\'Q1\')')
+    async with ferro.engines.session():
+        if db_backend == "sqlite":
+            await execute(
+                'CREATE TABLE "migreport" '
+                '("id" integer PRIMARY KEY AUTOINCREMENT, "title" varchar NOT NULL)'
+            )
+        else:
+            await execute(
+                'CREATE TABLE "migreport" ("id" serial PRIMARY KEY, "title" varchar NOT NULL)'
+            )
+        await execute('INSERT INTO "migreport" ("title") VALUES (\'Q1\')')
 
-    # Prepare (and cache) the SELECT against the narrow schema.
-    rows_before = await MigReport.all()
-    assert len(rows_before) == 1
+        # Prepare (and cache) the SELECT against the narrow schema.
+        rows_before = await MigReport.all()
+        assert len(rows_before) == 1
 
-    await ferro.migrate()
+        await ferro.migrate()
 
-    # Same query again: without the pool refresh this panics in the sqlx
-    # worker and silently returns zero rows on SQLite.
-    rows_after = await MigReport.all()
-    assert len(rows_after) == 1
-    assert rows_after[0].title == "Q1"
-    assert rows_after[0].summary is None
+        # Same query again: without the pool refresh this panics in the sqlx
+        # worker and silently returns zero rows on SQLite.
+        rows_after = await MigReport.all()
+        assert len(rows_after) == 1
+        assert rows_after[0].title == "Q1"
+        assert rows_after[0].summary is None
 
 
 @pytest.mark.asyncio
@@ -343,9 +351,10 @@ async def test_migrate_updates_not_null_without_default_fails_loudly(
     from datetime import datetime
 
     await ferro.connect(db_url)
-    await execute(
-        'CREATE TABLE "migstrict" ("id" integer PRIMARY KEY AUTOINCREMENT, "name" varchar NOT NULL)'
-    )
+    async with ferro.engines.session():
+        await execute(
+            'CREATE TABLE "migstrict" ("id" integer PRIMARY KEY AUTOINCREMENT, "name" varchar NOT NULL)'
+        )
     ferro.reset_engine()
 
     class MigStrict(Model):
@@ -363,10 +372,11 @@ async def test_sqlite_type_drift_warns_and_leaves_column_untouched(
     db_url, clean_registry
 ):
     await ferro.connect(db_url)
-    await execute(
-        'CREATE TABLE "migdrift" '
-        '("id" integer PRIMARY KEY AUTOINCREMENT, "count" varchar NOT NULL)'
-    )
+    async with ferro.engines.session():
+        await execute(
+            'CREATE TABLE "migdrift" '
+            '("id" integer PRIMARY KEY AUTOINCREMENT, "count" varchar NOT NULL)'
+        )
     ferro.reset_engine()
 
     class MigDrift(Model):
@@ -419,10 +429,11 @@ async def test_sqlite_genuine_text_to_blob_diff_still_warns(
     """Control: a pre-existing TEXT column adopted by a `bytes` model is a REAL
     difference and must still warn — the fix only silences blob==blob. (#165)"""
     await ferro.connect(db_url)
-    await execute(
-        'CREATE TABLE "attachment" '
-        '("id" integer PRIMARY KEY AUTOINCREMENT, "payload" text NOT NULL)'
-    )
+    async with ferro.engines.session():
+        await execute(
+            'CREATE TABLE "attachment" '
+            '("id" integer PRIMARY KEY AUTOINCREMENT, "payload" text NOT NULL)'
+        )
     ferro.reset_engine()
 
     class Attachment(Model):
@@ -489,10 +500,11 @@ async def test_pg_datetime_over_external_naive_timestamp_warns_and_skips(
     import datetime as dt
 
     await ferro.connect(db_url)
-    await execute(
-        'CREATE TABLE "event" '
-        '("id" serial PRIMARY KEY, "occurred_at" timestamp NOT NULL)'
-    )
+    async with ferro.engines.session():
+        await execute(
+            'CREATE TABLE "event" '
+            '("id" serial PRIMARY KEY, "occurred_at" timestamp NOT NULL)'
+        )
     ferro.reset_engine()
 
     class Event(Model):
@@ -520,10 +532,11 @@ async def test_pg_datetime_db_type_override_keeps_naive_no_drift(
     import warnings as _warnings
 
     await ferro.connect(db_url)
-    await execute(
-        'CREATE TABLE "event2" '
-        '("id" serial PRIMARY KEY, "occurred_at" timestamp NOT NULL)'
-    )
+    async with ferro.engines.session():
+        await execute(
+            'CREATE TABLE "event2" '
+            '("id" serial PRIMARY KEY, "occurred_at" timestamp NOT NULL)'
+        )
     ferro.reset_engine()
 
     class Event2(Model):
@@ -555,10 +568,11 @@ async def test_pg_ferro_created_timestamptz_no_drift(
         occurred_at: dt.datetime
 
     await ferro.connect(db_url, auto_migrate=True)  # Ferro creates it -> timestamptz
-    assert (
-        _pg_live_type(postgres_base_url, db_schema_name, "event3", "occurred_at")
-        == "timestamp with time zone"
-    )
+    async with ferro.engines.session():
+        assert (
+            _pg_live_type(postgres_base_url, db_schema_name, "event3", "occurred_at")
+            == "timestamp with time zone"
+        )
     ferro.reset_engine()
 
     with _warnings.catch_warnings():
@@ -581,32 +595,35 @@ async def test_migrate_destructive_drops_removed_columns(
         name: str
 
     await ferro.connect(db_url)
-    if db_backend == "sqlite":
+    async with ferro.engines.session():
+        if db_backend == "sqlite":
+            await execute(
+                'CREATE TABLE "migslim" ("id" integer PRIMARY KEY AUTOINCREMENT, '
+                '"name" varchar NOT NULL, "legacy_notes" text)'
+            )
+        else:
+            await execute(
+                'CREATE TABLE "migslim" ("id" serial PRIMARY KEY, '
+                '"name" varchar NOT NULL, "legacy_notes" text)'
+            )
         await execute(
-            'CREATE TABLE "migslim" ("id" integer PRIMARY KEY AUTOINCREMENT, '
-            '"name" varchar NOT NULL, "legacy_notes" text)'
+            'INSERT INTO "migslim" ("name", "legacy_notes") VALUES (\'keep\', \'bye\')'
         )
-    else:
-        await execute(
-            'CREATE TABLE "migslim" ("id" serial PRIMARY KEY, '
-            '"name" varchar NOT NULL, "legacy_notes" text)'
-        )
-    await execute(
-        'INSERT INTO "migslim" ("name", "legacy_notes") VALUES (\'keep\', \'bye\')'
-    )
     ferro.reset_engine()
 
     # Without the flag the extra column is untouched.
     await ferro.connect(db_url, migrate_updates=True)
-    rows = await fetch_all('SELECT * FROM "migslim"')
-    assert "legacy_notes" in rows[0]
+    async with ferro.engines.session():
+        rows = await fetch_all('SELECT * FROM "migslim"')
+        assert "legacy_notes" in rows[0]
     ferro.reset_engine()
 
     await ferro.connect(db_url, migrate_destructive=True)
-    rows = await fetch_all('SELECT * FROM "migslim"')
-    assert len(rows) == 1
-    assert rows[0]["name"] == "keep", "surviving data must be intact"
-    assert "legacy_notes" not in rows[0]
+    async with ferro.engines.session():
+        rows = await fetch_all('SELECT * FROM "migslim"')
+        assert len(rows) == 1
+        assert rows[0]["name"] == "keep", "surviving data must be intact"
+        assert "legacy_notes" not in rows[0]
 
 
 @pytest.mark.asyncio
@@ -619,23 +636,25 @@ async def test_destructive_drop_of_indexed_column_drops_index_first(
         name: str
 
     await ferro.connect(db_url)
-    await execute(
-        'CREATE TABLE "migidx" ("id" integer PRIMARY KEY AUTOINCREMENT, '
-        '"name" varchar NOT NULL, "old_status" varchar)'
-    )
-    await execute('CREATE INDEX "idx_migidx_old_status" ON "migidx" ("old_status")')
-    await execute(
-        'INSERT INTO "migidx" ("name", "old_status") VALUES (\'keep\', \'x\')'
-    )
+    async with ferro.engines.session():
+        await execute(
+            'CREATE TABLE "migidx" ("id" integer PRIMARY KEY AUTOINCREMENT, '
+            '"name" varchar NOT NULL, "old_status" varchar)'
+        )
+        await execute('CREATE INDEX "idx_migidx_old_status" ON "migidx" ("old_status")')
+        await execute(
+            'INSERT INTO "migidx" ("name", "old_status") VALUES (\'keep\', \'x\')'
+        )
     ferro.reset_engine()
 
     await ferro.connect(db_url, migrate_destructive=True)
+    async with ferro.engines.session():
 
-    columns = _sqlite_columns(db_url, "migidx")
-    assert "old_status" not in columns
-    assert "idx_migidx_old_status" not in _sqlite_index_names(db_url, "migidx")
-    rows = await fetch_all('SELECT * FROM "migidx"')
-    assert rows[0]["name"] == "keep"
+        columns = _sqlite_columns(db_url, "migidx")
+        assert "old_status" not in columns
+        assert "idx_migidx_old_status" not in _sqlite_index_names(db_url, "migidx")
+        rows = await fetch_all('SELECT * FROM "migidx"')
+        assert rows[0]["name"] == "keep"
 
 
 @pytest.mark.asyncio
@@ -648,10 +667,11 @@ async def test_destructive_refuses_unique_constraint_column_on_sqlite(
         name: str
 
     await ferro.connect(db_url)
-    await execute(
-        'CREATE TABLE "miguq" ("id" integer PRIMARY KEY AUTOINCREMENT, '
-        '"name" varchar NOT NULL, "old_code" varchar UNIQUE)'
-    )
+    async with ferro.engines.session():
+        await execute(
+            'CREATE TABLE "miguq" ("id" integer PRIMARY KEY AUTOINCREMENT, '
+            '"name" varchar NOT NULL, "old_code" varchar UNIQUE)'
+        )
     ferro.reset_engine()
 
     with pytest.raises(ValueError, match=r"miguq\.old_code.*UNIQUE.*Alembic"):
@@ -670,19 +690,21 @@ async def test_added_indexed_and_unique_columns_get_their_indexes(
         slug: Annotated[str | None, FerroField(unique=True)] = None
 
     await ferro.connect(db_url)
-    await execute(
-        'CREATE TABLE "migindexed" '
-        '("id" integer PRIMARY KEY AUTOINCREMENT, "name" varchar NOT NULL)'
-    )
+    async with ferro.engines.session():
+        await execute(
+            'CREATE TABLE "migindexed" '
+            '("id" integer PRIMARY KEY AUTOINCREMENT, "name" varchar NOT NULL)'
+        )
     ferro.reset_engine()
 
     # The uq_ index is the canonical unique shape on both dialects since
     # FF-B B4/D1 — no SQLite-compromise warning is emitted anymore.
     await ferro.connect(db_url, migrate_updates=True)
+    async with ferro.engines.session():
 
-    index_names = _sqlite_index_names(db_url, "migindexed")
-    assert "idx_migindexed_status" in index_names
-    assert "uq_migindexed_slug" in index_names
+        index_names = _sqlite_index_names(db_url, "migindexed")
+        assert "idx_migindexed_status" in index_names
+        assert "uq_migindexed_slug" in index_names
 
 
 @pytest.mark.asyncio
@@ -692,11 +714,12 @@ async def test_postgres_type_and_nullability_reconciliation(db_url, clean_regist
     existing data), SET NOT NULL, and no lingering server default after a
     backfilled NOT NULL add."""
     await ferro.connect(db_url)
-    await execute(
-        'CREATE TABLE "migpg" ("id" serial PRIMARY KEY, '
-        '"total" integer NOT NULL, "note" varchar)'
-    )
-    await execute('INSERT INTO "migpg" ("total", "note") VALUES (41, NULL)')
+    async with ferro.engines.session():
+        await execute(
+            'CREATE TABLE "migpg" ("id" serial PRIMARY KEY, '
+            '"total" integer NOT NULL, "note" varchar)'
+        )
+        await execute('INSERT INTO "migpg" ("total", "note") VALUES (41, NULL)')
     ferro.reset_engine()
 
     # Assignment style keeps this model valid. The #155 trap is an *invalid*
@@ -713,24 +736,25 @@ async def test_postgres_type_and_nullability_reconciliation(db_url, clean_regist
         status: str = ferro.Field(default="draft")
 
     await ferro.connect(db_url, migrate_updates=True)
+    async with ferro.engines.session():
 
-    rows = await fetch_all(
-        "SELECT column_name, data_type, is_nullable, column_default "
-        "FROM information_schema.columns "
-        "WHERE table_schema = current_schema() AND table_name = 'migpg'"
-    )
-    by_name = {row["column_name"]: row for row in rows}
-    assert by_name["total"]["data_type"] == "bigint", "integer -> bigint via USING cast"
-    assert by_name["status"]["is_nullable"] == "NO"
-    assert (
-        by_name["status"]["column_default"] is None
-    ), "backfill default must not linger"
+        rows = await fetch_all(
+            "SELECT column_name, data_type, is_nullable, column_default "
+            "FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = 'migpg'"
+        )
+        by_name = {row["column_name"]: row for row in rows}
+        assert by_name["total"]["data_type"] == "bigint", "integer -> bigint via USING cast"
+        assert by_name["status"]["is_nullable"] == "NO"
+        assert (
+            by_name["status"]["column_default"] is None
+        ), "backfill default must not linger"
 
-    data = await fetch_all('SELECT "total", "status" FROM "migpg"')
-    assert data[0]["total"] == 41, "existing data survives the type change"
-    assert (
-        data[0]["status"] == "draft"
-    ), "existing rows backfilled with the literal default"
+        data = await fetch_all('SELECT "total", "status" FROM "migpg"')
+        assert data[0]["total"] == 41, "existing data survives the type change"
+        assert (
+            data[0]["status"] == "draft"
+        ), "existing rows backfilled with the literal default"
 
 
 # ---------------------------------------------------------------------------
@@ -785,18 +809,19 @@ async def test_index_reconcile_adds_composite_index_to_existing_table(
 
     # Create the table without any indexes.
     await ferro.connect(db_url)
-    if db_backend == "sqlite":
-        await execute(
-            'CREATE TABLE "idxcompmodel" '
-            '("id" integer PRIMARY KEY AUTOINCREMENT, '
-            '"col_a" integer NOT NULL, "col_b" integer NOT NULL)'
-        )
-    else:
-        await execute(
-            'CREATE TABLE "idxcompmodel" '
-            '("id" serial PRIMARY KEY, '
-            '"col_a" integer NOT NULL, "col_b" integer NOT NULL)'
-        )
+    async with ferro.engines.session():
+        if db_backend == "sqlite":
+            await execute(
+                'CREATE TABLE "idxcompmodel" '
+                '("id" integer PRIMARY KEY AUTOINCREMENT, '
+                '"col_a" integer NOT NULL, "col_b" integer NOT NULL)'
+            )
+        else:
+            await execute(
+                'CREATE TABLE "idxcompmodel" '
+                '("id" serial PRIMARY KEY, '
+                '"col_a" integer NOT NULL, "col_b" integer NOT NULL)'
+            )
     ferro.reset_engine()
 
     # Re-register a NEW model class with the composite index annotation.
@@ -817,11 +842,12 @@ async def test_index_reconcile_adds_composite_index_to_existing_table(
         col_b: int
 
     await ferro.connect(db_url, migrate_updates=True)
+    async with ferro.engines.session():
 
-    names = _live_index_names(db_url, db_backend, "idxcompmodel")
-    assert "idx_idxcompmodel_col_a_col_b" in names, (
-        f"expected composite index idx_idxcompmodel_col_a_col_b, got: {names}"
-    )
+        names = _live_index_names(db_url, db_backend, "idxcompmodel")
+        assert "idx_idxcompmodel_col_a_col_b" in names, (
+            f"expected composite index idx_idxcompmodel_col_a_col_b, got: {names}"
+        )
 
 
 @pytest.mark.asyncio
@@ -838,16 +864,17 @@ async def test_index_reconcile_adds_single_column_index_to_existing_column(
 
     # Create table with 'status' but no index on it.
     await ferro.connect(db_url)
-    if db_backend == "sqlite":
-        await execute(
-            'CREATE TABLE "idxsinglemodel" '
-            '("id" integer PRIMARY KEY AUTOINCREMENT, "status" varchar NOT NULL)'
-        )
-    else:
-        await execute(
-            'CREATE TABLE "idxsinglemodel" '
-            '("id" serial PRIMARY KEY, "status" varchar NOT NULL)'
-        )
+    async with ferro.engines.session():
+        if db_backend == "sqlite":
+            await execute(
+                'CREATE TABLE "idxsinglemodel" '
+                '("id" integer PRIMARY KEY AUTOINCREMENT, "status" varchar NOT NULL)'
+            )
+        else:
+            await execute(
+                'CREATE TABLE "idxsinglemodel" '
+                '("id" serial PRIMARY KEY, "status" varchar NOT NULL)'
+            )
     ferro.reset_engine()
 
     # Re-register with index=True on the existing column.
@@ -864,11 +891,12 @@ async def test_index_reconcile_adds_single_column_index_to_existing_column(
         status: Annotated[str, FerroField(index=True)]
 
     await ferro.connect(db_url, migrate_updates=True)
+    async with ferro.engines.session():
 
-    names = _live_index_names(db_url, db_backend, "idxsinglemodel")
-    assert "idx_idxsinglemodel_status" in names, (
-        f"expected idx_idxsinglemodel_status, got: {names}"
-    )
+        names = _live_index_names(db_url, db_backend, "idxsinglemodel")
+        assert "idx_idxsinglemodel_status" in names, (
+            f"expected idx_idxsinglemodel_status, got: {names}"
+        )
 
 
 @pytest.mark.asyncio
@@ -890,17 +918,19 @@ async def test_index_reconcile_noop_when_index_already_present(
 
     # First connect creates the table + index.
     await ferro.connect(db_url, auto_migrate=True)
-    names_after_first = _live_index_names(db_url, db_backend, "idxnoopmodel")
-    assert "idx_idxnoopmodel_x_y" in names_after_first
+    async with ferro.engines.session():
+        names_after_first = _live_index_names(db_url, db_backend, "idxnoopmodel")
+        assert "idx_idxnoopmodel_x_y" in names_after_first
     ferro.reset_engine()
 
     # Second connect — same model, same index already present.
     await ferro.connect(db_url, migrate_updates=True)
+    async with ferro.engines.session():
 
-    names_after_second = _live_index_names(db_url, db_backend, "idxnoopmodel")
-    assert "idx_idxnoopmodel_x_y" in names_after_second, (
-        "index must survive second migrate_updates pass (no-op guard)"
-    )
+        names_after_second = _live_index_names(db_url, db_backend, "idxnoopmodel")
+        assert "idx_idxnoopmodel_x_y" in names_after_second, (
+            "index must survive second migrate_updates pass (no-op guard)"
+        )
 
 
 @pytest.mark.asyncio
@@ -923,8 +953,9 @@ async def test_index_reconcile_destructive_drops_removed_composite_index(
 
     # Bootstrap with the index present.
     await ferro.connect(db_url, auto_migrate=True)
-    names = _live_index_names(db_url, db_backend, "idxdropmodel")
-    assert "idx_idxdropmodel_p_q" in names
+    async with ferro.engines.session():
+        names = _live_index_names(db_url, db_backend, "idxdropmodel")
+        assert "idx_idxdropmodel_p_q" in names
     ferro.reset_engine()
 
     # Re-register model WITHOUT the composite index.
@@ -943,18 +974,20 @@ async def test_index_reconcile_destructive_drops_removed_composite_index(
 
     # Non-destructive: index must remain.
     await ferro.connect(db_url, migrate_updates=True)
-    names_after_updates = _live_index_names(db_url, db_backend, "idxdropmodel")
-    assert "idx_idxdropmodel_p_q" in names_after_updates, (
-        "non-destructive pass must leave orphaned ferro index intact"
-    )
+    async with ferro.engines.session():
+        names_after_updates = _live_index_names(db_url, db_backend, "idxdropmodel")
+        assert "idx_idxdropmodel_p_q" in names_after_updates, (
+            "non-destructive pass must leave orphaned ferro index intact"
+        )
     ferro.reset_engine()
 
     # Destructive: index must be dropped.
     await ferro.connect(db_url, migrate_destructive=True)
-    names_after_destructive = _live_index_names(db_url, db_backend, "idxdropmodel")
-    assert "idx_idxdropmodel_p_q" not in names_after_destructive, (
-        "migrate_destructive must drop the orphaned ferro index"
-    )
+    async with ferro.engines.session():
+        names_after_destructive = _live_index_names(db_url, db_backend, "idxdropmodel")
+        assert "idx_idxdropmodel_p_q" not in names_after_destructive, (
+            "migrate_destructive must drop the orphaned ferro index"
+        )
 
 
 @pytest.mark.asyncio
@@ -976,29 +1009,32 @@ async def test_index_reconcile_user_index_survives_auto_migrate(
 
     # Create table with a Ferro composite index AND a custom user index.
     await ferro.connect(db_url, auto_migrate=True)
-    await execute('CREATE INDEX "my_custom_idx" ON "idxusermodel" ("m")')
+    async with ferro.engines.session():
+        await execute('CREATE INDEX "my_custom_idx" ON "idxusermodel" ("m")')
 
-    names_initial = _live_index_names(db_url, db_backend, "idxusermodel")
-    assert "idx_idxusermodel_m_n" in names_initial
-    assert "my_custom_idx" in names_initial
+        names_initial = _live_index_names(db_url, db_backend, "idxusermodel")
+        assert "idx_idxusermodel_m_n" in names_initial
+        assert "my_custom_idx" in names_initial
     ferro.reset_engine()
 
     # Non-destructive pass: both indexes must survive.
     await ferro.connect(db_url, migrate_updates=True)
-    names_after_updates = _live_index_names(db_url, db_backend, "idxusermodel")
-    assert "idx_idxusermodel_m_n" in names_after_updates
-    assert "my_custom_idx" in names_after_updates, (
-        "user index must survive non-destructive auto-migrate"
-    )
+    async with ferro.engines.session():
+        names_after_updates = _live_index_names(db_url, db_backend, "idxusermodel")
+        assert "idx_idxusermodel_m_n" in names_after_updates
+        assert "my_custom_idx" in names_after_updates, (
+            "user index must survive non-destructive auto-migrate"
+        )
     ferro.reset_engine()
 
     # Destructive pass: Ferro index still present (model still has it), user index still present.
     await ferro.connect(db_url, migrate_destructive=True)
-    names_after_destructive = _live_index_names(db_url, db_backend, "idxusermodel")
-    assert "idx_idxusermodel_m_n" in names_after_destructive
-    assert "my_custom_idx" in names_after_destructive, (
-        "user index must survive destructive auto-migrate"
-    )
+    async with ferro.engines.session():
+        names_after_destructive = _live_index_names(db_url, db_backend, "idxusermodel")
+        assert "idx_idxusermodel_m_n" in names_after_destructive
+        assert "my_custom_idx" in names_after_destructive, (
+            "user index must survive destructive auto-migrate"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1147,21 +1183,22 @@ async def test_create_tables_pushes_modelset_for_model_defined_after_connect(
     # Connect first, with NO models registered yet — the connect-time modelset
     # snapshot is empty.
     await ferro.connect(db_url, auto_migrate=False)
+    async with ferro.engines.session():
 
-    # Now define a model AFTER connect().
-    class LateModel(Model):
-        id: int = Field(json_schema_extra={"primary_key": True})
-        label: str
+        # Now define a model AFTER connect().
+        class LateModel(Model):
+            id: int = Field(json_schema_extra={"primary_key": True})
+            label: str
 
-    # create_tables() must compile + push the up-to-date registry IR before the
-    # Rust create runs, otherwise this table never gets created.
-    await ferro.create_tables()
+        # create_tables() must compile + push the up-to-date registry IR before the
+        # Rust create runs, otherwise this table never gets created.
+        await ferro.create_tables()
 
-    # If the table exists, an INSERT + SELECT round-trips cleanly.
-    row = await LateModel.create(id=1, label="hello")
-    assert row.id == 1
-    fetched = await LateModel.get(1)
-    assert fetched.label == "hello"
+        # If the table exists, an INSERT + SELECT round-trips cleanly.
+        row = await LateModel.create(id=1, label="hello")
+        assert row.id == 1
+        fetched = await LateModel.get(1)
+        assert fetched.label == "hello"
 
 
 @pytest.mark.asyncio
@@ -1225,8 +1262,9 @@ async def test_db_check_reconnect_is_idempotent(db_url):
     # Second connect re-runs the create path against the existing schema —
     # this raised OperationalError before the idempotency fix.
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    rows = await fetch_all(
-        "SELECT conname FROM pg_constraint WHERE conname = 'ck_reconnectdoc_status'"
-    )
-    assert len(rows) == 1, f"expected exactly one CHECK constraint, got: {rows}"
+        rows = await fetch_all(
+            "SELECT conname FROM pg_constraint WHERE conname = 'ck_reconnectdoc_status'"
+        )
+        assert len(rows) == 1, f"expected exactly one CHECK constraint, got: {rows}"

--- a/tests/test_bulk_update.py
+++ b/tests/test_bulk_update.py
@@ -1,6 +1,6 @@
 import pytest
 from typing import Annotated
-from ferro import Model, connect, FerroField
+from ferro import Model, connect, FerroField, engines
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -16,23 +16,26 @@ async def test_bulk_update_operation(db_url):
         category: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    await BulkProduct(name="P1", in_stock=True, category="Electronics").save()
-    await BulkProduct(name="P2", in_stock=True, category="Electronics").save()
-    await BulkProduct(name="P3", in_stock=True, category="Furniture").save()
+        await BulkProduct(name="P1", in_stock=True, category="Electronics").save()
+        await BulkProduct(name="P2", in_stock=True, category="Electronics").save()
+        await BulkProduct(name="P3", in_stock=True, category="Furniture").save()
 
-    # Bulk update: set in_stock=False for all Electronics
-    updated_count = await BulkProduct.where(
-        BulkProduct.category == "Electronics"
-    ).update(in_stock=False)
-    assert updated_count == 2
+        # Bulk update: set in_stock=False for all Electronics
+        updated_count = await BulkProduct.where(
+            BulkProduct.category == "Electronics"
+        ).update(in_stock=False)
+        assert updated_count == 2
 
-    # Verify results
-    electronics = await BulkProduct.where(BulkProduct.category == "Electronics").all()
-    assert all(p.in_stock is False for p in electronics)
+        # Verify results
+        electronics = await BulkProduct.where(
+            BulkProduct.category == "Electronics"
+        ).all()
+        assert all(p.in_stock is False for p in electronics)
 
-    furniture = await BulkProduct.where(BulkProduct.category == "Furniture").all()
-    assert furniture[0].in_stock is True
+        furniture = await BulkProduct.where(BulkProduct.category == "Furniture").all()
+        assert furniture[0].in_stock is True
 
 
 @pytest.mark.asyncio
@@ -45,18 +48,19 @@ async def test_bulk_update_evicts_identity_map(db_url):
         price: float
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    p1 = BulkProduct(name="Gadget", price=10.0)
-    await p1.save()
+        p1 = BulkProduct(name="Gadget", price=10.0)
+        await p1.save()
 
-    # Ensure it's in Identity Map
-    cached_p1 = await BulkProduct.get(p1.id)
-    assert cached_p1 is p1
+        # Ensure it's in Identity Map
+        cached_p1 = await BulkProduct.get(p1.id)
+        assert cached_p1 is p1
 
-    # Update price via bulk query
-    await BulkProduct.where(BulkProduct.id == p1.id).update(price=20.0)
+        # Update price via bulk query
+        await BulkProduct.where(BulkProduct.id == p1.id).update(price=20.0)
 
-    # Fetching again should NOT return the old 'p1' object (it should be a fresh object or re-hydrated)
-    fresh_p1 = await BulkProduct.get(p1.id)
-    assert fresh_p1 is not p1
-    assert fresh_p1.price == 20.0
+        # Fetching again should NOT return the old 'p1' object (it should be a fresh object or re-hydrated)
+        fresh_p1 = await BulkProduct.get(p1.id)
+        assert fresh_p1 is not p1
+        assert fresh_p1.price == 20.0

--- a/tests/test_catalog_cache.py
+++ b/tests/test_catalog_cache.py
@@ -59,55 +59,58 @@ async def test_steady_state_crud_issues_zero_catalog_queries(db_url, clean_regis
         tags: Relation[list["C2Tag"]] = ManyToMany(related_name="tasks")
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    # Warm-up: touch every table (model tables and the m2m join table) once.
-    tag = await C2Tag.create(label="warm")
-    task = await C2Task.create(
-        title="warm",
-        priority=C2Priority.HIGH,
-        run_id=uuid.uuid4(),
-        due=datetime(2026, 7, 2, 12, 0, tzinfo=UTC),
-    )
-    await task.tags.add(tag)
-    await task.tags.remove(tag)
-    await C2Task.where(lambda t: t.priority == C2Priority.HIGH).all()
-    await C2Task.where(lambda t: t.title == "warm").count()
-    await C2Task.where(lambda t: t.title == "nope").delete()
-    await C2Task.where(lambda t: t.title == "warm").update(title="warmed")
-
-    baseline = _catalog_query_count_for_test()
-
-    # Steady state: the same operation mix, several times over.
-    for i in range(3):
-        row = await C2Task.create(
-            title=f"steady-{i}",
+        # Warm-up: touch every table (model tables and the m2m join table) once.
+        tag = await C2Tag.create(label="warm")
+        task = await C2Task.create(
+            title="warm",
             priority=C2Priority.HIGH,
             run_id=uuid.uuid4(),
-            due=datetime(2026, 7, 2, 13, i, tzinfo=UTC),
+            due=datetime(2026, 7, 2, 12, 0, tzinfo=UTC),
         )
-        fetched = await C2Task.get(row.id)
-        assert fetched.priority is C2Priority.HIGH
-        assert fetched.run_id == row.run_id
-
+        await task.tags.add(tag)
+        await task.tags.remove(tag)
         await C2Task.where(lambda t: t.priority == C2Priority.HIGH).all()
-        assert await C2Task.where(lambda t, i=i: t.title == f"steady-{i}").count() == 1
-        await C2Task.where(lambda t, i=i: t.title == f"steady-{i}").update(
-            title=f"steady-{i}-renamed"
+        await C2Task.where(lambda t: t.title == "warm").count()
+        await C2Task.where(lambda t: t.title == "nope").delete()
+        await C2Task.where(lambda t: t.title == "warm").update(title="warmed")
+
+        baseline = _catalog_query_count_for_test()
+
+        # Steady state: the same operation mix, several times over.
+        for i in range(3):
+            row = await C2Task.create(
+                title=f"steady-{i}",
+                priority=C2Priority.HIGH,
+                run_id=uuid.uuid4(),
+                due=datetime(2026, 7, 2, 13, i, tzinfo=UTC),
+            )
+            fetched = await C2Task.get(row.id)
+            assert fetched.priority is C2Priority.HIGH
+            assert fetched.run_id == row.run_id
+
+            await C2Task.where(lambda t: t.priority == C2Priority.HIGH).all()
+            assert (
+                await C2Task.where(lambda t, i=i: t.title == f"steady-{i}").count() == 1
+            )
+            await C2Task.where(lambda t, i=i: t.title == f"steady-{i}").update(
+                title=f"steady-{i}-renamed"
+            )
+
+            row.title = f"steady-{i}-saved"
+            await row.save()
+
+            await row.tags.add(tag)
+            assert await row.tags.count() == 1
+            await row.tags.remove(tag)
+
+            await row.delete()
+
+        steady = _catalog_query_count_for_test()
+        assert steady - baseline == 0, (
+            f"steady-state CRUD issued {steady - baseline} catalog queries; expected 0"
         )
-
-        row.title = f"steady-{i}-saved"
-        await row.save()
-
-        await row.tags.add(tag)
-        assert await row.tags.count() == 1
-        await row.tags.remove(tag)
-
-        await row.delete()
-
-    steady = _catalog_query_count_for_test()
-    assert steady - baseline == 0, (
-        f"steady-state CRUD issued {steady - baseline} catalog queries; expected 0"
-    )
 
 
 @pytest.mark.asyncio
@@ -139,16 +142,17 @@ async def test_native_enum_str_model_steady_state_and_correct_casts(
         conn.commit()
 
     await connect(db_url, auto_migrate=False)
+    async with ferro.engines.session():
 
-    first = await C2StrRow.create(status="active")
-    assert (await C2StrRow.get(first.id)).status == "active"
+        first = await C2StrRow.create(status="active")
+        assert (await C2StrRow.get(first.id)).status == "active"
 
-    baseline = _catalog_query_count_for_test()
-    for _ in range(3):
-        row = await C2StrRow.create(status="inactive")
-        fetched = await C2StrRow.get(row.id)
-        assert fetched.status == "inactive"
-    assert _catalog_query_count_for_test() == baseline
+        baseline = _catalog_query_count_for_test()
+        for _ in range(3):
+            row = await C2StrRow.create(status="inactive")
+            fetched = await C2StrRow.get(row.id)
+            assert fetched.status == "inactive"
+        assert _catalog_query_count_for_test() == baseline
 
 
 @pytest.mark.asyncio
@@ -164,16 +168,17 @@ async def test_warm_up_issues_at_most_one_catalog_query_per_table(
         due: datetime | None = None
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    before = _catalog_query_count_for_test()
-    await C2Cold.create(name="first", due=datetime(2026, 7, 2, tzinfo=UTC))
-    after_first = _catalog_query_count_for_test()
-    assert after_first - before <= 1, (
-        f"first op issued {after_first - before} catalog queries; expected ≤ 1"
-    )
+        before = _catalog_query_count_for_test()
+        await C2Cold.create(name="first", due=datetime(2026, 7, 2, tzinfo=UTC))
+        after_first = _catalog_query_count_for_test()
+        assert after_first - before <= 1, (
+            f"first op issued {after_first - before} catalog queries; expected ≤ 1"
+        )
 
-    await C2Cold.create(name="second")
-    assert _catalog_query_count_for_test() == after_first
+        await C2Cold.create(name="second")
+        assert _catalog_query_count_for_test() == after_first
 
 
 @pytest.mark.asyncio
@@ -187,10 +192,12 @@ async def test_sqlite_crud_issues_zero_catalog_queries(db_url, db_backend, clean
         name: str
 
     await connect(db_url, auto_migrate=True)
-    row = await C2Lite.create(name="a")
-    await C2Lite.get(row.id)
-    await C2Lite.where(lambda r: r.name == "a").count()
-    assert _catalog_query_count_for_test() == 0
+    async with ferro.engines.session():
+
+        row = await C2Lite.create(name="a")
+        await C2Lite.get(row.id)
+        await C2Lite.where(lambda r: r.name == "a").count()
+        assert _catalog_query_count_for_test() == 0
 
 
 @pytest.mark.asyncio
@@ -214,20 +221,24 @@ async def test_catalog_cache_invalidated_by_mid_session_migrate(
     from ferro.raw import execute
 
     await connect(db_url, auto_migrate=False)
-    await execute(
-        'CREATE TABLE "c2grow" ("id" bigserial PRIMARY KEY, "name" varchar NOT NULL)'
-    )
+    async with ferro.engines.session():
 
-    # Populate the cache for c2grow via reads (the mood column doesn't exist yet).
-    assert await C2Grow.where(lambda g: g.name == "x").count() == 0
-    assert await C2Grow.where(lambda g: g.name == "x").count() == 0
+        await execute(
+            'CREATE TABLE "c2grow" ("id" bigserial PRIMARY KEY, "name" varchar NOT NULL)'
+        )
+
+        # Populate the cache for c2grow via reads (the mood column doesn't exist yet).
+        assert await C2Grow.where(lambda g: g.name == "x").count() == 0
+        assert await C2Grow.where(lambda g: g.name == "x").count() == 0
 
     # Mid-session schema change through the supported path.
     await ferro.migrate(updates=True)
 
-    # The new native-enum column must be visible to bind casting immediately;
-    # a stale cache (no enum entry for "mood") would bind plain text and the
-    # prepared INSERT would fail against the enum column.
-    row = await C2Grow.create(name="grown", mood=C2Priority.HIGH)
-    fetched = await C2Grow.get(row.id)
-    assert fetched.mood is C2Priority.HIGH
+    async with ferro.engines.session():
+
+        # The new native-enum column must be visible to bind casting immediately;
+        # a stale cache (no enum entry for "mood") would bind plain text and the
+        # prepared INSERT would fail against the enum column.
+        row = await C2Grow.create(name="grown", mood=C2Priority.HIGH)
+        fetched = await C2Grow.get(row.id)
+        assert fetched.mood is C2Priority.HIGH

--- a/tests/test_codec_plan.py
+++ b/tests/test_codec_plan.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import pytest
 
-from ferro import Field, Model, connect
+from ferro import Field, Model, connect, engines
 from ferro.raw import fetch_all
 
 
@@ -32,23 +32,24 @@ async def test_str_field_with_numeric_pattern_round_trips_as_str(db_url):
         year_code: str = Field(pattern=r"^\d{4}$")
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    row = await Vehicle.create(year_code="2024")
-    assert type(row.year_code) is str
+        row = await Vehicle.create(year_code="2024")
+        assert type(row.year_code) is str
 
-    fetched = await Vehicle.get(row.id)
-    assert fetched is not None
-    assert type(fetched.year_code) is str
-    assert fetched.year_code == "2024"
+        fetched = await Vehicle.get(row.id)
+        assert fetched is not None
+        assert type(fetched.year_code) is str
+        assert fetched.year_code == "2024"
 
-    # The stored value must be the exact string — not an f64 round-trip
-    # ('2024.0') and not a numeric-cast rewrite.
-    raw = await fetch_all("SELECT year_code FROM vehicle")
-    assert raw == [{"year_code": "2024"}]
+        # The stored value must be the exact string — not an f64 round-trip
+        # ('2024.0') and not a numeric-cast rewrite.
+        raw = await fetch_all("SELECT year_code FROM vehicle")
+        assert raw == [{"year_code": "2024"}]
 
-    filtered = await Vehicle.where(lambda v: v.year_code == "2024").all()
-    assert len(filtered) == 1
-    assert type(filtered[0].year_code) is str
+        filtered = await Vehicle.where(lambda v: v.year_code == "2024").all()
+        assert len(filtered) == 1
+        assert type(filtered[0].year_code) is str
 
 
 @pytest.mark.backend_matrix
@@ -61,19 +62,20 @@ async def test_nullable_str_field_with_leading_zero_pattern_value(db_url):
         serial: str | None = Field(default=None, pattern=r"^\d{6}$")
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    row = await Part.create(serial="007207")
-    fetched = await Part.get(row.id)
-    assert fetched is not None
-    assert type(fetched.serial) is str
-    assert fetched.serial == "007207"
+        row = await Part.create(serial="007207")
+        fetched = await Part.get(row.id)
+        assert fetched is not None
+        assert type(fetched.serial) is str
+        assert fetched.serial == "007207"
 
-    # `get` can serve the identity-mapped instance; the stored value is the
-    # honest witness. Leading zeros must survive (no f64 round-trip).
-    raw = await fetch_all("SELECT serial FROM part WHERE serial IS NOT NULL")
-    assert raw == [{"serial": "007207"}]
+        # `get` can serve the identity-mapped instance; the stored value is the
+        # honest witness. Leading zeros must survive (no f64 round-trip).
+        raw = await fetch_all("SELECT serial FROM part WHERE serial IS NOT NULL")
+        assert raw == [{"serial": "007207"}]
 
-    empty = await Part.create()
-    refetched = await Part.get(empty.id)
-    assert refetched is not None
-    assert refetched.serial is None
+        empty = await Part.create()
+        refetched = await Part.get(empty.id)
+        assert refetched is not None
+        assert refetched.serial is None

--- a/tests/test_composite_index.py
+++ b/tests/test_composite_index.py
@@ -13,6 +13,7 @@ from ferro import (
     Relation,
     clear_registry,
     connect,
+    engines,
     reset_engine,
 )
 from ferro.migrations import get_metadata
@@ -744,23 +745,24 @@ async def test_use_case_m2m_reverse_query(db_url):
         tags: Relation[list["TagF1"]] = BackRef()
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    python_tag = await TagF1.create(name="python")
-    rust_tag = await TagF1.create(name="rust")
-    article_a = await ArticleF1.create(title="A")
-    article_b = await ArticleF1.create(title="B")
+        python_tag = await TagF1.create(name="python")
+        rust_tag = await TagF1.create(name="rust")
+        article_a = await ArticleF1.create(title="A")
+        article_b = await ArticleF1.create(title="B")
 
-    await python_tag.articles.add(article_a)
-    await python_tag.articles.add(article_b)
-    await rust_tag.articles.add(article_a)
+        await python_tag.articles.add(article_a)
+        await python_tag.articles.add(article_b)
+        await rust_tag.articles.add(article_a)
 
-    fetched_a = await ArticleF1.get(article_a.id)
-    a_tags = await fetched_a.tags.all()
-    assert {t.name for t in a_tags} == {"python", "rust"}
+        fetched_a = await ArticleF1.get(article_a.id)
+        a_tags = await fetched_a.tags.all()
+        assert {t.name for t in a_tags} == {"python", "rust"}
 
-    fetched_b = await ArticleF1.get(article_b.id)
-    b_tags = await fetched_b.tags.all()
-    assert {t.name for t in b_tags} == {"python"}
+        fetched_b = await ArticleF1.get(article_b.id)
+        b_tags = await fetched_b.tags.all()
+        assert {t.name for t in b_tags} == {"python"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_composite_unique.py
+++ b/tests/test_composite_unique.py
@@ -15,6 +15,7 @@ from ferro import (
     UniqueViolationError,
     clear_registry,
     connect,
+    engines,
     reset_engine,
 )
 from ferro.migrations import get_metadata
@@ -83,10 +84,11 @@ async def test_composite_unique_enforced_on_user_model(db_url):
         beta_id: int
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    await PairRow(alpha_id=1, beta_id=2).save()
-    with pytest.raises(UniqueViolationError, match="Save failed"):
         await PairRow(alpha_id=1, beta_id=2).save()
+        with pytest.raises(UniqueViolationError, match="Save failed"):
+            await PairRow(alpha_id=1, beta_id=2).save()
 
 
 @pytest.mark.asyncio
@@ -104,12 +106,13 @@ async def test_m2m_duplicate_link_rejected(db_url):
         actors: Relation[list["Actor"]] = BackRef()
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    actor = await Actor.create(name="Alice")
-    movie = await Movie.create(title="Matrix")
-    await actor.movies.add(movie)
-    with pytest.raises(UniqueViolationError, match="Add M2M links failed"):
+        actor = await Actor.create(name="Alice")
+        movie = await Movie.create(title="Matrix")
         await actor.movies.add(movie)
+        with pytest.raises(UniqueViolationError, match="Add M2M links failed"):
+            await actor.movies.add(movie)
 
 
 def test_alembic_metadata_has_unique_constraints():

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -53,7 +53,8 @@ async def test_set_default_connection_routes_unqualified_operations(tmp_path):
     await ferro.connect(f"sqlite:{service_db}?mode=rwc", name="service")
 
     ferro.set_default_connection("service")
-    await ferro.execute("CREATE TABLE marker (id INTEGER PRIMARY KEY)")
+    async with ferro.engines.session():
+        await ferro.execute("CREATE TABLE marker (id INTEGER PRIMARY KEY)")
 
     with closing(sqlite3.connect(app_db)) as app_conn:
         app_tables = app_conn.execute(
@@ -133,12 +134,13 @@ async def test_model_using_routes_create_and_query_to_named_connection(tmp_path)
     await ferro.create_tables()
     await ferro.create_tables(using="service")
 
-    created = await ConnectionRouteMarker.using("service").create(id=42)
-    rows = await ConnectionRouteMarker.using("service").all()
+    async with ferro.engines.session():
+        created = await ConnectionRouteMarker.using("service").create(id=42)
+        rows = await ConnectionRouteMarker.using("service").all()
 
-    assert created.id == 42
-    assert [row.id for row in rows] == [42]
-    assert await ConnectionRouteMarker.all() == []
+        assert created.id == 42
+        assert [row.id for row in rows] == [42]
+        assert await ConnectionRouteMarker.all() == []
 
 
 @pytest.mark.asyncio
@@ -153,28 +155,29 @@ async def test_model_using_routes_query_mutations_to_named_connection(tmp_path):
     await ferro.create_tables()
     await ferro.create_tables(using="service")
 
-    await ConnectionRouteMarker.create(id=100, label="app")
-    await ConnectionRouteMarker.using("service").create(id=1, label="service")
-    await ConnectionRouteMarker.using("service").create(id=2, label="service-delete")
+    async with ferro.engines.session():
+        await ConnectionRouteMarker.create(id=100, label="app")
+        await ConnectionRouteMarker.using("service").create(id=1, label="service")
+        await ConnectionRouteMarker.using("service").create(id=2, label="service-delete")
 
-    service_query = ConnectionRouteMarker.using("service")
+        service_query = ConnectionRouteMarker.using("service")
 
-    assert await service_query.select().count() == 2
-    assert await service_query.where(ConnectionRouteMarker.label == "service").exists()
+        assert await service_query.select().count() == 2
+        assert await service_query.where(ConnectionRouteMarker.label == "service").exists()
 
-    updated = await service_query.where(ConnectionRouteMarker.id == 1).update(
-        label="service-updated"
-    )
-    deleted = await service_query.where(ConnectionRouteMarker.id == 2).delete()
+        updated = await service_query.where(ConnectionRouteMarker.id == 1).update(
+            label="service-updated"
+        )
+        deleted = await service_query.where(ConnectionRouteMarker.id == 2).delete()
 
-    assert updated == 1
-    assert deleted == 1
-    assert [(row.id, row.label) for row in await service_query.all()] == [
-        (1, "service-updated")
-    ]
-    assert [(row.id, row.label) for row in await ConnectionRouteMarker.all()] == [
-        (100, "app")
-    ]
+        assert updated == 1
+        assert deleted == 1
+        assert [(row.id, row.label) for row in await service_query.all()] == [
+            (1, "service-updated")
+        ]
+        assert [(row.id, row.label) for row in await ConnectionRouteMarker.all()] == [
+            (100, "app")
+        ]
 
 
 @pytest.mark.asyncio
@@ -191,29 +194,32 @@ async def test_model_using_routes_helper_writes_to_named_connection(tmp_path):
 
     service_model = ConnectionRouteMarker.using("service")
 
-    inserted = await service_model.bulk_create(
-        [ConnectionRouteMarker(id=10, label="bulk")]
-    )
-    created_row, created = await service_model.get_or_create(
-        defaults={"label": "created"}, id=11
-    )
-    updated_row, updated_created = await service_model.update_or_create(
-        defaults={"label": "updated"}, id=10
-    )
+    async with ferro.engines.session():
+        inserted = await service_model.bulk_create(
+            [ConnectionRouteMarker(id=10, label="bulk")]
+        )
+        created_row, created = await service_model.get_or_create(
+            defaults={"label": "created"}, id=11
+        )
+        updated_row, updated_created = await service_model.update_or_create(
+            defaults={"label": "updated"}, id=10
+        )
 
-    assert inserted == 1
-    assert created is True
-    assert created_row.label == "created"
-    assert updated_created is False
-    assert updated_row.label == "updated"
-    assert [
-        (row.id, row.label)
-        for row in await service_model.select().order_by(ConnectionRouteMarker.id).all()
-    ] == [
-        (10, "updated"),
-        (11, "created"),
-    ]
-    assert await ConnectionRouteMarker.all() == []
+        assert inserted == 1
+        assert created is True
+        assert created_row.label == "created"
+        assert updated_created is False
+        assert updated_row.label == "updated"
+        assert [
+            (row.id, row.label)
+            for row in await service_model.select()
+            .order_by(ConnectionRouteMarker.id)
+            .all()
+        ] == [
+            (10, "updated"),
+            (11, "created"),
+        ]
+        assert await ConnectionRouteMarker.all() == []
 
 
 @pytest.mark.asyncio
@@ -228,11 +234,13 @@ async def test_identity_map_is_scoped_by_named_connection(tmp_path):
     await ferro.create_tables()
     await ferro.create_tables(using="service")
 
-    await ConnectionRouteMarker.create(id=1, label="app")
-    await ConnectionRouteMarker.using("service").create(id=1, label="service")
+    async with ferro.engines.session():
+        await ConnectionRouteMarker.create(id=1, label="app")
+        app_row = await ConnectionRouteMarker.get(1)
 
-    app_row = await ConnectionRouteMarker.get(1)
-    service_row = await ConnectionRouteMarker.using("service").get(1)
+    async with ferro.engines.session("service"):
+        await ConnectionRouteMarker.using("service").create(id=1, label="service")
+        service_row = await ConnectionRouteMarker.using("service").get(1)
 
     assert app_row is not None
     assert service_row is not None
@@ -253,16 +261,19 @@ async def test_service_loaded_instance_save_uses_origin_connection(tmp_path):
     await ferro.create_tables()
     await ferro.create_tables(using="service")
 
-    await ConnectionRouteMarker.create(id=1, label="app")
+    async with ferro.engines.session():
+        await ConnectionRouteMarker.create(id=1, label="app")
     await ConnectionRouteMarker.using("service").create(id=1, label="service")
 
     service_row = await ConnectionRouteMarker.using("service").get(1)
     assert service_row is not None
 
-    service_row.label = "service-saved"
-    await service_row.save()
+    async with ferro.engines.session("service"):
+        service_row.label = "service-saved"
+        await service_row.save()
 
-    app_row = await ConnectionRouteMarker.get(1)
+    async with ferro.engines.session():
+        app_row = await ConnectionRouteMarker.get(1)
     reloaded_service_row = await ConnectionRouteMarker.using("service").get(1)
 
     assert app_row is not None
@@ -283,15 +294,18 @@ async def test_service_loaded_instance_delete_uses_origin_connection(tmp_path):
     await ferro.create_tables()
     await ferro.create_tables(using="service")
 
-    await ConnectionRouteMarker.create(id=1, label="app")
+    async with ferro.engines.session():
+        await ConnectionRouteMarker.create(id=1, label="app")
     await ConnectionRouteMarker.using("service").create(id=1, label="service")
 
     service_row = await ConnectionRouteMarker.using("service").get(1)
     assert service_row is not None
 
-    await service_row.delete()
+    async with ferro.engines.session("service"):
+        await service_row.delete()
 
-    assert await ConnectionRouteMarker.get(1) is not None
+    async with ferro.engines.session():
+        assert await ConnectionRouteMarker.get(1) is not None
     assert await ConnectionRouteMarker.using("service").get_or_none(1) is None
 
 
@@ -307,7 +321,8 @@ async def test_service_loaded_instance_refresh_uses_origin_connection(tmp_path):
     await ferro.create_tables()
     await ferro.create_tables(using="service")
 
-    await ConnectionRouteMarker.create(id=1, label="app")
+    async with ferro.engines.session():
+        await ConnectionRouteMarker.create(id=1, label="app")
     await ConnectionRouteMarker.using("service").create(id=1, label="service")
 
     service_row = await ConnectionRouteMarker.using("service").get(1)
@@ -319,7 +334,8 @@ async def test_service_loaded_instance_refresh_uses_origin_connection(tmp_path):
         1,
         using="service",
     )
-    await service_row.refresh()
+    async with ferro.engines.session("service"):
+        await service_row.refresh()
 
     assert service_row.label == "service-refreshed"
 
@@ -347,11 +363,13 @@ async def test_backref_query_inherits_source_instance_origin(tmp_path):
     await ferro.create_tables()
     await ferro.create_tables(using="service")
 
-    app_parent = await RouteParent.create(id=1, label="app-parent")
+    async with ferro.engines.session():
+        app_parent = await RouteParent.create(id=1, label="app-parent")
     service_parent = await RouteParent.using("service").create(
         id=1, label="service-parent"
     )
-    await RouteChild.create(id=1, label="app-child", parent=app_parent)
+    async with ferro.engines.session():
+        await RouteChild.create(id=1, label="app-child", parent=app_parent)
     await RouteChild.using("service").create(
         id=1, label="service-child", parent=service_parent
     )
@@ -387,11 +405,13 @@ async def test_forward_fk_load_inherits_source_instance_origin(tmp_path):
     await ferro.create_tables()
     await ferro.create_tables(using="service")
 
-    app_parent = await RouteForwardParent.create(id=1, label="app-parent")
+    async with ferro.engines.session():
+        app_parent = await RouteForwardParent.create(id=1, label="app-parent")
     service_parent = await RouteForwardParent.using("service").create(
         id=1, label="service-parent"
     )
-    await RouteForwardChild.create(id=1, label="app-child", parent=app_parent)
+    async with ferro.engines.session():
+        await RouteForwardChild.create(id=1, label="app-child", parent=app_parent)
     await RouteForwardChild.using("service").create(
         id=1, label="service-child", parent=service_parent
     )
@@ -430,8 +450,9 @@ async def test_m2m_relation_writes_inherit_source_instance_origin(tmp_path):
     await ferro.create_tables()
     await ferro.create_tables(using="service")
 
-    app_student = await RouteStudent.create(id=1, label="app-student")
-    app_course = await RouteCourse.create(id=1, label="app-course")
+    async with ferro.engines.session():
+        app_student = await RouteStudent.create(id=1, label="app-student")
+        app_course = await RouteCourse.create(id=1, label="app-course")
     service_student = await RouteStudent.using("service").create(
         id=1, label="service-student"
     )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -134,12 +134,13 @@ async def test_model_using_routes_create_and_query_to_named_connection(tmp_path)
     await ferro.create_tables()
     await ferro.create_tables(using="service")
 
-    async with ferro.engines.session():
-        created = await ConnectionRouteMarker.using("service").create(id=42)
-        rows = await ConnectionRouteMarker.using("service").all()
+    # `using=` is its own explicit route — no session needed (D4).
+    created = await ConnectionRouteMarker.using("service").create(id=42)
+    rows = await ConnectionRouteMarker.using("service").all()
 
-        assert created.id == 42
-        assert [row.id for row in rows] == [42]
+    assert created.id == 42
+    assert [row.id for row in rows] == [42]
+    async with ferro.engines.session():
         assert await ConnectionRouteMarker.all() == []
 
 
@@ -157,24 +158,27 @@ async def test_model_using_routes_query_mutations_to_named_connection(tmp_path):
 
     async with ferro.engines.session():
         await ConnectionRouteMarker.create(id=100, label="app")
-        await ConnectionRouteMarker.using("service").create(id=1, label="service")
-        await ConnectionRouteMarker.using("service").create(id=2, label="service-delete")
 
-        service_query = ConnectionRouteMarker.using("service")
+    # `using=` is its own explicit route — no session needed (D4).
+    await ConnectionRouteMarker.using("service").create(id=1, label="service")
+    await ConnectionRouteMarker.using("service").create(id=2, label="service-delete")
 
-        assert await service_query.select().count() == 2
-        assert await service_query.where(ConnectionRouteMarker.label == "service").exists()
+    service_query = ConnectionRouteMarker.using("service")
 
-        updated = await service_query.where(ConnectionRouteMarker.id == 1).update(
-            label="service-updated"
-        )
-        deleted = await service_query.where(ConnectionRouteMarker.id == 2).delete()
+    assert await service_query.select().count() == 2
+    assert await service_query.where(ConnectionRouteMarker.label == "service").exists()
 
-        assert updated == 1
-        assert deleted == 1
-        assert [(row.id, row.label) for row in await service_query.all()] == [
-            (1, "service-updated")
-        ]
+    updated = await service_query.where(ConnectionRouteMarker.id == 1).update(
+        label="service-updated"
+    )
+    deleted = await service_query.where(ConnectionRouteMarker.id == 2).delete()
+
+    assert updated == 1
+    assert deleted == 1
+    assert [(row.id, row.label) for row in await service_query.all()] == [
+        (1, "service-updated")
+    ]
+    async with ferro.engines.session():
         assert [(row.id, row.label) for row in await ConnectionRouteMarker.all()] == [
             (100, "app")
         ]
@@ -194,31 +198,32 @@ async def test_model_using_routes_helper_writes_to_named_connection(tmp_path):
 
     service_model = ConnectionRouteMarker.using("service")
 
-    async with ferro.engines.session():
-        inserted = await service_model.bulk_create(
-            [ConnectionRouteMarker(id=10, label="bulk")]
-        )
-        created_row, created = await service_model.get_or_create(
-            defaults={"label": "created"}, id=11
-        )
-        updated_row, updated_created = await service_model.update_or_create(
-            defaults={"label": "updated"}, id=10
-        )
+    # `using=` is its own explicit route — no session needed (D4).
+    inserted = await service_model.bulk_create(
+        [ConnectionRouteMarker(id=10, label="bulk")]
+    )
+    created_row, created = await service_model.get_or_create(
+        defaults={"label": "created"}, id=11
+    )
+    updated_row, updated_created = await service_model.update_or_create(
+        defaults={"label": "updated"}, id=10
+    )
 
-        assert inserted == 1
-        assert created is True
-        assert created_row.label == "created"
-        assert updated_created is False
-        assert updated_row.label == "updated"
-        assert [
-            (row.id, row.label)
-            for row in await service_model.select()
-            .order_by(ConnectionRouteMarker.id)
-            .all()
-        ] == [
-            (10, "updated"),
-            (11, "created"),
-        ]
+    assert inserted == 1
+    assert created is True
+    assert created_row.label == "created"
+    assert updated_created is False
+    assert updated_row.label == "updated"
+    assert [
+        (row.id, row.label)
+        for row in await service_model.select()
+        .order_by(ConnectionRouteMarker.id)
+        .all()
+    ] == [
+        (10, "updated"),
+        (11, "created"),
+    ]
+    async with ferro.engines.session():
         assert await ConnectionRouteMarker.all() == []
 
 
@@ -517,7 +522,7 @@ async def test_unqualified_operation_requires_default_connection(tmp_path):
 
     await ferro.connect(f"sqlite:{db_file}?mode=rwc", name="app")
 
-    with pytest.raises(ferro.InterfaceError, match="No default connection selected"):
+    with pytest.raises(RuntimeError, match="No database route"):
         await ferro.execute("SELECT 1")
 
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,6 +1,6 @@
 import pytest
 from typing import Annotated
-from ferro import Model, UniqueViolationError, connect, FerroField
+from ferro import Model, UniqueViolationError, connect, FerroField, engines
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -14,13 +14,14 @@ async def test_unique_constraint(db_url):
         email: Annotated[str, FerroField(unique=True)]
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    # Save first user
-    await UniqueUser(email="test@example.com").save()
-
-    # Attempt to save second user with same email should fail
-    with pytest.raises(UniqueViolationError):
+        # Save first user
         await UniqueUser(email="test@example.com").save()
+
+        # Attempt to save second user with same email should fail
+        with pytest.raises(UniqueViolationError):
+            await UniqueUser(email="test@example.com").save()
 
 
 @pytest.mark.asyncio

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -16,9 +16,11 @@ async def test_model_save_new_record(db_url):
         email: str
 
     await ferro.connect(db_url, auto_migrate=True)
-    user = CrudUser(username="test_user", email="test@example.com")
-    await user.save()
-    assert user.id is not None
+    async with ferro.engines.session():
+
+        user = CrudUser(username="test_user", email="test@example.com")
+        await user.save()
+        assert user.id is not None
 
 
 @pytest.mark.asyncio
@@ -31,14 +33,16 @@ async def test_model_save_update_record(db_url):
         email: str
 
     await ferro.connect(db_url, auto_migrate=True)
-    user = CrudUser(id=1, username="initial_name", email="initial@example.com")
-    await user.save()
-    user.username = "updated_name"
-    await user.save()
+    async with ferro.engines.session():
 
-    users = await CrudUser.all()
-    assert len(users) == 1
-    assert users[0].username == "updated_name"
+        user = CrudUser(id=1, username="initial_name", email="initial@example.com")
+        await user.save()
+        user.username = "updated_name"
+        await user.save()
+
+        users = await CrudUser.all()
+        assert len(users) == 1
+        assert users[0].username == "updated_name"
 
 
 @pytest.mark.asyncio
@@ -51,14 +55,16 @@ async def test_model_all_fetching(db_url):
         email: str
 
     await ferro.connect(db_url, auto_migrate=True)
-    u1 = CrudUser(id=1, username="alice", email="alice@example.com")
-    u2 = CrudUser(id=2, username="bob", email="bob@example.com")
-    await u1.save()
-    await u2.save()
-    users = await CrudUser.all()
-    assert len(users) == 2
-    assert any(u.username == "alice" for u in users)
-    assert any(u.username == "bob" for u in users)
+    async with ferro.engines.session():
+
+        u1 = CrudUser(id=1, username="alice", email="alice@example.com")
+        u2 = CrudUser(id=2, username="bob", email="bob@example.com")
+        await u1.save()
+        await u2.save()
+        users = await CrudUser.all()
+        assert len(users) == 2
+        assert any(u.username == "alice" for u in users)
+        assert any(u.username == "bob" for u in users)
 
 
 @pytest.mark.asyncio
@@ -71,21 +77,25 @@ async def test_upsert_updates_existing_row_without_duplicate(db_url):
         email: str
 
     await ferro.connect(db_url, auto_migrate=True)
-    user = CrudUser(id=42, username="original", email="original@example.com")
-    await user.save()
-    users_before = await CrudUser.all()
-    assert len(users_before) == 1
+    async with ferro.engines.session():
 
-    with pytest.raises(ferro.UniqueViolationError):
-        await CrudUser(id=42, username="updated", email="original@example.com").save()
+        user = CrudUser(id=42, username="original", email="original@example.com")
+        await user.save()
+        users_before = await CrudUser.all()
+        assert len(users_before) == 1
 
-    await CrudUser.upsert(id=42, username="updated", email="original@example.com")
+        with pytest.raises(ferro.UniqueViolationError):
+            await CrudUser(id=42, username="updated", email="original@example.com").save()
+
+        await CrudUser.upsert(id=42, username="updated", email="original@example.com")
     ferro.reset_engine()
     await ferro.connect(db_url, auto_migrate=True)
-    fetched = await CrudUser.get(42)
-    assert fetched is not None
-    assert fetched.username == "updated"
-    assert len(await CrudUser.all()) == 1
+    async with ferro.engines.session():
+
+        fetched = await CrudUser.get(42)
+        assert fetched is not None
+        assert fetched.username == "updated"
+        assert len(await CrudUser.all()) == 1
 
 
 @pytest.mark.asyncio
@@ -98,14 +108,16 @@ async def test_identity_map_consistency(db_url):
         email: str
 
     await ferro.connect(db_url, auto_migrate=True)
-    u1 = CrudUser(id=100, username="identity", email="id@test.com")
-    await u1.save()
-    results_1 = await CrudUser.all()
-    results_2 = await CrudUser.all()
-    user_a = results_1[0]
-    user_b = results_2[0]
-    assert user_a is user_b
-    assert user_a.id == 100
+    async with ferro.engines.session():
+
+        u1 = CrudUser(id=100, username="identity", email="id@test.com")
+        await u1.save()
+        results_1 = await CrudUser.all()
+        results_2 = await CrudUser.all()
+        user_a = results_1[0]
+        user_b = results_2[0]
+        assert user_a is user_b
+        assert user_a.id == 100
 
 
 @pytest.mark.asyncio
@@ -118,15 +130,17 @@ async def test_identity_map_disabled_returns_distinct_instances(db_url):
         email: str
 
     await ferro.connect(db_url, auto_migrate=True, identity_map=False)
-    u1 = CrudUser(id=200, username="nomap", email="nomap@test.com")
-    await u1.save()
-    results_1 = await CrudUser.all()
-    results_2 = await CrudUser.all()
-    user_a = results_1[0]
-    user_b = results_2[0]
-    assert user_a is not user_b
-    assert user_a.id == user_b.id == 200
-    assert user_a.username == user_b.username
+    async with ferro.engines.session():
+
+        u1 = CrudUser(id=200, username="nomap", email="nomap@test.com")
+        await u1.save()
+        results_1 = await CrudUser.all()
+        results_2 = await CrudUser.all()
+        user_a = results_1[0]
+        user_b = results_2[0]
+        assert user_a is not user_b
+        assert user_a.id == user_b.id == 200
+        assert user_a.username == user_b.username
 
 
 @pytest.mark.asyncio
@@ -139,12 +153,14 @@ async def test_model_get_operation(db_url):
         email: str
 
     await ferro.connect(db_url, auto_migrate=True)
-    u1 = CrudUser(id=500, username="get_test", email="get@test.com")
-    await u1.save()
-    user = await CrudUser.get(500)
-    assert user is not None
-    assert user.id == 500
-    assert user is u1
+    async with ferro.engines.session():
+
+        u1 = CrudUser(id=500, username="get_test", email="get@test.com")
+        await u1.save()
+        user = await CrudUser.get(500)
+        assert user is not None
+        assert user.id == 500
+        assert user is u1
 
 
 @pytest.mark.asyncio
@@ -157,10 +173,12 @@ async def test_model_get_invalid_usage(db_url):
         email: str
 
     await ferro.connect(db_url, auto_migrate=True)
-    with pytest.raises(TypeError):
-        await CrudUser.get(id=1)
-    with pytest.raises(TypeError):
-        await CrudUser.get()
+    async with ferro.engines.session():
+
+        with pytest.raises(TypeError):
+            await CrudUser.get(id=1)
+        with pytest.raises(TypeError):
+            await CrudUser.get()
 
 
 @pytest.mark.asyncio
@@ -173,8 +191,10 @@ async def test_model_get_not_found(db_url):
         email: str
 
     await ferro.connect(db_url, auto_migrate=True)
-    with pytest.raises(ModelDoesNotExist) as exc_info:
-        await CrudUser.get(9999)
-    assert exc_info.value.model is CrudUser
-    assert exc_info.value.pk == 9999
-    assert await CrudUser.get_or_none(9999) is None
+    async with ferro.engines.session():
+
+        with pytest.raises(ModelDoesNotExist) as exc_info:
+            await CrudUser.get(9999)
+        assert exc_info.value.model is CrudUser
+        assert exc_info.value.pk == 9999
+        assert await CrudUser.get_or_none(9999) is None

--- a/tests/test_db_type_integration.py
+++ b/tests/test_db_type_integration.py
@@ -13,6 +13,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+import ferro
 from ferro import Field, Model, clear_registry, connect, reset_engine, varchar
 from ferro.state import _MODEL_REGISTRY_PY
 
@@ -256,19 +257,19 @@ async def test_strenum_text_storage_round_trip(db_url):
         format: _FileFormat = Field(db_type="text")
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        created = await TextFormatDoc.create(format=_FileFormat.JSON)
+        fetched = await TextFormatDoc.get(created.id)
+        assert fetched is not None
+        assert fetched.format == _FileFormat.JSON
 
-    created = await TextFormatDoc.create(format=_FileFormat.JSON)
-    fetched = await TextFormatDoc.get(created.id)
-    assert fetched is not None
-    assert fetched.format == _FileFormat.JSON
-
-    updated = await TextFormatDoc.where(TextFormatDoc.id == created.id).update(
-        format=_FileFormat.PDF
-    )
-    assert updated == 1
-    again = await TextFormatDoc.get(created.id)
-    assert again is not None
-    assert again.format == _FileFormat.PDF
+        updated = await TextFormatDoc.where(TextFormatDoc.id == created.id).update(
+            format=_FileFormat.PDF
+        )
+        assert updated == 1
+        again = await TextFormatDoc.get(created.id)
+        assert again is not None
+        assert again.format == _FileFormat.PDF
 
 
 @pytest.mark.asyncio
@@ -278,12 +279,12 @@ async def test_bigint_value_round_trip(db_url):
         value: int = Field(db_type="bigint")
 
     await connect(db_url, auto_migrate=True)
-
-    large = 9_000_000_000
-    row = await BigintCounter.create(value=large)
-    fetched = await BigintCounter.get(row.id)
-    assert fetched is not None
-    assert fetched.value == large
+    async with ferro.engines.session():
+        large = 9_000_000_000
+        row = await BigintCounter.create(value=large)
+        fetched = await BigintCounter.get(row.id)
+        assert fetched is not None
+        assert fetched.value == large
 
 
 @pytest.mark.asyncio
@@ -293,12 +294,12 @@ async def test_uuid_stored_as_text_round_trip(db_url):
         external_id: UUID = Field(db_type="text")
 
     await connect(db_url, auto_migrate=True)
-
-    uid = uuid4()
-    row = await UuidTextRecord.create(external_id=uid)
-    fetched = await UuidTextRecord.get(row.id)
-    assert fetched is not None
-    assert fetched.external_id == uid
+    async with ferro.engines.session():
+        uid = uuid4()
+        row = await UuidTextRecord.create(external_id=uid)
+        fetched = await UuidTextRecord.get(row.id)
+        assert fetched is not None
+        assert fetched.external_id == uid
 
 
 @pytest.mark.asyncio
@@ -308,11 +309,11 @@ async def test_varchar_helper_round_trip(db_url):
         code: str = Field(db_type=varchar(32))
 
     await connect(db_url, auto_migrate=True)
-
-    row = await CodeRow.create(code="ABC-123")
-    fetched = await CodeRow.get(row.id)
-    assert fetched is not None
-    assert fetched.code == "ABC-123"
+    async with ferro.engines.session():
+        row = await CodeRow.create(code="ABC-123")
+        fetched = await CodeRow.get(row.id)
+        assert fetched is not None
+        assert fetched.code == "ABC-123"
 
 
 # ---------------------------------------------------------------------------
@@ -330,7 +331,8 @@ async def test_db_check_rejects_invalid_value_on_insert(
         format: _FileFormat = Field(db_type="text", db_check=True)
 
     await connect(db_url, auto_migrate=True)
-    await CheckedDoc.create(format=_FileFormat.PDF)
+    async with ferro.engines.session():
+        await CheckedDoc.create(format=_FileFormat.PDF)
 
     import psycopg
     from psycopg import errors
@@ -375,7 +377,8 @@ async def test_default_strenum_without_db_type_runtime_ddl_and_round_trip(
         "auto_migrate should create the native PG enum type for a default enum"
     )
 
-    row = await NativeEnumDoc.create(format=_FileFormat.JSON)
-    fetched = await NativeEnumDoc.get(row.id)
-    assert fetched is not None
-    assert fetched.format == _FileFormat.JSON
+    async with ferro.engines.session():
+        row = await NativeEnumDoc.create(format=_FileFormat.JSON)
+        fetched = await NativeEnumDoc.get(row.id)
+        assert fetched is not None
+        assert fetched.format == _FileFormat.JSON

--- a/tests/test_deletion.py
+++ b/tests/test_deletion.py
@@ -1,6 +1,6 @@
 import pytest
 from typing import Annotated
-from ferro import Model, connect, FerroField
+from ferro import Model, connect, FerroField, engines
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -14,23 +14,24 @@ async def test_instance_delete(db_url):
         username: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    user = DeletableUser(username="delete_me")
-    await user.save()
-    user_id = user.id
+        user = DeletableUser(username="delete_me")
+        await user.save()
+        user_id = user.id
 
-    # Verify it exists
-    fetched = await DeletableUser.get(user_id)
-    assert fetched is not None
+        # Verify it exists
+        fetched = await DeletableUser.get(user_id)
+        assert fetched is not None
 
-    # Delete
-    await user.delete()
+        # Delete
+        await user.delete()
 
-    # Verify it's gone from DB
-    assert await DeletableUser.get_or_none(user_id) is None
+        # Verify it's gone from DB
+        assert await DeletableUser.get_or_none(user_id) is None
 
-    # Verify it's gone from Identity Map (fetching again should return None)
-    # Note: the 'user' object still exists in Python memory, but it's disconnected from the DB.
+        # Verify it's gone from Identity Map (fetching again should return None)
+        # Note: the 'user' object still exists in Python memory, but it's disconnected from the DB.
 
 
 @pytest.mark.asyncio
@@ -42,25 +43,26 @@ async def test_query_delete(db_url):
         username: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    await DeletableUser(username="keep_1").save()
-    await DeletableUser(username="delete_1").save()
-    await DeletableUser(username="delete_2").save()
-    await DeletableUser(username="keep_2").save()
+        await DeletableUser(username="keep_1").save()
+        await DeletableUser(username="delete_1").save()
+        await DeletableUser(username="delete_2").save()
+        await DeletableUser(username="keep_2").save()
 
-    # Delete matching
-    deleted_count = await DeletableUser.where(
-        DeletableUser.username == "delete_1"
-    ).delete()
-    deleted_count += await DeletableUser.where(
-        DeletableUser.username == "delete_2"
-    ).delete()
-    assert deleted_count == 2
+        # Delete matching
+        deleted_count = await DeletableUser.where(
+            DeletableUser.username == "delete_1"
+        ).delete()
+        deleted_count += await DeletableUser.where(
+            DeletableUser.username == "delete_2"
+        ).delete()
+        assert deleted_count == 2
 
-    # Verify results
-    remaining = await DeletableUser.all()
-    assert len(remaining) == 2
-    assert all("keep" in u.username for u in remaining)
+        # Verify results
+        remaining = await DeletableUser.all()
+        assert len(remaining) == 2
+        assert all("keep" in u.username for u in remaining)
 
 
 @pytest.mark.asyncio
@@ -72,16 +74,17 @@ async def test_delete_evicts_identity_map(db_url):
         username: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    user = DeletableUser(username="evict_me")
-    await user.save()
-    user_id = user.id
+        user = DeletableUser(username="evict_me")
+        await user.save()
+        user_id = user.id
 
-    # Ensure it's in IM
-    assert await DeletableUser.get(user_id) is user
+        # Ensure it's in IM
+        assert await DeletableUser.get(user_id) is user
 
-    # Delete via query
-    await DeletableUser.where(DeletableUser.id == user_id).delete()
+        # Delete via query
+        await DeletableUser.where(DeletableUser.id == user_id).delete()
 
-    # A fresh 'get' should NOT return the old 'user' object (it should be None)
-    assert await DeletableUser.get_or_none(user_id) is None
+        # A fresh 'get' should NOT return the old 'user' object (it should be None)
+        assert await DeletableUser.get_or_none(user_id) is None

--- a/tests/test_documentation_features.py
+++ b/tests/test_documentation_features.py
@@ -26,6 +26,7 @@ from ferro import (
     Relation,
     connect,
     create_tables,
+    engines,
     transaction,
 )
 
@@ -131,62 +132,67 @@ async def test_basic_model_definition(db_url):
         is_active: bool = True
 
     await connect(db_url, auto_migrate=True)
-    await create_tables()
-    user = SimpleUser(id=1, username="alice")
-    assert user.username == "alice"
-    assert user.is_active is True
+    async with engines.session():
+        await create_tables()
+        user = SimpleUser(id=1, username="alice")
+        assert user.username == "alice"
+        assert user.is_active is True
 
 
 @pytest.mark.asyncio
 async def test_field_types(db_url):
     """Test all documented field types work correctly"""
     await connect(db_url, auto_migrate=True)
-    product = await Product.create(
-        sku="PROD-001",
-        name="Test Product",
-        price=Decimal("19.99"),
-        stock=100,
-        metadata_json={"color": "blue", "size": "large"},
-    )
+    async with engines.session():
+        product = await Product.create(
+            sku="PROD-001",
+            name="Test Product",
+            price=Decimal("19.99"),
+            stock=100,
+            metadata_json={"color": "blue", "size": "large"},
+        )
 
-    assert product.sku == "PROD-001"
-    assert product.price == Decimal("19.99")
-    assert product.stock == 100
-    assert product.metadata_json["color"] == "blue"
-    assert isinstance(product.created_date, date)
+        assert product.sku == "PROD-001"
+        assert product.price == Decimal("19.99")
+        assert product.stock == 100
+        assert product.metadata_json["color"] == "blue"
+        assert isinstance(product.created_date, date)
 
 
 @pytest.mark.asyncio
 async def test_enum_field_type(db_url):
     """Test enum field type works as documented"""
     await connect(db_url, auto_migrate=True)
-    user = await User.create(
-        username="admin_user", email="admin@example.com", role=UserRole.ADMIN
-    )
+    async with engines.session():
+        user = await User.create(
+            username="admin_user", email="admin@example.com", role=UserRole.ADMIN
+        )
 
-    fetched = await User.get(user.id)
-    assert fetched.role == UserRole.ADMIN
-    assert isinstance(fetched.role, UserRole)
+        fetched = await User.get(user.id)
+        assert fetched.role == UserRole.ADMIN
+        assert isinstance(fetched.role, UserRole)
 
 
 @pytest.mark.asyncio
 async def test_field_constraints_pydantic_style(db_url):
     """Test Field() constraint syntax"""
     await connect(db_url, auto_migrate=True)
-    product = await Product.create(sku="TEST-001", name="Test", price=Decimal("10.00"))
-    assert product.sku == "TEST-001"
+    async with engines.session():
+        product = await Product.create(sku="TEST-001", name="Test", price=Decimal("10.00"))
+        assert product.sku == "TEST-001"
 
 
 @pytest.mark.asyncio
 async def test_field_constraints_annotated_style(db_url):
     """Test FerroField() annotated syntax"""
     await connect(db_url, auto_migrate=True)
-    user = await User.create(username="test", email="test@example.com")
-    assert user.username == "test"
+    async with engines.session():
+        user = await User.create(username="test", email="test@example.com")
+        assert user.username == "test"
 
-    # Verify unique constraint
-    with pytest.raises(Exception):  # Should raise integrity error
-        await User.create(username="test", email="other@example.com")
+        # Verify unique constraint
+        with pytest.raises(Exception):  # Should raise integrity error
+            await User.create(username="test", email="other@example.com")
 
 
 # ============================================================================
@@ -198,131 +204,140 @@ async def test_field_constraints_annotated_style(db_url):
 async def test_create_method(db_url):
     """Test Model.create() as documented"""
     await connect(db_url, auto_migrate=True)
-    user = await User.create(
-        username="alice", email="alice@example.com", is_active=True
-    )
+    async with engines.session():
+        user = await User.create(
+            username="alice", email="alice@example.com", is_active=True
+        )
 
-    assert user.id is not None
-    assert user.username == "alice"
-    assert user.email == "alice@example.com"
+        assert user.id is not None
+        assert user.username == "alice"
+        assert user.email == "alice@example.com"
 
 
 @pytest.mark.asyncio
 async def test_get_method(db_url):
     """Test Model.get() as documented"""
     await connect(db_url, auto_migrate=True)
-    user = await User.create(username="bob", email="bob@example.com")
+    async with engines.session():
+        user = await User.create(username="bob", email="bob@example.com")
 
-    fetched = await User.get(user.id)
-    assert fetched is not None
-    assert fetched.id == user.id
-    assert fetched.username == "bob"
+        fetched = await User.get(user.id)
+        assert fetched is not None
+        assert fetched.id == user.id
+        assert fetched.username == "bob"
 
 
 @pytest.mark.asyncio
 async def test_all_method(db_url):
     """Test Model.all() as documented"""
     await connect(db_url, auto_migrate=True)
-    await User.create(username="user1", email="user1@example.com")
-    await User.create(username="user2", email="user2@example.com")
+    async with engines.session():
+        await User.create(username="user1", email="user1@example.com")
+        await User.create(username="user2", email="user2@example.com")
 
-    all_users = await User.all()
-    assert len(all_users) == 2
+        all_users = await User.all()
+        assert len(all_users) == 2
 
 
 @pytest.mark.asyncio
 async def test_save_method(db_url):
     """Test instance.save() as documented"""
     await connect(db_url, auto_migrate=True)
-    user = await User.create(username="alice", email="alice@example.com")
+    async with engines.session():
+        user = await User.create(username="alice", email="alice@example.com")
 
-    user.email = "alice.new@example.com"
-    user.is_active = False
-    await user.save()
+        user.email = "alice.new@example.com"
+        user.is_active = False
+        await user.save()
 
-    fetched = await User.get(user.id)
-    assert fetched.email == "alice.new@example.com"
-    assert fetched.is_active is False
+        fetched = await User.get(user.id)
+        assert fetched.email == "alice.new@example.com"
+        assert fetched.is_active is False
 
 
 @pytest.mark.asyncio
 async def test_delete_method(db_url):
     """Test instance.delete() as documented"""
     await connect(db_url, auto_migrate=True)
-    user = await User.create(username="alice", email="alice@example.com")
-    user_id = user.id
+    async with engines.session():
+        user = await User.create(username="alice", email="alice@example.com")
+        user_id = user.id
 
-    await user.delete()
+        await user.delete()
 
-    assert await User.get_or_none(user_id) is None
+        assert await User.get_or_none(user_id) is None
 
 
 @pytest.mark.asyncio
 async def test_refresh_method(db_url):
     """Test instance.refresh() as documented"""
     await connect(db_url, auto_migrate=True)
-    user = await User.create(username="alice", email="alice@example.com")
+    async with engines.session():
+        user = await User.create(username="alice", email="alice@example.com")
 
-    # Simulate external update
-    await User.where(lambda t: t.id == user.id).update(email="updated@example.com")
+        # Simulate external update
+        await User.where(lambda t: t.id == user.id).update(email="updated@example.com")
 
-    # Refresh instance
-    await user.refresh()
-    assert user.email == "updated@example.com"
+        # Refresh instance
+        await user.refresh()
+        assert user.email == "updated@example.com"
 
 
 @pytest.mark.asyncio
 async def test_bulk_create(db_url):
     """Test Model.bulk_create() as documented"""
     await connect(db_url, auto_migrate=True)
-    users = [
-        User(username=f"user_{i}", email=f"user{i}@example.com") for i in range(100)
-    ]
+    async with engines.session():
+        users = [
+            User(username=f"user_{i}", email=f"user{i}@example.com") for i in range(100)
+        ]
 
-    count = await User.bulk_create(users)
-    assert count == 100
+        count = await User.bulk_create(users)
+        assert count == 100
 
-    all_users = await User.all()
-    assert len(all_users) == 100
+        all_users = await User.all()
+        assert len(all_users) == 100
 
 
 @pytest.mark.asyncio
 async def test_get_or_create(db_url):
     """Test Model.get_or_create() as documented"""
     await connect(db_url, auto_migrate=True)
-    # First call creates
-    user1, created1 = await User.get_or_create(
-        email="test@example.com", defaults={"username": "testuser"}
-    )
-    assert created1 is True
-    assert user1.username == "testuser"
+    async with engines.session():
+        # First call creates
+        user1, created1 = await User.get_or_create(
+            email="test@example.com", defaults={"username": "testuser"}
+        )
+        assert created1 is True
+        assert user1.username == "testuser"
 
-    # Second call retrieves
-    user2, created2 = await User.get_or_create(
-        email="test@example.com", defaults={"username": "different"}
-    )
-    assert created2 is False
-    assert user2.id == user1.id
-    assert user2.username == "testuser"  # Defaults not applied
+        # Second call retrieves
+        user2, created2 = await User.get_or_create(
+            email="test@example.com", defaults={"username": "different"}
+        )
+        assert created2 is False
+        assert user2.id == user1.id
+        assert user2.username == "testuser"  # Defaults not applied
 
 
 @pytest.mark.asyncio
 async def test_update_or_create(db_url):
     """Test Model.update_or_create() as documented"""
     await connect(db_url, auto_migrate=True)
-    # First call creates
-    user1, created1 = await User.update_or_create(
-        email="test@example.com", defaults={"username": "testuser"}
-    )
-    assert created1 is True
+    async with engines.session():
+        # First call creates
+        user1, created1 = await User.update_or_create(
+            email="test@example.com", defaults={"username": "testuser"}
+        )
+        assert created1 is True
 
-    # Second call updates
-    user2, created2 = await User.update_or_create(
-        email="test@example.com", defaults={"username": "updated"}
-    )
-    assert created2 is False
-    assert user2.id == user1.id
-    assert user2.username == "updated"
+        # Second call updates
+        user2, created2 = await User.update_or_create(
+            email="test@example.com", defaults={"username": "updated"}
+        )
+        assert created2 is False
+        assert user2.id == user1.id
+        assert user2.username == "updated"
 
 
 # ============================================================================
@@ -334,208 +349,221 @@ async def test_update_or_create(db_url):
 async def test_where_equality(db_url):
     """Test .where() with equality operator"""
     await connect(db_url, auto_migrate=True)
-    await User.create(username="alice", email="alice@example.com", is_active=True)
-    await User.create(username="bob", email="bob@example.com", is_active=False)
+    async with engines.session():
+        await User.create(username="alice", email="alice@example.com", is_active=True)
+        await User.create(username="bob", email="bob@example.com", is_active=False)
 
-    active_users = await User.where(lambda t: t.is_active == True).all()  # noqa: E712
-    assert len(active_users) == 1
-    assert active_users[0].username == "alice"
+        active_users = await User.where(lambda t: t.is_active == True).all()  # noqa: E712
+        assert len(active_users) == 1
+        assert active_users[0].username == "alice"
 
 
 @pytest.mark.asyncio
 async def test_where_comparison_operators(db_url):
     """Test comparison operators in queries"""
     await connect(db_url, auto_migrate=True)
-    for i in range(5):
-        await Product.create(
-            sku=f"PROD-{i}", name=f"Product {i}", price=Decimal(str(i * 10))
-        )
+    async with engines.session():
+        for i in range(5):
+            await Product.create(
+                sku=f"PROD-{i}", name=f"Product {i}", price=Decimal(str(i * 10))
+            )
 
-    # Greater than
-    expensive = await Product.where(lambda t: t.price > Decimal("20")).all()
-    assert len(expensive) == 2  # 30 and 40
+        # Greater than
+        expensive = await Product.where(lambda t: t.price > Decimal("20")).all()
+        assert len(expensive) == 2  # 30 and 40
 
-    # Less than or equal
-    cheap = await Product.where(lambda t: t.price <= Decimal("20")).all()
-    assert len(cheap) == 3  # 0, 10, 20
+        # Less than or equal
+        cheap = await Product.where(lambda t: t.price <= Decimal("20")).all()
+        assert len(cheap) == 3  # 0, 10, 20
 
 
 @pytest.mark.asyncio
 async def test_where_like_operator(db_url):
     """Test .like() operator as documented"""
     await connect(db_url, auto_migrate=True)
-    await User.create(username="alice", email="alice@gmail.com")
-    await User.create(username="bob", email="bob@yahoo.com")
-    await User.create(username="charlie", email="charlie@gmail.com")
+    async with engines.session():
+        await User.create(username="alice", email="alice@gmail.com")
+        await User.create(username="bob", email="bob@yahoo.com")
+        await User.create(username="charlie", email="charlie@gmail.com")
 
-    gmail_users = await User.where(lambda t: t.email.like("%gmail.com")).all()
-    assert len(gmail_users) == 2
+        gmail_users = await User.where(lambda t: t.email.like("%gmail.com")).all()
+        assert len(gmail_users) == 2
 
 
 @pytest.mark.asyncio
 async def test_where_in_operator(db_url):
     """Test .in_() operator as documented"""
     await connect(db_url, auto_migrate=True)
-    await User.create(username="alice", email="alice@example.com", role=UserRole.ADMIN)
-    await User.create(username="bob", email="bob@example.com", role=UserRole.MODERATOR)
-    await User.create(
-        username="charlie", email="charlie@example.com", role=UserRole.USER
-    )
+    async with engines.session():
+        await User.create(username="alice", email="alice@example.com", role=UserRole.ADMIN)
+        await User.create(username="bob", email="bob@example.com", role=UserRole.MODERATOR)
+        await User.create(
+            username="charlie", email="charlie@example.com", role=UserRole.USER
+        )
 
-    # Use enum values instead of enum instances
-    staff = await User.where(
-        lambda t: t.role.in_([UserRole.ADMIN.value, UserRole.MODERATOR.value])
-    ).all()
-    assert len(staff) == 2
+        # Use enum values instead of enum instances
+        staff = await User.where(
+            lambda t: t.role.in_([UserRole.ADMIN.value, UserRole.MODERATOR.value])
+        ).all()
+        assert len(staff) == 2
 
 
 @pytest.mark.asyncio
 async def test_logical_and_operator(db_url):
     """Test & (AND) operator in queries"""
     await connect(db_url, auto_migrate=True)
-    await User.create(
-        username="alice", email="alice@example.com", is_active=True, role=UserRole.ADMIN
-    )
-    await User.create(
-        username="bob", email="bob@example.com", is_active=True, role=UserRole.USER
-    )
-    await User.create(
-        username="charlie",
-        email="charlie@example.com",
-        is_active=False,
-        role=UserRole.ADMIN,
-    )
+    async with engines.session():
+        await User.create(
+            username="alice", email="alice@example.com", is_active=True, role=UserRole.ADMIN
+        )
+        await User.create(
+            username="bob", email="bob@example.com", is_active=True, role=UserRole.USER
+        )
+        await User.create(
+            username="charlie",
+            email="charlie@example.com",
+            is_active=False,
+            role=UserRole.ADMIN,
+        )
 
-    active_admins = await User.where(
-        lambda t: (t.is_active == True) & (t.role == UserRole.ADMIN.value)  # noqa: E712
-    ).all()
-    assert len(active_admins) == 1
-    assert active_admins[0].username == "alice"
+        active_admins = await User.where(
+            lambda t: (t.is_active == True) & (t.role == UserRole.ADMIN.value)  # noqa: E712
+        ).all()
+        assert len(active_admins) == 1
+        assert active_admins[0].username == "alice"
 
 
 @pytest.mark.asyncio
 async def test_logical_or_operator(db_url):
     """Test | (OR) operator in queries"""
     await connect(db_url, auto_migrate=True)
-    await User.create(username="alice", email="alice@example.com", role=UserRole.ADMIN)
-    await User.create(username="bob", email="bob@example.com", role=UserRole.MODERATOR)
-    await User.create(
-        username="charlie", email="charlie@example.com", role=UserRole.USER
-    )
+    async with engines.session():
+        await User.create(username="alice", email="alice@example.com", role=UserRole.ADMIN)
+        await User.create(username="bob", email="bob@example.com", role=UserRole.MODERATOR)
+        await User.create(
+            username="charlie", email="charlie@example.com", role=UserRole.USER
+        )
 
-    staff = await User.where(
-        lambda t: (t.role == UserRole.ADMIN.value)
-        | (t.role == UserRole.MODERATOR.value)
-    ).all()
-    assert len(staff) == 2
+        staff = await User.where(
+            lambda t: (t.role == UserRole.ADMIN.value)
+            | (t.role == UserRole.MODERATOR.value)
+        ).all()
+        assert len(staff) == 2
 
 
 @pytest.mark.asyncio
 async def test_order_by(db_url):
     """Test .order_by() as documented"""
     await connect(db_url, auto_migrate=True)
-    await User.create(username="charlie", email="charlie@example.com")
-    await User.create(username="alice", email="alice@example.com")
-    await User.create(username="bob", email="bob@example.com")
+    async with engines.session():
+        await User.create(username="charlie", email="charlie@example.com")
+        await User.create(username="alice", email="alice@example.com")
+        await User.create(username="bob", email="bob@example.com")
 
-    # Ascending
-    users_asc = await User.select().order_by(User.username, "asc").all()
-    assert users_asc[0].username == "alice"
-    assert users_asc[1].username == "bob"
-    assert users_asc[2].username == "charlie"
+        # Ascending
+        users_asc = await User.select().order_by(User.username, "asc").all()
+        assert users_asc[0].username == "alice"
+        assert users_asc[1].username == "bob"
+        assert users_asc[2].username == "charlie"
 
-    # Descending
-    users_desc = await User.select().order_by(User.username, "desc").all()
-    assert users_desc[0].username == "charlie"
+        # Descending
+        users_desc = await User.select().order_by(User.username, "desc").all()
+        assert users_desc[0].username == "charlie"
 
 
 @pytest.mark.asyncio
 async def test_limit_and_offset(db_url):
     """Test .limit() and .offset() as documented"""
     await connect(db_url, auto_migrate=True)
-    for i in range(10):
-        await User.create(username=f"user_{i}", email=f"user{i}@example.com")
+    async with engines.session():
+        for i in range(10):
+            await User.create(username=f"user_{i}", email=f"user{i}@example.com")
 
-    # Limit
-    first_5 = await User.select().order_by(User.id).limit(5).all()
-    assert len(first_5) == 5
+        # Limit
+        first_5 = await User.select().order_by(User.id).limit(5).all()
+        assert len(first_5) == 5
 
-    # Offset
-    skip_5 = await User.select().order_by(User.id).offset(5).limit(5).all()
-    assert len(skip_5) == 5
-    assert skip_5[0].id != first_5[0].id
+        # Offset
+        skip_5 = await User.select().order_by(User.id).offset(5).limit(5).all()
+        assert len(skip_5) == 5
+        assert skip_5[0].id != first_5[0].id
 
 
 @pytest.mark.asyncio
 async def test_query_first(db_url):
     """Test .first() as documented"""
     await connect(db_url, auto_migrate=True)
-    await User.create(username="alice", email="alice@example.com")
+    async with engines.session():
+        await User.create(username="alice", email="alice@example.com")
 
-    user = await User.where(lambda t: t.username == "alice").first()
-    assert user is not None
-    assert user.username == "alice"
+        user = await User.where(lambda t: t.username == "alice").first()
+        assert user is not None
+        assert user.username == "alice"
 
-    none_user = await User.where(lambda t: t.username == "nonexistent").first()
-    assert none_user is None
+        none_user = await User.where(lambda t: t.username == "nonexistent").first()
+        assert none_user is None
 
 
 @pytest.mark.asyncio
 async def test_query_count(db_url):
     """Test .count() as documented"""
     await connect(db_url, auto_migrate=True)
-    await User.create(username="alice", email="alice@example.com", is_active=True)
-    await User.create(username="bob", email="bob@example.com", is_active=True)
-    await User.create(username="charlie", email="charlie@example.com", is_active=False)
+    async with engines.session():
+        await User.create(username="alice", email="alice@example.com", is_active=True)
+        await User.create(username="bob", email="bob@example.com", is_active=True)
+        await User.create(username="charlie", email="charlie@example.com", is_active=False)
 
-    active_count = await User.where(lambda t: t.is_active == True).count()  # noqa: E712
-    assert active_count == 2
+        active_count = await User.where(lambda t: t.is_active == True).count()  # noqa: E712
+        assert active_count == 2
 
 
 @pytest.mark.asyncio
 async def test_query_exists(db_url):
     """Test .exists() as documented"""
     await connect(db_url, auto_migrate=True)
-    await User.create(username="alice", email="alice@example.com", role=UserRole.ADMIN)
+    async with engines.session():
+        await User.create(username="alice", email="alice@example.com", role=UserRole.ADMIN)
 
-    has_admin = await User.where(lambda t: t.role == UserRole.ADMIN.value).exists()
-    assert has_admin is True
+        has_admin = await User.where(lambda t: t.role == UserRole.ADMIN.value).exists()
+        assert has_admin is True
 
-    has_moderator = await User.where(
-        lambda t: t.role == UserRole.MODERATOR.value
-    ).exists()
-    assert has_moderator is False
+        has_moderator = await User.where(
+            lambda t: t.role == UserRole.MODERATOR.value
+        ).exists()
+        assert has_moderator is False
 
 
 @pytest.mark.asyncio
 async def test_query_update(db_url):
     """Test .update() as documented"""
     await connect(db_url, auto_migrate=True)
-    await User.create(username="alice", email="alice@example.com", is_active=True)
-    await User.create(username="bob", email="bob@example.com", is_active=True)
+    async with engines.session():
+        await User.create(username="alice", email="alice@example.com", is_active=True)
+        await User.create(username="bob", email="bob@example.com", is_active=True)
 
-    count = await User.where(lambda t: t.is_active == True).update(  # noqa: E712
-        is_active=False
-    )
-    assert count == 2
+        count = await User.where(lambda t: t.is_active == True).update(  # noqa: E712
+            is_active=False
+        )
+        assert count == 2
 
-    active_users = await User.where(lambda t: t.is_active == True).all()  # noqa: E712
-    assert len(active_users) == 0
+        active_users = await User.where(lambda t: t.is_active == True).all()  # noqa: E712
+        assert len(active_users) == 0
 
 
 @pytest.mark.asyncio
 async def test_query_delete(db_url):
     """Test .delete() on query as documented"""
     await connect(db_url, auto_migrate=True)
-    await User.create(username="alice", email="alice@example.com", is_active=True)
-    await User.create(username="bob", email="bob@example.com", is_active=False)
+    async with engines.session():
+        await User.create(username="alice", email="alice@example.com", is_active=True)
+        await User.create(username="bob", email="bob@example.com", is_active=False)
 
-    count = await User.where(lambda t: t.is_active == False).delete()  # noqa: E712
-    assert count == 1
+        count = await User.where(lambda t: t.is_active == False).delete()  # noqa: E712
+        assert count == 1
 
-    remaining = await User.all()
-    assert len(remaining) == 1
-    assert remaining[0].username == "alice"
+        remaining = await User.all()
+        assert len(remaining) == 1
+        assert remaining[0].username == "alice"
 
 
 # ============================================================================
@@ -547,70 +575,75 @@ async def test_query_delete(db_url):
 async def test_foreign_key_creation(db_url):
     """Test creating records with ForeignKey relationships"""
     await connect(db_url, auto_migrate=True)
-    author = await User.create(username="alice", email="alice@example.com")
+    async with engines.session():
+        author = await User.create(username="alice", email="alice@example.com")
 
-    # Pass model instance
-    post = await Post.create(title="My Post", content="Content here", author=author)
+        # Pass model instance
+        post = await Post.create(title="My Post", content="Content here", author=author)
 
-    assert post.author_id == author.id
+        assert post.author_id == author.id
 
 
 @pytest.mark.asyncio
 async def test_foreign_key_forward_relation(db_url):
     """Test accessing forward relation (ForeignKey)"""
     await connect(db_url, auto_migrate=True)
-    author = await User.create(username="alice", email="alice@example.com")
-    post = await Post.create(title="Test", content="Content", author=author)
+    async with engines.session():
+        author = await User.create(username="alice", email="alice@example.com")
+        post = await Post.create(title="Test", content="Content", author=author)
 
-    # Access forward relation
-    post_author = await post.author
-    assert post_author.id == author.id
-    assert post_author.username == "alice"
+        # Access forward relation
+        post_author = await post.author
+        assert post_author.id == author.id
+        assert post_author.username == "alice"
 
 
 @pytest.mark.asyncio
 async def test_foreign_key_reverse_relation(db_url):
     """Test accessing reverse relation (BackRef)"""
     await connect(db_url, auto_migrate=True)
-    author = await User.create(username="alice", email="alice@example.com")
+    async with engines.session():
+        author = await User.create(username="alice", email="alice@example.com")
 
-    await Post.create(title="Post 1", content="Content 1", author=author)
-    await Post.create(title="Post 2", content="Content 2", author=author)
+        await Post.create(title="Post 1", content="Content 1", author=author)
+        await Post.create(title="Post 2", content="Content 2", author=author)
 
-    # Access reverse relation
-    author_posts = await author.posts.all()
-    assert len(author_posts) == 2
+        # Access reverse relation
+        author_posts = await author.posts.all()
+        assert len(author_posts) == 2
 
 
 @pytest.mark.asyncio
 async def test_reverse_relation_filtering(db_url):
     """Test filtering on reverse relations"""
     await connect(db_url, auto_migrate=True)
-    author = await User.create(username="alice", email="alice@example.com")
+    async with engines.session():
+        author = await User.create(username="alice", email="alice@example.com")
 
-    await Post.create(
-        title="Published", content="Content", author=author, published=True
-    )
-    await Post.create(title="Draft", content="Content", author=author, published=False)
+        await Post.create(
+            title="Published", content="Content", author=author, published=True
+        )
+        await Post.create(title="Draft", content="Content", author=author, published=False)
 
-    published = await author.posts.where(lambda t: t.published == True).all()  # noqa: E712
-    assert len(published) == 1
-    assert published[0].title == "Published"
+        published = await author.posts.where(lambda t: t.published == True).all()  # noqa: E712
+        assert len(published) == 1
+        assert published[0].title == "Published"
 
 
 @pytest.mark.asyncio
 async def test_shadow_field_access(db_url):
     """Test accessing shadow fields (author_id) as documented"""
     await connect(db_url, auto_migrate=True)
-    author = await User.create(username="alice", email="alice@example.com")
-    post = await Post.create(title="Test", content="Content", author=author)
+    async with engines.session():
+        author = await User.create(username="alice", email="alice@example.com")
+        post = await Post.create(title="Test", content="Content", author=author)
 
-    # Access shadow field
-    assert post.author_id == author.id
+        # Access shadow field
+        assert post.author_id == author.id
 
-    # Query by shadow field
-    posts = await Post.where(lambda t: t.author_id == author.id).all()
-    assert len(posts) == 1
+        # Query by shadow field
+        posts = await Post.where(lambda t: t.author_id == author.id).all()
+        assert len(posts) == 1
 
 
 @pytest.mark.skip(
@@ -713,51 +746,54 @@ async def test_many_to_many_reverse(db_url):
 async def test_transaction_commit(db_url):
     """Test transaction commits on success"""
     await connect(db_url, auto_migrate=True)
-    async with transaction():
-        user = await User.create(username="alice", email="alice@example.com")
-        await Post.create(title="Test", content="Content", author=user)
+    async with engines.session():
+        async with transaction():
+            user = await User.create(username="alice", email="alice@example.com")
+            await Post.create(title="Test", content="Content", author=user)
 
-    # Verify data persisted
-    users = await User.all()
-    posts = await Post.all()
-    assert len(users) == 1
-    assert len(posts) == 1
+        # Verify data persisted
+        users = await User.all()
+        posts = await Post.all()
+        assert len(users) == 1
+        assert len(posts) == 1
 
 
 @pytest.mark.asyncio
 async def test_transaction_rollback(db_url):
     """Test transaction rolls back on exception"""
     await connect(db_url, auto_migrate=True)
-    try:
-        async with transaction():
-            await User.create(username="alice", email="alice@example.com")
-            raise ValueError("Test error")
-    except ValueError:
-        pass
+    async with engines.session():
+        try:
+            async with transaction():
+                await User.create(username="alice", email="alice@example.com")
+                raise ValueError("Test error")
+        except ValueError:
+            pass
 
-    # Verify data was rolled back
-    users = await User.all()
-    assert len(users) == 0
+        # Verify data was rolled back
+        users = await User.all()
+        assert len(users) == 0
 
 
 @pytest.mark.asyncio
 async def test_transaction_isolation(db_url):
     """Test transaction isolation between concurrent tasks"""
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    async def task_a():
-        async with transaction():
-            await User.create(username="task_a_user", email="a@example.com")
-            await asyncio.sleep(0.1)
+        async def task_a():
+            async with transaction():
+                await User.create(username="task_a_user", email="a@example.com")
+                await asyncio.sleep(0.1)
 
-    async def task_b():
-        async with transaction():
-            await User.create(username="task_b_user", email="b@example.com")
+        async def task_b():
+            async with transaction():
+                await User.create(username="task_b_user", email="b@example.com")
 
-    await asyncio.gather(task_a(), task_b())
+        await asyncio.gather(task_a(), task_b())
 
-    users = await User.all()
-    assert len(users) == 2
+        users = await User.all()
+        assert len(users) == 2
 
 
 # ============================================================================
@@ -769,64 +805,65 @@ async def test_transaction_isolation(db_url):
 async def test_tutorial_blog_example(db_url):
     """Test the complete tutorial blog example"""
     await connect(db_url, auto_migrate=True)
-    # Create users
-    alice = await User.create(username="alice", email="alice@example.com")
-    bob = await User.create(username="bob", email="bob@example.com")
+    async with engines.session():
+        # Create users
+        alice = await User.create(username="alice", email="alice@example.com")
+        bob = await User.create(username="bob", email="bob@example.com")
 
-    # Create posts
-    post1 = await Post.create(
-        title="Why Ferro is Fast",
-        content="Ferro uses a Rust engine...",
-        published=True,
-        author=alice,
-    )
+        # Create posts
+        post1 = await Post.create(
+            title="Why Ferro is Fast",
+            content="Ferro uses a Rust engine...",
+            published=True,
+            author=alice,
+        )
 
-    post2 = await Post.create(
-        title="Getting Started with Async Python",
-        content="Async programming can be tricky...",
-        published=True,
-        author=alice,
-    )
+        post2 = await Post.create(
+            title="Getting Started with Async Python",
+            content="Async programming can be tricky...",
+            published=True,
+            author=alice,
+        )
 
-    draft = await Post.create(
-        title="Draft Post",
-        content="This is not published yet",
-        published=False,
-        author=bob,
-    )
+        draft = await Post.create(
+            title="Draft Post",
+            content="This is not published yet",
+            published=False,
+            author=bob,
+        )
 
-    # Create comments
-    comment1 = await Comment.create(text="Great article!", author=bob, post=post1)
+        # Create comments
+        comment1 = await Comment.create(text="Great article!", author=bob, post=post1)
 
-    comment2 = await Comment.create(text="Thanks for sharing", author=alice, post=post1)
+        comment2 = await Comment.create(text="Thanks for sharing", author=alice, post=post1)
 
-    # Query: Find all published posts
-    published = await Post.where(lambda t: t.published == True).all()  # noqa: E712
-    assert len(published) == 2
+        # Query: Find all published posts
+        published = await Post.where(lambda t: t.published == True).all()  # noqa: E712
+        assert len(published) == 2
 
-    # Query: Find posts by author
-    alice_posts = await Post.where(lambda t: t.author_id == alice.id).all()
-    assert len(alice_posts) == 2
+        # Query: Find posts by author
+        alice_posts = await Post.where(lambda t: t.author_id == alice.id).all()
+        assert len(alice_posts) == 2
 
-    # Query: Get post with pattern matching
-    post = await Post.where(lambda t: t.title.like("%Fast%")).first()
-    assert post is not None
-    assert post.title == "Why Ferro is Fast"
+        # Query: Get post with pattern matching
+        post = await Post.where(lambda t: t.title.like("%Fast%")).first()
+        assert post is not None
+        assert post.title == "Why Ferro is Fast"
 
-    # Query: Access forward relation
-    post_author = await post.author
-    assert post_author.username == "alice"
+        # Query: Access forward relation
+        post_author = await post.author
+        assert post_author.username == "alice"
 
-    # Query: Access reverse relation
-    post_comments = await post.comments.all()
-    assert len(post_comments) == 2
+        # Query: Access reverse relation
+        post_comments = await post.comments.all()
+        assert len(post_comments) == 2
 
-    # Update: Publish draft
-    draft.published = True
-    await draft.save()
+        # Update: Publish draft
+        draft.published = True
+        await draft.save()
 
-    published_after = await Post.where(lambda t: t.published == True).all()  # noqa: E712
-    assert len(published_after) == 3
+        published_after = await Post.where(lambda t: t.published == True).all()  # noqa: E712
+        assert len(published_after) == 3
 
 
 if __name__ == "__main__":

--- a/tests/test_enum_cold_hydration.py
+++ b/tests/test_enum_cold_hydration.py
@@ -8,7 +8,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from ferro import FerroField, Model, clear_registry, connect, reset_engine
+from ferro import FerroField, Model, clear_registry, connect, engines, reset_engine
 from ferro.state import _MODEL_REGISTRY_PY
 
 pytestmark = pytest.mark.backend_matrix
@@ -52,13 +52,16 @@ def test_enum_type_name_unchanged_for_deferred_annotated_strenum():
 async def test_annotated_strenum_text_cold_fetch_after_reset_engine(db_url):
     """Cold read after reset_engine must return StrEnum members, not str (#65)."""
     await connect(db_url, auto_migrate=True)
-    row_id = uuid4()
-    await BillingRow.create(id=row_id, name="x", billing_mode=BillingMode.HOURLY)
+    async with engines.session():
+
+        row_id = uuid4()
+        await BillingRow.create(id=row_id, name="x", billing_mode=BillingMode.HOURLY)
 
     reset_engine()
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    loaded = (await BillingRow.all())[0]
-    assert isinstance(loaded.billing_mode, BillingMode)
-    assert loaded.billing_mode == BillingMode.HOURLY
-    assert loaded.billing_mode.value == "hourly"
+        loaded = (await BillingRow.all())[0]
+        assert isinstance(loaded.billing_mode, BillingMode)
+        assert loaded.billing_mode == BillingMode.HOURLY
+        assert loaded.billing_mode.value == "hourly"

--- a/tests/test_exception_mapping.py
+++ b/tests/test_exception_mapping.py
@@ -20,6 +20,7 @@ from ferro import (
     Relation,
     UniqueViolationError,
     connect,
+    engines,
 )
 from ferro import Field
 from ferro.exceptions import CheckViolationError, ForeignKeyViolationError
@@ -33,17 +34,19 @@ async def test_unique_violation_is_typed(db_url, db_backend):
         email: Annotated[str, FerroField(unique=True)]
 
     await connect(db_url, auto_migrate=True)
-    await UniqueUser(email="a@b.com").save()
+    async with engines.session():
 
-    with pytest.raises(UniqueViolationError) as excinfo:
         await UniqueUser(email="a@b.com").save()
 
-    exc = excinfo.value
-    assert isinstance(exc, IntegrityError)
-    assert exc.driver_message is not None
-    if db_backend == "postgres":
-        assert exc.sqlstate == "23505"
-        assert exc.constraint is not None
+        with pytest.raises(UniqueViolationError) as excinfo:
+            await UniqueUser(email="a@b.com").save()
+
+        exc = excinfo.value
+        assert isinstance(exc, IntegrityError)
+        assert exc.driver_message is not None
+        if db_backend == "postgres":
+            assert exc.sqlstate == "23505"
+            assert exc.constraint is not None
 
 
 @pytest.mark.backend_matrix
@@ -54,18 +57,20 @@ async def test_not_null_violation_is_typed(db_url, db_backend):
         body: str
 
     await connect(db_url, auto_migrate=True)
-    note = NotNullNote(body="text")
-    await note.save()
-    pk = note.id
+    async with engines.session():
 
-    with pytest.raises(NotNullViolationError) as excinfo:
-        await NotNullNote.where(lambda note: note.id == pk).update(body=None)
+        note = NotNullNote(body="text")
+        await note.save()
+        pk = note.id
 
-    exc = excinfo.value
-    assert isinstance(exc, IntegrityError)
-    assert exc.driver_message is not None
-    if db_backend == "postgres":
-        assert exc.sqlstate == "23502"
+        with pytest.raises(NotNullViolationError) as excinfo:
+            await NotNullNote.where(lambda note: note.id == pk).update(body=None)
+
+        exc = excinfo.value
+        assert isinstance(exc, IntegrityError)
+        assert exc.driver_message is not None
+        if db_backend == "postgres":
+            assert exc.sqlstate == "23502"
 
 
 # db_check constraints are emitted on Postgres only (SQLite would need a
@@ -85,19 +90,21 @@ async def test_check_violation_is_typed(db_url, db_backend):
         format: Annotated[DocFormat, Field(db_type="text", db_check=True)]
 
     await connect(db_url, auto_migrate=True)
-    doc = CheckedDoc(format=DocFormat.MARKDOWN)
-    await doc.save()
-    pk = doc.id
+    async with engines.session():
 
-    # Pydantic validation is bypassed on the bulk-update path by design;
-    # the DB CHECK constraint is the enforcement of record.
-    with pytest.raises(CheckViolationError) as excinfo:
-        await CheckedDoc.where(lambda doc: doc.id == pk).update(format="bogus")
+        doc = CheckedDoc(format=DocFormat.MARKDOWN)
+        await doc.save()
+        pk = doc.id
 
-    exc = excinfo.value
-    assert isinstance(exc, IntegrityError)
-    if db_backend == "postgres":
-        assert exc.sqlstate == "23514"
+        # Pydantic validation is bypassed on the bulk-update path by design;
+        # the DB CHECK constraint is the enforcement of record.
+        with pytest.raises(CheckViolationError) as excinfo:
+            await CheckedDoc.where(lambda doc: doc.id == pk).update(format="bogus")
+
+        exc = excinfo.value
+        assert isinstance(exc, IntegrityError)
+        if db_backend == "postgres":
+            assert exc.sqlstate == "23514"
 
 
 @pytest.mark.backend_matrix
@@ -114,14 +121,15 @@ async def test_foreign_key_violation_is_typed(db_url, db_backend):
         author: Annotated[FkAuthor, ForeignKey(related_name="books")]
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    with pytest.raises(ForeignKeyViolationError) as excinfo:
-        await FkBook(title="Ghost", author_id=99999).save()
+        with pytest.raises(ForeignKeyViolationError) as excinfo:
+            await FkBook(title="Ghost", author_id=99999).save()
 
-    exc = excinfo.value
-    assert isinstance(exc, IntegrityError)
-    if db_backend == "postgres":
-        assert exc.sqlstate == "23503"
+        exc = excinfo.value
+        assert isinstance(exc, IntegrityError)
+        if db_backend == "postgres":
+            assert exc.sqlstate == "23503"
 
 
 @pytest.mark.asyncio

--- a/tests/test_field_wrapper.py
+++ b/tests/test_field_wrapper.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 import pytest
 
-from ferro import FerroField, Field, Model, connect
+from ferro import FerroField, Field, Model, connect, engines
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -26,9 +26,11 @@ async def test_ferro_field_wrapper_sets_metadata_and_pydantic_schema(db_url):
     assert schema["properties"]["email"]["description"] == "Email address"
 
     await connect(db_url, auto_migrate=True)
-    user = WrappedUser(email="one@example.com")
-    await user.save()
-    assert user.id is not None
+    async with engines.session():
+
+        user = WrappedUser(email="one@example.com")
+        await user.save()
+        assert user.id is not None
 
 
 def test_assignment_and_annotation_field_patterns_equivalent_ferro_metadata():
@@ -74,9 +76,11 @@ async def test_annotation_field_pattern_persists_like_assignment(db_url):
     assert schema["properties"]["email"]["description"] == "Login email"
 
     await connect(db_url, auto_migrate=True)
-    user = AnnotatedUser(email="ann@example.com")
-    await user.save()
-    assert user.id is not None
+    async with engines.session():
+
+        user = AnnotatedUser(email="ann@example.com")
+        await user.save()
+        assert user.id is not None
 
 
 @pytest.mark.asyncio
@@ -86,11 +90,13 @@ async def test_optional_patterned_string_roundtrip(db_url):
         code: str | None = Field(default=None, pattern=r"^SKU-[0-9]+$")
 
     await connect(db_url, auto_migrate=True)
-    item = await WrappedInventory.create(code="SKU-123")
-    fetched = await WrappedInventory.get(item.id)
+    async with engines.session():
 
-    assert fetched is not None
-    assert fetched.code == "SKU-123"
+        item = await WrappedInventory.create(code="SKU-123")
+        fetched = await WrappedInventory.get(item.id)
+
+        assert fetched is not None
+        assert fetched.code == "SKU-123"
 
 
 def test_annotated_and_wrapped_ferro_field_conflict_raises():

--- a/tests/test_fk_target_pk.py
+++ b/tests/test_fk_target_pk.py
@@ -1,0 +1,39 @@
+"""FF-D D5: relationship inputs must read the *target* model's PK field.
+
+Today `Model.__init__` scans the source class's ferro_fields for the PK name
+and reads that name off the target instance — correct only while every PK is
+named `id`.
+"""
+
+from typing import Annotated
+
+from ferro import Field, Model
+from ferro.base import ForeignKey
+
+
+def test_fk_extraction_uses_target_pk_name():
+    class D5Warehouse(Model):
+        code: int | None = Field(default=None, primary_key=True)
+        city: str
+
+    class D5Shipment(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        warehouse: Annotated[D5Warehouse, ForeignKey(related_name="shipments")]
+
+    wh = D5Warehouse(code=7, city="Reno")
+    shipment = D5Shipment(warehouse=wh)
+    assert shipment.warehouse_id == 7
+
+
+def test_fk_extraction_with_target_pk_named_id_still_works():
+    class D5Author(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    class D5Book(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        author: Annotated[D5Author, ForeignKey(related_name="books")]
+
+    a = D5Author(id=3, name="x")
+    b = D5Book(author=a)
+    assert b.author_id == 3

--- a/tests/test_fk_target_pk.py
+++ b/tests/test_fk_target_pk.py
@@ -7,8 +7,38 @@ named `id`.
 
 from typing import Annotated
 
+import pytest
+
 from ferro import Field, Model
 from ferro.base import ForeignKey
+
+
+@pytest.fixture(autouse=True)
+def _isolate_relation_state():
+    """Restore the global relation registries after each test.
+
+    Each test below declares its models *inside the test function*, but
+    `ModelMetaclass` still appends their `ForeignKey` metadata to the
+    module-level `_PENDING_RELATIONS` list and registers the classes in
+    `_MODEL_REGISTRY_PY` (see `src/ferro/metaclass.py`) unconditionally at
+    class-creation time -- nothing about being defined inside a function
+    scopes that registration. Nothing ever removes those entries once the
+    test function returns, so without this fixture the test-local
+    `D5Warehouse`/`D5Shipment`/`D5Author`/`D5Book` FK metadata leaks into
+    later tests: the next `connect(auto_migrate=True)` anywhere in the
+    suite calls `resolve_relationships()`, which replays *every* pending
+    relation, including these stale ones, and blows up because their
+    target models never declared the matching `BackRef()`.
+    """
+    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+
+    models_snapshot = dict(_MODEL_REGISTRY_PY)
+    relations_snapshot = list(_PENDING_RELATIONS)
+    yield
+    _MODEL_REGISTRY_PY.clear()
+    _MODEL_REGISTRY_PY.update(models_snapshot)
+    _PENDING_RELATIONS.clear()
+    _PENDING_RELATIONS.extend(relations_snapshot)
 
 
 def test_fk_extraction_uses_target_pk_name():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,5 @@
 import pytest
+import ferro
 from typing import Annotated
 from ferro import Model, connect, FerroField
 
@@ -15,14 +16,15 @@ async def test_create_helper(db_url):
         is_active: bool = True
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    user = await HelperUser.create(username="taylor")
-    assert user.id is not None
-    assert user.username == "taylor"
+        user = await HelperUser.create(username="taylor")
+        assert user.id is not None
+        assert user.username == "taylor"
 
-    # Verify in DB
-    fetched = await HelperUser.get(user.id)
-    assert fetched.username == "taylor"
+        # Verify in DB
+        fetched = await HelperUser.get(user.id)
+        assert fetched.username == "taylor"
 
 
 @pytest.mark.asyncio
@@ -35,16 +37,18 @@ async def test_exists_helper(db_url):
         is_active: bool = True
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    await HelperUser.create(username="exists_check")
+        await HelperUser.create(username="exists_check")
 
-    assert (
-        await HelperUser.where(HelperUser.username == "exists_check").exists() is True
-    )
-    assert (
-        await HelperUser.where(HelperUser.username == "does_not_exist").exists()
-        is False
-    )
+        assert (
+            await HelperUser.where(HelperUser.username == "exists_check").exists()
+            is True
+        )
+        assert (
+            await HelperUser.where(HelperUser.username == "does_not_exist").exists()
+            is False
+        )
 
 
 @pytest.mark.asyncio
@@ -57,19 +61,20 @@ async def test_bulk_create_helper(db_url):
         is_active: bool = True
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    users = [
-        HelperUser(username="user1"),
-        HelperUser(username="user2"),
-        HelperUser(username="user3"),
-    ]
+        users = [
+            HelperUser(username="user1"),
+            HelperUser(username="user2"),
+            HelperUser(username="user3"),
+        ]
 
-    count = await HelperUser.bulk_create(users)
-    assert count == 3
+        count = await HelperUser.bulk_create(users)
+        assert count == 3
 
-    all_users = await HelperUser.all()
-    assert len(all_users) == 3
-    assert {u.username for u in all_users} == {"user1", "user2", "user3"}
+        all_users = await HelperUser.all()
+        assert len(all_users) == 3
+        assert {u.username for u in all_users} == {"user1", "user2", "user3"}
 
 
 @pytest.mark.asyncio
@@ -82,20 +87,21 @@ async def test_get_or_create(db_url):
         is_active: bool = True
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    # 1. Create case
-    user1, created = await HelperUser.get_or_create(
-        username="new_user", defaults={"is_active": False}
-    )
-    assert created is True
-    assert user1.username == "new_user"
-    assert user1.is_active is False
+        # 1. Create case
+        user1, created = await HelperUser.get_or_create(
+            username="new_user", defaults={"is_active": False}
+        )
+        assert created is True
+        assert user1.username == "new_user"
+        assert user1.is_active is False
 
-    # 2. Get case
-    user2, created = await HelperUser.get_or_create(username="new_user")
-    assert created is False
-    assert user2.id == user1.id
-    assert user2 is user1  # Identity Map should return same object
+        # 2. Get case
+        user2, created = await HelperUser.get_or_create(username="new_user")
+        assert created is False
+        assert user2.id == user1.id
+        assert user2 is user1  # Identity Map should return same object
 
 
 @pytest.mark.asyncio
@@ -108,22 +114,23 @@ async def test_update_or_create(db_url):
         is_active: bool = True
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    # 1. Create case
-    user1, created = await HelperUser.update_or_create(
-        username="up_user", defaults={"is_active": True}
-    )
-    assert created is True
-    assert user1.is_active is True
+        # 1. Create case
+        user1, created = await HelperUser.update_or_create(
+            username="up_user", defaults={"is_active": True}
+        )
+        assert created is True
+        assert user1.is_active is True
 
-    # 2. Update case
-    user2, created = await HelperUser.update_or_create(
-        username="up_user", defaults={"is_active": False}
-    )
-    assert created is False
-    assert user2.id == user1.id
-    assert user2.is_active is False
+        # 2. Update case
+        user2, created = await HelperUser.update_or_create(
+            username="up_user", defaults={"is_active": False}
+        )
+        assert created is False
+        assert user2.id == user1.id
+        assert user2.is_active is False
 
-    # Verify DB
-    fetched = await HelperUser.get(user1.id)
-    assert fetched.is_active is False
+        # Verify DB
+        fetched = await HelperUser.get(user1.id)
+        assert fetched.is_active is False

--- a/tests/test_hydration.py
+++ b/tests/test_hydration.py
@@ -38,28 +38,30 @@ async def test_direct_injection_bypasses_init(db_url):
             INIT_CALLED_COUNT += 1
 
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    # 1. Create a record normally (this WILL call __init__)
-    global INIT_CALLED_COUNT
-    INIT_CALLED_COUNT = 0
-    user = HydrationTestUser(id=1, name="Direct Injector")
-    await user.save()
-    assert INIT_CALLED_COUNT == 1
+        # 1. Create a record normally (this WILL call __init__)
+        global INIT_CALLED_COUNT
+        INIT_CALLED_COUNT = 0
+        user = HydrationTestUser(id=1, name="Direct Injector")
+        await user.save()
+        assert INIT_CALLED_COUNT == 1
 
     # 2. Reset engine to clear Identity Map (so we force a DB fetch)
     ferro.reset_engine()
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    # 3. Fetch the record
-    INIT_CALLED_COUNT = 0
-    fetched_user = await HydrationTestUser.get(1)
+        # 3. Fetch the record
+        INIT_CALLED_COUNT = 0
+        fetched_user = await HydrationTestUser.get(1)
 
-    assert fetched_user is not None
-    assert fetched_user.name == "Direct Injector"
+        assert fetched_user is not None
+        assert fetched_user.name == "Direct Injector"
 
-    # CRITICAL ASSERTION: If Direct Injection is working, __init__ was never called
-    # by the Rust core when instantiating this object.
-    assert INIT_CALLED_COUNT == 0
+        # CRITICAL ASSERTION: If Direct Injection is working, __init__ was never called
+        # by the Rust core when instantiating this object.
+        assert INIT_CALLED_COUNT == 0
 
 
 @pytest.mark.asyncio
@@ -71,23 +73,25 @@ async def test_hydrated_row_initializes_pydantic_slots(db_url):
         name: str
 
     await ferro.connect(db_url, auto_migrate=True)
-    created = SlotCheckUser(id=1, name="slot-check")
-    await created.save()
+    async with ferro.engines.session():
+        created = SlotCheckUser(id=1, name="slot-check")
+        await created.save()
 
     ferro.reset_engine()
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    row = await SlotCheckUser.get(1)
-    assert row is not None
-    _assert_pydantic_slots(
-        row,
-        expected_fields={"id", "name"},
-        expected_extra=None,
-    )
-    assert dict(row)["name"] == "slot-check"
-    copied = row.model_copy()
-    assert copied.name == row.name
-    assert dict(copied)["name"] == "slot-check"
+        row = await SlotCheckUser.get(1)
+        assert row is not None
+        _assert_pydantic_slots(
+            row,
+            expected_fields={"id", "name"},
+            expected_extra=None,
+        )
+        assert dict(row)["name"] == "slot-check"
+        copied = row.model_copy()
+        assert copied.name == row.name
+        assert dict(copied)["name"] == "slot-check"
 
 
 @pytest.mark.asyncio
@@ -101,20 +105,22 @@ async def test_hydrated_extra_allow_starts_with_empty_extra_dict(db_url):
         name: str
 
     await ferro.connect(db_url, auto_migrate=True)
-    created = ExtraAllowUser(id=1, name="ea")
-    await created.save()
+    async with ferro.engines.session():
+        created = ExtraAllowUser(id=1, name="ea")
+        await created.save()
 
     ferro.reset_engine()
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    row = await ExtraAllowUser.get(1)
-    assert row is not None
-    _assert_pydantic_slots(
-        row,
-        expected_fields={"id", "name"},
-        expected_extra={},
-    )
-    assert dict(row)["name"] == "ea"
+        row = await ExtraAllowUser.get(1)
+        assert row is not None
+        _assert_pydantic_slots(
+            row,
+            expected_fields={"id", "name"},
+            expected_extra={},
+        )
+        assert dict(row)["name"] == "ea"
 
 
 @pytest.mark.asyncio
@@ -124,24 +130,26 @@ async def test_hydration_slots_match_across_get_all_and_first(db_url):
         name: str
 
     await ferro.connect(db_url, auto_migrate=True)
-    await SlotPathUser(id=1, name="one").save()
+    async with ferro.engines.session():
+        await SlotPathUser(id=1, name="one").save()
 
     ferro.reset_engine()
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    by_get = await SlotPathUser.get(1)
-    by_all = (await SlotPathUser.all())[0]
-    by_first = await SlotPathUser.where(SlotPathUser.id == 1).first()
-    assert by_get is not None
-    assert by_first is not None
+        by_get = await SlotPathUser.get(1)
+        by_all = (await SlotPathUser.all())[0]
+        by_first = await SlotPathUser.where(SlotPathUser.id == 1).first()
+        assert by_get is not None
+        assert by_first is not None
 
-    for row in (by_get, by_all, by_first):
-        _assert_pydantic_slots(
-            row,
-            expected_fields={"id", "name"},
-            expected_extra=None,
-        )
-        assert row.name == "one"
+        for row in (by_get, by_all, by_first):
+            _assert_pydantic_slots(
+                row,
+                expected_fields={"id", "name"},
+                expected_extra=None,
+            )
+            assert row.name == "one"
 
 
 @pytest.mark.asyncio
@@ -153,15 +161,17 @@ async def test_hydrated_extra_forbid_initializes_slots(db_url):
         name: str
 
     await ferro.connect(db_url, auto_migrate=True)
-    await ExtraForbidUser(id=1, name="ef").save()
+    async with ferro.engines.session():
+        await ExtraForbidUser(id=1, name="ef").save()
 
     ferro.reset_engine()
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    row = await ExtraForbidUser.get(1)
-    assert row is not None
-    _assert_pydantic_slots(
-        row,
-        expected_fields={"id", "name"},
-        expected_extra=None,
-    )
+        row = await ExtraForbidUser.get(1)
+        assert row is not None
+        _assert_pydantic_slots(
+            row,
+            expected_fields={"id", "name"},
+            expected_extra=None,
+        )

--- a/tests/test_hydration_equivalence.py
+++ b/tests/test_hydration_equivalence.py
@@ -111,13 +111,17 @@ def _make_specimen(cls: type[Model]) -> Model:
     )
 
 
-async def _connect_and_save(db_url: str) -> tuple[type[Model], int]:
+async def _connect(db_url: str) -> type[Model]:
     specimen_cls = _build_specimen()
     await ferro.connect(db_url, auto_migrate=True, identity_map=False)
+    return specimen_cls
+
+
+async def _save_specimen(specimen_cls: type[Model]) -> int:
     row = _make_specimen(specimen_cls)
     await row.save()
     assert row.id is not None
-    return specimen_cls, row.id
+    return row.id
 
 
 def _assert_core_values(row: Model) -> None:
@@ -155,49 +159,57 @@ def _assert_core_values(row: Model) -> None:
 
 @pytest.mark.asyncio
 async def test_full_type_row_hydrates_expected_values(db_url):
-    specimen_cls, _pk = await _connect_and_save(db_url)
+    specimen_cls = await _connect(db_url)
+    async with ferro.engines.session():
+        await _save_specimen(specimen_cls)
 
-    rows = await specimen_cls.all()
-    assert len(rows) == 1
-    _assert_core_values(rows[0])
+        rows = await specimen_cls.all()
+        assert len(rows) == 1
+        _assert_core_values(rows[0])
 
 
 @pytest.mark.asyncio
 async def test_every_fetch_path_hydrates_identically(db_url):
     """all(), get(), where().all(), first(), get_or_none(), refresh() agree."""
-    specimen_cls, pk = await _connect_and_save(db_url)
+    specimen_cls = await _connect(db_url)
+    async with ferro.engines.session():
+        pk = await _save_specimen(specimen_cls)
 
-    fetched = [
-        (await specimen_cls.all())[0],
-        await specimen_cls.get(pk),
-        (await specimen_cls.where(lambda s: s.name == "specimen").all())[0],
-        await specimen_cls.where(lambda s: s.token == TOKEN).first(),
-        await specimen_cls.get_or_none(pk),
-    ]
+        fetched = [
+            (await specimen_cls.all())[0],
+            await specimen_cls.get(pk),
+            (await specimen_cls.where(lambda s: s.name == "specimen").all())[0],
+            await specimen_cls.where(lambda s: s.token == TOKEN).first(),
+            await specimen_cls.get_or_none(pk),
+        ]
 
-    refreshed = await specimen_cls.get(pk)
-    await refreshed.refresh()
-    fetched.append(refreshed)
+        refreshed = await specimen_cls.get(pk)
+        await refreshed.refresh()
+        fetched.append(refreshed)
 
-    for row in fetched:
-        _assert_core_values(row)
+        for row in fetched:
+            _assert_core_values(row)
 
 
 @pytest.mark.asyncio
 async def test_uuid_exact_object_equality_not_str(db_url):
     """UUID casing must not leak: compare UUID objects and canonical str."""
-    specimen_cls, pk = await _connect_and_save(db_url)
-    row = await specimen_cls.get(pk)
-    assert row.token == TOKEN
-    assert str(row.token) == str(TOKEN)  # canonical lowercase hyphenated
+    specimen_cls = await _connect(db_url)
+    async with ferro.engines.session():
+        pk = await _save_specimen(specimen_cls)
+        row = await specimen_cls.get(pk)
+        assert row.token == TOKEN
+        assert str(row.token) == str(TOKEN)  # canonical lowercase hyphenated
 
 
 @pytest.mark.asyncio
 async def test_decimal_survives_filter_roundtrip(db_url):
-    specimen_cls, _pk = await _connect_and_save(db_url)
-    row = await specimen_cls.where(lambda s: s.amount == AMOUNT).first()
-    assert row is not None
-    assert row.amount == AMOUNT
+    specimen_cls = await _connect(db_url)
+    async with ferro.engines.session():
+        await _save_specimen(specimen_cls)
+        row = await specimen_cls.where(lambda s: s.amount == AMOUNT).first()
+        assert row is not None
+        assert row.amount == AMOUNT
 
 
 # --------------------------------------------------------------------------
@@ -208,18 +220,22 @@ async def test_decimal_survives_filter_roundtrip(db_url):
 
 @pytest.mark.asyncio
 async def test_time_hydrates_datetime_time(db_url):
-    specimen_cls, pk = await _connect_and_save(db_url)
-    row = await specimen_cls.get(pk)
-    assert type(row.opens_at) is datetime.time
-    assert row.opens_at == OPENS_AT
+    specimen_cls = await _connect(db_url)
+    async with ferro.engines.session():
+        pk = await _save_specimen(specimen_cls)
+        row = await specimen_cls.get(pk)
+        assert type(row.opens_at) is datetime.time
+        assert row.opens_at == OPENS_AT
 
 
 @pytest.mark.asyncio
 async def test_int_enum_hydrates_member(db_url):
-    specimen_cls, pk = await _connect_and_save(db_url)
-    row = await specimen_cls.get(pk)
-    assert isinstance(row.priority, Priority)
-    assert row.priority is Priority.HIGH
+    specimen_cls = await _connect(db_url)
+    async with ferro.engines.session():
+        pk = await _save_specimen(specimen_cls)
+        row = await specimen_cls.get(pk)
+        assert isinstance(row.priority, Priority)
+        assert row.priority is Priority.HIGH
 
 
 @pytest.mark.asyncio
@@ -241,16 +257,19 @@ async def test_timestamptz_stable_under_non_utc_session_timezone(db_url):
         identity_map=False,
         pool=ferro.PoolConfig(max_connections=1),
     )
-    await execute("SET TIME ZONE 'America/Chicago'")
-    assert (await ferro.raw.fetch_one("SHOW timezone"))["TimeZone"] == "America/Chicago"
+    async with ferro.engines.session():
+        await execute("SET TIME ZONE 'America/Chicago'")
+        assert (
+            await ferro.raw.fetch_one("SHOW timezone")
+        )["TimeZone"] == "America/Chicago"
 
-    row = _make_specimen(specimen_cls)
-    await row.save()
-    pk = row.id
-    row = await specimen_cls.get(pk)
+        row = _make_specimen(specimen_cls)
+        await row.save()
+        pk = row.id
+        row = await specimen_cls.get(pk)
 
-    assert row.aware_at == AWARE_AT
-    assert row.aware_at.utcoffset() == datetime.timedelta(0), (
-        "hydrated timestamptz must be stable UTC regardless of session TimeZone, "
-        f"got offset {row.aware_at.utcoffset()!r}"
-    )
+        assert row.aware_at == AWARE_AT
+        assert row.aware_at.utcoffset() == datetime.timedelta(0), (
+            "hydrated timestamptz must be stable UTC regardless of session TimeZone, "
+            f"got offset {row.aware_at.utcoffset()!r}"
+        )

--- a/tests/test_identity_memory.py
+++ b/tests/test_identity_memory.py
@@ -1,0 +1,80 @@
+"""FF-D D1a exit gate: the identity map is memory-bounded.
+
+The map holds weak references: instances are released when user code drops
+them; a dead entry is a miss. This is the deterministic form of the roadmap's
+"bounded RSS after GC" gate — live-entry count and weakref death prove the
+bound without RSS flakiness. (Strong-ref map fails both tests today.)
+"""
+
+import asyncio
+import gc
+import weakref
+
+import pytest
+
+from ferro import Field, Model, connect, engines
+from ferro._core import identity_map_len
+
+
+@pytest.mark.asyncio
+async def test_dropped_instances_are_released_by_the_map(db_url):
+    class MemItem(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        payload: str
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session() as s:
+        created = await MemItem.create(payload="x")
+        pk = created.id
+        ref = weakref.ref(created)
+
+        del created
+        gc.collect()
+        # The map must not keep the instance alive.
+        assert ref() is None
+
+        # A dead entry is a miss: re-fetch hydrates a fresh, correct instance.
+        fresh = await MemItem.get(pk)
+        assert fresh.id == pk
+        assert fresh.payload == "x"
+
+
+@pytest.mark.asyncio
+async def test_identity_map_is_bounded_under_bulk_scanning(db_url):
+    class MemScan(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        n: int
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session() as s:
+        await MemScan.bulk_create([MemScan(n=i) for i in range(20_000)])
+        for _ in range(3):
+            rows = await MemScan.all()
+            assert len(rows) == 20_000
+            del rows
+            gc.collect()
+            # pyo3-async-runtimes resolves the awaited future from a Tokio
+            # worker thread via `call_soon_threadsafe`; the done-callback that
+            # drops the bridge Future's last strong ref to the result is
+            # itself scheduled with `call_soon` and only runs on the *next*
+            # event-loop iteration. One uncontended `sleep(0)` flushes that
+            # tick so refcounting (not gc) frees the instances — this is a
+            # property of the cross-thread bridge, not of the identity map.
+            await asyncio.sleep(0)
+            gc.collect()
+            # Live entries collapse once user refs are gone — the map is
+            # bounded by *live* instances, not by rows ever loaded.
+            assert identity_map_len(s.session_id) < 100
+
+
+@pytest.mark.asyncio
+async def test_identity_dedup_still_works_for_live_instances(db_url):
+    class MemLive(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        n: int
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        a = await MemLive.create(n=1)
+        b = await MemLive.get(a.id)
+        assert b is a  # weak map still dedupes while the instance is alive

--- a/tests/test_identity_refresh.py
+++ b/tests/test_identity_refresh.py
@@ -1,0 +1,79 @@
+"""FF-D D1b exit gate: fetch-hits refresh the cached instance in place.
+
+Guarantee: within a session, fetching a row you already hold returns the same
+object, updated to the database's current values. The database wins over
+unsaved local mutations. (Today the freshly decoded row is discarded.)
+"""
+
+import pytest
+
+from ferro import Field, Model, connect, engines, execute
+
+pytestmark = pytest.mark.backend_matrix
+
+
+def _ph(db_url: str, n: int = 1) -> str:
+    """Return the Nth positional placeholder for the active backend."""
+    return f"${n}" if "postgres" in db_url else "?"
+
+
+@pytest.mark.asyncio
+async def test_refetch_returns_fresh_values_with_identity_preserved(db_url):
+    class RefUser(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+        score: int
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        u = await RefUser.create(name="old", score=1)
+
+        # External write the ORM cache knows nothing about.
+        await execute(
+            f"UPDATE refuser SET name = {_ph(db_url, 1)}, "
+            f"score = {_ph(db_url, 2)} WHERE id = {_ph(db_url, 3)}",
+            "new",
+            2,
+            u.id,
+        )
+
+        again = await RefUser.get(u.id)
+        assert again is u          # identity preserved
+        assert u.name == "new"     # FAILS today: stale "old"
+        assert u.score == 2
+
+
+@pytest.mark.asyncio
+async def test_database_wins_over_unsaved_local_mutation(db_url):
+    class RefDoc(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        body: str
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        d = await RefDoc.create(body="persisted")
+        d.body = "unsaved local edit"
+
+        again = await RefDoc.get(d.id)
+        assert again is d
+        assert d.body == "persisted"  # documented: re-fetch overwrites
+
+
+@pytest.mark.asyncio
+async def test_refresh_resets_fields_set_like_fresh_hydration(db_url):
+    class RefFlag(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        a: str
+        b: str
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        f = await RefFlag.create(a="1", b="2")
+        first_fetch = await RefFlag.get(f.id)
+        expected_fields_set = set(first_fetch.__pydantic_fields_set__)
+
+        f.a = "mutated"
+        again = await RefFlag.get(f.id)
+        assert again is f
+        assert set(f.__pydantic_fields_set__) == expected_fields_set
+        assert f.a == "1"

--- a/tests/test_identity_scoped_invalidation.py
+++ b/tests/test_identity_scoped_invalidation.py
@@ -1,0 +1,86 @@
+"""FF-D D2 exit gate: invalidation is scoped, never a global clear.
+
+Rollback evicts only the affected (connection, session); bulk update/delete
+evict only (connection, model). Unrelated cached instances survive.
+"""
+
+import pytest
+
+from ferro import Field, Model, connect, engines, transaction
+
+
+@pytest.mark.asyncio
+async def test_rollback_evicts_only_the_affected_session(db_url):
+    class InvA(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    # Session 1: cache an instance, then let the session end.
+    async with engines.session():
+        kept = await InvA.create(name="kept-in-s1")
+
+    # Session 2: roll back a transaction; only this session's map is evicted.
+    async with engines.session():
+        outer = await InvA.create(name="s2-outer")
+        try:
+            async with transaction():
+                await InvA.create(name="rolled-back")
+                raise RuntimeError("force rollback")
+        except RuntimeError:
+            pass
+
+        # s2's map was evicted by the rollback: re-fetch hydrates fresh.
+        refetched = await InvA.get(outer.id)
+        assert refetched is not outer
+        assert refetched.name == "s2-outer"
+
+    # A different session was never touched (its map died with it anyway;
+    # the point is the rollback path no longer clears anything global).
+    async with engines.session():
+        still_there = await InvA.get(kept.id)
+        assert still_there.name == "kept-in-s1"
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_evicts_only_that_model(db_url):
+    class InvUser(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    class InvOrder(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        item: str
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        u = await InvUser.create(name="before")
+        o = await InvOrder.create(item="widget")
+
+        await InvUser.where(lambda t: t.id == u.id).update(name="after")
+
+        fresh_u = await InvUser.get(u.id)
+        assert fresh_u is not u  # evicted: fresh instance
+        assert fresh_u.name == "after"
+
+        same_o = await InvOrder.get(o.id)
+        assert same_o is o  # unrelated model survived
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_evicts_only_that_model(db_url):
+    class InvDelA(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        n: int
+
+    class InvDelB(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        n: int
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        a = await InvDelA.create(n=1)
+        b = await InvDelB.create(n=2)
+        await InvDelA.where(lambda t: t.n == 1).delete()
+        assert await InvDelA.get_or_none(a.id) is None
+        assert (await InvDelB.get(b.id)) is b

--- a/tests/test_identity_weakref.py
+++ b/tests/test_identity_weakref.py
@@ -1,0 +1,37 @@
+"""FF-D D1: Ferro identity mapping requires weakly referenceable instances."""
+
+import gc
+import weakref
+
+import pytest
+
+from ferro import Field, Model
+from ferro.metaclass import _assert_weakref_support
+
+
+def test_model_instances_support_weakref():
+    class WRUser(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    u = WRUser(id=1, name="a")
+    r = weakref.ref(u)
+    assert r() is u
+    del u
+    gc.collect()
+    assert r() is None
+
+
+def test_weakref_guard_rejects_unweakrefable_class():
+    class NoWeakref:
+        __slots__ = ()  # no __dict__, no __weakref__ anywhere in MRO
+
+    with pytest.raises(TypeError, match="weak"):
+        _assert_weakref_support(NoWeakref)
+
+
+def test_weakref_guard_accepts_model_classes():
+    class WRGuarded(Model):
+        id: int | None = Field(default=None, primary_key=True)
+
+    _assert_weakref_support(WRGuarded)  # must not raise

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,7 +1,7 @@
 import pytest
 import uuid
 from typing import Annotated
-from ferro import Model, connect, FerroField
+from ferro import Model, connect, FerroField, engines
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -17,16 +17,17 @@ async def test_autoincrement_id_retrieval(db_url):
         name: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    user = AutoUser(name="taylor")
-    assert user.id is None
+        user = AutoUser(name="taylor")
+        assert user.id is None
 
-    await user.save()
+        await user.save()
 
-    # The ID should have been updated on the instance
-    assert user.id is not None
-    assert isinstance(user.id, int)
-    assert user.id > 0
+        # The ID should have been updated on the instance
+        assert user.id is not None
+        assert isinstance(user.id, int)
+        assert user.id > 0
 
 
 @pytest.mark.asyncio
@@ -40,16 +41,17 @@ async def test_manual_id_no_autoincrement(db_url):
         name: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    user = ManualUser(id=999, name="jeff")
-    await user.save()
+        user = ManualUser(id=999, name="jeff")
+        await user.save()
 
-    assert user.id == 999
+        assert user.id == 999
 
-    # Verify it actually persisted with that ID
-    fetched = await ManualUser.get(999)
-    assert fetched is not None
-    assert fetched.name == "jeff"
+        # Verify it actually persisted with that ID
+        fetched = await ManualUser.get(999)
+        assert fetched is not None
+        assert fetched.name == "jeff"
 
 
 @pytest.mark.asyncio
@@ -63,12 +65,13 @@ async def test_string_primary_key(db_url):
         user_id: int
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    token = str(uuid.uuid4())
-    s = Session(token=token, user_id=1)
-    await s.save()
+        token = str(uuid.uuid4())
+        s = Session(token=token, user_id=1)
+        await s.save()
 
-    assert s.token == token
-    fetched = await Session.get(token)
-    assert fetched is not None
-    assert fetched.user_id == 1
+        assert s.token == token
+        fetched = await Session.get(token)
+        assert fetched is not None
+        assert fetched.user_id == 1

--- a/tests/test_mutation_pagination_guard.py
+++ b/tests/test_mutation_pagination_guard.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 import pytest
 
-from ferro import FerroField, Model, connect
+from ferro import FerroField, Model, connect, engines
 
 
 class PaginationGuardItem(Model):
@@ -65,17 +65,18 @@ async def test_failed_paginated_mutation_touches_no_rows(db_url):
         label: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    for label in ("a", "b", "c"):
-        await GuardedRow(label=label).save()
+        for label in ("a", "b", "c"):
+            await GuardedRow(label=label).save()
 
-    with pytest.raises(ValueError):
-        await GuardedRow.where(lambda row: row.id > 0).limit(1).delete()
-    with pytest.raises(ValueError):
-        await GuardedRow.where(lambda row: row.id > 0).offset(1).update(label="x")
+        with pytest.raises(ValueError):
+            await GuardedRow.where(lambda row: row.id > 0).limit(1).delete()
+        with pytest.raises(ValueError):
+            await GuardedRow.where(lambda row: row.id > 0).offset(1).update(label="x")
 
-    rows = await GuardedRow.where(lambda row: row.id > 0).order_by("label").all()
-    assert [row.label for row in rows] == ["a", "b", "c"]
+        rows = await GuardedRow.where(lambda row: row.id > 0).order_by("label").all()
+        assert [row.label for row in rows] == ["a", "b", "c"]
 
 
 @pytest.mark.backend_matrix
@@ -86,12 +87,13 @@ async def test_first_then_delete_on_same_query_still_allowed(db_url):
         label: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    await FirstThenDelete(label="only").save()
+        await FirstThenDelete(label="only").save()
 
-    query = FirstThenDelete.where(lambda row: row.label == "only")
-    found = await query.first()
-    assert found is not None
+        query = FirstThenDelete.where(lambda row: row.label == "only")
+        found = await query.first()
+        assert found is not None
 
-    deleted = await query.delete()
-    assert deleted == 1
+        deleted = await query.delete()
+        assert deleted == 1

--- a/tests/test_named_connections_integration.py
+++ b/tests/test_named_connections_integration.py
@@ -73,35 +73,38 @@ async def test_named_connections_smoke_matrix_sqlite(tmp_path):
     await ferro.create_tables()
     await ferro.create_tables(using="service")
 
-    app_row = await NamedSmokeMarker.create(id=1, label="app")
-    service_row = await NamedSmokeMarker.using("service").create(id=1, label="service")
+    async with ferro.engines.session():
 
-    assert app_row is not service_row
-    assert (await NamedSmokeMarker.get(1)).label == "app"
-    assert (await NamedSmokeMarker.using("service").get(1)).label == "service"
+        app_row = await NamedSmokeMarker.create(id=1, label="app")
+        service_row = await NamedSmokeMarker.using("service").create(id=1, label="service")
 
-    async with ferro.transaction(using="service"):
-        await ferro.execute(
-            "UPDATE namedsmokemarker SET label = ? WHERE id = ?",
-            "service-tx",
+        assert app_row is not service_row
+        assert (await NamedSmokeMarker.get(1)).label == "app"
+        assert (await NamedSmokeMarker.using("service").get(1)).label == "service"
+
+        async with ferro.transaction(using="service") as tx:
+            await tx.execute(
+                "UPDATE namedsmokemarker SET label = ? WHERE id = ?",
+                "service-tx",
+                1,
+            )
+
+        assert (await NamedSmokeMarker.get(1)).label == "app"
+        raw_service = await ferro.fetch_one(
+            "SELECT label FROM namedsmokemarker WHERE id = ?",
             1,
+            using="service",
         )
+        assert raw_service == {"label": "service-tx"}
+        async with ferro.engines.session("service"):
+            await service_row.refresh()
+        assert service_row.label == "service-tx"
 
-    assert (await NamedSmokeMarker.get(1)).label == "app"
-    raw_service = await ferro.fetch_one(
-        "SELECT label FROM namedsmokemarker WHERE id = ?",
-        1,
-        using="service",
-    )
-    assert raw_service == {"label": "service-tx"}
-    await service_row.refresh()
-    assert service_row.label == "service-tx"
+        from ferro._core import delete_record
 
-    from ferro._core import delete_record
-
-    assert await delete_record("NamedSmokeMarker", "1", using="service") is True
-    assert await NamedSmokeMarker.get(1) is app_row
-    assert await NamedSmokeMarker.using("service").get_or_none(1) is None
+        assert await delete_record("NamedSmokeMarker", "1", using="service") is True
+        assert await NamedSmokeMarker.get(1) is app_row
+        assert await NamedSmokeMarker.using("service").get_or_none(1) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_named_connections_integration.py
+++ b/tests/test_named_connections_integration.py
@@ -111,10 +111,18 @@ async def test_named_connections_smoke_matrix_sqlite(tmp_path):
         assert service_row.label == "service-tx"
 
         # A raw FFI escape hatch — bypasses the Python-level route resolver
-        # (and its D4 conflict check) entirely, so no session is needed.
-        from ferro._core import delete_record
+        # (and its D4 conflict check) entirely, so no session is needed. FF-D
+        # D3 collapsed the tx_id/using/session_id triple into one resolved
+        # RouteHandle; build it directly since this deliberately skips
+        # resolve_operation_scope.
+        from ferro._core import RouteHandle, delete_record
 
-        assert await delete_record("NamedSmokeMarker", "1", using="service") is True
+        assert (
+            await delete_record(
+                "NamedSmokeMarker", "1", RouteHandle(connection_name="service")
+            )
+            is True
+        )
         assert await NamedSmokeMarker.get(1) is app_row
         async with ferro.engines.session("service"):
             assert await NamedSmokeMarker.using("service").get_or_none(1) is None

--- a/tests/test_named_connections_integration.py
+++ b/tests/test_named_connections_integration.py
@@ -76,35 +76,48 @@ async def test_named_connections_smoke_matrix_sqlite(tmp_path):
     async with ferro.engines.session():
 
         app_row = await NamedSmokeMarker.create(id=1, label="app")
-        service_row = await NamedSmokeMarker.using("service").create(id=1, label="service")
+
+        # `using="service"` conflicts with the ambient "app" session (D4)
+        # unless the ambient session for that call is itself "service" —
+        # a nested `engines.session("service")` block gives .using("service")
+        # a matching ambient session while the outer "app" session (and its
+        # identity map) stays open underneath.
+        async with ferro.engines.session("service"):
+            service_row = await NamedSmokeMarker.using("service").create(id=1, label="service")
 
         assert app_row is not service_row
         assert (await NamedSmokeMarker.get(1)).label == "app"
-        assert (await NamedSmokeMarker.using("service").get(1)).label == "service"
+        async with ferro.engines.session("service"):
+            assert (await NamedSmokeMarker.using("service").get(1)).label == "service"
 
-        async with ferro.transaction(using="service") as tx:
-            await tx.execute(
-                "UPDATE namedsmokemarker SET label = ? WHERE id = ?",
-                "service-tx",
-                1,
-            )
+        async with ferro.engines.session("service"):
+            async with ferro.transaction(using="service") as tx:
+                await tx.execute(
+                    "UPDATE namedsmokemarker SET label = ? WHERE id = ?",
+                    "service-tx",
+                    1,
+                )
 
         assert (await NamedSmokeMarker.get(1)).label == "app"
-        raw_service = await ferro.fetch_one(
-            "SELECT label FROM namedsmokemarker WHERE id = ?",
-            1,
-            using="service",
-        )
+        async with ferro.engines.session("service"):
+            raw_service = await ferro.fetch_one(
+                "SELECT label FROM namedsmokemarker WHERE id = ?",
+                1,
+                using="service",
+            )
         assert raw_service == {"label": "service-tx"}
         async with ferro.engines.session("service"):
             await service_row.refresh()
         assert service_row.label == "service-tx"
 
+        # A raw FFI escape hatch — bypasses the Python-level route resolver
+        # (and its D4 conflict check) entirely, so no session is needed.
         from ferro._core import delete_record
 
         assert await delete_record("NamedSmokeMarker", "1", using="service") is True
         assert await NamedSmokeMarker.get(1) is app_row
-        assert await NamedSmokeMarker.using("service").get_or_none(1) is None
+        async with ferro.engines.session("service"):
+            assert await NamedSmokeMarker.using("service").get_or_none(1) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_one_to_one.py
+++ b/tests/test_one_to_one.py
@@ -4,6 +4,7 @@ from typing import Annotated
 from ferro import (
     Model,
     connect,
+    engines,
     FerroField,
     ForeignKey,
     BackRef,
@@ -40,26 +41,27 @@ async def test_one_to_one_relationship(db_url):
         user: Annotated[User, ForeignKey(related_name="profile", unique=True)]
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    # 1. Create User and Profile
-    alice = await User.create(username="alice")
-    p1 = await Profile.create(bio="Alice's Bio", user=alice)
+        # 1. Create User and Profile
+        alice = await User.create(username="alice")
+        p1 = await Profile.create(bio="Alice's Bio", user=alice)
 
-    # 2. Verify reverse lookup (1:1 should return object directly)
-    # Note: RelationshipDescriptor returns query.first() which is a coroutine
-    alice_profile = await alice.profile
-    assert alice_profile is not None
-    assert alice_profile.bio == "Alice's Bio"
-    assert alice_profile.id == p1.id
+        # 2. Verify reverse lookup (1:1 should return object directly)
+        # Note: RelationshipDescriptor returns query.first() which is a coroutine
+        alice_profile = await alice.profile
+        assert alice_profile is not None
+        assert alice_profile.bio == "Alice's Bio"
+        assert alice_profile.id == p1.id
 
-    # 3. Verify forward lookup (already working)
-    p1_user = await p1.user
-    assert p1_user.username == "alice"
+        # 3. Verify forward lookup (already working)
+        p1_user = await p1.user
+        assert p1_user.username == "alice"
 
-    # 4. Verify Uniqueness Enforcement
-    with pytest.raises(Exception):
-        # Should fail because alice already has a profile
-        await Profile.create(bio="Another bio", user=alice)
+        # 4. Verify Uniqueness Enforcement
+        with pytest.raises(Exception):
+            # Should fail because alice already has a profile
+            await Profile.create(bio="Another bio", user=alice)
 
 
 @pytest.mark.asyncio

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 from enum import Enum
 
 import pytest
+
+import ferro
 from ferro import Model, connect
 from ferro.query import Query, QueryNode, col
 from ferro.query.builder import _query_ir_payload_to_json
@@ -201,27 +203,28 @@ async def test_query_execution(db_url):
     # Initialize connection and auto-migrate
     await connect(db_url, auto_migrate=True)
 
-    # Seed data
-    await FilterUser(id=1, username="taylor", age=30).save()
-    await FilterUser(id=2, username="jeff", age=25).save()
-    await FilterUser(id=3, username="alice", age=35).save()
+    async with ferro.engines.session():
+        # Seed data
+        await FilterUser(id=1, username="taylor", age=30).save()
+        await FilterUser(id=2, username="jeff", age=25).save()
+        await FilterUser(id=3, username="alice", age=35).save()
 
-    # 1. Test basic filter
-    results = await FilterUser.where(lambda t: t.age >= 30).all()
-    assert len(results) == 2
-    assert {r.username for r in results} == {"taylor", "alice"}
+        # 1. Test basic filter
+        results = await FilterUser.where(lambda t: t.age >= 30).all()
+        assert len(results) == 2
+        assert {r.username for r in results} == {"taylor", "alice"}
 
-    # 2. Test IN filter
-    results_in = await FilterUser.where(lambda t: t.username << ["jeff", "alice"]).all()
-    assert len(results_in) == 2
-    assert {r.username for r in results_in} == {"jeff", "alice"}
+        # 2. Test IN filter
+        results_in = await FilterUser.where(lambda t: t.username << ["jeff", "alice"]).all()
+        assert len(results_in) == 2
+        assert {r.username for r in results_in} == {"jeff", "alice"}
 
-    # 3. Test combined filters (Chaining)
-    results_chained = await FilterUser.where(lambda t: t.age < 35).where(
-        lambda t: t.age > 20
-    ).all()
-    assert len(results_chained) == 2
-    assert {r.username for r in results_chained} == {"taylor", "jeff"}
+        # 3. Test combined filters (Chaining)
+        results_chained = await FilterUser.where(lambda t: t.age < 35).where(
+            lambda t: t.age > 20
+        ).all()
+        assert len(results_chained) == 2
+        assert {r.username for r in results_chained} == {"taylor", "jeff"}
 
 
 @pytest.mark.asyncio
@@ -235,16 +238,17 @@ async def test_query_first(db_url):
         username: str
 
     await connect(db_url, auto_migrate=True)
-    await FirstUser(id=1, username="taylor").save()
+    async with ferro.engines.session():
+        await FirstUser(id=1, username="taylor").save()
 
-    # 1. Match found
-    user = await FirstUser.where(lambda t: t.username == "taylor").first()
-    assert user is not None
-    assert user.username == "taylor"
+        # 1. Match found
+        user = await FirstUser.where(lambda t: t.username == "taylor").first()
+        assert user is not None
+        assert user.username == "taylor"
 
-    # 2. No match found
-    no_user = await FirstUser.where(lambda t: t.username == "nonexistent").first()
-    assert no_user is None
+        # 2. No match found
+        no_user = await FirstUser.where(lambda t: t.username == "nonexistent").first()
+        assert no_user is None
 
 
 @pytest.mark.asyncio
@@ -258,16 +262,17 @@ async def test_sql_injection_protection(db_url):
         username: str
 
     await connect(db_url, auto_migrate=True)
-    await SafeUser(id=1, username="taylor").save()
+    async with ferro.engines.session():
+        await SafeUser(id=1, username="taylor").save()
 
-    # Attempt standard SQL injection
-    injection_string = "' OR '1'='1"
+        # Attempt standard SQL injection
+        injection_string = "' OR '1'='1"
 
-    # If not parameterized, this might return the user.
-    # If parameterized, it should look for the literal string and return None.
-    result = await SafeUser.where(lambda t: t.username == injection_string).first()
+        # If not parameterized, this might return the user.
+        # If parameterized, it should look for the literal string and return None.
+        result = await SafeUser.where(lambda t: t.username == injection_string).first()
 
-    assert result is None
+        assert result is None
 
 
 @pytest.mark.asyncio
@@ -282,34 +287,35 @@ async def test_query_bitwise_logic(db_url):
         age: int
 
     await connect(db_url, auto_migrate=True)
-    await LogicUser(id=1, username="taylor", age=30).save()
-    await LogicUser(id=2, username="jeff", age=25).save()
-    await LogicUser(id=3, username="alice", age=35).save()
+    async with ferro.engines.session():
+        await LogicUser(id=1, username="taylor", age=30).save()
+        await LogicUser(id=2, username="jeff", age=25).save()
+        await LogicUser(id=3, username="alice", age=35).save()
 
-    # 1. Test OR (|)
-    # SQL: SELECT * FROM logicuser WHERE age < 30 OR username == 'alice'
-    results_or = await LogicUser.where(
-        lambda t: (t.age < 30) | (t.username == "alice")
-    ).all()
-    assert len(results_or) == 2
-    assert {r.username for r in results_or} == {"jeff", "alice"}
+        # 1. Test OR (|)
+        # SQL: SELECT * FROM logicuser WHERE age < 30 OR username == 'alice'
+        results_or = await LogicUser.where(
+            lambda t: (t.age < 30) | (t.username == "alice")
+        ).all()
+        assert len(results_or) == 2
+        assert {r.username for r in results_or} == {"jeff", "alice"}
 
-    # 2. Test nested AND (&) within WHERE
-    # SQL: SELECT * FROM logicuser WHERE (age > 20) AND (username != 'taylor')
-    results_and = await LogicUser.where(
-        lambda t: (t.age > 20) & (t.username != "taylor")
-    ).all()
-    assert len(results_and) == 2
-    assert {r.username for r in results_and} == {"jeff", "alice"}
+        # 2. Test nested AND (&) within WHERE
+        # SQL: SELECT * FROM logicuser WHERE (age > 20) AND (username != 'taylor')
+        results_and = await LogicUser.where(
+            lambda t: (t.age > 20) & (t.username != "taylor")
+        ).all()
+        assert len(results_and) == 2
+        assert {r.username for r in results_and} == {"jeff", "alice"}
 
-    # 3. Test Complex Nesting: (A OR B) AND C
-    # SQL: SELECT * FROM logicuser WHERE (username == 'taylor' OR username == 'jeff') AND age > 28
-    # Only taylor (30) matches both. jeff (25) is under 28.
-    results_complex = await LogicUser.where(
-        lambda t: ((t.username == "taylor") | (t.username == "jeff")) & (t.age > 28)
-    ).all()
-    assert len(results_complex) == 1
-    assert results_complex[0].username == "taylor"
+        # 3. Test Complex Nesting: (A OR B) AND C
+        # SQL: SELECT * FROM logicuser WHERE (username == 'taylor' OR username == 'jeff') AND age > 28
+        # Only taylor (30) matches both. jeff (25) is under 28.
+        results_complex = await LogicUser.where(
+            lambda t: ((t.username == "taylor") | (t.username == "jeff")) & (t.age > 28)
+        ).all()
+        assert len(results_complex) == 1
+        assert results_complex[0].username == "taylor"
 
 
 @pytest.mark.asyncio
@@ -324,14 +330,15 @@ async def test_query_bitwise_multiple_where(db_url):
         age: int
 
     await connect(db_url, auto_migrate=True)
-    await LogicUser(id=1, username="taylor", age=30).save()
-    await LogicUser(id=2, username="jeff", age=25).save()
-    await LogicUser(id=3, username="alice", age=35).save()
+    async with ferro.engines.session():
+        await LogicUser(id=1, username="taylor", age=30).save()
+        await LogicUser(id=2, username="jeff", age=25).save()
+        await LogicUser(id=3, username="alice", age=35).save()
 
-    # (A OR B) AND (C)
-    query = LogicUser.where(lambda t: (t.username == "jeff") | (t.username == "alice"))
-    query = query.where(lambda t: t.age > 30)
+        # (A OR B) AND (C)
+        query = LogicUser.where(lambda t: (t.username == "jeff") | (t.username == "alice"))
+        query = query.where(lambda t: t.age > 30)
 
-    results = await query.all()
-    assert len(results) == 1
-    assert results[0].username == "alice"
+        results = await query.all()
+        assert len(results) == 1
+        assert results[0].username == "alice"

--- a/tests/test_query_typing.py
+++ b/tests/test_query_typing.py
@@ -87,11 +87,12 @@ class TestColWrapper:
             archived: bool = False
 
         await ferro.connect(db_url, auto_migrate=True)
-        await ColUser(id=1, username="alice", archived=False).save()
-        await ColUser(id=2, username="bob", archived=True).save()
+        async with ferro.engines.session():
+            await ColUser(id=1, username="alice", archived=False).save()
+            await ColUser(id=2, username="bob", archived=True).save()
 
-        active = await ColUser.where(col(ColUser.archived) == False).all()  # noqa: E712
-        assert {u.username for u in active} == {"alice"}
+            active = await ColUser.where(col(ColUser.archived) == False).all()  # noqa: E712
+            assert {u.username for u in active} == {"alice"}
 
 
 # ---------------------------------------------------------------------------
@@ -163,11 +164,12 @@ class TestLambdaPredicates:
             archived: bool = False
 
         await ferro.connect(db_url, auto_migrate=True)
-        await LamUser(id=1, username="alice", archived=False).save()
-        await LamUser(id=2, username="bob", archived=True).save()
+        async with ferro.engines.session():
+            await LamUser(id=1, username="alice", archived=False).save()
+            await LamUser(id=2, username="bob", archived=True).save()
 
-        active = await LamUser.where(lambda t: t.archived == False).all()  # noqa: E712
-        assert {u.username for u in active} == {"alice"}
+            active = await LamUser.where(lambda t: t.archived == False).all()  # noqa: E712
+            assert {u.username for u in active} == {"alice"}
 
 
 # ---------------------------------------------------------------------------
@@ -194,15 +196,16 @@ class TestOperatorPathUnchanged:
             email: str
 
         await ferro.connect(db_url, auto_migrate=True)
-        await OpUser(id=1, email="a@b.com").save()
-        await OpUser(id=2, email="c@d.com").save()
+        async with ferro.engines.session():
+            await OpUser(id=1, email="a@b.com").save()
+            await OpUser(id=2, email="c@d.com").save()
 
-        with pytest.deprecated_call(match="Operator predicate style.*v0\\.14\\.0"):
-            rows = await OpUser.where(
-                OpUser.email == "a@b.com"
-            ).all()  # ty: ignore[no-matching-overload]
-        assert len(rows) == 1
-        assert rows[0].email == "a@b.com"
+            with pytest.deprecated_call(match="Operator predicate style.*v0\\.14\\.0"):
+                rows = await OpUser.where(
+                    OpUser.email == "a@b.com"
+                ).all()  # ty: ignore[no-matching-overload]
+            assert len(rows) == 1
+            assert rows[0].email == "a@b.com"
 
 
 # ---------------------------------------------------------------------------
@@ -223,19 +226,20 @@ class TestCombinedStyles:
             archived: bool = False
 
         await ferro.connect(db_url, auto_migrate=True)
-        await MixUser(id=1, role="admin", archived=False).save()
-        await MixUser(id=1_001, role="admin", archived=True).save()
-        await MixUser(id=2, role="user", archived=False).save()
+        async with ferro.engines.session():
+            await MixUser(id=1, role="admin", archived=False).save()
+            await MixUser(id=1_001, role="admin", archived=True).save()
+            await MixUser(id=2, role="user", archived=False).save()
 
-        with pytest.deprecated_call(match="Operator predicate style.*v0\\.14\\.0"):
-            rows = await (
-                MixUser.where(MixUser.id == 1)  # ty: ignore[no-matching-overload]
-                .where(col(MixUser.archived) == False)  # noqa: E712
-                .where(lambda t: t.role == "admin")
-                .all()
-            )
-        assert len(rows) == 1
-        assert rows[0].id == 1
+            with pytest.deprecated_call(match="Operator predicate style.*v0\\.14\\.0"):
+                rows = await (
+                    MixUser.where(MixUser.id == 1)  # ty: ignore[no-matching-overload]
+                    .where(col(MixUser.archived) == False)  # noqa: E712
+                    .where(lambda t: t.role == "admin")
+                    .all()
+                )
+            assert len(rows) == 1
+            assert rows[0].id == 1
 
 
 # ---------------------------------------------------------------------------
@@ -260,13 +264,14 @@ class TestRelationLambda:
             author: Annotated[RelAuthor, ForeignKey(related_name="posts")]
 
         await ferro.connect(db_url, auto_migrate=True)
-        author = RelAuthor(id=1, name="taylor")
-        await author.save()
-        await RelPost(id=10, title="draft", published=False, author=author).save()
-        await RelPost(id=11, title="live", published=True, author=author).save()
+        async with ferro.engines.session():
+            author = RelAuthor(id=1, name="taylor")
+            await author.save()
+            await RelPost(id=10, title="draft", published=False, author=author).save()
+            await RelPost(id=11, title="live", published=True, author=author).save()
 
-        published = await author.posts.where(lambda t: t.published == True).all()  # noqa: E712
-        assert {p.title for p in published} == {"live"}
+            published = await author.posts.where(lambda t: t.published == True).all()  # noqa: E712
+            assert {p.title for p in published} == {"live"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_raw_sql.py
+++ b/tests/test_raw_sql.py
@@ -27,12 +27,18 @@ def _ph(db_url: str, n: int = 1) -> str:
 @pytest.mark.asyncio
 async def test_raw_execute_ffi_smoke(db_url):
     """Task 2 smoke: ferro._core.raw_execute is callable and creates a table."""
-    from ferro._core import raw_execute
+    from ferro._core import RouteHandle, raw_execute
 
     await connect(db_url)
-    async with engines.session():
+    async with engines.session() as session:
+        # FF-D D3: raw_execute takes a single resolved RouteHandle rather than
+        # a tx_id/using/session_id triple. This low-level smoke test builds
+        # one directly instead of going through resolve_operation_scope.
+        route = RouteHandle(
+            connection_name=session.connection_name, session_id=session.session_id
+        )
         rows_affected = await raw_execute(
-            "CREATE TABLE raw_smoke (id INTEGER PRIMARY KEY)", [], None
+            "CREATE TABLE raw_smoke (id INTEGER PRIMARY KEY)", [], route
         )
         assert isinstance(rows_affected, int)
 

--- a/tests/test_raw_sql.py
+++ b/tests/test_raw_sql.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ferro import connect
+from ferro import connect, engines
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -30,10 +30,11 @@ async def test_raw_execute_ffi_smoke(db_url):
     from ferro._core import raw_execute
 
     await connect(db_url)
-    rows_affected = await raw_execute(
-        "CREATE TABLE raw_smoke (id INTEGER PRIMARY KEY)", [], None
-    )
-    assert isinstance(rows_affected, int)
+    async with engines.session():
+        rows_affected = await raw_execute(
+            "CREATE TABLE raw_smoke (id INTEGER PRIMARY KEY)", [], None
+        )
+        assert isinstance(rows_affected, int)
 
 
 @pytest.mark.asyncio
@@ -42,10 +43,11 @@ async def test_top_level_execute_outside_tx_creates_table(db_url):
     from ferro import execute
 
     await connect(db_url)
-    rows_affected = await execute(
-        "CREATE TABLE t3_users (id INTEGER PRIMARY KEY, name TEXT)"
-    )
-    assert isinstance(rows_affected, int)
+    async with engines.session():
+        rows_affected = await execute(
+            "CREATE TABLE t3_users (id INTEGER PRIMARY KEY, name TEXT)"
+        )
+        assert isinstance(rows_affected, int)
 
 
 @pytest.mark.asyncio
@@ -54,9 +56,10 @@ async def test_top_level_execute_returns_rows_affected(db_url):
     from ferro import execute
 
     await connect(db_url)
-    await execute(f"CREATE TABLE t3b ({_id_pk(db_url)}, n INTEGER)")
-    inserted = await execute("INSERT INTO t3b (n) VALUES (1), (2), (3)")
-    assert inserted == 3
+    async with engines.session():
+        await execute(f"CREATE TABLE t3b ({_id_pk(db_url)}, n INTEGER)")
+        inserted = await execute("INSERT INTO t3b (n) VALUES (1), (2), (3)")
+        assert inserted == 3
 
 
 @pytest.mark.asyncio
@@ -65,13 +68,14 @@ async def test_top_level_execute_binds_scalars(db_url):
     from ferro import execute
 
     await connect(db_url)
-    await execute(f"CREATE TABLE t3c ({_id_pk(db_url)}, name TEXT, n INTEGER)")
-    inserted = await execute(
-        f"INSERT INTO t3c (n, name) VALUES ({_ph(db_url, 1)}, {_ph(db_url, 2)})",
-        7,
-        "alice",
-    )
-    assert inserted == 1
+    async with engines.session():
+        await execute(f"CREATE TABLE t3c ({_id_pk(db_url)}, name TEXT, n INTEGER)")
+        inserted = await execute(
+            f"INSERT INTO t3c (n, name) VALUES ({_ph(db_url, 1)}, {_ph(db_url, 2)})",
+            7,
+            "alice",
+        )
+        assert inserted == 1
 
 
 @pytest.mark.asyncio
@@ -80,10 +84,11 @@ async def test_empty_sql_raises_valueerror(db_url):
     from ferro import execute
 
     await connect(db_url)
-    with pytest.raises(ValueError, match="non-empty"):
-        await execute("")
-    with pytest.raises(ValueError, match="non-empty"):
-        await execute("   \n\t")
+    async with engines.session():
+        with pytest.raises(ValueError, match="non-empty"):
+            await execute("")
+        with pytest.raises(ValueError, match="non-empty"):
+            await execute("   \n\t")
 
 
 @pytest.mark.asyncio
@@ -94,12 +99,13 @@ async def test_unsupported_bind_type_raises_typeerror(db_url):
     from ferro import execute
 
     await connect(db_url)
-    await execute(f"CREATE TABLE t3d ({_id_pk(db_url)}, p TEXT)")
-    with pytest.raises(TypeError, match="PosixPath|Path"):
-        await execute(
-            f"INSERT INTO t3d (p) VALUES ({_ph(db_url)})",
-            pathlib.Path("/tmp"),
-        )
+    async with engines.session():
+        await execute(f"CREATE TABLE t3d ({_id_pk(db_url)}, p TEXT)")
+        with pytest.raises(TypeError, match="PosixPath|Path"):
+            await execute(
+                f"INSERT INTO t3d (p) VALUES ({_ph(db_url)})",
+                pathlib.Path("/tmp"),
+            )
 
 
 @pytest.mark.asyncio
@@ -108,14 +114,15 @@ async def test_top_level_execute_picks_up_active_tx_commit(db_url):
     from ferro import execute, fetch_one, transaction
 
     await connect(db_url)
-    await execute(f"CREATE TABLE t4 ({_id_pk(db_url)}, n INTEGER)")
+    async with engines.session():
+        await execute(f"CREATE TABLE t4 ({_id_pk(db_url)}, n INTEGER)")
 
-    async with transaction():
-        await execute(f"INSERT INTO t4 (n) VALUES ({_ph(db_url)})", 1)
-        await execute(f"INSERT INTO t4 (n) VALUES ({_ph(db_url)})", 2)
+        async with transaction():
+            await execute(f"INSERT INTO t4 (n) VALUES ({_ph(db_url)})", 1)
+            await execute(f"INSERT INTO t4 (n) VALUES ({_ph(db_url)})", 2)
 
-    row = await fetch_one("SELECT COUNT(*) AS c FROM t4")
-    assert row is not None and row["c"] == 2
+        row = await fetch_one("SELECT COUNT(*) AS c FROM t4")
+        assert row is not None and row["c"] == 2
 
 
 @pytest.mark.asyncio
@@ -124,15 +131,16 @@ async def test_top_level_execute_rolls_back_on_exception(db_url):
     from ferro import execute, fetch_one, transaction
 
     await connect(db_url)
-    await execute(f"CREATE TABLE t4b ({_id_pk(db_url)}, n INTEGER)")
+    async with engines.session():
+        await execute(f"CREATE TABLE t4b ({_id_pk(db_url)}, n INTEGER)")
 
-    with pytest.raises(RuntimeError, match="boom"):
-        async with transaction():
-            await execute(f"INSERT INTO t4b (n) VALUES ({_ph(db_url)})", 99)
-            raise RuntimeError("boom")
+        with pytest.raises(RuntimeError, match="boom"):
+            async with transaction():
+                await execute(f"INSERT INTO t4b (n) VALUES ({_ph(db_url)})", 99)
+                raise RuntimeError("boom")
 
-    row = await fetch_one("SELECT COUNT(*) AS c FROM t4b")
-    assert row is not None and row["c"] == 0
+        row = await fetch_one("SELECT COUNT(*) AS c FROM t4b")
+        assert row is not None and row["c"] == 0
 
 
 @pytest.mark.asyncio
@@ -141,12 +149,13 @@ async def test_tx_execute_runs_on_tx_connection(db_url):
     from ferro import execute, transaction
 
     await connect(db_url)
-    await execute(f"CREATE TABLE t5 ({_id_pk(db_url)}, n INTEGER)")
+    async with engines.session():
+        await execute(f"CREATE TABLE t5 ({_id_pk(db_url)}, n INTEGER)")
 
-    async with transaction() as tx:
-        await tx.execute(f"INSERT INTO t5 (n) VALUES ({_ph(db_url)})", 42)
-        row = await tx.fetch_one("SELECT n FROM t5 ORDER BY id DESC LIMIT 1")
-        assert row is not None and row["n"] == 42
+        async with transaction() as tx:
+            await tx.execute(f"INSERT INTO t5 (n) VALUES ({_ph(db_url)})", 42)
+            row = await tx.fetch_one("SELECT n FROM t5 ORDER BY id DESC LIMIT 1")
+            assert row is not None and row["n"] == 42
 
 
 @pytest.mark.asyncio
@@ -155,15 +164,16 @@ async def test_tx_handle_after_exit_raises(db_url):
     from ferro import execute, transaction
 
     await connect(db_url)
-    await execute("CREATE TABLE t5b (id INTEGER PRIMARY KEY)")
+    async with engines.session():
+        await execute("CREATE TABLE t5b (id INTEGER PRIMARY KEY)")
 
-    captured = None
-    async with transaction() as tx:
-        captured = tx
+        captured = None
+        async with transaction() as tx:
+            captured = tx
 
-    assert captured is not None
-    with pytest.raises(RuntimeError, match="closed"):
-        await captured.execute("SELECT 1")
+        assert captured is not None
+        with pytest.raises(RuntimeError, match="closed"):
+            await captured.execute("SELECT 1")
 
 
 @pytest.mark.asyncio
@@ -172,8 +182,9 @@ async def test_transaction_yields_transaction_handle(db_url):
     from ferro import Transaction, transaction
 
     await connect(db_url)
-    async with transaction() as tx:
-        assert isinstance(tx, Transaction)
+    async with engines.session():
+        async with transaction() as tx:
+            assert isinstance(tx, Transaction)
 
 
 @pytest.mark.asyncio
@@ -182,13 +193,14 @@ async def test_transaction_without_as_clause_still_works(db_url):
     from ferro import execute, fetch_one, transaction
 
     await connect(db_url)
-    await execute(f"CREATE TABLE t5d ({_id_pk(db_url)}, n INTEGER)")
+    async with engines.session():
+        await execute(f"CREATE TABLE t5d ({_id_pk(db_url)}, n INTEGER)")
 
-    async with transaction():
-        await execute(f"INSERT INTO t5d (n) VALUES ({_ph(db_url)})", 1)
+        async with transaction():
+            await execute(f"INSERT INTO t5d (n) VALUES ({_ph(db_url)})", 1)
 
-    row = await fetch_one("SELECT COUNT(*) AS c FROM t5d")
-    assert row is not None and row["c"] == 1
+        row = await fetch_one("SELECT COUNT(*) AS c FROM t5d")
+        assert row is not None and row["c"] == 1
 
 
 @pytest.mark.asyncio
@@ -197,17 +209,18 @@ async def test_fetch_all_returns_list_of_dicts(db_url):
     from ferro import execute, fetch_all
 
     await connect(db_url)
-    await execute(f"CREATE TABLE t6 ({_id_pk(db_url)}, name TEXT, n INTEGER)")
-    p1 = _ph(db_url, 1)
-    p2 = _ph(db_url, 2)
-    await execute(f"INSERT INTO t6 (name, n) VALUES ({p1}, {p2})", "alice", 1)
-    await execute(f"INSERT INTO t6 (name, n) VALUES ({p1}, {p2})", "bob", 2)
+    async with engines.session():
+        await execute(f"CREATE TABLE t6 ({_id_pk(db_url)}, name TEXT, n INTEGER)")
+        p1 = _ph(db_url, 1)
+        p2 = _ph(db_url, 2)
+        await execute(f"INSERT INTO t6 (name, n) VALUES ({p1}, {p2})", "alice", 1)
+        await execute(f"INSERT INTO t6 (name, n) VALUES ({p1}, {p2})", "bob", 2)
 
-    rows = await fetch_all("SELECT name, n FROM t6 ORDER BY n")
-    assert isinstance(rows, list)
-    assert len(rows) == 2
-    assert rows[0] == {"name": "alice", "n": 1}
-    assert rows[1] == {"name": "bob", "n": 2}
+        rows = await fetch_all("SELECT name, n FROM t6 ORDER BY n")
+        assert isinstance(rows, list)
+        assert len(rows) == 2
+        assert rows[0] == {"name": "alice", "n": 1}
+        assert rows[1] == {"name": "bob", "n": 2}
 
 
 @pytest.mark.asyncio
@@ -216,10 +229,11 @@ async def test_fetch_one_returns_none_when_empty(db_url):
     from ferro import execute, fetch_one
 
     await connect(db_url)
-    await execute("CREATE TABLE t6b (id INTEGER PRIMARY KEY)")
+    async with engines.session():
+        await execute("CREATE TABLE t6b (id INTEGER PRIMARY KEY)")
 
-    row = await fetch_one("SELECT id FROM t6b WHERE id = -1")
-    assert row is None
+        row = await fetch_one("SELECT id FROM t6b WHERE id = -1")
+        assert row is None
 
 
 @pytest.mark.asyncio
@@ -228,13 +242,14 @@ async def test_fetch_one_returns_first_row_when_multiple(db_url):
     from ferro import execute, fetch_one
 
     await connect(db_url)
-    await execute(f"CREATE TABLE t6c ({_id_pk(db_url)}, n INTEGER)")
-    p = _ph(db_url)
-    await execute(f"INSERT INTO t6c (n) VALUES ({p})", 10)
-    await execute(f"INSERT INTO t6c (n) VALUES ({p})", 20)
+    async with engines.session():
+        await execute(f"CREATE TABLE t6c ({_id_pk(db_url)}, n INTEGER)")
+        p = _ph(db_url)
+        await execute(f"INSERT INTO t6c (n) VALUES ({p})", 10)
+        await execute(f"INSERT INTO t6c (n) VALUES ({p})", 20)
 
-    row = await fetch_one("SELECT n FROM t6c ORDER BY n")
-    assert row == {"n": 10}
+        row = await fetch_one("SELECT n FROM t6c ORDER BY n")
+        assert row == {"n": 10}
 
 
 @pytest.mark.asyncio
@@ -243,12 +258,13 @@ async def test_fetch_inside_tx_sees_uncommitted_writes(db_url):
     from ferro import execute, transaction
 
     await connect(db_url)
-    await execute(f"CREATE TABLE t6d ({_id_pk(db_url)}, n INTEGER)")
+    async with engines.session():
+        await execute(f"CREATE TABLE t6d ({_id_pk(db_url)}, n INTEGER)")
 
-    async with transaction() as tx:
-        await tx.execute(f"INSERT INTO t6d (n) VALUES ({_ph(db_url)})", 7)
-        rows = await tx.fetch_all("SELECT n FROM t6d")
-        assert rows == [{"n": 7}]
+        async with transaction() as tx:
+            await tx.execute(f"INSERT INTO t6d (n) VALUES ({_ph(db_url)})", 7)
+            rows = await tx.fetch_all("SELECT n FROM t6d")
+            assert rows == [{"n": 7}]
 
 
 @pytest.mark.asyncio
@@ -259,16 +275,17 @@ async def test_marshal_uuid(db_url):
     from ferro import execute, fetch_one
 
     await connect(db_url)
-    if "postgres" in db_url:
-        await execute("CREATE TABLE t7a (id UUID PRIMARY KEY)")
-        await execute("INSERT INTO t7a (id) VALUES ($1::uuid)", uuid.UUID(int=1))
-        row = await fetch_one("SELECT id::text AS id FROM t7a")
-    else:
-        await execute("CREATE TABLE t7a (id TEXT PRIMARY KEY)")
-        await execute("INSERT INTO t7a (id) VALUES (?)", uuid.UUID(int=1))
-        row = await fetch_one("SELECT id FROM t7a")
-    assert row is not None
-    assert row["id"] == "00000000-0000-0000-0000-000000000001"
+    async with engines.session():
+        if "postgres" in db_url:
+            await execute("CREATE TABLE t7a (id UUID PRIMARY KEY)")
+            await execute("INSERT INTO t7a (id) VALUES ($1::uuid)", uuid.UUID(int=1))
+            row = await fetch_one("SELECT id::text AS id FROM t7a")
+        else:
+            await execute("CREATE TABLE t7a (id TEXT PRIMARY KEY)")
+            await execute("INSERT INTO t7a (id) VALUES (?)", uuid.UUID(int=1))
+            row = await fetch_one("SELECT id FROM t7a")
+        assert row is not None
+        assert row["id"] == "00000000-0000-0000-0000-000000000001"
 
 
 @pytest.mark.asyncio
@@ -279,17 +296,18 @@ async def test_marshal_datetime(db_url):
     from ferro import execute, fetch_one
 
     await connect(db_url)
-    dt = datetime.datetime(2026, 4, 27, 20, 13, 45, tzinfo=datetime.timezone.utc)
-    if "postgres" in db_url:
-        await execute("CREATE TABLE t7b (id INTEGER PRIMARY KEY, ts TIMESTAMPTZ)")
-        await execute("INSERT INTO t7b (id, ts) VALUES (1, $1::timestamptz)", dt)
-        row = await fetch_one("SELECT ts::text AS ts FROM t7b")
-    else:
-        await execute("CREATE TABLE t7b (id INTEGER PRIMARY KEY, ts TEXT)")
-        await execute("INSERT INTO t7b (id, ts) VALUES (1, ?)", dt)
-        row = await fetch_one("SELECT ts FROM t7b")
-    assert row is not None
-    assert "2026-04-27" in str(row["ts"])
+    async with engines.session():
+        dt = datetime.datetime(2026, 4, 27, 20, 13, 45, tzinfo=datetime.timezone.utc)
+        if "postgres" in db_url:
+            await execute("CREATE TABLE t7b (id INTEGER PRIMARY KEY, ts TIMESTAMPTZ)")
+            await execute("INSERT INTO t7b (id, ts) VALUES (1, $1::timestamptz)", dt)
+            row = await fetch_one("SELECT ts::text AS ts FROM t7b")
+        else:
+            await execute("CREATE TABLE t7b (id INTEGER PRIMARY KEY, ts TEXT)")
+            await execute("INSERT INTO t7b (id, ts) VALUES (1, ?)", dt)
+            row = await fetch_one("SELECT ts FROM t7b")
+        assert row is not None
+        assert "2026-04-27" in str(row["ts"])
 
 
 @pytest.mark.asyncio
@@ -300,17 +318,18 @@ async def test_marshal_date(db_url):
     from ferro import execute, fetch_one
 
     await connect(db_url)
-    d = datetime.date(2026, 4, 27)
-    if "postgres" in db_url:
-        await execute("CREATE TABLE t7c (id INTEGER PRIMARY KEY, day DATE)")
-        await execute("INSERT INTO t7c (id, day) VALUES (1, $1::date)", d)
-        row = await fetch_one("SELECT day::text AS day FROM t7c")
-    else:
-        await execute("CREATE TABLE t7c (id INTEGER PRIMARY KEY, day TEXT)")
-        await execute("INSERT INTO t7c (id, day) VALUES (1, ?)", d)
-        row = await fetch_one("SELECT day FROM t7c")
-    assert row is not None
-    assert "2026-04-27" in str(row["day"])
+    async with engines.session():
+        d = datetime.date(2026, 4, 27)
+        if "postgres" in db_url:
+            await execute("CREATE TABLE t7c (id INTEGER PRIMARY KEY, day DATE)")
+            await execute("INSERT INTO t7c (id, day) VALUES (1, $1::date)", d)
+            row = await fetch_one("SELECT day::text AS day FROM t7c")
+        else:
+            await execute("CREATE TABLE t7c (id INTEGER PRIMARY KEY, day TEXT)")
+            await execute("INSERT INTO t7c (id, day) VALUES (1, ?)", d)
+            row = await fetch_one("SELECT day FROM t7c")
+        assert row is not None
+        assert "2026-04-27" in str(row["day"])
 
 
 @pytest.mark.asyncio
@@ -321,17 +340,18 @@ async def test_marshal_time(db_url):
     from ferro import execute, fetch_one
 
     await connect(db_url)
-    t = datetime.time(20, 13, 45)
-    if "postgres" in db_url:
-        await execute("CREATE TABLE t7c2 (id INTEGER PRIMARY KEY, t TIME)")
-        await execute("INSERT INTO t7c2 (id, t) VALUES (1, $1::time)", t)
-        row = await fetch_one("SELECT t::text AS t FROM t7c2")
-    else:
-        await execute("CREATE TABLE t7c2 (id INTEGER PRIMARY KEY, t TEXT)")
-        await execute("INSERT INTO t7c2 (id, t) VALUES (1, ?)", t)
-        row = await fetch_one("SELECT t FROM t7c2")
-    assert row is not None
-    assert "20:13:45" in str(row["t"])
+    async with engines.session():
+        t = datetime.time(20, 13, 45)
+        if "postgres" in db_url:
+            await execute("CREATE TABLE t7c2 (id INTEGER PRIMARY KEY, t TIME)")
+            await execute("INSERT INTO t7c2 (id, t) VALUES (1, $1::time)", t)
+            row = await fetch_one("SELECT t::text AS t FROM t7c2")
+        else:
+            await execute("CREATE TABLE t7c2 (id INTEGER PRIMARY KEY, t TEXT)")
+            await execute("INSERT INTO t7c2 (id, t) VALUES (1, ?)", t)
+            row = await fetch_one("SELECT t FROM t7c2")
+        assert row is not None
+        assert "20:13:45" in str(row["t"])
 
 
 @pytest.mark.asyncio
@@ -342,17 +362,18 @@ async def test_marshal_decimal(db_url):
     from ferro import execute, fetch_one
 
     await connect(db_url)
-    amt = decimal.Decimal("1234.5678")
-    if "postgres" in db_url:
-        await execute("CREATE TABLE t7d (id INTEGER PRIMARY KEY, amt NUMERIC(10,4))")
-        await execute("INSERT INTO t7d (id, amt) VALUES (1, $1::numeric)", amt)
-        row = await fetch_one("SELECT amt::text AS amt FROM t7d")
-    else:
-        await execute("CREATE TABLE t7d (id INTEGER PRIMARY KEY, amt TEXT)")
-        await execute("INSERT INTO t7d (id, amt) VALUES (1, ?)", amt)
-        row = await fetch_one("SELECT amt FROM t7d")
-    assert row is not None
-    assert "1234.5678" in str(row["amt"])
+    async with engines.session():
+        amt = decimal.Decimal("1234.5678")
+        if "postgres" in db_url:
+            await execute("CREATE TABLE t7d (id INTEGER PRIMARY KEY, amt NUMERIC(10,4))")
+            await execute("INSERT INTO t7d (id, amt) VALUES (1, $1::numeric)", amt)
+            row = await fetch_one("SELECT amt::text AS amt FROM t7d")
+        else:
+            await execute("CREATE TABLE t7d (id INTEGER PRIMARY KEY, amt TEXT)")
+            await execute("INSERT INTO t7d (id, amt) VALUES (1, ?)", amt)
+            row = await fetch_one("SELECT amt FROM t7d")
+        assert row is not None
+        assert "1234.5678" in str(row["amt"])
 
 
 @pytest.mark.asyncio
@@ -367,11 +388,12 @@ async def test_marshal_enum_str(db_url):
         BLUE = "blue"
 
     await connect(db_url)
-    await execute("CREATE TABLE t7e (id INTEGER PRIMARY KEY, c TEXT)")
-    p = "$1" if "postgres" in db_url else "?"
-    await execute(f"INSERT INTO t7e (id, c) VALUES (1, {p})", Color.RED)
-    row = await fetch_one("SELECT c FROM t7e")
-    assert row is not None and row["c"] == "red"
+    async with engines.session():
+        await execute("CREATE TABLE t7e (id INTEGER PRIMARY KEY, c TEXT)")
+        p = "$1" if "postgres" in db_url else "?"
+        await execute(f"INSERT INTO t7e (id, c) VALUES (1, {p})", Color.RED)
+        row = await fetch_one("SELECT c FROM t7e")
+        assert row is not None and row["c"] == "red"
 
 
 @pytest.mark.asyncio
@@ -386,11 +408,12 @@ async def test_marshal_enum_int(db_url):
         HIGH = 9
 
     await connect(db_url)
-    await execute("CREATE TABLE t7f (id INTEGER PRIMARY KEY, p INTEGER)")
-    p_ph = "$1" if "postgres" in db_url else "?"
-    await execute(f"INSERT INTO t7f (id, p) VALUES (1, {p_ph})", Priority.HIGH)
-    row = await fetch_one("SELECT p FROM t7f")
-    assert row is not None and row["p"] == 9
+    async with engines.session():
+        await execute("CREATE TABLE t7f (id INTEGER PRIMARY KEY, p INTEGER)")
+        p_ph = "$1" if "postgres" in db_url else "?"
+        await execute(f"INSERT INTO t7f (id, p) VALUES (1, {p_ph})", Priority.HIGH)
+        row = await fetch_one("SELECT p FROM t7f")
+        assert row is not None and row["p"] == 9
 
 
 @pytest.mark.postgres_only
@@ -402,12 +425,13 @@ async def test_marshal_dict_to_jsonb(db_url):
     from ferro import execute, fetch_one
 
     await connect(db_url)
-    await execute("CREATE TABLE t7g (id INTEGER PRIMARY KEY, data JSONB)")
-    payload = {"a": 1, "b": [2, 3]}
-    await execute("INSERT INTO t7g (id, data) VALUES (1, $1::jsonb)", payload)
-    row = await fetch_one("SELECT data::text AS data FROM t7g")
-    assert row is not None
-    assert json.loads(row["data"]) == payload
+    async with engines.session():
+        await execute("CREATE TABLE t7g (id INTEGER PRIMARY KEY, data JSONB)")
+        payload = {"a": 1, "b": [2, 3]}
+        await execute("INSERT INTO t7g (id, data) VALUES (1, $1::jsonb)", payload)
+        row = await fetch_one("SELECT data::text AS data FROM t7g")
+        assert row is not None
+        assert json.loads(row["data"]) == payload
 
 
 @pytest.mark.asyncio
@@ -416,20 +440,21 @@ async def test_marshal_bool_before_int_order(db_url):
     from ferro import execute, fetch_all
 
     await connect(db_url)
-    if "postgres" in db_url:
-        await execute("CREATE TABLE t7h (id INTEGER PRIMARY KEY, b BOOLEAN)")
-        await execute("INSERT INTO t7h (id, b) VALUES (1, $1)", True)
-        await execute("INSERT INTO t7h (id, b) VALUES (2, $1)", False)
-    else:
-        # SQLite stores booleans as integers, but the bind path must still type as bool.
-        await execute("CREATE TABLE t7h (id INTEGER PRIMARY KEY, b INTEGER)")
-        await execute("INSERT INTO t7h (id, b) VALUES (1, ?)", True)
-        await execute("INSERT INTO t7h (id, b) VALUES (2, ?)", False)
-    rows = await fetch_all("SELECT id, b FROM t7h ORDER BY id")
-    assert len(rows) == 2
-    # Truthiness check works on both 1/0 and True/False.
-    assert bool(rows[0]["b"]) is True
-    assert bool(rows[1]["b"]) is False
+    async with engines.session():
+        if "postgres" in db_url:
+            await execute("CREATE TABLE t7h (id INTEGER PRIMARY KEY, b BOOLEAN)")
+            await execute("INSERT INTO t7h (id, b) VALUES (1, $1)", True)
+            await execute("INSERT INTO t7h (id, b) VALUES (2, $1)", False)
+        else:
+            # SQLite stores booleans as integers, but the bind path must still type as bool.
+            await execute("CREATE TABLE t7h (id INTEGER PRIMARY KEY, b INTEGER)")
+            await execute("INSERT INTO t7h (id, b) VALUES (1, ?)", True)
+            await execute("INSERT INTO t7h (id, b) VALUES (2, ?)", False)
+        rows = await fetch_all("SELECT id, b FROM t7h ORDER BY id")
+        assert len(rows) == 2
+        # Truthiness check works on both 1/0 and True/False.
+        assert bool(rows[0]["b"]) is True
+        assert bool(rows[1]["b"]) is False
 
 
 @pytest.mark.asyncio
@@ -438,9 +463,10 @@ async def test_invalid_sql_raises_operational_error_with_db_message(db_url):
     from ferro import OperationalError, execute
 
     await connect(db_url)
-    with pytest.raises(OperationalError, match="Raw SQL execute failed") as excinfo:
-        await execute("THIS IS NOT VALID SQL")
-    assert excinfo.value.driver_message is not None
+    async with engines.session():
+        with pytest.raises(OperationalError, match="Raw SQL execute failed") as excinfo:
+            await execute("THIS IS NOT VALID SQL")
+        assert excinfo.value.driver_message is not None
 
 
 @pytest.mark.asyncio
@@ -449,22 +475,23 @@ async def test_savepoint_rollback_preserves_outer_writes(db_url):
     from ferro import execute, fetch_all, transaction
 
     await connect(db_url)
-    await execute(f"CREATE TABLE t8 ({_id_pk(db_url)}, n INTEGER)")
-    p = _ph(db_url)
+    async with engines.session():
+        await execute(f"CREATE TABLE t8 ({_id_pk(db_url)}, n INTEGER)")
+        p = _ph(db_url)
 
-    async with transaction() as outer:
-        await outer.execute(f"INSERT INTO t8 (n) VALUES ({p})", 1)
-        try:
-            async with transaction() as inner:
-                await inner.execute(f"INSERT INTO t8 (n) VALUES ({p})", 2)
-                raise RuntimeError("inner-fail")
-        except RuntimeError:
-            pass
-        rows = await outer.fetch_all("SELECT n FROM t8 ORDER BY n")
-        assert rows == [{"n": 1}]
+        async with transaction() as outer:
+            await outer.execute(f"INSERT INTO t8 (n) VALUES ({p})", 1)
+            try:
+                async with transaction() as inner:
+                    await inner.execute(f"INSERT INTO t8 (n) VALUES ({p})", 2)
+                    raise RuntimeError("inner-fail")
+            except RuntimeError:
+                pass
+            rows = await outer.fetch_all("SELECT n FROM t8 ORDER BY n")
+            assert rows == [{"n": 1}]
 
-    final = await fetch_all("SELECT n FROM t8 ORDER BY n")
-    assert final == [{"n": 1}]
+        final = await fetch_all("SELECT n FROM t8 ORDER BY n")
+        assert final == [{"n": 1}]
 
 
 @pytest.mark.postgres_only
@@ -480,15 +507,16 @@ async def test_set_config_then_current_setting_inside_tx(db_url):
     from ferro import transaction
 
     await connect(db_url)
-    claims = '{"sub": "user-123", "role": "tenant_admin"}'
+    async with engines.session():
+        claims = '{"sub": "user-123", "role": "tenant_admin"}'
 
-    async with transaction() as tx:
-        await tx.execute(
-            "select set_config('request.jwt.claims', $1, true)",
-            claims,
-        )
-        row = await tx.fetch_one(
-            "select current_setting('request.jwt.claims', true) as v"
-        )
-        assert row is not None
-        assert row["v"] == claims
+        async with transaction() as tx:
+            await tx.execute(
+                "select set_config('request.jwt.claims', $1, true)",
+                claims,
+            )
+            row = await tx.fetch_one(
+                "select current_setting('request.jwt.claims', true) as v"
+            )
+            assert row is not None
+            assert row["v"] == claims

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -1,6 +1,6 @@
 import pytest
 from typing import Annotated
-from ferro import Model, connect, FerroField
+from ferro import Model, connect, FerroField, engines
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -15,23 +15,24 @@ async def test_instance_refresh(db_url):
         points: int
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    # 1. Create a user
-    user = await RefreshUser.create(username="taylor", points=100)
-    assert user.points == 100
+        # 1. Create a user
+        user = await RefreshUser.create(username="taylor", points=100)
+        assert user.points == 100
 
-    # 2. Update the DB directly (bypassing the 'user' object)
-    # We'll use the QueryBuilder to perform a bulk update
-    await RefreshUser.where(RefreshUser.id == user.id).update(points=200)
+        # 2. Update the DB directly (bypassing the 'user' object)
+        # We'll use the QueryBuilder to perform a bulk update
+        await RefreshUser.where(RefreshUser.id == user.id).update(points=200)
 
-    # The 'user' object still has 100 points
-    assert user.points == 100
+        # The 'user' object still has 100 points
+        assert user.points == 100
 
-    # 3. Refresh the user
-    await user.refresh()
+        # 3. Refresh the user
+        await user.refresh()
 
-    # 4. Verify it was updated
-    assert user.points == 200
+        # 4. Verify it was updated
+        assert user.points == 200
 
 
 @pytest.mark.asyncio
@@ -43,11 +44,12 @@ async def test_refresh_not_found(db_url):
         username: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    user = await RefreshUser.create(username="deleted_soon")
+        user = await RefreshUser.create(username="deleted_soon")
 
-    # Delete it from DB
-    await RefreshUser.where(RefreshUser.id == user.id).delete()
+        # Delete it from DB
+        await RefreshUser.where(RefreshUser.id == user.id).delete()
 
-    with pytest.raises(RuntimeError, match="Instance not found in database"):
-        await user.refresh()
+        with pytest.raises(RuntimeError, match="Instance not found in database"):
+            await user.refresh()

--- a/tests/test_route_single_site.py
+++ b/tests/test_route_single_site.py
@@ -27,3 +27,7 @@ def test_route_handle_constructed_only_in_state_py():
 def test_rust_route_rederivation_is_gone():
     assert _grep(ROOT / "src", "active_route_for_operation", ".rs") == []
     assert _grep(ROOT / "src", "active_engine_for_connection", ".rs") == []
+
+
+def test_global_identity_map_is_gone():
+    assert _grep(ROOT / "src", "IDENTITY_MAP", ".rs") == []

--- a/tests/test_route_single_site.py
+++ b/tests/test_route_single_site.py
@@ -1,0 +1,29 @@
+"""FF-D D3 exit gate: exactly one route-resolution site per operation.
+
+RouteHandle may only be constructed inside src/ferro/state.py (the two
+resolvers). Rust must not re-derive routes per operation.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _grep(root: Path, pattern: str, suffix: str) -> list[str]:
+    hits = []
+    for path in root.rglob(f"*{suffix}"):
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if pattern in line and not line.lstrip().startswith(("#", "//", "///")):
+                hits.append(f"{path.relative_to(ROOT)}:{lineno}")
+    return hits
+
+
+def test_route_handle_constructed_only_in_state_py():
+    hits = _grep(ROOT / "src" / "ferro", "RouteHandle(", ".py")
+    assert hits, "expected RouteHandle construction in src/ferro/state.py"
+    assert all(h.startswith("src/ferro/state.py") for h in hits), hits
+
+
+def test_rust_route_rederivation_is_gone():
+    assert _grep(ROOT / "src", "active_route_for_operation", ".rs") == []
+    assert _grep(ROOT / "src", "active_engine_for_connection", ".rs") == []

--- a/tests/test_routing_errors.py
+++ b/tests/test_routing_errors.py
@@ -1,0 +1,64 @@
+"""FF-D D4 + ambient-default removal (v0.13, one minor ahead of the notice).
+
+Every operation needs an explicit route: a session (ambient or session=) or
+using=. The silent using-bypasses-session path is a ValueError.
+"""
+
+import pytest
+
+from ferro import Field, Model, connect, engines, execute
+
+
+@pytest.mark.asyncio
+async def test_operation_with_no_route_raises(db_url):
+    class RtA(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    with pytest.raises(RuntimeError, match="No database route"):
+        await RtA.all()
+
+
+@pytest.mark.asyncio
+async def test_raw_with_no_route_raises(db_url):
+    await connect(db_url, auto_migrate=True)
+    with pytest.raises(RuntimeError, match="No database route"):
+        await execute("SELECT 1")
+
+
+@pytest.mark.asyncio
+async def test_using_matching_ambient_session_is_allowed(db_url):
+    class RtB(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session() as s:
+        a = await RtB.create(name="x")
+        b = await RtB.all(using=s.connection_name)
+        assert b[0] is a  # same connection: session-scoped, not a bypass
+
+
+@pytest.mark.asyncio
+async def test_using_conflicting_with_ambient_session_raises(db_url, tmp_path):
+    class RtC(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+    await connect(f"sqlite:{tmp_path}/other.db?mode=rwc", auto_migrate=True, name="other")
+    async with engines.session():
+        with pytest.raises(ValueError, match="conflicts with the ambient session"):
+            await RtC.all(using="other")
+
+
+@pytest.mark.asyncio
+async def test_using_alone_still_works_without_identity(db_url, tmp_path):
+    class RtD(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    await connect(f"sqlite:{tmp_path}/named.db?mode=rwc", auto_migrate=True, name="named")
+    rows = await RtD.all(using="named")
+    assert rows == []  # runs fine sessionless; no identity map involved

--- a/tests/test_save_semantics.py
+++ b/tests/test_save_semantics.py
@@ -344,11 +344,15 @@ async def test_model_connection_upsert(tmp_path):
         await ferro.create_tables(using="service")
 
         await ConnUpsertMarker.create(id=1, label="app")
-        await ConnUpsertMarker.using("service").create(id=1, label="service")
 
-        await ConnUpsertMarker.using("service").upsert(id=1, label="service-v2")
+        # `using="service"` conflicts with the ambient "app" session (D4);
+        # a nested `engines.session("service")` gives it a matching ambient.
+        async with ferro.engines.session("service"):
+            await ConnUpsertMarker.using("service").create(id=1, label="service")
+            await ConnUpsertMarker.using("service").upsert(id=1, label="service-v2")
 
         app_row = await ConnUpsertMarker.get(1)
-        service_row = await ConnUpsertMarker.using("service").get(1)
+        async with ferro.engines.session("service"):
+            service_row = await ConnUpsertMarker.using("service").get(1)
         assert app_row.label == "app"
         assert service_row.label == "service-v2"

--- a/tests/test_save_semantics.py
+++ b/tests/test_save_semantics.py
@@ -30,19 +30,20 @@ async def test_create_duplicate_pk_raises_unique_violation(db_url, db_backend):
         name: str
 
     await connect(db_url, auto_migrate=True)
-    await CreateInsertUser.create(id=1, name="first")
+    async with ferro.engines.session():
+        await CreateInsertUser.create(id=1, name="first")
 
-    with pytest.raises(UniqueViolationError) as excinfo:
-        await CreateInsertUser.create(id=1, name="second")
+        with pytest.raises(UniqueViolationError) as excinfo:
+            await CreateInsertUser.create(id=1, name="second")
 
-    exc = excinfo.value
-    assert isinstance(exc, IntegrityError)
-    if db_backend == "postgres":
-        assert exc.sqlstate == "23505"
+        exc = excinfo.value
+        assert isinstance(exc, IntegrityError)
+        if db_backend == "postgres":
+            assert exc.sqlstate == "23505"
 
-    rows = await CreateInsertUser.all()
-    assert len(rows) == 1
-    assert rows[0].name == "first"
+        rows = await CreateInsertUser.all()
+        assert len(rows) == 1
+        assert rows[0].name == "first"
 
 
 async def test_save_transient_instance_with_taken_pk_raises(db_url):
@@ -51,14 +52,15 @@ async def test_save_transient_instance_with_taken_pk_raises(db_url):
         name: str
 
     await connect(db_url, auto_migrate=True)
-    await TransientPkUser(id=1, name="original").save()
+    async with ferro.engines.session():
+        await TransientPkUser(id=1, name="original").save()
 
-    with pytest.raises(UniqueViolationError):
-        await TransientPkUser(id=1, name="intruder").save()
+        with pytest.raises(UniqueViolationError):
+            await TransientPkUser(id=1, name="intruder").save()
 
-    rows = await TransientPkUser.all()
-    assert len(rows) == 1
-    assert rows[0].name == "original"
+        rows = await TransientPkUser.all()
+        assert len(rows) == 1
+        assert rows[0].name == "original"
 
 
 async def test_save_persisted_instance_is_update(db_url):
@@ -67,17 +69,19 @@ async def test_save_persisted_instance_is_update(db_url):
         name: str
 
     await connect(db_url, auto_migrate=True)
-    user = await PersistedUpdateUser.create(id=1, name="before")
-    user.name = "after"
-    await user.save()
+    async with ferro.engines.session():
+        user = await PersistedUpdateUser.create(id=1, name="before")
+        user.name = "after"
+        await user.save()
 
-    rows = await PersistedUpdateUser.all()
-    assert len(rows) == 1
+        rows = await PersistedUpdateUser.all()
+        assert len(rows) == 1
 
     ferro.reset_engine()
     await connect(db_url, auto_migrate=True)
-    fetched = await PersistedUpdateUser.get(1)
-    assert fetched.name == "after"
+    async with ferro.engines.session():
+        fetched = await PersistedUpdateUser.get(1)
+        assert fetched.name == "after"
 
 
 async def test_save_twice_on_same_transient_instance_updates(db_url):
@@ -86,15 +90,16 @@ async def test_save_twice_on_same_transient_instance_updates(db_url):
         name: str
 
     await connect(db_url, auto_migrate=True)
-    user = DoubleSaveUser(name="a")
-    await user.save()
-    assert user.id is not None
-    user.name = "b"
-    await user.save()
+    async with ferro.engines.session():
+        user = DoubleSaveUser(name="a")
+        await user.save()
+        assert user.id is not None
+        user.name = "b"
+        await user.save()
 
-    rows = await DoubleSaveUser.all()
-    assert len(rows) == 1
-    assert rows[0].name == "b"
+        rows = await DoubleSaveUser.all()
+        assert len(rows) == 1
+        assert rows[0].name == "b"
 
 
 async def test_fetched_instance_save_is_update(db_url):
@@ -105,17 +110,19 @@ async def test_fetched_instance_save_is_update(db_url):
         name: str
 
     await connect(db_url, auto_migrate=True)
-    await HydratedSaveUser.create(id=7, name="cold")
+    async with ferro.engines.session():
+        await HydratedSaveUser.create(id=7, name="cold")
 
     ferro.reset_engine()
     await connect(db_url, auto_migrate=True)
-    fetched = await HydratedSaveUser.get(7)
-    fetched.name = "warm"
-    await fetched.save()
+    async with ferro.engines.session():
+        fetched = await HydratedSaveUser.get(7)
+        fetched.name = "warm"
+        await fetched.save()
 
-    rows = await HydratedSaveUser.all()
-    assert len(rows) == 1
-    assert rows[0].name == "warm"
+        rows = await HydratedSaveUser.all()
+        assert len(rows) == 1
+        assert rows[0].name == "warm"
 
 
 async def test_save_after_row_deleted_raises_model_does_not_exist(db_url):
@@ -124,15 +131,16 @@ async def test_save_after_row_deleted_raises_model_does_not_exist(db_url):
         name: str
 
     await connect(db_url, auto_migrate=True)
-    user = await StaleRowUser.create(id=3, name="here")
-    await StaleRowUser.where(lambda u: u.id == 3).delete()
+    async with ferro.engines.session():
+        user = await StaleRowUser.create(id=3, name="here")
+        await StaleRowUser.where(lambda u: u.id == 3).delete()
 
-    user.name = "gone"
-    with pytest.raises(ModelDoesNotExist) as excinfo:
-        await user.save()
+        user.name = "gone"
+        with pytest.raises(ModelDoesNotExist) as excinfo:
+            await user.save()
 
-    assert excinfo.value.model is StaleRowUser
-    assert excinfo.value.pk == 3
+        assert excinfo.value.model is StaleRowUser
+        assert excinfo.value.pk == 3
 
 
 async def test_pk_mutation_on_persisted_instance_targets_current_pk(db_url):
@@ -145,21 +153,23 @@ async def test_pk_mutation_on_persisted_instance_targets_current_pk(db_url):
         name: str
 
     await connect(db_url, auto_migrate=True)
-    user = await PkMutationUser.create(id=1, name="a")
-    user.id = 999
+    async with ferro.engines.session():
+        user = await PkMutationUser.create(id=1, name="a")
+        user.id = 999
 
-    with pytest.raises(ModelDoesNotExist) as excinfo:
-        await user.save()
-    assert excinfo.value.pk == 999
+        with pytest.raises(ModelDoesNotExist) as excinfo:
+            await user.save()
+        assert excinfo.value.pk == 999
 
     # Assert durable state across a reconnect: the identity map would
     # otherwise hand back the same live object whose PK the test mutated.
     ferro.reset_engine()
     await connect(db_url, auto_migrate=True)
-    rows = await PkMutationUser.all()
-    assert len(rows) == 1
-    assert rows[0].id == 1
-    assert rows[0].name == "a"
+    async with ferro.engines.session():
+        rows = await PkMutationUser.all()
+        assert len(rows) == 1
+        assert rows[0].id == 1
+        assert rows[0].name == "a"
 
 
 async def test_upsert_inserts_when_row_missing(db_url):
@@ -168,18 +178,19 @@ async def test_upsert_inserts_when_row_missing(db_url):
         label: str
 
     await connect(db_url, auto_migrate=True)
-    doc = await UpsertInsertDoc.upsert(id=7, label="a")
+    async with ferro.engines.session():
+        doc = await UpsertInsertDoc.upsert(id=7, label="a")
 
-    rows = await UpsertInsertDoc.all()
-    assert len(rows) == 1
-    assert rows[0].label == "a"
+        rows = await UpsertInsertDoc.all()
+        assert len(rows) == 1
+        assert rows[0].label == "a"
 
-    # The returned instance is persisted: a follow-up save() is an UPDATE.
-    doc.label = "b"
-    await doc.save()
-    rows = await UpsertInsertDoc.all()
-    assert len(rows) == 1
-    assert rows[0].label == "b"
+        # The returned instance is persisted: a follow-up save() is an UPDATE.
+        doc.label = "b"
+        await doc.save()
+        rows = await UpsertInsertDoc.all()
+        assert len(rows) == 1
+        assert rows[0].label == "b"
 
 
 async def test_upsert_updates_existing_row(db_url):
@@ -188,12 +199,13 @@ async def test_upsert_updates_existing_row(db_url):
         label: str
 
     await connect(db_url, auto_migrate=True)
-    await UpsertUpdateDoc.create(id=7, label="a")
-    await UpsertUpdateDoc.upsert(id=7, label="b")
+    async with ferro.engines.session():
+        await UpsertUpdateDoc.create(id=7, label="a")
+        await UpsertUpdateDoc.upsert(id=7, label="b")
 
-    rows = await UpsertUpdateDoc.all()
-    assert len(rows) == 1
-    assert rows[0].label == "b"
+        rows = await UpsertUpdateDoc.all()
+        assert len(rows) == 1
+        assert rows[0].label == "b"
 
 
 async def test_save_on_conflict_update_primitive(db_url):
@@ -204,13 +216,14 @@ async def test_save_on_conflict_update_primitive(db_url):
         label: str
 
     await connect(db_url, auto_migrate=True)
-    await OnConflictDoc.create(id=1, label="a")
+    async with ferro.engines.session():
+        await OnConflictDoc.create(id=1, label="a")
 
-    await OnConflictDoc(id=1, label="b").save(on_conflict="update")
+        await OnConflictDoc(id=1, label="b").save(on_conflict="update")
 
-    rows = await OnConflictDoc.all()
-    assert len(rows) == 1
-    assert rows[0].label == "b"
+        rows = await OnConflictDoc.all()
+        assert len(rows) == 1
+        assert rows[0].label == "b"
 
 
 async def test_save_rejects_unknown_on_conflict_value(db_url):
@@ -219,12 +232,13 @@ async def test_save_rejects_unknown_on_conflict_value(db_url):
         label: str
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    with pytest.raises(ValueError):
-        await BadOnConflictDoc(id=1, label="a").save(on_conflict="ignore")
+        with pytest.raises(ValueError):
+            await BadOnConflictDoc(id=1, label="a").save(on_conflict="ignore")
 
-    rows = await BadOnConflictDoc.all()
-    assert len(rows) == 0
+        rows = await BadOnConflictDoc.all()
+        assert len(rows) == 0
 
 
 async def test_upsert_with_unset_auto_pk_inserts(db_url):
@@ -235,11 +249,12 @@ async def test_upsert_with_unset_auto_pk_inserts(db_url):
         label: str
 
     await connect(db_url, auto_migrate=True)
-    doc = await AutoPkUpsertDoc.upsert(label="x")
+    async with ferro.engines.session():
+        doc = await AutoPkUpsertDoc.upsert(label="x")
 
-    assert doc.id is not None
-    rows = await AutoPkUpsertDoc.all()
-    assert len(rows) == 1
+        assert doc.id is not None
+        rows = await AutoPkUpsertDoc.all()
+        assert len(rows) == 1
 
 
 async def test_delete_returns_instance_to_transient(db_url):
@@ -248,15 +263,16 @@ async def test_delete_returns_instance_to_transient(db_url):
         label: str
 
     await connect(db_url, auto_migrate=True)
-    doc = await DeleteResaveDoc.create(id=4, label="v1")
-    await doc.delete()
-    assert len(await DeleteResaveDoc.all()) == 0
+    async with ferro.engines.session():
+        doc = await DeleteResaveDoc.create(id=4, label="v1")
+        await doc.delete()
+        assert len(await DeleteResaveDoc.all()) == 0
 
-    # A deleted instance is transient again: save() re-INSERTs.
-    await doc.save()
-    rows = await DeleteResaveDoc.all()
-    assert len(rows) == 1
-    assert rows[0].id == 4
+        # A deleted instance is transient again: save() re-INSERTs.
+        await doc.save()
+        rows = await DeleteResaveDoc.all()
+        assert len(rows) == 1
+        assert rows[0].id == 4
 
 
 async def test_refresh_keeps_instance_persisted(db_url):
@@ -265,14 +281,15 @@ async def test_refresh_keeps_instance_persisted(db_url):
         label: str
 
     await connect(db_url, auto_migrate=True)
-    doc = await RefreshDoc.create(id=5, label="a")
-    await doc.refresh()
-    doc.label = "b"
-    await doc.save()
+    async with ferro.engines.session():
+        doc = await RefreshDoc.create(id=5, label="a")
+        await doc.refresh()
+        doc.label = "b"
+        await doc.save()
 
-    rows = await RefreshDoc.all()
-    assert len(rows) == 1
-    assert rows[0].label == "b"
+        rows = await RefreshDoc.all()
+        assert len(rows) == 1
+        assert rows[0].label == "b"
 
 
 async def test_model_copy_of_persisted_instance_updates_same_row(db_url):
@@ -281,15 +298,16 @@ async def test_model_copy_of_persisted_instance_updates_same_row(db_url):
         label: str
 
     await connect(db_url, auto_migrate=True)
-    doc = await CopySaveDoc.create(id=6, label="a")
+    async with ferro.engines.session():
+        doc = await CopySaveDoc.create(id=6, label="a")
 
-    copy = doc.model_copy()
-    copy.label = "b"
-    await copy.save()
+        copy = doc.model_copy()
+        copy.label = "b"
+        await copy.save()
 
-    rows = await CopySaveDoc.all()
-    assert len(rows) == 1
-    assert rows[0].label == "b"
+        rows = await CopySaveDoc.all()
+        assert len(rows) == 1
+        assert rows[0].label == "b"
 
 
 async def test_nonauto_pk_insert_then_duplicate_raises(db_url):
@@ -298,16 +316,17 @@ async def test_nonauto_pk_insert_then_duplicate_raises(db_url):
         label: str
 
     await connect(db_url, auto_migrate=True)
-    pk = uuid4()
-    await UuidPkDoc(id=pk, label="first").save()
+    async with ferro.engines.session():
+        pk = uuid4()
+        await UuidPkDoc(id=pk, label="first").save()
 
-    with pytest.raises(UniqueViolationError):
-        await UuidPkDoc(id=pk, label="dup").save()
+        with pytest.raises(UniqueViolationError):
+            await UuidPkDoc(id=pk, label="dup").save()
 
-    await UuidPkDoc.upsert(id=pk, label="second")
-    rows = await UuidPkDoc.all()
-    assert len(rows) == 1
-    assert rows[0].label == "second"
+        await UuidPkDoc.upsert(id=pk, label="second")
+        rows = await UuidPkDoc.all()
+        assert len(rows) == 1
+        assert rows[0].label == "second"
 
 
 @pytest.mark.sqlite_only
@@ -320,15 +339,16 @@ async def test_model_connection_upsert(tmp_path):
     service_db = tmp_path / "service.db"
     await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
     await ferro.connect(f"sqlite:{service_db}?mode=rwc", name="service")
-    await ferro.create_tables()
-    await ferro.create_tables(using="service")
+    async with ferro.engines.session():
+        await ferro.create_tables()
+        await ferro.create_tables(using="service")
 
-    await ConnUpsertMarker.create(id=1, label="app")
-    await ConnUpsertMarker.using("service").create(id=1, label="service")
+        await ConnUpsertMarker.create(id=1, label="app")
+        await ConnUpsertMarker.using("service").create(id=1, label="service")
 
-    await ConnUpsertMarker.using("service").upsert(id=1, label="service-v2")
+        await ConnUpsertMarker.using("service").upsert(id=1, label="service-v2")
 
-    app_row = await ConnUpsertMarker.get(1)
-    service_row = await ConnUpsertMarker.using("service").get(1)
-    assert app_row.label == "app"
-    assert service_row.label == "service-v2"
+        app_row = await ConnUpsertMarker.get(1)
+        service_row = await ConnUpsertMarker.using("service").get(1)
+        assert app_row.label == "app"
+        assert service_row.label == "service-v2"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -44,11 +44,9 @@ async def test_session_query_api_routes_to_bound_connection(tmp_path):
     assert fetched is not None
     assert fetched.label == "analytics"
 
-    with pytest.warns(
-        DeprecationWarning, match="Implicit default-connection routing.*v0\\.14\\.0"
-    ):
-        default_rows = await SessionMarker.all()
-    assert default_rows == []
+    # No ambient session and no explicit `using=`/`session=`: no route (D4).
+    with pytest.raises(RuntimeError, match="No database route"):
+        await SessionMarker.all()
 
 
 @pytest.mark.asyncio
@@ -115,22 +113,16 @@ async def test_unnamed_session_binds_default_connection(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_legacy_unqualified_operation_warns(tmp_path):
+async def test_unqualified_operation_without_session_raises(tmp_path):
+    """No ambient session, no `using=`/`session=`: no route (D4)."""
     app_db = tmp_path / "app.db"
     await ferro.connect(f"sqlite:{app_db}?mode=rwc", name="app", default=True)
     await ferro.create_tables()
 
-    with pytest.warns(
-        DeprecationWarning, match="Implicit default-connection routing.*v0\\.14\\.0"
-    ):
-        created = await SessionMarker.create(id=10, label="legacy")
-    with pytest.warns(
-        DeprecationWarning, match="Implicit default-connection routing.*v0\\.14\\.0"
-    ):
-        loaded = await SessionMarker.get(10)
-
-    assert created.id == 10
-    assert loaded.label == "legacy"
+    with pytest.raises(RuntimeError, match="No database route"):
+        await SessionMarker.create(id=10, label="legacy")
+    with pytest.raises(RuntimeError, match="No database route"):
+        await SessionMarker.get(10)
 
 
 @pytest.mark.asyncio
@@ -337,6 +329,10 @@ async def test_same_context_outer_close_after_inner_cross_context_close_raises(
 
 @pytest.mark.asyncio
 async def test_stale_ambient_with_using_still_raises_session_closed(tmp_path):
+    """A closed ambient session still blocks operations whose `using=`
+    matches its connection — the D4 conflict check only fires on a
+    mismatch, so a matching `using=` reaches the closed-session guard.
+    """
     app_db = tmp_path / "app.db"
     analytics_db = tmp_path / "analytics.db"
 
@@ -354,7 +350,7 @@ async def test_stale_ambient_with_using_still_raises_session_closed(tmp_path):
     await asyncio.create_task(close_session())
 
     with pytest.raises(RuntimeError, match="Session is closed.*Open a new session"):
-        await SessionMarker.all(using="analytics")
+        await SessionMarker.all(using="app")
 
 
 @pytest.mark.asyncio

--- a/tests/test_shadow_fk_types.py
+++ b/tests/test_shadow_fk_types.py
@@ -101,29 +101,30 @@ async def test_uuid_fk_create_get_dump(db_url):
         parent: Annotated[UuidIssueParent, ForeignKey(related_name="children")]
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    parent = await UuidIssueParent.create(name="p")
-    child = await UuidIssueChild.create(parent=parent)
+        parent = await UuidIssueParent.create(name="p")
+        child = await UuidIssueChild.create(parent=parent)
 
-    fetched = await UuidIssueChild.get(child.id)
-    assert fetched.parent_id == parent.id
+        fetched = await UuidIssueChild.get(child.id)
+        assert fetched.parent_id == parent.id
 
-    by_shadow = await UuidIssueChild.where(
-        UuidIssueChild.parent_id == parent.id
-    ).first()
-    assert by_shadow is not None
-    assert by_shadow.id == child.id
+        by_shadow = await UuidIssueChild.where(
+            UuidIssueChild.parent_id == parent.id
+        ).first()
+        assert by_shadow is not None
+        assert by_shadow.id == child.id
 
-    for dumper in (fetched.model_dump, fetched.model_dump_json):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            dumper()
-        unexpected = [
-            x
-            for x in w
-            if x.category.__name__ == "PydanticSerializationUnexpectedValue"
-        ]
-        assert not unexpected
+        for dumper in (fetched.model_dump, fetched.model_dump_json):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                dumper()
+            unexpected = [
+                x
+                for x in w
+                if x.category.__name__ == "PydanticSerializationUnexpectedValue"
+            ]
+            assert not unexpected
 
 
 @pytest.mark.asyncio
@@ -142,11 +143,12 @@ async def test_uuid_fk_forward_ref_child_declared_first(db_url):
         children: Relation[list[UuidFrwChild]] = BackRef()
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    parent = await UuidFrwParent.create(name="p")
-    child = await UuidFrwChild.create(parent=parent)
-    fetched = await UuidFrwChild.get(child.id)
-    assert fetched.parent_id == parent.id
+        parent = await UuidFrwParent.create(name="p")
+        child = await UuidFrwChild.create(parent=parent)
+        fetched = await UuidFrwChild.get(child.id)
+        assert fetched.parent_id == parent.id
 
 
 def test_uuid_child_model_validate_accepts_string_parent_id():
@@ -209,19 +211,20 @@ async def test_uuid_fk_save_after_reparenting(db_url):
         parent: Annotated[UuidMutParent, ForeignKey(related_name="kids")]
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    parent_a = await UuidMutParent.create(name="a")
-    parent_b = await UuidMutParent.create(name="b")
-    child = await UuidMutChild.create(label="row", parent=parent_a)
-    assert child.parent_id == parent_a.id
+        parent_a = await UuidMutParent.create(name="a")
+        parent_b = await UuidMutParent.create(name="b")
+        child = await UuidMutChild.create(label="row", parent=parent_a)
+        assert child.parent_id == parent_a.id
 
-    child.parent_id = parent_b.id
-    await child.save()
+        child.parent_id = parent_b.id
+        await child.save()
 
-    refetched = await UuidMutChild.get(child.id)
-    assert refetched is not None
-    assert refetched.parent_id == parent_b.id
-    assert refetched.label == "row"
+        refetched = await UuidMutChild.get(child.id)
+        assert refetched is not None
+        assert refetched.parent_id == parent_b.id
+        assert refetched.label == "row"
 
 
 @pytest.mark.asyncio
@@ -241,22 +244,23 @@ async def test_uuid_fk_bulk_create(db_url):
         parent: Annotated[UuidBulkParent, ForeignKey(related_name="items")]
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    px = await UuidBulkParent.create(name="x")
-    py = await UuidBulkParent.create(name="y")
+        px = await UuidBulkParent.create(name="x")
+        py = await UuidBulkParent.create(name="y")
 
-    rows = [
-        UuidBulkItem(sku="1", parent_id=px.id),
-        UuidBulkItem(sku="2", parent_id=py.id),
-        UuidBulkItem(sku="3", parent_id=px.id),
-    ]
-    inserted = await UuidBulkItem.bulk_create(rows)
-    assert inserted == 3
+        rows = [
+            UuidBulkItem(sku="1", parent_id=px.id),
+            UuidBulkItem(sku="2", parent_id=py.id),
+            UuidBulkItem(sku="3", parent_id=px.id),
+        ]
+        inserted = await UuidBulkItem.bulk_create(rows)
+        assert inserted == 3
 
-    all_items = await UuidBulkItem.all()
-    assert len(all_items) == 3
-    by_sku = {item.sku: item for item in all_items}
-    # Hydration may return UUID or TEXT from SQLite; compare normalized strings.
-    assert str(by_sku["1"].parent_id) == str(px.id)
-    assert str(by_sku["2"].parent_id) == str(py.id)
-    assert str(by_sku["3"].parent_id) == str(px.id)
+        all_items = await UuidBulkItem.all()
+        assert len(all_items) == 3
+        by_sku = {item.sku: item for item in all_items}
+        # Hydration may return UUID or TEXT from SQLite; compare normalized strings.
+        assert str(by_sku["1"].parent_id) == str(px.id)
+        assert str(by_sku["2"].parent_id) == str(py.id)
+        assert str(by_sku["3"].parent_id) == str(px.id)

--- a/tests/test_shadow_reports.py
+++ b/tests/test_shadow_reports.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from pydantic import Field
 
-from ferro import Model, connect
+from ferro import Model, connect, engines
 from ferro._core import (
     _render_create_table_sql_for_test,
     _render_migration_sql_for_test,
@@ -118,17 +118,19 @@ async def test_shadow_runtime_strict_has_no_mismatch(monkeypatch: pytest.MonkeyP
         age: int
 
     await connect(db_url, auto_migrate=True)
-    await ShadowRuntimeUser(id=1, name="alice", age=22).save()
-    await ShadowRuntimeUser(id=2, name="bob", age=17).save()
+    async with engines.session():
 
-    rows = await ShadowRuntimeUser.where(lambda t: t.age >= 18).all()
-    assert [row.name for row in rows] == ["alice"]
+        await ShadowRuntimeUser(id=1, name="alice", age=22).save()
+        await ShadowRuntimeUser(id=2, name="bob", age=17).save()
 
-    count = await ShadowRuntimeUser.where(lambda t: t.age >= 18).count()
-    assert count == 1
+        rows = await ShadowRuntimeUser.where(lambda t: t.age >= 18).all()
+        assert [row.name for row in rows] == ["alice"]
 
-    updated = await ShadowRuntimeUser.where(lambda t: t.name == "alice").update(age=23)
-    assert updated == 1
+        count = await ShadowRuntimeUser.where(lambda t: t.age >= 18).count()
+        assert count == 1
 
-    deleted = await ShadowRuntimeUser.where(lambda t: t.name == "bob").delete()
-    assert deleted == 1
+        updated = await ShadowRuntimeUser.where(lambda t: t.name == "alice").update(age=23)
+        assert updated == 1
+
+        deleted = await ShadowRuntimeUser.where(lambda t: t.name == "bob").delete()
+        assert deleted == 1

--- a/tests/test_sqlite_alembic_reconnect_hydration.py
+++ b/tests/test_sqlite_alembic_reconnect_hydration.py
@@ -68,8 +68,9 @@ async def _alembic_sqlite_db() -> AsyncIterator[tuple[str, Path]]:
 async def _reload_row[M: Model](model: type[M], uri: str, row_id: str) -> M:
     reset_engine()
     await ferro.connect(uri, auto_migrate=False)
-    row = await model.where(model.id == row_id).first()  # type: ignore[attr-defined]
-    assert row is not None
+    async with ferro.engines.session():
+        row = await model.where(model.id == row_id).first()  # type: ignore[attr-defined]
+        assert row is not None
     return row
 
 
@@ -93,7 +94,8 @@ async def test_null_optional_datetime_is_none_not_zero() -> None:
 
     async with _alembic_sqlite_db() as (uri, db_path):
         await ferro.connect(uri, auto_migrate=False)
-        created = await Client.create(name="Acme")
+        async with ferro.engines.session():
+            created = await Client.create(name="Acme")
         row = await _reload_row(Client, uri, created.id)
         raw, affinity = _sqlite_typeof(db_path, "client", "archived_at", created.id)
 
@@ -110,7 +112,8 @@ async def test_non_null_datetime_round_trips() -> None:
     async with _alembic_sqlite_db() as (uri, db_path):
         await ferro.connect(uri, auto_migrate=False)
         expected = datetime(2026, 4, 24, 18, 30, tzinfo=UTC)
-        created = await Event.create(happened_at=expected)
+        async with ferro.engines.session():
+            created = await Event.create(happened_at=expected)
         row = await _reload_row(Event, uri, created.id)
         _sqlite_typeof(db_path, "event", "happened_at", created.id)
 
@@ -126,7 +129,8 @@ async def test_non_null_date_round_trips() -> None:
     async with _alembic_sqlite_db() as (uri, db_path):
         await ferro.connect(uri, auto_migrate=False)
         expected = date(2026, 4, 24)
-        created = await Day.create(on_date=expected)
+        async with ferro.engines.session():
+            created = await Day.create(on_date=expected)
         row = await _reload_row(Day, uri, created.id)
         _sqlite_typeof(db_path, "day", "on_date", created.id)
 
@@ -152,7 +156,8 @@ async def test_decimal_round_trips(hours: Decimal, expected: Decimal) -> None:
 
     async with _alembic_sqlite_db() as (uri, db_path):
         await ferro.connect(uri, auto_migrate=False)
-        created = await Widget.create(hours=hours)
+        async with ferro.engines.session():
+            created = await Widget.create(hours=hours)
         row = await _reload_row(Widget, uri, created.id)
         raw, affinity = _sqlite_typeof(db_path, "widget", "hours", created.id)
 
@@ -194,7 +199,8 @@ async def test_optional_decimal_null_is_none() -> None:
 
     async with _alembic_sqlite_db() as (uri, db_path):
         await ferro.connect(uri, auto_migrate=False)
-        created = await Line.create()
+        async with ferro.engines.session():
+            created = await Line.create()
         row = await _reload_row(Line, uri, created.id)
         raw, _ = _sqlite_typeof(db_path, "line", "amount", created.id)
 
@@ -210,7 +216,8 @@ async def test_bool_round_trips() -> None:
 
     async with _alembic_sqlite_db() as (uri, db_path):
         await ferro.connect(uri, auto_migrate=False)
-        created = await Flag.create(is_active=True)
+        async with ferro.engines.session():
+            created = await Flag.create(is_active=True)
         row = await _reload_row(Flag, uri, created.id)
         raw, affinity = _sqlite_typeof(db_path, "flag", "is_active", created.id)
 
@@ -228,7 +235,8 @@ async def test_uuid_round_trips() -> None:
     token = uuid4()
     async with _alembic_sqlite_db() as (uri, db_path):
         await ferro.connect(uri, auto_migrate=False)
-        created = await Token.create(subject_id=token)
+        async with ferro.engines.session():
+            created = await Token.create(subject_id=token)
         row = await _reload_row(Token, uri, created.id)
         _sqlite_typeof(db_path, "token", "subject_id", created.id)
 
@@ -244,7 +252,8 @@ async def test_json_dict_round_trips() -> None:
     data = {"k": "v", "n": "2"}
     async with _alembic_sqlite_db() as (uri, db_path):
         await ferro.connect(uri, auto_migrate=False)
-        created = await Doc.create(payload=data)
+        async with ferro.engines.session():
+            created = await Doc.create(payload=data)
         row = await _reload_row(Doc, uri, created.id)
         raw, affinity = _sqlite_typeof(db_path, "doc", "payload", created.id)
 
@@ -263,7 +272,8 @@ async def test_non_null_int_zero_round_trips() -> None:
 
     async with _alembic_sqlite_db() as (uri, db_path):
         await ferro.connect(uri, auto_migrate=False)
-        created = await Counter.create(score=0)
+        async with ferro.engines.session():
+            created = await Counter.create(score=0)
         row = await _reload_row(Counter, uri, created.id)
         raw, affinity = _sqlite_typeof(db_path, "counter", "score", created.id)
 

--- a/tests/test_string_search.py
+++ b/tests/test_string_search.py
@@ -1,6 +1,6 @@
 import pytest
 from typing import Annotated
-from ferro import Model, connect, FerroField
+from ferro import Model, connect, FerroField, engines
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -14,14 +14,15 @@ async def test_like_search(db_url):
         name: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    await SearchableUser.create(name="Taylor")
-    await SearchableUser.create(name="Tyler")
+        await SearchableUser.create(name="Taylor")
+        await SearchableUser.create(name="Tyler")
 
-    # .like()
-    results = await SearchableUser.where(SearchableUser.name.like("Tay%")).all()
-    assert len(results) >= 1
-    assert any(r.name == "Taylor" for r in results)
+        # .like()
+        results = await SearchableUser.where(SearchableUser.name.like("Tay%")).all()
+        assert len(results) >= 1
+        assert any(r.name == "Taylor" for r in results)
 
 
 @pytest.mark.asyncio
@@ -33,20 +34,21 @@ async def test_in_helper(db_url):
         name: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    await SearchableUser.create(name="user1")
-    await SearchableUser.create(name="user2")
-    await SearchableUser.create(name="user3")
+        await SearchableUser.create(name="user1")
+        await SearchableUser.create(name="user2")
+        await SearchableUser.create(name="user3")
 
-    # Use .in_()
-    results = await SearchableUser.where(
-        SearchableUser.name.in_(["user1", "user3"])
-    ).all()
-    assert len(results) == 2
-    assert {r.name for r in results} == {"user1", "user3"}
+        # Use .in_()
+        results = await SearchableUser.where(
+            SearchableUser.name.in_(["user1", "user3"])
+        ).all()
+        assert len(results) == 2
+        assert {r.name for r in results} == {"user1", "user3"}
 
-    # Verify << still works
-    results_legacy = await SearchableUser.where(
-        SearchableUser.name << ["user1", "user3"]
-    ).all()
-    assert len(results_legacy) == 2
+        # Verify << still works
+        results_legacy = await SearchableUser.where(
+            SearchableUser.name << ["user1", "user3"]
+        ).all()
+        assert len(results_legacy) == 2

--- a/tests/test_structural_types.py
+++ b/tests/test_structural_types.py
@@ -6,6 +6,7 @@ from typing import Annotated, Dict, List
 
 from pydantic import BaseModel, Field
 
+import ferro
 from ferro import Model, connect, FerroField
 
 pytestmark = pytest.mark.backend_matrix
@@ -38,47 +39,48 @@ async def test_structural_types_roundtrip(db_url):
         balance: Decimal
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    uid = uuid.uuid4()
-    raw_data = b"hello world"
-    balance = Decimal("123.456")
+        uid = uuid.uuid4()
+        raw_data = b"hello world"
+        balance = Decimal("123.456")
 
-    item = await ComplexModel.create(
-        user_id=uid,
-        metadata={"key": "value"},
-        tags=["a", "b"],
-        role=UserRole.ADMIN,
-        data=raw_data,
-        balance=balance,
-    )
-    item_id = item.id
+        item = await ComplexModel.create(
+            user_id=uid,
+            metadata={"key": "value"},
+            tags=["a", "b"],
+            role=UserRole.ADMIN,
+            data=raw_data,
+            balance=balance,
+        )
+        item_id = item.id
 
-    # Force eviction from Identity Map to test database hydration
-    from ferro import evict_instance
+        # Force eviction from Identity Map to test database hydration
+        from ferro import evict_instance
 
-    evict_instance("ComplexModel", str(item_id))
+        evict_instance("ComplexModel", str(item_id))
 
-    fetched = await ComplexModel.get(item_id)
-    assert fetched is not None
+        fetched = await ComplexModel.get(item_id)
+        assert fetched is not None
 
-    # Assertions
-    assert isinstance(fetched.user_id, uuid.UUID)
-    assert fetched.user_id == uid
+        # Assertions
+        assert isinstance(fetched.user_id, uuid.UUID)
+        assert fetched.user_id == uid
 
-    assert isinstance(fetched.metadata, dict)
-    assert fetched.metadata == {"key": "value"}
+        assert isinstance(fetched.metadata, dict)
+        assert fetched.metadata == {"key": "value"}
 
-    assert isinstance(fetched.tags, list)
-    assert fetched.tags == ["a", "b"]
+        assert isinstance(fetched.tags, list)
+        assert fetched.tags == ["a", "b"]
 
-    assert isinstance(fetched.role, UserRole)
-    assert fetched.role == UserRole.ADMIN
+        assert isinstance(fetched.role, UserRole)
+        assert fetched.role == UserRole.ADMIN
 
-    assert isinstance(fetched.data, bytes)
-    assert fetched.data == raw_data
+        assert isinstance(fetched.data, bytes)
+        assert fetched.data == raw_data
 
-    assert isinstance(fetched.balance, Decimal)
-    assert fetched.balance == balance
+        assert isinstance(fetched.balance, Decimal)
+        assert fetched.balance == balance
 
 
 @pytest.mark.asyncio
@@ -94,30 +96,31 @@ async def test_json_column_list_of_nested_pydantic_models_roundtrip(db_url):
         items: list[JsonListItem] = Field(default_factory=list)
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    empty = await JsonListParent.create(items=[])
-    from ferro import evict_instance
+        empty = await JsonListParent.create(items=[])
+        from ferro import evict_instance
 
-    evict_instance("JsonListParent", str(empty.id))
-    fetched_empty = await JsonListParent.get(empty.id)
-    assert fetched_empty is not None
-    assert fetched_empty.items == []
+        evict_instance("JsonListParent", str(empty.id))
+        fetched_empty = await JsonListParent.get(empty.id)
+        assert fetched_empty is not None
+        assert fetched_empty.items == []
 
-    payload = [
-        JsonListItem(field_a="x", field_b=1),
-        JsonListItem(field_a="y", field_b=2),
-    ]
-    row = await JsonListParent.create(items=payload)
-    assert all(isinstance(it, JsonListItem) for it in row.items)
-    evict_instance("JsonListParent", str(row.id))
-    fetched = await JsonListParent.get(row.id)
-    assert fetched is not None
-    assert isinstance(fetched.items, list)
-    assert len(fetched.items) == 2
-    assert all(isinstance(it, dict) for it in fetched.items)
-    assert fetched.items == [p.model_dump() for p in payload]
-    revived = [JsonListItem.model_validate(it) for it in fetched.items]
-    assert revived == payload
+        payload = [
+            JsonListItem(field_a="x", field_b=1),
+            JsonListItem(field_a="y", field_b=2),
+        ]
+        row = await JsonListParent.create(items=payload)
+        assert all(isinstance(it, JsonListItem) for it in row.items)
+        evict_instance("JsonListParent", str(row.id))
+        fetched = await JsonListParent.get(row.id)
+        assert fetched is not None
+        assert isinstance(fetched.items, list)
+        assert len(fetched.items) == 2
+        assert all(isinstance(it, dict) for it in fetched.items)
+        assert fetched.items == [p.model_dump() for p in payload]
+        revived = [JsonListItem.model_validate(it) for it in fetched.items]
+        assert revived == payload
 
 
 @pytest.mark.asyncio
@@ -130,22 +133,23 @@ async def test_structural_filtering(db_url):
         balance: Decimal
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    uid1 = uuid.uuid4()
-    uid2 = uuid.uuid4()
+        uid1 = uuid.uuid4()
+        uid2 = uuid.uuid4()
 
-    await ComplexModel.create(user_id=uid1, balance=Decimal("10.0"))
-    await ComplexModel.create(user_id=uid2, balance=Decimal("20.0"))
+        await ComplexModel.create(user_id=uid1, balance=Decimal("10.0"))
+        await ComplexModel.create(user_id=uid2, balance=Decimal("20.0"))
 
-    # Filter by UUID
-    res = await ComplexModel.where(ComplexModel.user_id == uid1).first()
-    assert res is not None
-    assert res.user_id == uid1
+        # Filter by UUID
+        res = await ComplexModel.where(ComplexModel.user_id == uid1).first()
+        assert res is not None
+        assert res.user_id == uid1
 
-    # Filter by Decimal
-    res = await ComplexModel.where(ComplexModel.balance > Decimal("15.0")).first()
-    assert res is not None
-    assert res.balance == Decimal("20.0")
+        # Filter by Decimal
+        res = await ComplexModel.where(ComplexModel.balance > Decimal("15.0")).first()
+        assert res is not None
+        assert res.balance == Decimal("20.0")
 
 
 @pytest.mark.asyncio
@@ -157,17 +161,18 @@ async def test_uuid_in_filter_serializes_collection_values(db_url):
         user_id: uuid.UUID
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    uid1 = uuid.uuid4()
-    uid2 = uuid.uuid4()
-    uid3 = uuid.uuid4()
+        uid1 = uuid.uuid4()
+        uid2 = uuid.uuid4()
+        uid3 = uuid.uuid4()
 
-    await ComplexModel.create(user_id=uid1)
-    await ComplexModel.create(user_id=uid2)
-    await ComplexModel.create(user_id=uid3)
+        await ComplexModel.create(user_id=uid1)
+        await ComplexModel.create(user_id=uid2)
+        await ComplexModel.create(user_id=uid3)
 
-    results = await ComplexModel.where(ComplexModel.user_id << [uid1, uid3]).all()
-    assert {row.user_id for row in results} == {uid1, uid3}
+        results = await ComplexModel.where(ComplexModel.user_id << [uid1, uid3]).all()
+        assert {row.user_id for row in results} == {uid1, uid3}
 
 
 @pytest.mark.asyncio
@@ -180,25 +185,26 @@ async def test_uuid_filter_serializes_for_update_and_delete_queries(db_url):
         label: str
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    uid1 = uuid.uuid4()
-    uid2 = uuid.uuid4()
-    await UuidMutationModel.create(run_id=uid1, label="old")
-    await UuidMutationModel.create(run_id=uid2, label="keep")
+        uid1 = uuid.uuid4()
+        uid2 = uuid.uuid4()
+        await UuidMutationModel.create(run_id=uid1, label="old")
+        await UuidMutationModel.create(run_id=uid2, label="keep")
 
-    updated = await UuidMutationModel.where(
-        UuidMutationModel.run_id == uid1
-    ).update(label="new")
-    assert updated == 1
+        updated = await UuidMutationModel.where(
+            UuidMutationModel.run_id == uid1
+        ).update(label="new")
+        assert updated == 1
 
-    fetched = await UuidMutationModel.where(UuidMutationModel.run_id == uid1).first()
-    assert fetched is not None
-    assert fetched.label == "new"
+        fetched = await UuidMutationModel.where(UuidMutationModel.run_id == uid1).first()
+        assert fetched is not None
+        assert fetched.label == "new"
 
-    deleted = await UuidMutationModel.where(UuidMutationModel.run_id == uid1).delete()
-    assert deleted == 1
-    remaining = await UuidMutationModel.all()
-    assert [row.run_id for row in remaining] == [uid2]
+        deleted = await UuidMutationModel.where(UuidMutationModel.run_id == uid1).delete()
+        assert deleted == 1
+        remaining = await UuidMutationModel.all()
+        assert [row.run_id for row in remaining] == [uid2]
 
 
 @pytest.mark.asyncio
@@ -213,31 +219,32 @@ async def test_postgres_json_and_decimal_updates_keep_typed_hydration(db_url):
         balance: Decimal
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    row = await PgTypedMutation.create(
-        metadata={"old": "value"},
-        tags=["a"],
-        balance=Decimal("1.50"),
-    )
+        row = await PgTypedMutation.create(
+            metadata={"old": "value"},
+            tags=["a"],
+            balance=Decimal("1.50"),
+        )
 
-    updated = await PgTypedMutation.where(PgTypedMutation.id == row.id).update(
-        metadata={"new": "value"},
-        tags=["b", "c"],
-        balance=Decimal("2.75"),
-    )
-    assert updated == 1
+        updated = await PgTypedMutation.where(PgTypedMutation.id == row.id).update(
+            metadata={"new": "value"},
+            tags=["b", "c"],
+            balance=Decimal("2.75"),
+        )
+        assert updated == 1
 
-    fetched = await PgTypedMutation.get(row.id)
-    assert fetched is not None
-    assert fetched.metadata == {"new": "value"}
-    assert fetched.tags == ["b", "c"]
-    assert fetched.balance == Decimal("2.75")
+        fetched = await PgTypedMutation.get(row.id)
+        assert fetched is not None
+        assert fetched.metadata == {"new": "value"}
+        assert fetched.tags == ["b", "c"]
+        assert fetched.balance == Decimal("2.75")
 
-    filtered = await PgTypedMutation.where(
-        PgTypedMutation.balance > Decimal("2.00")
-    ).first()
-    assert filtered is not None
-    assert filtered.id == row.id
+        filtered = await PgTypedMutation.where(
+            PgTypedMutation.balance > Decimal("2.00")
+        ).first()
+        assert filtered is not None
+        assert filtered.id == row.id
 
 
 @pytest.mark.asyncio
@@ -270,10 +277,11 @@ async def test_native_postgres_enum_column_decodes_via_text_cast(
         conn.commit()
 
     await connect(db_url)
+    async with ferro.engines.session():
 
-    fetched = await Transcript.get(1)
-    assert fetched is not None
-    assert fetched.format == TranscriptFormat.PDF
+        fetched = await Transcript.get(1)
+        assert fetched is not None
+        assert fetched.format == TranscriptFormat.PDF
 
 
 @pytest.mark.asyncio
@@ -306,13 +314,14 @@ async def test_native_postgres_enum_where_lambda_count(db_url, postgres_base_url
         conn.commit()
 
     await connect(db_url, auto_migrate=False)
+    async with ferro.engines.session():
 
-    count = await Widget.where(lambda w, c=Color.RED: w.color == c).count()
-    assert count == 1
+        count = await Widget.where(lambda w, c=Color.RED: w.color == c).count()
+        assert count == 1
 
-    rows = await Widget.where(lambda w: w.color != Color.BLUE).all()
-    assert len(rows) == 1
-    assert rows[0].color == Color.RED
+        rows = await Widget.where(lambda w: w.color != Color.BLUE).all()
+        assert len(rows) == 1
+        assert rows[0].color == Color.RED
 
 
 @pytest.mark.asyncio
@@ -345,12 +354,13 @@ async def test_native_postgres_enum_plain_str_column(
         )
 
     await connect(db_url, auto_migrate=False)
+    async with ferro.engines.session():
 
-    row = await StrFieldEnumModel.create(status="active")
-    fetched = await StrFieldEnumModel.get(row.id)
+        row = await StrFieldEnumModel.create(status="active")
+        fetched = await StrFieldEnumModel.get(row.id)
 
-    assert fetched is not None
-    assert fetched.status == "active"
+        assert fetched is not None
+        assert fetched.status == "active"
 
 
 @pytest.mark.asyncio
@@ -379,15 +389,16 @@ async def test_native_uuid_null_inserts(
         conn.commit()
 
     await connect(db_url, auto_migrate=False)
+    async with ferro.engines.session():
 
-    row = await UuidRun.create()
-    assert row.id is not None
-    assert row.run_id is None
-    u = uuid.uuid4()
-    row2 = await UuidRun.create(run_id=u)
-    f2 = await UuidRun.get(row2.id)
-    assert f2 is not None
-    assert f2.run_id == u
+        row = await UuidRun.create()
+        assert row.id is not None
+        assert row.run_id is None
+        u = uuid.uuid4()
+        row2 = await UuidRun.create(run_id=u)
+        f2 = await UuidRun.get(row2.id)
+        assert f2 is not None
+        assert f2.run_id == u
 
 
 @pytest.mark.asyncio
@@ -418,11 +429,12 @@ async def test_native_timestamp_without_time_zone_null_and_value(
         conn.commit()
 
     await connect(db_url, auto_migrate=False)
+    async with ferro.engines.session():
 
-    row = await RowWithTs.create()
-    assert row.scrubbed_at is None
-    d = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
-    row2 = await RowWithTs.create(scrubbed_at=d)
-    f2 = await RowWithTs.get(row2.id)
-    assert f2 is not None
-    assert f2.scrubbed_at is not None
+        row = await RowWithTs.create()
+        assert row.scrubbed_at is None
+        d = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+        row2 = await RowWithTs.create(scrubbed_at=d)
+        f2 = await RowWithTs.get(row2.id)
+        assert f2 is not None
+        assert f2.scrubbed_at is not None

--- a/tests/test_temporal_types.py
+++ b/tests/test_temporal_types.py
@@ -1,7 +1,7 @@
 import pytest
 from datetime import datetime, date, timezone
 from typing import Annotated
-from ferro import Model, connect, FerroField
+from ferro import Model, connect, FerroField, engines
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -16,30 +16,31 @@ async def test_temporal_types_roundtrip(db_url):
         day: date
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    # Create fixed timestamps (stripping microseconds for SQLite TEXT comparison stability)
-    now = datetime.now(timezone.utc).replace(microsecond=0)
-    today = date.today()
+        # Create fixed timestamps (stripping microseconds for SQLite TEXT comparison stability)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        today = date.today()
 
-    item = await TemporalModel.create(occurred_at=now, day=today)
-    item_id = item.id
+        item = await TemporalModel.create(occurred_at=now, day=today)
+        item_id = item.id
 
-    # Force eviction from Identity Map to test database hydration
-    from ferro import evict_instance
+        # Force eviction from Identity Map to test database hydration
+        from ferro import evict_instance
 
-    evict_instance("TemporalModel", str(item_id))
+        evict_instance("TemporalModel", str(item_id))
 
-    fetched = await TemporalModel.get(item_id)
-    assert fetched is not None
+        fetched = await TemporalModel.get(item_id)
+        assert fetched is not None
 
-    # Assertions: Pydantic should have converted the stored strings back to objects
-    assert isinstance(fetched.occurred_at, datetime)
-    assert isinstance(fetched.day, date)
+        # Assertions: Pydantic should have converted the stored strings back to objects
+        assert isinstance(fetched.occurred_at, datetime)
+        assert isinstance(fetched.day, date)
 
-    # Values should match (within precision)
-    # Note: SQLite stores as ISO strings, Pydantic parses them back.
-    assert fetched.occurred_at.isoformat() == now.isoformat()
-    assert fetched.day == today
+        # Values should match (within precision)
+        # Note: SQLite stores as ISO strings, Pydantic parses them back.
+        assert fetched.occurred_at.isoformat() == now.isoformat()
+        assert fetched.day == today
 
 
 @pytest.mark.asyncio
@@ -51,21 +52,24 @@ async def test_temporal_filtering(db_url):
         occurred_at: datetime
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    past = datetime(2020, 1, 1, tzinfo=timezone.utc)
-    future = datetime(2030, 1, 1, tzinfo=timezone.utc)
+        past = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        future = datetime(2030, 1, 1, tzinfo=timezone.utc)
 
-    await TemporalModel.create(occurred_at=past)
-    await TemporalModel.create(occurred_at=future)
+        await TemporalModel.create(occurred_at=past)
+        await TemporalModel.create(occurred_at=future)
 
-    now = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        now = datetime(2025, 1, 1, tzinfo=timezone.utc)
 
-    # Filter for future events
-    future_events = await TemporalModel.where(TemporalModel.occurred_at > now).all()
-    assert len(future_events) == 1
-    assert future_events[0].occurred_at.year == 2030
+        # Filter for future events
+        future_events = await TemporalModel.where(
+            TemporalModel.occurred_at > now
+        ).all()
+        assert len(future_events) == 1
+        assert future_events[0].occurred_at.year == 2030
 
-    # Filter for past events
-    past_events = await TemporalModel.where(TemporalModel.occurred_at < now).all()
-    assert len(past_events) == 1
-    assert past_events[0].occurred_at.year == 2020
+        # Filter for past events
+        past_events = await TemporalModel.where(TemporalModel.occurred_at < now).all()
+        assert len(past_events) == 1
+        assert past_events[0].occurred_at.year == 2020

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -11,6 +11,7 @@ from ferro import (
     Model,
     Relation,
     connect,
+    engines,
     evict_instance,
     execute,
     transaction,
@@ -70,39 +71,40 @@ async def test_relationships_loaded_inside_transaction_inherit_transaction(db_ur
         courses: Relation[list[TxRelationCourse]] = ManyToMany(related_name="students")
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    parent = await TxRelationParent.create(id=1, label="parent")
-    await TxRelationChild.create(id=1, label="child", parent=parent)
-    student = await TxRelationStudent.create(id=1, label="student")
-    course_a = await TxRelationCourse.create(id=1, label="course-a")
-    course_b = await TxRelationCourse.create(id=2, label="course-b")
-    await student.courses.add(course_a)
+        parent = await TxRelationParent.create(id=1, label="parent")
+        await TxRelationChild.create(id=1, label="child", parent=parent)
+        student = await TxRelationStudent.create(id=1, label="student")
+        course_a = await TxRelationCourse.create(id=1, label="course-a")
+        course_b = await TxRelationCourse.create(id=2, label="course-b")
+        await student.courses.add(course_a)
 
-    evict_instance("TxRelationParent", "1")
-    evict_instance("TxRelationChild", "1")
-    evict_instance("TxRelationStudent", "1")
+        evict_instance("TxRelationParent", "1")
+        evict_instance("TxRelationChild", "1")
+        evict_instance("TxRelationStudent", "1")
 
-    async with transaction():
-        loaded_parent = await TxRelationParent.get(1)
-        assert loaded_parent is not None
-        children = await loaded_parent.children.all()
-        assert [child.label for child in children] == ["child"]
+        async with transaction():
+            loaded_parent = await TxRelationParent.get(1)
+            assert loaded_parent is not None
+            children = await loaded_parent.children.all()
+            assert [child.label for child in children] == ["child"]
 
-        loaded_child = await TxRelationChild.get(1)
-        assert loaded_child is not None
-        loaded_child_parent = await loaded_child.parent
-        assert loaded_child_parent.label == "parent"
+            loaded_child = await TxRelationChild.get(1)
+            assert loaded_child is not None
+            loaded_child_parent = await loaded_child.parent
+            assert loaded_child_parent.label == "parent"
 
-        loaded_student = await TxRelationStudent.get(1)
-        assert loaded_student is not None
-        courses = await loaded_student.courses.all()
-        assert [course.label for course in courses] == ["course-a"]
-        await loaded_student.courses.add(course_b)
+            loaded_student = await TxRelationStudent.get(1)
+            assert loaded_student is not None
+            courses = await loaded_student.courses.all()
+            assert [course.label for course in courses] == ["course-a"]
+            await loaded_student.courses.add(course_b)
 
-    reloaded_student = await TxRelationStudent.get(1)
-    assert reloaded_student is not None
-    courses = await reloaded_student.courses.order_by(TxRelationCourse.id).all()
-    assert [course.label for course in courses] == ["course-a", "course-b"]
+        reloaded_student = await TxRelationStudent.get(1)
+        assert reloaded_student is not None
+        courses = await reloaded_student.courses.order_by(TxRelationCourse.id).all()
+        assert [course.label for course in courses] == ["course-a", "course-b"]
 
 
 @pytest.mark.asyncio
@@ -114,28 +116,29 @@ async def test_instance_methods_loaded_inside_transaction_inherit_transaction(db
         username: str
 
     await connect(db_url, auto_migrate=True)
-    created = await TxInstanceMethodUser.create(id=1, username="before")
-    evict_instance("TxInstanceMethodUser", str(created.id))
+    async with engines.session():
+        created = await TxInstanceMethodUser.create(id=1, username="before")
+        evict_instance("TxInstanceMethodUser", str(created.id))
 
-    async with transaction():
-        loaded = await TxInstanceMethodUser.get(1)
-        assert loaded is not None
+        async with transaction():
+            loaded = await TxInstanceMethodUser.get(1)
+            assert loaded is not None
 
-        loaded.username = "saved"
-        await loaded.save()
+            loaded.username = "saved"
+            await loaded.save()
 
-        placeholder_sql = (
-            "UPDATE txinstancemethoduser SET username = $1 WHERE id = $2"
-            if db_url.startswith(("postgres://", "postgresql://"))
-            else "UPDATE txinstancemethoduser SET username = ? WHERE id = ?"
-        )
-        await execute(placeholder_sql, "refreshed", 1)
-        await loaded.refresh()
-        assert loaded.username == "refreshed"
+            placeholder_sql = (
+                "UPDATE txinstancemethoduser SET username = $1 WHERE id = $2"
+                if db_url.startswith(("postgres://", "postgresql://"))
+                else "UPDATE txinstancemethoduser SET username = ? WHERE id = ?"
+            )
+            await execute(placeholder_sql, "refreshed", 1)
+            await loaded.refresh()
+            assert loaded.username == "refreshed"
 
-        await loaded.delete()
+            await loaded.delete()
 
-    assert await TxInstanceMethodUser.get_or_none(1) is None
+        assert await TxInstanceMethodUser.get_or_none(1) is None
 
 
 @pytest.mark.asyncio
@@ -157,7 +160,8 @@ async def test_instance_methods_loaded_inside_named_transaction_keep_identity_sc
     await create_tables()
     await create_tables(using="service")
 
-    await TxNamedInstanceMethodUser.create(id=1, username="app")
+    async with engines.session():
+        await TxNamedInstanceMethodUser.create(id=1, username="app")
     await TxNamedInstanceMethodUser.using("service").create(id=1, username="service")
     evict_instance("TxNamedInstanceMethodUser", "1")
     evict_instance("TxNamedInstanceMethodUser", "1", using="service")
@@ -176,7 +180,8 @@ async def test_instance_methods_loaded_inside_named_transaction_keep_identity_sc
         await loaded.refresh()
         assert loaded.username == "service-refreshed"
 
-    app_row = await TxNamedInstanceMethodUser.get(1)
+    async with engines.session():
+        app_row = await TxNamedInstanceMethodUser.get(1)
     service_row = await TxNamedInstanceMethodUser.using("service").get(1)
 
     assert app_row is not None
@@ -204,7 +209,8 @@ async def test_matching_explicit_using_inside_named_transaction_is_allowed(tmp_p
 
     await create_tables()
     await create_tables(using="service")
-    await TxMatchingUsingUser.create(id=1, username="app")
+    async with engines.session():
+        await TxMatchingUsingUser.create(id=1, username="app")
     await TxMatchingUsingUser.using("service").create(id=1, username="service")
     evict_instance("TxMatchingUsingUser", "1")
     evict_instance("TxMatchingUsingUser", "1", using="service")
@@ -220,7 +226,8 @@ async def test_matching_explicit_using_inside_named_transaction_is_allowed(tmp_p
         with pytest.raises(ValueError, match="inherit the transaction connection"):
             await TxMatchingUsingUser.using("app").get(1)
 
-    app_row = await TxMatchingUsingUser.get(1)
+    async with engines.session():
+        app_row = await TxMatchingUsingUser.get(1)
     service_row = await TxMatchingUsingUser.using("service").get(1)
 
     assert app_row is not None
@@ -238,14 +245,15 @@ async def test_transaction_commit(db_url):
         username: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    async with transaction():
-        await TxUser.create(username="alice")
-        await TxUser.create(username="bob")
+        async with transaction():
+            await TxUser.create(username="alice")
+            await TxUser.create(username="bob")
 
-    # Verify both exist
-    assert await TxUser.where(TxUser.username == "alice").exists()
-    assert await TxUser.where(TxUser.username == "bob").exists()
+        # Verify both exist
+        assert await TxUser.where(TxUser.username == "alice").exists()
+        assert await TxUser.where(TxUser.username == "bob").exists()
 
 
 @pytest.mark.asyncio
@@ -257,16 +265,17 @@ async def test_transaction_rollback(db_url):
         username: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    try:
-        async with transaction():
-            await TxUser.create(username="charlie")
-            raise ValueError("Something went wrong!")
-    except ValueError:
-        pass
+        try:
+            async with transaction():
+                await TxUser.create(username="charlie")
+                raise ValueError("Something went wrong!")
+        except ValueError:
+            pass
 
-    # Verify charlie DOES NOT exist
-    assert not await TxUser.where(TxUser.username == "charlie").exists()
+        # Verify charlie DOES NOT exist
+        assert not await TxUser.where(TxUser.username == "charlie").exists()
 
 
 @pytest.mark.asyncio
@@ -278,34 +287,35 @@ async def test_transaction_atomicity(db_url):
         username: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    # Create initial user
-    await TxUser.create(username="dave")
+        # Create initial user
+        await TxUser.create(username="dave")
 
-    try:
-        async with transaction():
-            # Update dave
-            dave = await TxUser.where(TxUser.username == "dave").first()
-            dave.username = "dave_updated"
-            await dave.save()
+        try:
+            async with transaction():
+                # Update dave
+                dave = await TxUser.where(TxUser.username == "dave").first()
+                dave.username = "dave_updated"
+                await dave.save()
 
-            # Create eve
-            await TxUser.create(username="eve")
+                # Create eve
+                await TxUser.create(username="eve")
 
-            # Trigger failure
-            raise RuntimeError("Abort!")
-    except RuntimeError:
-        pass
+                # Trigger failure
+                raise RuntimeError("Abort!")
+        except RuntimeError:
+            pass
 
-    # dave should still be "dave", eve should not exist
-    from ferro import evict_instance
+        # dave should still be "dave", eve should not exist
+        from ferro import evict_instance
 
-    evict_instance("TxUser", "1")
+        evict_instance("TxUser", "1")
 
-    dave_check = await TxUser.where(TxUser.username == "dave").first()
-    assert dave_check is not None
-    assert dave_check.username == "dave"
-    assert not await TxUser.where(TxUser.username == "eve").exists()
+        dave_check = await TxUser.where(TxUser.username == "dave").first()
+        assert dave_check is not None
+        assert dave_check.username == "dave"
+        assert not await TxUser.where(TxUser.username == "eve").exists()
 
 
 @pytest.mark.asyncio
@@ -317,20 +327,21 @@ async def test_nested_transaction_rolls_back_with_outer(db_url):
         username: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    try:
-        async with transaction():
-            await TxUser.create(username="outer")
-
+        try:
             async with transaction():
-                await TxUser.create(username="inner")
+                await TxUser.create(username="outer")
 
-            raise RuntimeError("abort outer")
-    except RuntimeError:
-        pass
+                async with transaction():
+                    await TxUser.create(username="inner")
 
-    assert not await TxUser.where(TxUser.username == "outer").exists()
-    assert not await TxUser.where(TxUser.username == "inner").exists()
+                raise RuntimeError("abort outer")
+        except RuntimeError:
+            pass
+
+        assert not await TxUser.where(TxUser.username == "outer").exists()
+        assert not await TxUser.where(TxUser.username == "inner").exists()
 
 
 @pytest.mark.asyncio
@@ -342,19 +353,20 @@ async def test_bulk_create_participates_in_transaction(db_url):
         username: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    rows = [TxUser(username="bulk_a"), TxUser(username="bulk_b")]
+        rows = [TxUser(username="bulk_a"), TxUser(username="bulk_b")]
 
-    try:
-        async with transaction():
-            inserted = await TxUser.bulk_create(rows)
-            assert inserted == 2
-            raise RuntimeError("abort bulk transaction")
-    except RuntimeError:
-        pass
+        try:
+            async with transaction():
+                inserted = await TxUser.bulk_create(rows)
+                assert inserted == 2
+                raise RuntimeError("abort bulk transaction")
+        except RuntimeError:
+            pass
 
-    assert not await TxUser.where(TxUser.username == "bulk_a").exists()
-    assert not await TxUser.where(TxUser.username == "bulk_b").exists()
+        assert not await TxUser.where(TxUser.username == "bulk_a").exists()
+        assert not await TxUser.where(TxUser.username == "bulk_b").exists()
 
 
 @pytest.mark.asyncio
@@ -366,19 +378,20 @@ async def test_nested_transaction_inner_rollback_allows_outer_commit(db_url):
         username: str
 
     await connect(db_url, auto_migrate=True)
+    async with engines.session():
 
-    async with transaction():
-        await TxUser.create(username="outer_before")
+        async with transaction():
+            await TxUser.create(username="outer_before")
 
-        try:
-            async with transaction():
-                await TxUser.create(username="inner")
-                raise ValueError("abort inner")
-        except ValueError:
-            pass
+            try:
+                async with transaction():
+                    await TxUser.create(username="inner")
+                    raise ValueError("abort inner")
+            except ValueError:
+                pass
 
-        await TxUser.create(username="outer_after")
+            await TxUser.create(username="outer_after")
 
-    assert await TxUser.where(TxUser.username == "outer_before").exists()
-    assert await TxUser.where(TxUser.username == "outer_after").exists()
-    assert not await TxUser.where(TxUser.username == "inner").exists()
+        assert await TxUser.where(TxUser.username == "outer_before").exists()
+        assert await TxUser.where(TxUser.username == "outer_after").exists()
+        assert not await TxUser.where(TxUser.username == "inner").exists()

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -163,7 +163,9 @@ async def test_instance_methods_loaded_inside_named_transaction_keep_identity_sc
     async with engines.session():
         await TxNamedInstanceMethodUser.create(id=1, username="app")
     await TxNamedInstanceMethodUser.using("service").create(id=1, username="service")
-    evict_instance("TxNamedInstanceMethodUser", "1")
+    # No implicit default-connection route (FF-D D3/D4): each evict is scoped
+    # to the connection it targets.
+    evict_instance("TxNamedInstanceMethodUser", "1", using="app")
     evict_instance("TxNamedInstanceMethodUser", "1", using="service")
 
     async with transaction(using="service"):
@@ -212,7 +214,9 @@ async def test_matching_explicit_using_inside_named_transaction_is_allowed(tmp_p
     async with engines.session():
         await TxMatchingUsingUser.create(id=1, username="app")
     await TxMatchingUsingUser.using("service").create(id=1, username="service")
-    evict_instance("TxMatchingUsingUser", "1")
+    # No implicit default-connection route (FF-D D3/D4): each evict is scoped
+    # to the connection it targets.
+    evict_instance("TxMatchingUsingUser", "1", using="app")
     evict_instance("TxMatchingUsingUser", "1", using="service")
 
     async with transaction(using="service"):

--- a/tests/test_typed_null_binds.py
+++ b/tests/test_typed_null_binds.py
@@ -27,6 +27,7 @@ from typing import Annotated, Any
 import pytest
 from pydantic import Field
 
+import ferro
 from ferro import FerroField, Model, connect
 
 
@@ -46,21 +47,22 @@ async def test_insert_with_none_for_each_nullable_primitive(db_url):
         blob: bytes | None = None
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    row = await Mixed.create()
-    assert row.id is not None
-    assert row.count is None
-    assert row.active is None
-    assert row.ratio is None
-    assert row.name is None
-    assert row.blob is None
+        row = await Mixed.create()
+        assert row.id is not None
+        assert row.count is None
+        assert row.active is None
+        assert row.ratio is None
+        assert row.name is None
+        assert row.blob is None
 
-    fetched = await Mixed.get(row.id)
-    assert fetched is not None
-    assert fetched.count is None
-    assert fetched.active is None
-    assert fetched.ratio is None
-    assert fetched.name is None
+        fetched = await Mixed.get(row.id)
+        assert fetched is not None
+        assert fetched.count is None
+        assert fetched.active is None
+        assert fetched.ratio is None
+        assert fetched.name is None
 
 
 @pytest.mark.asyncio
@@ -76,14 +78,15 @@ async def test_insert_with_value_round_trips_for_each_type(db_url):
         name: str | None = None
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    row = await Mixed.create(count=42, active=True, ratio=3.14, name="ferro")
-    fetched = await Mixed.get(row.id)
-    assert fetched is not None
-    assert fetched.count == 42
-    assert fetched.active is True
-    assert fetched.ratio == pytest.approx(3.14)
-    assert fetched.name == "ferro"
+        row = await Mixed.create(count=42, active=True, ratio=3.14, name="ferro")
+        fetched = await Mixed.get(row.id)
+        assert fetched is not None
+        assert fetched.count == 42
+        assert fetched.active is True
+        assert fetched.ratio == pytest.approx(3.14)
+        assert fetched.name == "ferro"
 
 
 @pytest.mark.asyncio
@@ -100,17 +103,18 @@ async def test_insert_with_none_for_uuid(db_url):
         run_id: uuid.UUID | None = None
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    null_row = await WithUuid.create()
-    fetched_null = await WithUuid.get(null_row.id)
-    assert fetched_null is not None
-    assert fetched_null.run_id is None
+        null_row = await WithUuid.create()
+        fetched_null = await WithUuid.get(null_row.id)
+        assert fetched_null is not None
+        assert fetched_null.run_id is None
 
-    u = uuid.uuid4()
-    set_row = await WithUuid.create(run_id=u)
-    fetched_set = await WithUuid.get(set_row.id)
-    assert fetched_set is not None
-    assert fetched_set.run_id == u
+        u = uuid.uuid4()
+        set_row = await WithUuid.create(run_id=u)
+        fetched_set = await WithUuid.get(set_row.id)
+        assert fetched_set is not None
+        assert fetched_set.run_id == u
 
 
 @pytest.mark.asyncio
@@ -135,14 +139,15 @@ async def test_uuid_pk_round_trips_through_bind_layer(db_url):
         )
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    target = uuid.uuid4()
-    created = await UuidPk.create(id=target)
-    assert created.id == target
+        target = uuid.uuid4()
+        created = await UuidPk.create(id=target)
+        assert created.id == target
 
-    fetched = await UuidPk.get(target)
-    assert fetched is not None
-    assert fetched.id == target
+        fetched = await UuidPk.get(target)
+        assert fetched is not None
+        assert fetched.id == target
 
 
 @pytest.mark.asyncio
@@ -162,17 +167,18 @@ async def test_uuid_pk_filter_by_string_does_not_send_text(db_url):
         name: str | None = None
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    target = uuid.uuid4()
-    await UuidProfile.create(id=target, name="alice")
+        target = uuid.uuid4()
+        await UuidProfile.create(id=target, name="alice")
 
-    matched_str = await UuidProfile.where(UuidProfile.id == str(target)).first()
-    assert matched_str is not None
-    assert matched_str.name == "alice"
+        matched_str = await UuidProfile.where(UuidProfile.id == str(target)).first()
+        assert matched_str is not None
+        assert matched_str.name == "alice"
 
-    matched_uuid = await UuidProfile.where(UuidProfile.id == target).first()
-    assert matched_uuid is not None
-    assert matched_uuid.name == "alice"
+        matched_uuid = await UuidProfile.where(UuidProfile.id == target).first()
+        assert matched_uuid is not None
+        assert matched_uuid.name == "alice"
 
 
 @pytest.mark.asyncio
@@ -185,11 +191,12 @@ async def test_insert_with_none_for_decimal(db_url):
         amount: Decimal | None = None
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    null_row = await WithDecimal.create()
-    fetched = await WithDecimal.get(null_row.id)
-    assert fetched is not None
-    assert fetched.amount is None
+        null_row = await WithDecimal.create()
+        fetched = await WithDecimal.get(null_row.id)
+        assert fetched is not None
+        assert fetched.amount is None
 
 
 @pytest.mark.asyncio
@@ -209,10 +216,11 @@ async def test_issue_38_exact_regression(db_url):
         bench_level: int | None = None
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    row = await Scorecard.create()
-    assert row.id is not None
-    assert row.bench_level is None
+        row = await Scorecard.create()
+        assert row.id is not None
+        assert row.bench_level is None
 
 
 @pytest.mark.asyncio
@@ -236,18 +244,19 @@ async def test_update_to_none_succeeds_on_postgres(db_url):
         name: str | None = None
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    row = await Mixed.create(count=99, active=True, name="initial")
-    updated = await Mixed.where(Mixed.id == row.id).update(
-        count=None, active=None, name=None
-    )
-    assert updated == 1
+        row = await Mixed.create(count=99, active=True, name="initial")
+        updated = await Mixed.where(Mixed.id == row.id).update(
+            count=None, active=None, name=None
+        )
+        assert updated == 1
 
-    fetched = await Mixed.get(row.id)
-    assert fetched is not None
-    assert fetched.count is None
-    assert fetched.active is None
-    assert fetched.name is None
+        fetched = await Mixed.get(row.id)
+        assert fetched is not None
+        assert fetched.count is None
+        assert fetched.active is None
+        assert fetched.name is None
 
 
 @pytest.mark.asyncio
@@ -266,10 +275,11 @@ async def test_update_to_none_executes_without_error(db_url):
         count: int | None = None
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    row = await Mixed.create(count=99)
-    updated = await Mixed.where(Mixed.id == row.id).update(count=None)
-    assert updated == 1
+        row = await Mixed.create(count=99)
+        updated = await Mixed.where(Mixed.id == row.id).update(count=None)
+        assert updated == 1
 
 
 @pytest.mark.asyncio
@@ -285,17 +295,18 @@ async def test_filter_by_none_does_not_reproduce_38(db_url):
         count: int | None = None
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    with_value = await Filterable.create(count=1)
-    null_row = await Filterable.create()  # count = None
+        with_value = await Filterable.create(count=1)
+        null_row = await Filterable.create()  # count = None
 
-    matched_null = await Filterable.where(Filterable.count == None).all()  # noqa: E711
-    assert len(matched_null) == 1
-    assert matched_null[0].id == null_row.id
+        matched_null = await Filterable.where(Filterable.count == None).all()  # noqa: E711
+        assert len(matched_null) == 1
+        assert matched_null[0].id == null_row.id
 
-    matched_non_null = await Filterable.where(Filterable.count != None).all()  # noqa: E711
-    assert len(matched_non_null) == 1
-    assert matched_non_null[0].id == with_value.id
+        matched_non_null = await Filterable.where(Filterable.count != None).all()  # noqa: E711
+        assert len(matched_non_null) == 1
+        assert matched_non_null[0].id == with_value.id
 
 
 @pytest.mark.asyncio
@@ -313,30 +324,31 @@ async def test_lambda_predicate_null_filter_datetime_and_json(db_url):
         payload: list[Any] | None = None
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    null_dt = await Pending.create(name="null-dt", attached_at=None, payload=[{"x": 1}])
-    null_json = await Pending.create(name="null-json", attached_at=datetime.now(UTC))
-    with_values = await Pending.create(
-        name="set",
-        attached_at=datetime.now(UTC),
-        payload=[{"x": 2}],
-    )
+        null_dt = await Pending.create(name="null-dt", attached_at=None, payload=[{"x": 1}])
+        null_json = await Pending.create(name="null-json", attached_at=datetime.now(UTC))
+        with_values = await Pending.create(
+            name="set",
+            attached_at=datetime.now(UTC),
+            payload=[{"x": 2}],
+        )
 
-    matched_dt_null = await Pending.where(lambda t: t.attached_at == None).all()  # noqa: E711
-    assert len(matched_dt_null) == 1
-    assert matched_dt_null[0].id == null_dt.id
+        matched_dt_null = await Pending.where(lambda t: t.attached_at == None).all()  # noqa: E711
+        assert len(matched_dt_null) == 1
+        assert matched_dt_null[0].id == null_dt.id
 
-    matched_json_null = await Pending.where(lambda t: t.payload == None).all()  # noqa: E711
-    assert len(matched_json_null) == 1
-    assert matched_json_null[0].id == null_json.id
+        matched_json_null = await Pending.where(lambda t: t.payload == None).all()  # noqa: E711
+        assert len(matched_json_null) == 1
+        assert matched_json_null[0].id == null_json.id
 
-    matched_dt_set = await Pending.where(lambda t: t.attached_at != None).all()  # noqa: E711
-    assert len(matched_dt_set) == 2
-    assert {r.id for r in matched_dt_set} == {null_json.id, with_values.id}
+        matched_dt_set = await Pending.where(lambda t: t.attached_at != None).all()  # noqa: E711
+        assert len(matched_dt_set) == 2
+        assert {r.id for r in matched_dt_set} == {null_json.id, with_values.id}
 
-    matched_json_set = await Pending.where(lambda t: t.payload != None).all()  # noqa: E711
-    assert len(matched_json_set) == 2
-    assert {r.id for r in matched_json_set} == {null_dt.id, with_values.id}
+        matched_json_set = await Pending.where(lambda t: t.payload != None).all()  # noqa: E711
+        assert len(matched_json_set) == 2
+        assert {r.id for r in matched_json_set} == {null_dt.id, with_values.id}
 
 
 @pytest.mark.asyncio
@@ -355,16 +367,17 @@ async def test_invalid_uuid_raises_pyvalueerror_or_pydantic_error(db_url):
         run_id: uuid.UUID | None = None
 
     await connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    with pytest.raises((ValueError, TypeError)) as exc_info:
-        await WithUuid.create(run_id="not-a-uuid")
+        with pytest.raises((ValueError, TypeError)) as exc_info:
+            await WithUuid.create(run_id="not-a-uuid")
 
-    msg = str(exc_info.value)
-    if "Invalid UUID for" in msg:
-        # Rust-core diagnostic shape (U5)
-        assert "withuuid" in msg.lower() or "WithUuid" in msg
-        assert "run_id" in msg
-        assert "not-a-uuid" in msg
+        msg = str(exc_info.value)
+        if "Invalid UUID for" in msg:
+            # Rust-core diagnostic shape (U5)
+            assert "withuuid" in msg.lower() or "WithUuid" in msg
+            assert "run_id" in msg
+            assert "not-a-uuid" in msg
 
 
 @pytest.mark.asyncio
@@ -375,13 +388,14 @@ async def test_temporal_update_to_none_uses_unified_codec_path(db_url):
         attached_at: datetime | None = None
 
     await connect(db_url, auto_migrate=True)
-    row = await TemporalUpdate.create(attached_at=datetime.now(UTC))
-    updated = await TemporalUpdate.where(TemporalUpdate.id == row.id).update(attached_at=None)
-    assert updated == 1
+    async with ferro.engines.session():
+        row = await TemporalUpdate.create(attached_at=datetime.now(UTC))
+        updated = await TemporalUpdate.where(TemporalUpdate.id == row.id).update(attached_at=None)
+        assert updated == 1
 
-    fetched = await TemporalUpdate.get(row.id)
-    assert fetched is not None
-    assert fetched.attached_at is None
+        fetched = await TemporalUpdate.get(row.id)
+        assert fetched is not None
+        assert fetched.attached_at is None
 
 
 @pytest.mark.asyncio
@@ -396,12 +410,13 @@ async def test_nullable_enum_null_and_value_roundtrip(db_url):
         state: RunState | None = None
 
     await connect(db_url, auto_migrate=True)
-    null_row = await EnumNullRow.create()
-    set_row = await EnumNullRow.create(state=RunState.READY)
+    async with ferro.engines.session():
+        null_row = await EnumNullRow.create()
+        set_row = await EnumNullRow.create(state=RunState.READY)
 
-    fetched_null = await EnumNullRow.get(null_row.id)
-    fetched_set = await EnumNullRow.get(set_row.id)
-    assert fetched_null is not None
-    assert fetched_set is not None
-    assert fetched_null.state is None
-    assert fetched_set.state == RunState.READY
+        fetched_null = await EnumNullRow.get(null_row.id)
+        fetched_set = await EnumNullRow.get(set_row.id)
+        assert fetched_null is not None
+        assert fetched_set is not None
+        assert fetched_null.state is None
+        assert fetched_set.state == RunState.READY

--- a/tests/test_typed_save_bind.py
+++ b/tests/test_typed_save_bind.py
@@ -36,12 +36,13 @@ async def test_save_roundtrips_binary(db_url, payload):
         data: bytes = b""
 
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    doc = SaveDoc(id=uuid4(), data=payload)
-    await doc.save()
-    got = (await SaveDoc.all())[0].data
-    assert isinstance(got, bytes)
-    assert got == payload
+        doc = SaveDoc(id=uuid4(), data=payload)
+        await doc.save()
+        got = (await SaveDoc.all())[0].data
+        assert isinstance(got, bytes)
+        assert got == payload
 
 
 @pytest.mark.asyncio
@@ -51,10 +52,11 @@ async def test_save_nullable_bytes_roundtrips_none(db_url):
         blob: bytes | None = None
 
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    doc = SaveNullDoc(id=uuid4(), blob=None)
-    await doc.save()
-    assert (await SaveNullDoc.all())[0].blob is None
+        doc = SaveNullDoc(id=uuid4(), blob=None)
+        await doc.save()
+        assert (await SaveNullDoc.all())[0].blob is None
 
 
 @pytest.mark.asyncio
@@ -70,24 +72,25 @@ async def test_save_preserves_rich_types(db_url):
         note: str | None = None
 
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    uid = uuid4()
-    when = datetime.datetime(2026, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)
-    amount = decimal.Decimal("12.34")
-    rec = SaveRec(
-        id=uuid4(), uid=uid, when=when, amount=amount,
-        count=7, active=True, tags=["a", "b"],
-    )
-    await rec.save()
+        uid = uuid4()
+        when = datetime.datetime(2026, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)
+        amount = decimal.Decimal("12.34")
+        rec = SaveRec(
+            id=uuid4(), uid=uid, when=when, amount=amount,
+            count=7, active=True, tags=["a", "b"],
+        )
+        await rec.save()
 
-    got = (await SaveRec.all())[0]
-    assert got.uid == uid
-    assert got.amount == amount
-    assert got.count == 7
-    assert got.active is True
-    assert got.tags == ["a", "b"]
-    assert got.note is None
-    assert got.when == when
+        got = (await SaveRec.all())[0]
+        assert got.uid == uid
+        assert got.amount == amount
+        assert got.count == 7
+        assert got.active is True
+        assert got.tags == ["a", "b"]
+        assert got.note is None
+        assert got.when == when
 
 
 @pytest.mark.parametrize(
@@ -103,14 +106,15 @@ async def test_update_roundtrips_binary(db_url, payload):
         data: bytes = b""
 
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    doc = UpdDoc(id=uuid4(), name="x", data=b"seed")
-    await doc.save()
-    n = await UpdDoc.where(lambda d: d.name == "x").update(data=payload)
-    assert n == 1
-    got = (await UpdDoc.where(lambda d: d.name == "x").all())[0].data
-    assert isinstance(got, bytes)
-    assert got == payload
+        doc = UpdDoc(id=uuid4(), name="x", data=b"seed")
+        await doc.save()
+        n = await UpdDoc.where(lambda d: d.name == "x").update(data=payload)
+        assert n == 1
+        got = (await UpdDoc.where(lambda d: d.name == "x").all())[0].data
+        assert isinstance(got, bytes)
+        assert got == payload
 
 
 @pytest.mark.asyncio
@@ -121,15 +125,16 @@ async def test_update_preserves_rich_types(db_url):
         count: int = 0
 
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    rid = uuid4()
-    await UpdRec(id=rid, amount=decimal.Decimal("1.00"), count=1).save()
-    await UpdRec.where(lambda r: r.id == rid).update(
-        amount=decimal.Decimal("99.99"), count=42
-    )
-    got = (await UpdRec.all())[0]
-    assert got.amount == decimal.Decimal("99.99")
-    assert got.count == 42
+        rid = uuid4()
+        await UpdRec(id=rid, amount=decimal.Decimal("1.00"), count=1).save()
+        await UpdRec.where(lambda r: r.id == rid).update(
+            amount=decimal.Decimal("99.99"), count=42
+        )
+        got = (await UpdRec.all())[0]
+        assert got.amount == decimal.Decimal("99.99")
+        assert got.count == 42
 
 
 @pytest.mark.asyncio
@@ -139,13 +144,14 @@ async def test_bulk_create_roundtrips_binary(db_url):
         data: bytes = b""
 
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    docs = [BulkDoc(id=uuid4(), data=v) for v in BINARY_VECTORS]
-    n = await BulkDoc.bulk_create(docs)
-    assert n == len(BINARY_VECTORS)
+        docs = [BulkDoc(id=uuid4(), data=v) for v in BINARY_VECTORS]
+        n = await BulkDoc.bulk_create(docs)
+        assert n == len(BINARY_VECTORS)
 
-    stored = {bytes(d.data) for d in await BulkDoc.all()}
-    assert stored == {bytes(v) for v in BINARY_VECTORS}
+        stored = {bytes(d.data) for d in await BulkDoc.all()}
+        assert stored == {bytes(v) for v in BINARY_VECTORS}
 
 
 @pytest.mark.asyncio
@@ -155,13 +161,14 @@ async def test_bulk_create_preserves_rich_types(db_url):
         amount: decimal.Decimal = decimal.Decimal("0")
 
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    await BulkRec.bulk_create([
-        BulkRec(id=uuid4(), amount=decimal.Decimal("1.11")),
-        BulkRec(id=uuid4(), amount=decimal.Decimal("2.22")),
-    ])
-    amounts = sorted(r.amount for r in await BulkRec.all())
-    assert amounts == [decimal.Decimal("1.11"), decimal.Decimal("2.22")]
+        await BulkRec.bulk_create([
+            BulkRec(id=uuid4(), amount=decimal.Decimal("1.11")),
+            BulkRec(id=uuid4(), amount=decimal.Decimal("2.22")),
+        ])
+        amounts = sorted(r.amount for r in await BulkRec.all())
+        assert amounts == [decimal.Decimal("1.11"), decimal.Decimal("2.22")]
 
 
 @pytest.mark.asyncio
@@ -171,18 +178,19 @@ async def test_update_unbindable_value_raises_clear_typeerror(db_url):
         name: str = ""
 
     await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
 
-    rid = uuid4()
-    await FloorDoc(id=rid, name="x").save()
+        rid = uuid4()
+        await FloorDoc(id=rid, name="x").save()
 
-    import pydantic_core
+        import pydantic_core
 
-    # Use an object() — genuinely unbindable (pydantic_core.to_json rejects it with
-    # PydanticSerializationError; a raw set is silently coerced to a list by to_json
-    # and would not trigger the error floor).
-    with pytest.raises((TypeError, pydantic_core.PydanticSerializationError)) as exc:
-        await FloorDoc.where(lambda d: d.id == rid).update(name=object())
-    # Whichever layer rejects it, the message must not be an opaque deep-DB error.
-    # pydantic_core says "Unable to serialize unknown type" — clear, not a DB error.
-    msg = str(exc.value).lower()
-    assert "serialize" in msg or "type" in msg or "name" in msg
+        # Use an object() — genuinely unbindable (pydantic_core.to_json rejects it with
+        # PydanticSerializationError; a raw set is silently coerced to a list by to_json
+        # and would not trigger the error floor).
+        with pytest.raises((TypeError, pydantic_core.PydanticSerializationError)) as exc:
+            await FloorDoc.where(lambda d: d.id == rid).update(name=object())
+        # Whichever layer rejects it, the message must not be an opaque deep-DB error.
+        # pydantic_core says "Unable to serialize unknown type" — clear, not a DB error.
+        msg = str(exc.value).lower()
+        assert "serialize" in msg or "type" in msg or "name" in msg


### PR DESCRIPTION
Closes Epic FF-D (findings **F3**, **F13**). Design: `docs/plans/2026-07-02-005-ff-d-identity-routing-design.md` · Plan: `docs/plans/2026-07-02-006-ff-d-identity-routing-plan.md`.

## Memory bound — the identity map never keeps an instance alive (D1a, F3)

Map values are now `weakref.ref` objects (was: strong `Py<PyAny>` for the life of the process). Deterministic proof in `tests/test_identity_memory.py`:

- drop the last user reference → `weakref` dies (`ref() is None`) and the next fetch hydrates fresh;
- scan 20k rows 3× in one session, dropping results each pass → `identity_map_len(session) < 100` after GC.

Dead entries are pruned on lookup and by an amortized sweep (every 1024 tracked ops). A class that can't be weakly referenced fails **loudly** (`TypeError` at insert + metaclass guard at class definition) — never a silent strong-ref fallback.

## Stale reads are gone, identity preserved (D1b, F3)

Fetch-hits used to *discard* the freshly decoded row and return the cached (stale) instance. Now the decoded row is written into the cached instance through the **same materialization path as fresh hydration** (`apply_decoded_fields`), and `__pydantic_fields_set__` is reset identically. Proof in `tests/test_identity_refresh.py`: external `UPDATE` + re-fetch → fresh values with `a is b` preserved.

Semantics, stated plainly: **the database wins** — a re-fetch overwrites unsaved local mutations (documented in `docs/pages/concepts/identity-map.md`). `fetch_one`'s pre-query cache short-circuit is deleted: the identity map is a dedup structure, not a query cache; every fetch reads the database.

## Routing: one handle, resolved once (D3, F13)

The stringly `(tx_id, using, session_id)` triple — threaded through 18 FFI signatures and re-derived per operation in Rust — is replaced by a frozen `RouteHandle` pyclass (`tx_id`, non-optional `connection_name`, `session_id`) resolved **exactly once** in `resolve_operation_scope`. `active_route_for_operation` / `active_engine_for_connection` / `get_transaction_route` are deleted; Rust consumes the handle via one `route_engine` map-lookup.

Grep-verified by `tests/test_route_single_site.py`: `RouteHandle(` constructions exist only in `src/ferro/state.py`; the re-derivation helpers appear nowhere.

## Scoped invalidation + global map deleted (D2, F3)

- Transaction rollback evicts the affected **session's** map (was: `IDENTITY_MAP.clear()` — everything, process-wide).
- Bulk `update()`/`delete()` evict per **model** within the session; unrelated cached instances survive (`tests/test_identity_scoped_invalidation.py`).
- The global `IDENTITY_MAP`/`IDENTITY_MAP_OPS` statics and their clear sites (`reset_engine`, `migrate`) are **deleted**, not kept as a fallback. Grep gate: zero hits in `src/` and `crates/`.

## The sessionless path (breaking, decided in design review)

Identity is a **session** feature — the session is the only honest bound on the map's lifetime:

- `using="name"` without a session **still works**, but with **no identity map**: fresh instances every load, nothing cached, nothing to go stale, no cross-call `a is b`.
- **No route at all** (no session, no `using=`) now raises `RuntimeError` — this lands the ambient default-connection removal (deprecated since v0.12, announced for **v0.14**) **one minor early, in v0.13**. Deliberate and accepted; the migration guide carries the note.
- **D4:** explicit `using=` that conflicts with the ambient session raises `ValueError` (was: silent bypass onto the global map). An instance's origin connection participates in the same conflict check.

## D5 — `Model.__init__` FK extraction

Relationship inputs now read the **target** model's PK field (was: the source model's PK name applied to the target — correct only while every PK was named `id`). Test with a target whose PK ≠ `id` in `tests/test_fk_target_pk.py`.

## Verification

- Full matrix (sqlite + postgres): **1071 passed, 11 skipped, 1 xfailed, 0 failed**
- `cargo test`: crates 52+3, root (`--no-default-features --features testing`) 142 — green
- Shadow-strict (`FERRO_SHADOW_RUNTIME=1` + `_STRICT=1`) over touched suites: 39 passed, no mismatch
- Grep gates: `IDENTITY_MAP` 0 · `allow_legacy_default` 0 · `RouteHandle(` outside `state.py` 0
- 39 test files + docs examples migrated to explicit `engines.session()` blocks (the same migration users will perform)

## Notes for reviewers

- `Model.get()` on a cached row now always queries (correctness over the old memoization fast-path).
- Post-merge follow-ups (from final review): test for target model with no declared PK; direct tombstone/sweep assertion; regression test for X-origin instance saved inside a transaction on Y.
