### PR TITLE
feat: compile ModelCodecPlan from SchemaIR at registration

### DIFF
--- a/crates/ferro-ddl-lowering/src/lib.rs
+++ b/crates/ferro-ddl-lowering/src/lib.rs
@@ -342,8 +342,29 @@ pub fn canonical_from_schema_column(
     col: &SchemaColumn,
     dialect: Dialect,
 ) -> Result<CanonicalType, String> {
-    canonical_from_parts(&col.logical_type, col.format.as_deref(), col.db_type.as_deref().unwrap_or(""), dialect)
-        .map_err(|reason| format!("unresolvable type on column '{}': {reason}", col.name))
+    canonical_from_parts(
+        &col.logical_type,
+        col.format.as_deref(),
+        col.db_type.as_deref().unwrap_or(""),
+        dialect,
+    )
+    .map_err(|reason| format!("unresolvable type on column '{}': {reason}", col.name))
+}
+
+/// Resolve a [`SchemaColumn`] to its logical codec type — the Python-facing
+/// value family — without applying an explicit `db_type` override. Storage may
+/// legally widen away from this family (e.g. UUID stored as `text`); the
+/// logical canonical preserves bind/decode shapes.
+pub fn logical_canonical_from_schema_column(
+    col: &SchemaColumn,
+    dialect: Dialect,
+) -> Result<CanonicalType, String> {
+    canonical_from_parts(&col.logical_type, col.format.as_deref(), "", dialect).map_err(|reason| {
+        format!(
+            "unresolvable logical type on column '{}': {reason}",
+            col.name
+        )
+    })
 }
 
 /// A column's fully resolved storage: either a scalar [`CanonicalType`] or a
@@ -1074,6 +1095,55 @@ mod tests {
         assert_eq!(canonical_from_parts("integer", None, "", Dialect::Sqlite), Ok(CanonicalType::Integer));
         // unknown is an error (CREATE path maps this to Varchar at its call site)
         assert!(canonical_from_parts("mystery", None, "", Dialect::Postgres).is_err());
+    }
+
+    #[test]
+    fn logical_canonical_from_schema_column_ignores_explicit_db_type() {
+        let col = SchemaColumn {
+            name: "external_id".to_string(),
+            logical_type: "uuid".to_string(),
+            db_type: Some("text".to_string()),
+            db_type_explicit: Some(true),
+            nullable: false,
+            primary_key: false,
+            autoincrement: false,
+            unique: false,
+            index: false,
+            default: None,
+            format: Some("uuid".to_string()),
+            enum_values: None,
+            enum_type_name: None,
+            postgres_native_enum: false,
+        };
+        assert_eq!(
+            logical_canonical_from_schema_column(&col, Dialect::Postgres),
+            Ok(CanonicalType::Uuid)
+        );
+        assert_eq!(
+            canonical_from_schema_column(&col, Dialect::Postgres),
+            Ok(CanonicalType::Text)
+        );
+    }
+
+    #[test]
+    fn logical_canonical_from_schema_column_errors_on_unknown() {
+        let col = SchemaColumn {
+            name: "mystery".to_string(),
+            logical_type: "bogus".to_string(),
+            db_type: None,
+            db_type_explicit: None,
+            nullable: true,
+            primary_key: false,
+            autoincrement: false,
+            unique: false,
+            index: false,
+            default: None,
+            format: None,
+            enum_values: None,
+            enum_type_name: None,
+            postgres_native_enum: false,
+        };
+        assert!(logical_canonical_from_schema_column(&col, Dialect::Postgres).is_err());
     }
 
     #[test]

--- a/src/codec_plan.rs
+++ b/src/codec_plan.rs
@@ -3,7 +3,8 @@
 //! Every per-column type decision is made **once per model per schema epoch**
 //! (at registration) instead of per value per row. Both facets of a column
 //! come from the FF-B derived-type decision table
-//! (`ferro_ddl_lowering::resolve_column_storage` / `canonical_from_parts`):
+//! (`ferro_ddl_lowering::resolve_column_storage` /
+//! `logical_canonical_from_schema_column`):
 //!
 //! - the **storage** token (`db_type`) — what the DDL emitters create, the
 //!   codec↔DDL consistency witness;
@@ -17,13 +18,12 @@
 //! is the runtime producer pinned by the golden vector
 //! `tests/fixtures/ir_vectors/codec_registry_core_v1.json`.
 
-use ferro_ddl_lowering::{
-    CanonicalType, ResolvedStorage, canonical_from_parts, canonical_to_db_type_token,
-    enum_label_strings,
-};
-use crate::schema::{json_schema_logical_type, property_json_type_and_format, resolve_column_storage_json};
 use crate::state::Dialect;
-use ferro_schema_ir::{CodecBindRule, CodecFetchRule, CodecIrPayload, HydrationAbi};
+use ferro_ddl_lowering::{
+    CanonicalType, ResolvedStorage, canonical_to_db_type_token, enum_label_strings,
+    logical_canonical_from_schema_column, resolve_column_storage,
+};
+use ferro_schema_ir::{CodecBindRule, CodecFetchRule, CodecIrPayload, HydrationAbi, SchemaColumn};
 use std::collections::HashMap;
 
 /// Storage decision for an enum-typed column.
@@ -60,7 +60,7 @@ pub enum ColumnCodec {
         values: Vec<String>,
         storage: EnumStorage,
         /// Enum member values are integers (`IntEnum`) — drives integer-typed
-        /// binds and typed NULLs, mirroring the schema's `type: "integer"`.
+        /// binds and typed NULLs, mirroring SchemaIR `logical_type: "integer"`.
         int_valued: bool,
     },
 }
@@ -94,9 +94,9 @@ impl ModelCodecPlan {
         self.columns.get(col_name)
     }
 
-    /// Compile a model's enriched Pydantic JSON schema into a codec plan.
+    /// Compile a model's SchemaIR columns into a codec plan.
     ///
-    /// Storage resolves through `resolve_column_storage_json` at the Postgres
+    /// Storage resolves through `resolve_column_storage` at the Postgres
     /// dialect — the dialect that preserves the most type information
     /// (Boolean, Uuid, native enums). The plan itself is dialect-agnostic;
     /// dialect-specific behavior (SQLite bool-as-int, etc.) stays a
@@ -104,57 +104,26 @@ impl ModelCodecPlan {
     /// type family, storage refines width (`int` + `db_type="bigint"` →
     /// `BigInt`); when an explicit `db_type` crosses families (UUID stored as
     /// text), the logical codec wins so Python value shapes are preserved.
-    pub fn compile(schema: &serde_json::Value) -> ModelCodecPlan {
-        let mut columns = HashMap::new();
-        if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
-            for (col_name, raw_col) in properties {
-                let resolved = resolve_ref(schema, raw_col);
-                let storage =
-                    resolve_column_storage_json(col_name, raw_col, resolved, Dialect::Postgres);
-                columns.insert(
-                    col_name.clone(),
-                    compile_column(raw_col, resolved, &storage),
-                );
-            }
+    pub fn compile_from_columns(columns: &[SchemaColumn]) -> Result<ModelCodecPlan, String> {
+        let mut map = HashMap::new();
+        for col in columns {
+            map.insert(col.name.clone(), compile_column_from_ir(col)?);
         }
-        ModelCodecPlan { columns }
+        Ok(ModelCodecPlan { columns: map })
     }
 }
 
-fn resolve_ref<'a>(
-    schema: &'a serde_json::Value,
-    col_info: &'a serde_json::Value,
-) -> &'a serde_json::Value {
-    if let Some(ref_path) = col_info.get("$ref").and_then(|r| r.as_str())
-        && let Some(def_name) = ref_path.strip_prefix("#/$defs/")
-        && let Some(def) = schema.get("$defs").and_then(|defs| defs.get(def_name))
-    {
-        return def;
-    }
-    col_info
-}
-
-fn compile_column(
-    raw_col: &serde_json::Value,
-    resolved: &serde_json::Value,
-    storage: &ResolvedStorage,
-) -> ColumnCodecEntry {
-    let db_type = match storage {
+fn compile_column_from_ir(col: &SchemaColumn) -> Result<ColumnCodecEntry, String> {
+    let storage = resolve_column_storage(col, Dialect::Postgres)?;
+    let db_type = match &storage {
         ResolvedStorage::Scalar(canonical) => {
             canonical_to_db_type_token(*canonical, Dialect::Postgres)
         }
         ResolvedStorage::PgEnum { type_name, .. } => type_name.clone(),
     };
 
-    let (json_type, format) = property_json_type_and_format(resolved);
-
-    let enum_values = resolved
-        .get("enum")
-        .or_else(|| raw_col.get("enum"))
-        .and_then(|v| v.as_array())
-        .filter(|v| !v.is_empty());
-    if let Some(values) = enum_values {
-        let enum_storage = match storage {
+    if let Some(values) = col.enum_values.as_ref().filter(|v| !v.is_empty()) {
+        let enum_storage = match &storage {
             ResolvedStorage::PgEnum { type_name, .. } => EnumStorage::PgNative {
                 type_name: type_name.clone(),
             },
@@ -163,28 +132,25 @@ fn compile_column(
                 _ => EnumStorage::Text,
             },
         };
-        return ColumnCodecEntry {
+        return Ok(ColumnCodecEntry {
             codec: ColumnCodec::Enum {
                 values: enum_label_strings(values),
                 storage: enum_storage,
-                int_valued: json_type == Some("integer"),
+                int_valued: col.logical_type == "integer",
             },
             db_type,
-        };
+        });
     }
-    // Logical side: JSON Schema → domain token, without the explicit `db_type`
-    // override (storage may widen away from the logical family, e.g. UUID as text).
-    let logical_type = json_schema_logical_type(json_type.unwrap_or(""), format);
-    let logical = canonical_from_parts(logical_type, None, "", Dialect::Postgres)
-        .unwrap_or(CanonicalType::Varchar(None));
-    let canonical = match storage {
+
+    let logical = logical_canonical_from_schema_column(col, Dialect::Postgres)?;
+    let canonical = match &storage {
         ResolvedStorage::Scalar(c) if type_family(*c) == type_family(logical) => *c,
         _ => logical,
     };
-    ColumnCodecEntry {
+    Ok(ColumnCodecEntry {
         codec: scalar_codec(canonical),
         db_type,
-    }
+    })
 }
 
 #[derive(PartialEq, Eq)]
@@ -394,6 +360,50 @@ mod tests {
     use ferro_schema_ir::IrEnvelope;
     use serde_json::json;
 
+    fn ir_col(name: &str, logical_type: &str) -> SchemaColumn {
+        SchemaColumn {
+            name: name.to_string(),
+            logical_type: logical_type.to_string(),
+            db_type: None,
+            db_type_explicit: None,
+            nullable: true,
+            primary_key: false,
+            autoincrement: false,
+            unique: false,
+            index: false,
+            default: None,
+            format: None,
+            enum_values: None,
+            enum_type_name: None,
+            postgres_native_enum: false,
+        }
+    }
+
+    fn ir_col_format(name: &str, logical_type: &str, format: &str) -> SchemaColumn {
+        SchemaColumn {
+            format: Some(format.to_string()),
+            ..ir_col(name, logical_type)
+        }
+    }
+
+    fn ir_col_db_type(
+        name: &str,
+        logical_type: &str,
+        db_type: &str,
+        format: Option<&str>,
+    ) -> SchemaColumn {
+        SchemaColumn {
+            db_type: Some(db_type.to_string()),
+            db_type_explicit: Some(true),
+            format: format.map(str::to_string),
+            ..ir_col(name, logical_type)
+        }
+    }
+
+    fn plan_for_columns(columns: Vec<SchemaColumn>) -> ModelCodecPlan {
+        ModelCodecPlan::compile_from_columns(&columns).expect("test columns should compile")
+    }
+
     /// The golden vector pins the RUNTIME rule table: every rule in
     /// `codec_registry_core_v1.json` must appear byte-identically in
     /// [`runtime_codec_ir_payload`] (which is a superset), and the hydration
@@ -434,37 +444,22 @@ mod tests {
         }
     }
 
-    fn plan_for(properties: serde_json::Value) -> ModelCodecPlan {
-        ModelCodecPlan::compile(&json!({ "properties": properties }))
-    }
-
     /// F5: a `pattern=` constraint must never change a column's codec.
     #[test]
     fn numeric_pattern_str_field_compiles_to_str() {
-        let plan = plan_for(json!({
-            "year_code": {"type": "string", "pattern": "^\\d{4}$"},
-            "serial": {"anyOf": [
-                {"type": "string", "pattern": "^\\d{6}$"},
-                {"type": "null"}
-            ]}
-        }));
+        let plan = plan_for_columns(vec![
+            ir_col("serial", "string"),
+            ir_col("year_code", "string"),
+        ]);
         assert_eq!(plan.codec("year_code"), Some(&ColumnCodec::Str));
         assert_eq!(plan.codec("serial"), Some(&ColumnCodec::Str));
         assert_eq!(plan.entry("year_code").unwrap().db_type, "varchar");
     }
 
-    /// Real Decimal fields are recognized by the enriched `format: "decimal"`.
+    /// Real Decimal fields are recognized by SchemaIR `logical_type: "decimal"`.
     #[test]
     fn decimal_format_compiles_to_decimal() {
-        let plan = plan_for(json!({
-            "amount": {
-                "anyOf": [
-                    {"type": "number"},
-                    {"type": "string", "pattern": "^-?\\d+(\\.\\d+)?$"}
-                ],
-                "format": "decimal"
-            }
-        }));
+        let plan = plan_for_columns(vec![ir_col("amount", "decimal")]);
         assert_eq!(plan.codec("amount"), Some(&ColumnCodec::Decimal));
         assert_eq!(plan.entry("amount").unwrap().db_type, "numeric");
     }
@@ -474,9 +469,12 @@ mod tests {
     /// witnesses the DDL decision.
     #[test]
     fn uuid_stored_as_text_keeps_uuid_codec_with_text_storage() {
-        let plan = plan_for(json!({
-            "external_id": {"type": "string", "format": "uuid", "db_type": "text"}
-        }));
+        let plan = plan_for_columns(vec![ir_col_db_type(
+            "external_id",
+            "uuid",
+            "text",
+            Some("uuid"),
+        )]);
         let entry = plan.entry("external_id").unwrap();
         assert_eq!(entry.codec, ColumnCodec::Uuid);
         assert_eq!(entry.db_type, "text");
@@ -485,9 +483,7 @@ mod tests {
     /// Same-family explicit tokens refine width instead.
     #[test]
     fn same_family_db_type_refines_width() {
-        let plan = plan_for(json!({
-            "value": {"type": "integer", "db_type": "bigint"}
-        }));
+        let plan = plan_for_columns(vec![ir_col_db_type("value", "integer", "bigint", None)]);
         let entry = plan.entry("value").unwrap();
         assert_eq!(entry.codec, ColumnCodec::BigInt);
         assert_eq!(entry.db_type, "bigint");
@@ -495,14 +491,19 @@ mod tests {
 
     #[test]
     fn enum_columns_capture_values_storage_and_int_valuedness() {
-        let plan = plan_for(json!({
-            "status": {
-                "enum": ["active", "archived"],
-                "type": "string",
-                "enum_type_name": "docstatus"
+        let plan = plan_for_columns(vec![
+            SchemaColumn {
+                enum_values: Some(vec![json!("active"), json!("archived")]),
+                enum_type_name: Some("docstatus".to_string()),
+                ..ir_col("status", "string")
             },
-            "priority": {"enum": [1, 2], "type": "integer", "db_type": "smallint"}
-        }));
+            SchemaColumn {
+                enum_values: Some(vec![json!(1), json!(2)]),
+                db_type: Some("smallint".to_string()),
+                db_type_explicit: Some(true),
+                ..ir_col("priority", "integer")
+            },
+        ]);
         assert_eq!(
             plan.codec("status"),
             Some(&ColumnCodec::Enum {
@@ -527,19 +528,24 @@ mod tests {
     /// including the temporal/uuid/json formats.
     #[test]
     fn derived_families_match_ddl_cascade() {
-        let plan = plan_for(json!({
-            "id": {"type": "integer", "primary_key": true},
-            "name": {"type": "string"},
-            "ratio": {"type": "number"},
-            "active": {"type": "boolean"},
-            "payload": {"type": "object"},
-            "tags": {"type": "array"},
-            "data": {"type": "string", "format": "binary"},
-            "uid": {"type": "string", "format": "uuid"},
-            "created": {"type": "string", "format": "date-time"},
-            "day": {"type": "string", "format": "date"},
-            "at": {"type": "string", "format": "time"}
-        }));
+        let plan = plan_for_columns(vec![
+            SchemaColumn {
+                primary_key: true,
+                autoincrement: true,
+                nullable: false,
+                ..ir_col("id", "integer")
+            },
+            ir_col("name", "string"),
+            ir_col("ratio", "number"),
+            ir_col("active", "boolean"),
+            ir_col("payload", "json"),
+            ir_col("tags", "json"),
+            ir_col_format("data", "binary", "binary"),
+            ir_col_format("uid", "uuid", "uuid"),
+            ir_col_format("created", "datetime", "date-time"),
+            ir_col_format("day", "date", "date"),
+            ir_col_format("at", "time", "time"),
+        ]);
         for (col, codec) in [
             ("id", ColumnCodec::Int),
             ("name", ColumnCodec::Str),
@@ -557,17 +563,19 @@ mod tests {
         }
     }
 
-    /// Nullable `date` with explicit `db_type` (anyOf union shape) must hydrate
-    /// as `datetime.date`, not raw ISO strings.
+    /// Nullable `date` with explicit `db_type` must hydrate as `datetime.date`.
     #[test]
     fn explicit_db_type_date_anyof_uses_date_codec() {
-        let plan = plan_for(json!({
-            "paid_date": {
-                "anyOf": [{"type": "string", "format": "date"}, {"type": "null"}],
-                "db_type": "date",
-            }
-        }));
+        let plan = plan_for_columns(vec![ir_col_db_type("paid_date", "date", "date", Some("date"))]);
         assert_eq!(plan.codec("paid_date"), Some(&ColumnCodec::Date));
+    }
+
+    #[test]
+    fn unknown_logical_type_fails_at_compile_time() {
+        let err = ModelCodecPlan::compile_from_columns(&[ir_col("mystery", "bogus")])
+            .expect_err("unknown logical_type must fail");
+        assert!(err.contains("mystery"));
+        assert!(err.contains("bogus"));
     }
 
     /// The schema epoch: re-registering a model rebuilds its plan atomically.
@@ -578,14 +586,18 @@ mod tests {
             json!({
                 "properties": {"v": {"type": "integer"}}
             }),
+            vec![ir_col("v", "integer")],
             "epochmodel".to_string(),
-        );
+        )
+        .expect("first registration");
         let second = crate::state::RegisteredModel::new(
             json!({
                 "properties": {"v": {"type": "string"}}
             }),
+            vec![ir_col("v", "string")],
             "epochmodel".to_string(),
-        );
+        )
+        .expect("second registration");
         {
             let mut registry = crate::state::MODEL_REGISTRY.write().unwrap();
             registry.insert(name.clone(), first);

--- a/src/ferro/ir/__init__.py
+++ b/src/ferro/ir/__init__.py
@@ -3,11 +3,13 @@
 from .compiler import (
     compile_model_schema_ir,
     compile_registry_schema_ir,
+    register_model_with_ir,
     schema_ir_fingerprint,
 )
 
 __all__ = [
     "compile_model_schema_ir",
     "compile_registry_schema_ir",
+    "register_model_with_ir",
     "schema_ir_fingerprint",
 ]

--- a/src/ferro/ir/compiler.py
+++ b/src/ferro/ir/compiler.py
@@ -19,6 +19,7 @@ from .._core import (
     _ddl_fk_name,
     _ddl_single_index_name,
     _ddl_single_unique_name,
+    register_model_schema,
 )
 from ..schema_metadata import build_model_schema
 from ..state import (
@@ -370,6 +371,34 @@ def compile_schema_ir_payload(
     return {"dialect_agnostic": True, "models": [model_payload]}
 
 
+def _persist_schema_ir_envelope(model_name: str, envelope: dict[str, Any]) -> None:
+    """Store one model's compiled SchemaIR envelope and fingerprint."""
+    _SCHEMA_IR_BY_MODEL[model_name] = envelope
+    _SCHEMA_IR_FINGERPRINT_BY_MODEL[model_name] = _fingerprint(envelope)
+
+
+def register_model_with_ir(
+    model_name: str,
+    schema: dict[str, Any],
+    table_name: str,
+) -> dict[str, Any]:
+    """Compile SchemaIR once, register Rust state, and persist the envelope.
+
+    Single registration bundle for metaclass, relationship resolution, join
+    tables, and ``Model._reregister_ferro`` (#236).
+    """
+    payload = compile_schema_ir_payload(model_name, schema, table_name=table_name)
+    register_model_schema(
+        model_name,
+        json.dumps(schema),
+        json.dumps(payload["models"][0]["columns"]),
+        table_name,
+    )
+    envelope = wrap_schema_ir(payload)
+    _persist_schema_ir_envelope(model_name, envelope)
+    return envelope
+
+
 def wrap_schema_ir(payload: dict[str, Any]) -> dict[str, Any]:
     """Wrap a SchemaIR payload with the standard IR envelope fields."""
     return {
@@ -401,8 +430,7 @@ def compile_model_schema_ir(
         table_name=getattr(model_cls, "__ferro_table__", None),
     )
     envelope = wrap_schema_ir(payload)
-    _SCHEMA_IR_BY_MODEL[model_name] = envelope
-    _SCHEMA_IR_FINGERPRINT_BY_MODEL[model_name] = _fingerprint(envelope)
+    _persist_schema_ir_envelope(model_name, envelope)
     return envelope
 
 

--- a/src/ferro/metaclass.py
+++ b/src/ferro/metaclass.py
@@ -1,4 +1,3 @@
-import json
 import re
 import types
 from enum import Enum
@@ -22,11 +21,10 @@ from ._annotation_utils import (
     is_closed_domain_annotation,
     is_valid_db_type_token,
 )
-from ._core import register_model_schema
 from ._shadow_fk_types import shadow_annotation_for_foreign_key
 from .base import FerroField, ForeignKey, ManyToManyRelation
 from .fields import FERRO_FIELD_EXTRA_KEY
-from .ir import compile_model_schema_ir
+from .ir import register_model_with_ir
 from .query import Relation
 from .relations.descriptors import ForwardDescriptor
 from .schema_metadata import _enum_subclass_from_annotation, build_model_schema
@@ -629,7 +627,6 @@ class ModelMetaclass(type(BaseModel)):
 
             if schema:
                 setattr(cls, "__ferro_schema__", schema)
-                register_model_schema(name, json.dumps(schema), cls.__ferro_table__)
-                compile_model_schema_ir(name, cls, schema=schema)
+                register_model_with_ir(name, schema, cls.__ferro_table__)
         except Exception as e:
             raise RuntimeError(f"Ferro failed to register model '{name}': {e}")

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -211,10 +211,10 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         """Re-register this model's schema with the Rust core (e.g. after clear_registry)."""
         schema = getattr(cls, "__ferro_schema__", None)
         if schema is not None:
-            from ._core import register_model_schema
+            from .ir import register_model_with_ir
 
-            register_model_schema(
-                cls.__ferro_identity__, json.dumps(schema), cls.__ferro_table__
+            register_model_with_ir(
+                cls.__ferro_identity__, schema, cls.__ferro_table__
             )
 
     model_config = ConfigDict(

--- a/src/ferro/relations/__init__.py
+++ b/src/ferro/relations/__init__.py
@@ -1,7 +1,7 @@
 import json
 from typing import ForwardRef
 
-from .._core import register_model_schema
+from ..ir import register_model_with_ir
 from .._shadow_fk_types import (
     pk_python_type_for_model,
     reconcile_shadow_fk_types,
@@ -148,7 +148,7 @@ def resolve_relationships():
             }
             if rel.reverse_index:
                 join_schema["ferro_composite_indexes"] = [[target_col, source_col]]
-            register_model_schema(join_table, json.dumps(join_schema), join_table)
+            register_model_with_ir(join_table, join_schema, join_table)
             _JOIN_TABLE_REGISTRY[join_table] = join_schema
 
     reconcile_shadow_fk_types(_MODEL_REGISTRY_PY)
@@ -164,8 +164,8 @@ def resolve_relationships():
                 f"Ferro failed to rebuild the schema for model '{model_name}' "
                 f"while resolving relationships: {exc}"
             ) from exc
-        register_model_schema(
-            model_name, json.dumps(schema), model_cls.__ferro_table__
+        register_model_with_ir(
+            model_name, schema, model_cls.__ferro_table__
         )
 
     compile_registry_schema_ir()

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -448,7 +448,9 @@ fn engine_value_to_rust_value(
     schema: &serde_json::Value,
     col_name: &str,
 ) -> crate::state::RustValue {
-    let plan = crate::codec_plan::ModelCodecPlan::compile(schema);
+    let columns = crate::schema::infer_test_schema_columns(schema);
+    let plan = crate::codec_plan::ModelCodecPlan::compile_from_columns(&columns)
+        .expect("test schema columns should compile");
     crate::codec::decode_engine_value(value, &plan, col_name)
 }
 
@@ -2802,7 +2804,7 @@ mod m2m_value_tests {
             "properties": { "data": { "type": "string", "format": "binary" } }
         });
         let input = BindInput::Bytes(vec![0x89, 0x00, 0xff]);
-        let model = crate::state::RegisteredModel::new(schema, "test_table".to_string());
+        let model = crate::state::RegisteredModel::new_for_test(schema, "test_table".to_string());
         let expr = bind_input_to_expr(
             &model, "doc", "data", &input,
             &HashMap::new(), &HashSet::new(), &HashMap::new(), Dialect::Sqlite,
@@ -2841,7 +2843,7 @@ mod schema_value_expr_tests {
     ) -> pyo3::PyResult<(String, sea_query::Values)> {
         let enum_udt = HashMap::new();
         let ts_cast = HashMap::new();
-        let model = crate::state::RegisteredModel::new(schema.clone(), "test_table".to_string());
+        let model = crate::state::RegisteredModel::new_for_test(schema.clone(), "test_table".to_string());
         let expr = schema_value_expr(
             &model,
             table,
@@ -3057,7 +3059,7 @@ mod schema_value_expr_tests {
             let _ = py;
 
             let err = schema_value_expr(
-                &crate::state::RegisteredModel::new(schema.clone(), "test_table".to_string()),
+                &crate::state::RegisteredModel::new_for_test(schema.clone(), "test_table".to_string()),
                 "thing",
                 "id",
                 &serde_json::Value::String("not-a-uuid".to_string()),
@@ -3097,7 +3099,7 @@ mod schema_value_expr_tests {
         ts_cast.insert("created_at".to_string(), "timestamptz".to_string());
 
         let expr = schema_value_expr(
-            &crate::state::RegisteredModel::new(schema.clone(), "test_table".to_string()),
+            &crate::state::RegisteredModel::new_for_test(schema.clone(), "test_table".to_string()),
             "thing",
             "created_at",
             &serde_json::Value::Null,
@@ -3128,7 +3130,7 @@ mod schema_value_expr_tests {
         let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
 
         let expr = schema_value_expr(
-            &crate::state::RegisteredModel::new(schema.clone(), "test_table".to_string()),
+            &crate::state::RegisteredModel::new_for_test(schema.clone(), "test_table".to_string()),
             "thing",
             "id",
             &serde_json::Value::String(uuid_str.to_string()),
@@ -3561,7 +3563,7 @@ mod save_mode_sql_tests {
         backend: Dialect,
     ) -> (String, sea_query::Values, bool) {
         build_save_sql(
-            &crate::state::RegisteredModel::new(widget_schema(), "widget".to_string()),
+            &crate::state::RegisteredModel::new_for_test(widget_schema(), "widget".to_string()),
             "widget",
             inputs,
             Some("id"),
@@ -3582,7 +3584,7 @@ mod save_mode_sql_tests {
         backend: Dialect,
     ) -> super::PyResult<UpdateByPkSql> {
         build_update_by_pk_sql(
-            &crate::state::RegisteredModel::new(schema.clone(), "test_table".to_string()),
+            &crate::state::RegisteredModel::new_for_test(schema.clone(), "test_table".to_string()),
             "widget",
             inputs,
             pk_col,

--- a/src/query.rs
+++ b/src/query.rs
@@ -369,7 +369,7 @@ mod tests {
         // nullable integer column "count" so model_column lookups succeed.
         crate::state::MODEL_REGISTRY.write().unwrap().insert(
             "WidgetIntNull".to_string(),
-            crate::state::RegisteredModel::new(json!({
+            crate::state::RegisteredModel::new_for_test(json!({
                 "properties": {
                     "count": {"anyOf": [{"type": "integer"}, {"type": "null"}]}
                 }
@@ -394,7 +394,7 @@ mod tests {
     fn null_rhs_emits_typed_bool_null_for_bool_column() {
         crate::state::MODEL_REGISTRY.write().unwrap().insert(
             "WidgetBoolNull".to_string(),
-            crate::state::RegisteredModel::new(json!({
+            crate::state::RegisteredModel::new_for_test(json!({
                 "properties": {
                     "active": {"anyOf": [{"type": "boolean"}, {"type": "null"}]}
                 }
@@ -419,7 +419,7 @@ mod tests {
     fn null_rhs_emits_typed_uuid_null_for_uuid_column() {
         crate::state::MODEL_REGISTRY.write().unwrap().insert(
             "WidgetUuidNull".to_string(),
-            crate::state::RegisteredModel::new(json!({
+            crate::state::RegisteredModel::new_for_test(json!({
                 "properties": {
                     "id": {"anyOf": [{"type": "string", "format": "uuid"}, {"type": "null"}]}
                 }
@@ -444,7 +444,7 @@ mod tests {
     fn binary_rhs_emits_typed_bytes_no_cast() {
         crate::state::MODEL_REGISTRY.write().unwrap().insert(
             "WidgetBinary".to_string(),
-            crate::state::RegisteredModel::new(json!({
+            crate::state::RegisteredModel::new_for_test(json!({
                 "properties": {
                     "blob": {"type": "string", "format": "binary"}
                 }
@@ -496,7 +496,7 @@ mod tests {
     fn enum_rhs_skips_cast_without_native_enum_column() {
         crate::state::MODEL_REGISTRY.write().unwrap().insert(
             "WidgetTextColor".to_string(),
-            crate::state::RegisteredModel::new(json!({
+            crate::state::RegisteredModel::new_for_test(json!({
                 "properties": {
                     "color": {"enum_type_name": "color", "db_type": "text"}
                 }
@@ -525,7 +525,7 @@ mod tests {
         // Decimal still uses CAST AS numeric on Postgres.
         crate::state::MODEL_REGISTRY.write().unwrap().insert(
             "WidgetDecimal".to_string(),
-            crate::state::RegisteredModel::new(json!({
+            crate::state::RegisteredModel::new_for_test(json!({
                 "properties": {
                     "amount": {
                         // The enriched shape registration emits for Decimal

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -582,19 +582,10 @@ pub fn infer_test_schema_columns(schema: &serde_json::Value) -> Vec<ferro_schema
     for (name, raw_col) in properties {
         let resolved = resolve_ref(schema, raw_col);
         let (json_type, format) = property_json_type_and_format(resolved);
-        let logical_type =
-            json_schema_logical_type(json_type.unwrap_or(""), format).to_string();
         let db_type = raw_col
             .get("db_type")
             .or_else(|| resolved.get("db_type"))
             .and_then(|v| v.as_str());
-        let db_type_explicit = db_type.is_some_and(|token| !token.is_empty());
-        let primary_key = column_bool_metadata(raw_col, resolved, "primary_key").unwrap_or(false);
-        let autoincrement = if primary_key {
-            column_bool_metadata(raw_col, resolved, "autoincrement").unwrap_or(true)
-        } else {
-            false
-        };
         let enum_values = resolved
             .get("enum")
             .or_else(|| raw_col.get("enum"))
@@ -604,8 +595,21 @@ pub fn infer_test_schema_columns(schema: &serde_json::Value) -> Vec<ferro_schema
         let enum_type_name = raw_col
             .get("enum_type_name")
             .or_else(|| resolved.get("enum_type_name"))
-            .and_then(|v| v.as_str())
-            .map(str::to_string);
+            .and_then(|v| v.as_str());
+        let logical_type = infer_test_logical_type(
+            json_type,
+            format,
+            db_type,
+            enum_values.as_ref(),
+            enum_type_name,
+        );
+        let db_type_explicit = db_type.is_some_and(|token| !token.is_empty());
+        let primary_key = column_bool_metadata(raw_col, resolved, "primary_key").unwrap_or(false);
+        let autoincrement = if primary_key {
+            column_bool_metadata(raw_col, resolved, "autoincrement").unwrap_or(true)
+        } else {
+            false
+        };
         columns.push(SchemaColumn {
             name: name.clone(),
             logical_type,
@@ -619,11 +623,52 @@ pub fn infer_test_schema_columns(schema: &serde_json::Value) -> Vec<ferro_schema
             default: None,
             format: format.map(str::to_string),
             enum_values,
-            enum_type_name,
+            enum_type_name: enum_type_name.map(str::to_string),
             postgres_native_enum: false,
         });
     }
     columns
+}
+
+#[cfg(test)]
+fn infer_test_logical_type(
+    json_type: Option<&str>,
+    format: Option<&str>,
+    db_type: Option<&str>,
+    enum_values: Option<&Vec<serde_json::Value>>,
+    enum_type_name: Option<&str>,
+) -> String {
+    let from_json = json_schema_logical_type(json_type.unwrap_or(""), format);
+    if from_json != "unknown" {
+        return from_json.to_string();
+    }
+    if enum_values.is_some() {
+        return if json_type == Some("integer") {
+            "integer".to_string()
+        } else {
+            "string".to_string()
+        };
+    }
+    if enum_type_name.is_some() {
+        return "string".to_string();
+    }
+    if let Some(token) = db_type.filter(|t| !t.is_empty()) {
+        return match token {
+            "bytea" => "binary",
+            "uuid" => "uuid",
+            "int" | "integer" | "bigint" | "smallint" => "integer",
+            "boolean" => "boolean",
+            "double" | "float" | "real" => "number",
+            "numeric" | "decimal" => "decimal",
+            "date" => "date",
+            "time" => "time",
+            "timestamp" | "timestamptz" | "datetime" => "datetime",
+            "json" | "jsonb" => "json",
+            _ => "string",
+        }
+        .to_string();
+    }
+    "string".to_string()
 }
 
 #[cfg(test)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -460,25 +460,34 @@ pub async fn internal_create_tables(engine: Arc<EngineHandle>) -> PyResult<()> {
 /// # Errors
 /// Returns a `PyErr` if the schema is invalid or if the registry is locked.
 #[pyfunction]
-#[pyo3(signature = (name, schema, table_name))]
-pub fn register_model_schema(name: String, schema: String, table_name: String) -> PyResult<()> {
+#[pyo3(signature = (name, schema, columns, table_name))]
+pub fn register_model_schema(
+    name: String,
+    schema: String,
+    columns: String,
+    table_name: String,
+) -> PyResult<()> {
     let parsed_schema: serde_json::Value = serde_json::from_str(&schema).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("Invalid JSON schema: {}", e))
     })?;
+    let parsed_columns: Vec<ferro_schema_ir::SchemaColumn> =
+        serde_json::from_str(&columns).map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("Invalid SchemaIR columns: {}", e))
+        })?;
     if table_name.is_empty() {
         return Err(pyo3::exceptions::PyValueError::new_err(
             "table_name must be a non-empty string",
         ));
     }
 
+    let registered = crate::state::RegisteredModel::new(parsed_schema, parsed_columns, table_name)
+        .map_err(pyo3::exceptions::PyValueError::new_err)?;
+
     let mut registry = MODEL_REGISTRY
         .write()
         .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("Failed to lock Model Registry"))?;
 
-    registry.insert(
-        name.clone(),
-        crate::state::RegisteredModel::new(parsed_schema, table_name),
-    );
+    registry.insert(name.clone(), registered);
     crate::log_debug(format!("⚙️  Ferro Engine: Map generated for '{}'", name));
     Ok(())
 }
@@ -558,6 +567,63 @@ pub fn _render_create_table_sql_for_test(
         emission.post_create_sqls,
         emission.pre_create_sqls,
     ))
+}
+
+/// Build minimal SchemaIR columns from a JSON schema fixture for Rust unit tests.
+#[cfg(test)]
+pub fn infer_test_schema_columns(schema: &serde_json::Value) -> Vec<ferro_schema_ir::SchemaColumn> {
+    use ferro_schema_ir::SchemaColumn;
+
+    let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) else {
+        return Vec::new();
+    };
+
+    let mut columns = Vec::new();
+    for (name, raw_col) in properties {
+        let resolved = resolve_ref(schema, raw_col);
+        let (json_type, format) = property_json_type_and_format(resolved);
+        let logical_type =
+            json_schema_logical_type(json_type.unwrap_or(""), format).to_string();
+        let db_type = raw_col
+            .get("db_type")
+            .or_else(|| resolved.get("db_type"))
+            .and_then(|v| v.as_str());
+        let db_type_explicit = db_type.is_some_and(|token| !token.is_empty());
+        let primary_key = column_bool_metadata(raw_col, resolved, "primary_key").unwrap_or(false);
+        let autoincrement = if primary_key {
+            column_bool_metadata(raw_col, resolved, "autoincrement").unwrap_or(true)
+        } else {
+            false
+        };
+        let enum_values = resolved
+            .get("enum")
+            .or_else(|| raw_col.get("enum"))
+            .and_then(|v| v.as_array())
+            .filter(|v| !v.is_empty())
+            .cloned();
+        let enum_type_name = raw_col
+            .get("enum_type_name")
+            .or_else(|| resolved.get("enum_type_name"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        columns.push(SchemaColumn {
+            name: name.clone(),
+            logical_type,
+            db_type: db_type.map(str::to_string),
+            db_type_explicit: db_type_explicit.then_some(true),
+            nullable: !primary_key,
+            primary_key,
+            autoincrement,
+            unique: column_bool_metadata(raw_col, resolved, "unique").unwrap_or(false),
+            index: column_bool_metadata(raw_col, resolved, "index").unwrap_or(false),
+            default: None,
+            format: format.map(str::to_string),
+            enum_values,
+            enum_type_name,
+            postgres_native_enum: false,
+        });
+    }
+    columns
 }
 
 #[cfg(test)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,7 +5,7 @@
 
 use crate::backend::{EngineConnection, EngineHandle};
 use dashmap::DashMap;
-use ferro_schema_ir::{IrEnvelope, SchemaIrPayload};
+use ferro_schema_ir::{IrEnvelope, SchemaColumn, SchemaIrPayload};
 use once_cell::sync::Lazy;
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
@@ -33,6 +33,20 @@ pub struct ModelMeta {
 }
 
 impl ModelMeta {
+    /// Scan SchemaIR columns for primary-key metadata (FF-G G2 / #236).
+    pub fn from_columns(columns: &[SchemaColumn]) -> Self {
+        let mut pk_col = None;
+        let mut pk_autoincrement = true;
+        for col in columns {
+            if col.primary_key {
+                pk_col = Some(col.name.clone());
+                pk_autoincrement = col.autoincrement;
+                break;
+            }
+        }
+        ModelMeta { pk_col, pk_autoincrement }
+    }
+
     pub fn from_schema(schema: &serde_json::Value) -> Self {
         let mut pk_col = None;
         let mut pk_autoincrement = true;
@@ -75,10 +89,32 @@ pub struct RegisteredModel {
 
 impl RegisteredModel {
     /// Compile the codec plan and wrap the registration for the registry.
-    pub fn new(schema: serde_json::Value, table_name: String) -> Arc<Self> {
-        let codec_plan = crate::codec_plan::ModelCodecPlan::compile(&schema);
-        let meta = ModelMeta::from_schema(&schema);
-        Arc::new(RegisteredModel { schema, table_name, codec_plan, meta })
+    pub fn new(
+        schema: serde_json::Value,
+        columns: Vec<SchemaColumn>,
+        table_name: String,
+    ) -> Result<Arc<Self>, String> {
+        let codec_plan = crate::codec_plan::ModelCodecPlan::compile_from_columns(&columns)?;
+        let meta = ModelMeta::from_columns(&columns);
+        Ok(Arc::new(RegisteredModel {
+            schema,
+            table_name,
+            codec_plan,
+            meta,
+        }))
+    }
+}
+
+#[cfg(test)]
+impl RegisteredModel {
+    /// Test-only registration when only a JSON schema fixture is available.
+    pub fn new_for_test(schema: serde_json::Value, table_name: String) -> Arc<Self> {
+        Self::new(
+            schema.clone(),
+            crate::schema::infer_test_schema_columns(&schema),
+            table_name,
+        )
+        .expect("test model registration")
     }
 }
 
@@ -580,7 +616,114 @@ mod session_close_tests {
 #[cfg(test)]
 mod model_meta_tests {
     use super::ModelMeta;
+    use ferro_schema_ir::SchemaColumn;
     use serde_json::json;
+
+    #[test]
+    fn from_columns_no_primary_key_yields_none_and_default_autoincrement() {
+        let meta = ModelMeta::from_columns(&[SchemaColumn {
+            name: "name".to_string(),
+            logical_type: "string".to_string(),
+            db_type: None,
+            db_type_explicit: None,
+            nullable: true,
+            primary_key: false,
+            autoincrement: false,
+            unique: false,
+            index: false,
+            default: None,
+            format: None,
+            enum_values: None,
+            enum_type_name: None,
+            postgres_native_enum: false,
+        }]);
+        assert_eq!(meta.pk_col, None);
+        assert!(meta.pk_autoincrement);
+    }
+
+    #[test]
+    fn from_columns_pk_without_autoincrement_key_defaults_true() {
+        let meta = ModelMeta::from_columns(&[SchemaColumn {
+            name: "id".to_string(),
+            logical_type: "integer".to_string(),
+            db_type: None,
+            db_type_explicit: None,
+            nullable: false,
+            primary_key: true,
+            autoincrement: true,
+            unique: false,
+            index: false,
+            default: None,
+            format: None,
+            enum_values: None,
+            enum_type_name: None,
+            postgres_native_enum: false,
+        }]);
+        assert_eq!(meta.pk_col.as_deref(), Some("id"));
+        assert!(meta.pk_autoincrement);
+    }
+
+    #[test]
+    fn from_columns_pk_with_autoincrement_false_is_preserved() {
+        let meta = ModelMeta::from_columns(&[SchemaColumn {
+            name: "id".to_string(),
+            logical_type: "string".to_string(),
+            db_type: None,
+            db_type_explicit: None,
+            nullable: false,
+            primary_key: true,
+            autoincrement: false,
+            unique: false,
+            index: false,
+            default: None,
+            format: None,
+            enum_values: None,
+            enum_type_name: None,
+            postgres_native_enum: false,
+        }]);
+        assert_eq!(meta.pk_col.as_deref(), Some("id"));
+        assert!(!meta.pk_autoincrement);
+    }
+
+    #[test]
+    fn from_columns_first_flagged_column_in_declaration_order_wins() {
+        let meta = ModelMeta::from_columns(&[
+            SchemaColumn {
+                name: "b_id".to_string(),
+                logical_type: "integer".to_string(),
+                db_type: None,
+                db_type_explicit: None,
+                nullable: false,
+                primary_key: true,
+                autoincrement: false,
+                unique: false,
+                index: false,
+                default: None,
+                format: None,
+                enum_values: None,
+                enum_type_name: None,
+                postgres_native_enum: false,
+            },
+            SchemaColumn {
+                name: "a_id".to_string(),
+                logical_type: "integer".to_string(),
+                db_type: None,
+                db_type_explicit: None,
+                nullable: false,
+                primary_key: true,
+                autoincrement: true,
+                unique: false,
+                index: false,
+                default: None,
+                format: None,
+                enum_values: None,
+                enum_type_name: None,
+                postgres_native_enum: false,
+            },
+        ]);
+        assert_eq!(meta.pk_col.as_deref(), Some("b_id"));
+        assert!(!meta.pk_autoincrement);
+    }
 
     #[test]
     fn no_primary_key_yields_none_and_default_autoincrement() {


### PR DESCRIPTION
## Summary

- Build `ModelCodecPlan` from Python-compiled `SchemaColumn` IR at registration instead of re-parsing Pydantic JSON Schema in Rust — single type producer for codec + DDL logical tokens.
- Add `logical_canonical_from_schema_column` in `ferro-ddl-lowering` for the storage/logical split (uuid-as-text keeps `Uuid` codec; explicit `db_type` still drives storage).
- Introduce `register_model_with_ir` — one compile pass → Rust FFI (`columns[]`) → persist SchemaIR envelope; used by metaclass, relations, join tables, and `_reregister_ferro`.
- Derive `ModelMeta` from SchemaIR columns; fail loud at registration on unresolvable logical types.

Closes #236

## Test plan

- [x] `cargo test -p ferro-ddl-lowering -p ferro-migrate`
- [x] `uv run maturin develop`
- [x] `pytest tests/test_db_type_integration.py tests/test_db_type_cross_emitter_parity.py tests/test_hydration_equivalence.py tests/test_ir_vectors_contract.py`
- [ ] Full CI matrix (sqlite + postgres)

## Exit steps

- [x] PR body includes `Closes #236`
- [ ] Merge and confirm #236 auto-closes

## Follow-up

- #238 — drop `RegisteredModel.schema`, migrate FK ordering, dead JSON DDL path

Made with [Cursor](https://cursor.com)