### PR TITLE
refactor: centralize register/deregister registry entrypoints (#243)

### DIFF
--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -72,10 +72,18 @@ def clear_registry() -> None:
     models is what allows cold re-hydration after ``reset_engine`` (see
     ``tests/test_enum_cold_hydration.py``). Callers that want a full Python-side
     reset clear ``_MODEL_REGISTRY_PY`` / ``_PENDING_RELATIONS`` themselves.
+
+    Each purged join table's compiled SchemaIR envelope is also evicted from the
+    per-model envelope cache (via ``evict_model_envelope`` — envelope-only, so the
+    model registry stays intact per the promise above), keeping the two stores the
+    #153 guard depends on in agreement: a lingering join envelope would let a
+    future assemble step resurrect the stale join table.
     """
     _core_clear_registry()
-    from .state import _JOIN_TABLE_REGISTRY
+    from .state import _JOIN_TABLE_REGISTRY, evict_model_envelope
 
+    for join_table in list(_JOIN_TABLE_REGISTRY):
+        evict_model_envelope(join_table)
     _JOIN_TABLE_REGISTRY.clear()
 
 

--- a/src/ferro/ir/compiler.py
+++ b/src/ferro/ir/compiler.py
@@ -7,7 +7,6 @@ individual models and full model sets.
 
 from __future__ import annotations
 
-import hashlib
 import json
 from typing import Any
 
@@ -25,26 +24,9 @@ from ..schema_metadata import build_model_schema
 from ..state import (
     _JOIN_TABLE_REGISTRY,
     _MODEL_REGISTRY_PY,
-    _SCHEMA_IR_BY_MODEL,
-    _SCHEMA_IR_FINGERPRINT_BY_MODEL,
 )
 
 _IR_VERSION = 1
-
-
-def _canonical_json(value: dict[str, Any]) -> str:
-    """Serialize an IR artifact with deterministic key ordering."""
-    return json.dumps(
-        value,
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=True,
-    )
-
-
-def _fingerprint(value: dict[str, Any]) -> str:
-    """Return the canonical SHA-256 fingerprint for an IR artifact."""
-    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
 
 
 def _resolve_ref(schema: dict[str, Any], col_info: dict[str, Any]) -> dict[str, Any]:
@@ -372,9 +354,13 @@ def compile_schema_ir_payload(
 
 
 def _persist_schema_ir_envelope(model_name: str, envelope: dict[str, Any]) -> None:
-    """Store one model's compiled SchemaIR envelope and fingerprint."""
-    _SCHEMA_IR_BY_MODEL[model_name] = envelope
-    _SCHEMA_IR_FINGERPRINT_BY_MODEL[model_name] = _fingerprint(envelope)
+    """Store one model's compiled SchemaIR envelope and fingerprint.
+
+    Routes through the single ``ferro.state`` envelope-write entrypoint so every
+    per-model store mutation lives at the store-owning layer (#243); the
+    fingerprint is derived from the envelope inside that entrypoint.
+    """
+    ferro_state.persist_model_envelope(model_name, envelope)
 
 
 def register_model_with_ir(
@@ -467,10 +453,10 @@ def compile_registry_schema_ir() -> dict[str, Any]:
     }
 
     ferro_state._SCHEMA_IR_MODELSET = envelope
-    ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = _fingerprint(envelope)
+    ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = ferro_state.ir_fingerprint(envelope)
     return envelope
 
 
 def schema_ir_fingerprint(ir_envelope: dict[str, Any]) -> str:
     """Return a deterministic SHA-256 fingerprint for a SchemaIR envelope."""
-    return _fingerprint(ir_envelope)
+    return ferro_state.ir_fingerprint(ir_envelope)

--- a/src/ferro/metaclass.py
+++ b/src/ferro/metaclass.py
@@ -28,7 +28,7 @@ from .ir import register_model_with_ir
 from .query import Relation
 from .relations.descriptors import ForwardDescriptor
 from .schema_metadata import _enum_subclass_from_annotation, build_model_schema
-from .state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+from .state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS, register_model
 
 _TABLE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*\Z")
 
@@ -421,7 +421,7 @@ class ModelMetaclass(type(BaseModel)):
                     "models cannot share a table. Set __ferro_table__ on one of "
                     "them to give it a distinct table name."
                 )
-        _MODEL_REGISTRY_PY[identity] = cls
+        register_model(identity, cls)
         cls.ferro_relations = local_relations
 
         # Queryable-column set for build-time predicate validation (FF-F F-2):

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from contextvars import ContextVar
 
 from typing import Any, Protocol
@@ -80,6 +82,74 @@ _SCHEMA_IR_MODELSET_FINGERPRINT: str | None = None
 # Per-model compiled SchemaIR artifacts and fingerprints.
 _SCHEMA_IR_BY_MODEL: dict[str, dict[str, Any]] = {}
 _SCHEMA_IR_FINGERPRINT_BY_MODEL: dict[str, str] = {}
+
+
+def canonical_ir_json(value: dict[str, Any]) -> str:
+    """Serialize an IR artifact with deterministic key ordering."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def ir_fingerprint(value: dict[str, Any]) -> str:
+    """Return the canonical SHA-256 fingerprint for an IR artifact.
+
+    Single source of the fingerprint function so a stored fingerprint is always
+    a pure function of the envelope it accompanies (the ADR fingerprint gate
+    reads these; a mismatched pair would serve stale schema silently).
+    """
+    return hashlib.sha256(canonical_ir_json(value).encode("utf-8")).hexdigest()
+
+
+def register_model(key: str, cls: type) -> None:
+    """Record a model class in the Python registry (provisional registration).
+
+    Single entrypoint for every per-model ``_MODEL_REGISTRY_PY`` write. Today the
+    writers are the metaclass (class-body registration, keyed by
+    ``__ferro_identity__``) and a handful of test fixtures that re-add models
+    after a registry wipe. Centralizing the write is the prefactor (#243) that
+    lets a later slice (#242) hook one site — e.g. a generation counter —
+    instead of chasing scattered dict assignments. Idempotent by construction.
+
+    ``key`` is passed explicitly rather than derived from ``cls`` so behavior is
+    identical to the direct writes this replaced (some marker-model fixtures
+    deliberately register under a bare ``__name__`` that a raw-FFI test relies
+    on); normalizing that key is a behavior change out of scope for this slice.
+    """
+    _MODEL_REGISTRY_PY[key] = cls
+
+
+def persist_model_envelope(name: str, envelope: dict[str, Any]) -> None:
+    """Store one model's (or join table's) compiled SchemaIR envelope + fingerprint.
+
+    The envelope-cache half of registration. The fingerprint is computed here
+    from the envelope — it is a pure function of it, so no caller can persist a
+    stale envelope/fingerprint pair. Keyed by the same ``name`` the IR compiler
+    uses (a model's ``__ferro_identity__`` or a join-table name).
+    """
+    _SCHEMA_IR_BY_MODEL[name] = envelope
+    _SCHEMA_IR_FINGERPRINT_BY_MODEL[name] = ir_fingerprint(envelope)
+
+
+def evict_model_envelope(name: str) -> None:
+    """Evict one entry from the SchemaIR envelope + fingerprint caches only.
+
+    The envelope-only counterpart of :func:`persist_model_envelope`. Used by the
+    join-table cleanup path (``clear_registry``), where the model registry must
+    stay untouched — join tables never live there, and ``clear_registry`` promises
+    declared models survive so they can cold-rehydrate.
+    """
+    _SCHEMA_IR_BY_MODEL.pop(name, None)
+    _SCHEMA_IR_FINGERPRINT_BY_MODEL.pop(name, None)
+
+
+def deregister_model(name: str) -> None:
+    """Evict one model from every per-model store (registry + envelope caches).
+
+    Single deregistration entrypoint: removes the class-registry entry plus the
+    compiled SchemaIR envelope and its fingerprint. Idempotent — absent keys are
+    ignored — so it is safe for teardown paths and re-runs.
+    """
+    _MODEL_REGISTRY_PY.pop(name, None)
+    evict_model_envelope(name)
 
 
 _NO_ROUTE_MESSAGE = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,6 +210,34 @@ def cleanup_models():
     reset_engine()
 
 
+@pytest.fixture()
+def clean_registry():
+    """Fully wipe every per-model store before and after the test.
+
+    Shared home for the registry-wipe pattern that several suites previously
+    hand-rolled (e.g. ``test_ir_vectors_contract``'s ``clean_model_registry``,
+    the ``test_registry_entrypoints`` guard). Threading a newly added store into
+    the reset now happens once here instead of in each copy.
+    """
+    from ferro import clear_registry, reset_engine
+    from ferro import state as ferro_state
+
+    def _wipe() -> None:
+        reset_engine()
+        clear_registry()
+        ferro_state._MODEL_REGISTRY_PY.clear()
+        ferro_state._PENDING_RELATIONS.clear()
+        ferro_state._JOIN_TABLE_REGISTRY.clear()
+        ferro_state._SCHEMA_IR_BY_MODEL.clear()
+        ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL.clear()
+        ferro_state._SCHEMA_IR_MODELSET = None
+        ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = None
+
+    _wipe()
+    yield
+    _wipe()
+
+
 @pytest.fixture(autouse=True)
 def _ferro_registry_isolation():
     """Snapshot/restore the global model registries around every test (FF-E).
@@ -221,12 +249,22 @@ def _ferro_registry_isolation():
     captured in the baseline snapshot and survive; function-local models are
     dropped when the test ends.
     """
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.state import (
+        _JOIN_TABLE_REGISTRY,
+        _MODEL_REGISTRY_PY,
+        _PENDING_RELATIONS,
+        deregister_model,
+    )
 
     models_snapshot = dict(_MODEL_REGISTRY_PY)
     pending_snapshot = list(_PENDING_RELATIONS)
     joins_snapshot = dict(_JOIN_TABLE_REGISTRY)
     yield
+    # Deregister function-local models through the entrypoint so their envelope
+    # + fingerprint are evicted too — a bare `.clear()`/restore of the registry
+    # would leave those caches disagreeing (the divergence #243 eliminates).
+    for name in set(_MODEL_REGISTRY_PY) - set(models_snapshot):
+        deregister_model(name)
     _MODEL_REGISTRY_PY.clear()
     _MODEL_REGISTRY_PY.update(models_snapshot)
     _PENDING_RELATIONS.clear()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -17,10 +17,10 @@ class ConnectionRouteMarker(ferro.Model):
 
 @pytest.fixture(autouse=True)
 def _ensure_models_registered():
-    from ferro.state import _MODEL_REGISTRY_PY
+    from ferro.state import register_model
 
     ConnectionRouteMarker._reregister_ferro()
-    _MODEL_REGISTRY_PY[ConnectionRouteMarker.__name__] = ConnectionRouteMarker
+    register_model(ConnectionRouteMarker.__name__, ConnectionRouteMarker)
     yield
 
 

--- a/tests/test_documentation_features.py
+++ b/tests/test_documentation_features.py
@@ -101,10 +101,10 @@ class DocProduct(Model):
 def _ensure_models_registered():
     from ferro.base import ForeignKey, ManyToManyRelation
     from ferro.relations import resolve_relationships
-    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.state import _PENDING_RELATIONS, register_model
 
     for model_cls in (DocUser, DocPost, Comment, Tag, DocProduct):
-        _MODEL_REGISTRY_PY[model_cls.__ferro_identity__] = model_cls
+        register_model(model_cls.__ferro_identity__, model_cls)
 
     # Some tests clear private relationship state to model fresh imports. These
     # module-level models must restore both schemas and descriptors afterward.

--- a/tests/test_enum_cold_hydration.py
+++ b/tests/test_enum_cold_hydration.py
@@ -9,7 +9,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from ferro import FerroField, Model, clear_registry, connect, engines, reset_engine
-from ferro.state import _MODEL_REGISTRY_PY
+from ferro.state import _MODEL_REGISTRY_PY, deregister_model, register_model
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -28,14 +28,15 @@ class BillingRow(Model):
 def cleanup():
     registered_before = set(_MODEL_REGISTRY_PY)
     # Other tests (e.g. test_sqlite_alembic_reconnect_hydration) clear the Python registry.
-    _MODEL_REGISTRY_PY.setdefault(BillingRow.__ferro_identity__, BillingRow)
+    if BillingRow.__ferro_identity__ not in _MODEL_REGISTRY_PY:
+        register_model(BillingRow.__ferro_identity__, BillingRow)
     reset_engine()
     clear_registry()
     yield
     reset_engine()
     clear_registry()
     for name in set(_MODEL_REGISTRY_PY) - registered_before:
-        del _MODEL_REGISTRY_PY[name]
+        deregister_model(name)
 
 
 def test_enum_fields_populated_for_deferred_annotations():

--- a/tests/test_fk_target_pk.py
+++ b/tests/test_fk_target_pk.py
@@ -30,11 +30,15 @@ def _isolate_relation_state():
     relation, including these stale ones, and blows up because their
     target models never declared the matching `BackRef()`.
     """
-    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS, deregister_model
 
     models_snapshot = dict(_MODEL_REGISTRY_PY)
     relations_snapshot = list(_PENDING_RELATIONS)
     yield
+    # Evict test-local models through the entrypoint so their envelope caches go
+    # with them, then restore the baseline snapshot (bulk teardown restore).
+    for name in set(_MODEL_REGISTRY_PY) - set(models_snapshot):
+        deregister_model(name)
     _MODEL_REGISTRY_PY.clear()
     _MODEL_REGISTRY_PY.update(models_snapshot)
     _PENDING_RELATIONS.clear()

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from ferro import BackRef, Field, ManyToMany, Model, Relation, clear_registry, reset_engine
+from ferro import BackRef, Field, ManyToMany, Model, Relation, clear_registry
 
 
 VECTORS_DIR = Path(__file__).parent / "fixtures" / "ir_vectors"
@@ -211,28 +211,10 @@ def test_ir_vectors_match_phase0_contract_envelope() -> None:
 
 
 @pytest.fixture()
-def clean_model_registry() -> None:
-    from ferro import state as ferro_state
-
-    reset_engine()
-    clear_registry()
-    ferro_state._MODEL_REGISTRY_PY.clear()
-    ferro_state._PENDING_RELATIONS.clear()
-    ferro_state._JOIN_TABLE_REGISTRY.clear()
-    ferro_state._SCHEMA_IR_BY_MODEL.clear()
-    ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL.clear()
-    ferro_state._SCHEMA_IR_MODELSET = None
-    ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = None
+def clean_model_registry(clean_registry) -> None:
+    # Thin alias over the shared conftest `clean_registry` fixture, kept so the
+    # many `clean_model_registry` parameters below need not be renamed.
     yield
-    reset_engine()
-    clear_registry()
-    ferro_state._MODEL_REGISTRY_PY.clear()
-    ferro_state._PENDING_RELATIONS.clear()
-    ferro_state._JOIN_TABLE_REGISTRY.clear()
-    ferro_state._SCHEMA_IR_BY_MODEL.clear()
-    ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL.clear()
-    ferro_state._SCHEMA_IR_MODELSET = None
-    ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = None
 
 
 def _load_vector(path: Path) -> dict[str, Any]:

--- a/tests/test_named_connections_integration.py
+++ b/tests/test_named_connections_integration.py
@@ -50,10 +50,10 @@ if TYPE_CHECKING:
 
 @pytest.fixture(autouse=True)
 def _ensure_models_registered():
-    from ferro.state import _MODEL_REGISTRY_PY
+    from ferro.state import register_model
 
     NamedSmokeMarker._reregister_ferro()
-    _MODEL_REGISTRY_PY[NamedSmokeMarker.__name__] = NamedSmokeMarker
+    register_model(NamedSmokeMarker.__name__, NamedSmokeMarker)
     yield
 
 

--- a/tests/test_registry_entrypoints.py
+++ b/tests/test_registry_entrypoints.py
@@ -1,0 +1,291 @@
+"""#243 prefactor: centralized register/deregister registry entrypoints.
+
+Every per-model registry/envelope write and eviction goes through the single
+``register_model`` / ``persist_model_envelope`` / ``deregister_model``
+entrypoints in :mod:`ferro.state`; no ``src/`` code mutates
+``_MODEL_REGISTRY_PY`` / ``_SCHEMA_IR_BY_MODEL`` (or their fingerprint maps)
+directly. ``clear_registry()`` additionally evicts join-table envelopes from
+the per-model envelope cache, preserving the #153 stale-join-table guard.
+
+These are the "make the change easy" seams that a later slice (#242 generation
+counter, bulk install) hooks; this slice is a no-behavior-change prefactor.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Annotated, ClassVar
+
+from ferro import (
+    BackRef,
+    FerroField,
+    ManyToMany,
+    Model,
+    Relation,
+    clear_registry,
+)
+
+
+def test_register_model_is_the_single_registry_write(clean_registry):
+    from ferro import state as ferro_state
+
+    class Widget(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    identity = Widget.__ferro_identity__
+    # Class-body registration flowed through the entrypoint into the registry
+    # (keyed by the canonical identity) and persisted the envelope + fingerprint.
+    assert ferro_state._MODEL_REGISTRY_PY[identity] is Widget
+    assert identity in ferro_state._SCHEMA_IR_BY_MODEL
+    assert identity in ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL
+
+
+def test_register_model_records_under_given_key(clean_registry):
+    from ferro import state as ferro_state
+    from ferro.state import register_model
+
+    class Marker(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+
+    ferro_state._MODEL_REGISTRY_PY.clear()
+    register_model(Marker.__ferro_identity__, Marker)
+
+    assert ferro_state._MODEL_REGISTRY_PY[Marker.__ferro_identity__] is Marker
+
+
+def test_persist_model_envelope_fingerprint_matches_envelope(clean_registry):
+    from ferro import state as ferro_state
+
+    envelope = {"ir_kind": "schema", "ir_version": 1, "payload": {"models": []}}
+    ferro_state.persist_model_envelope("x.Thing", envelope)
+
+    assert ferro_state._SCHEMA_IR_BY_MODEL["x.Thing"] is envelope
+    assert ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL[
+        "x.Thing"
+    ] == ferro_state.ir_fingerprint(envelope)
+
+
+def test_deregister_model_evicts_registry_and_envelope(clean_registry):
+    from ferro import state as ferro_state
+    from ferro.state import deregister_model
+
+    class Gadget(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    identity = Gadget.__ferro_identity__
+    assert identity in ferro_state._MODEL_REGISTRY_PY
+    assert identity in ferro_state._SCHEMA_IR_BY_MODEL
+    assert identity in ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL
+
+    deregister_model(identity)
+
+    assert identity not in ferro_state._MODEL_REGISTRY_PY
+    assert identity not in ferro_state._SCHEMA_IR_BY_MODEL
+    assert identity not in ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL
+
+
+def test_evict_model_envelope_leaves_model_registry(clean_registry):
+    from ferro import state as ferro_state
+    from ferro.state import evict_model_envelope
+
+    class Doohickey(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+
+    identity = Doohickey.__ferro_identity__
+    evict_model_envelope(identity)
+
+    # Envelope-only: the model registry entry survives (cold-rehydration path).
+    assert identity in ferro_state._MODEL_REGISTRY_PY
+    assert identity not in ferro_state._SCHEMA_IR_BY_MODEL
+    assert identity not in ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL
+
+
+def test_deregister_model_is_idempotent(clean_registry):
+    from ferro.state import deregister_model
+
+    # Evicting an unknown identity is a no-op, not a KeyError.
+    deregister_model("does.not.Exist")
+
+
+def test_clear_registry_evicts_join_table_envelopes(clean_registry):
+    """#153 guard: a stale join-table envelope must not survive clear_registry.
+
+    A join table left behind in the per-model envelope cache would let the
+    assembled modelset resurrect foreign keys to tables that no longer exist —
+    tolerated by SQLite, rejected by Postgres.
+    """
+    from ferro import state as ferro_state
+    from ferro.relations import resolve_relationships
+
+    class Page(Model):
+        __ferro_table__: ClassVar[str] = "reg_pages"
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        tags: Relation[list["PageTag"]] = ManyToMany(related_name="pages")
+
+    class PageTag(Model):
+        __ferro_table__: ClassVar[str] = "reg_page_tags"
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        pages: Relation[list[Page]] = BackRef()
+
+    resolve_relationships()
+
+    join_table = "reg_pages_tags"
+    assert join_table in ferro_state._JOIN_TABLE_REGISTRY
+    assert join_table in ferro_state._SCHEMA_IR_BY_MODEL
+    assert join_table in ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL
+
+    clear_registry()
+
+    assert join_table not in ferro_state._JOIN_TABLE_REGISTRY
+    assert join_table not in ferro_state._SCHEMA_IR_BY_MODEL
+    assert join_table not in ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL
+
+
+def test_clear_registry_keeps_model_registry(clean_registry):
+    """clear_registry() promises declared models survive (cold rehydration)."""
+    from ferro import state as ferro_state
+
+    class Survivor(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+
+    identity = Survivor.__ferro_identity__
+    clear_registry()
+    assert ferro_state._MODEL_REGISTRY_PY[identity] is Survivor
+
+
+# ---------------------------------------------------------------------------
+# Single-writer guard: an AST walk (comments/strings/formatting-agnostic) is
+# the source of truth for "no direct per-model store write escapes the
+# entrypoints". It catches subscript assignment (incl. nested keys and
+# multi-line statements), augmented assignment (`|=`), `del`, and the mutating
+# dict methods (`pop`, `popitem`, `clear`, `setdefault`, `update`).
+# ---------------------------------------------------------------------------
+
+_SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "ferro"
+_STORE_NAMES = {
+    "_MODEL_REGISTRY_PY",
+    "_SCHEMA_IR_BY_MODEL",
+    "_SCHEMA_IR_FINGERPRINT_BY_MODEL",
+}
+_MUTATING_METHODS = {"pop", "popitem", "clear", "setdefault", "update"}
+# state.py is where the entrypoints live — the one file allowed to mutate the
+# stores directly. Matched by path relative to _SRC_ROOT (not basename), so a
+# nested ``.../state.py`` would still be scanned.
+_ALLOWED_RELPATHS = {Path("state.py")}
+
+
+def _refers_to_store(node: ast.AST) -> bool:
+    """True if ``node`` (a subscript/method container) resolves to a store.
+
+    Peels nested subscripts (``store[a][b]``) down to the container, then matches
+    a bare imported name (``_MODEL_REGISTRY_PY``) or an attribute access
+    (``ferro_state._MODEL_REGISTRY_PY``).
+    """
+    while isinstance(node, ast.Subscript):
+        node = node.value
+    if isinstance(node, ast.Name):
+        return node.id in _STORE_NAMES
+    if isinstance(node, ast.Attribute):
+        return node.attr in _STORE_NAMES
+    return False
+
+
+def _is_store_ref(node: ast.AST) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id in _STORE_NAMES
+    if isinstance(node, ast.Attribute):
+        return node.attr in _STORE_NAMES
+    return False
+
+
+def _store_write_linenos(source: str) -> list[int]:
+    """Line numbers of every direct per-model store mutation in ``source``."""
+    tree = ast.parse(source)
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        targets: list[ast.AST] = []
+        if isinstance(node, (ast.Assign, ast.Delete)):
+            targets = list(node.targets)
+        elif isinstance(node, (ast.AugAssign, ast.AnnAssign)):
+            targets = [node.target]
+
+        for target in targets:
+            if isinstance(target, ast.Subscript) and _refers_to_store(target.value):
+                hits.append(node.lineno)
+            elif _is_store_ref(target):  # whole-store rebind / `store |= ...`
+                hits.append(node.lineno)
+
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr in _MUTATING_METHODS and _refers_to_store(
+                node.func.value
+            ):
+                hits.append(node.lineno)
+    return sorted(set(hits))
+
+
+def _iter_src_files():
+    for path in sorted(_SRC_ROOT.rglob("*.py")):
+        if path.relative_to(_SRC_ROOT) in _ALLOWED_RELPATHS:
+            continue
+        yield path
+
+
+def test_no_direct_store_writes_outside_state():
+    """The register/deregister entrypoints own every per-model store write."""
+    scanned = 0
+    offenders: list[str] = []
+    for path in _iter_src_files():
+        scanned += 1
+        source = path.read_text(encoding="utf-8")
+        for lineno in _store_write_linenos(source):
+            rel = path.relative_to(_SRC_ROOT)
+            offenders.append(f"{rel}:{lineno}")
+    # Guard against a silently-empty scan (e.g. _SRC_ROOT drifting).
+    assert scanned >= 10, f"expected to scan the ferro package, only saw {scanned} files"
+    assert not offenders, (
+        "Direct per-model registry/envelope writes must route through "
+        "ferro.state.register_model / persist_model_envelope / "
+        "evict_model_envelope / deregister_model:\n" + "\n".join(offenders)
+    )
+
+
+def test_store_write_detector_flags_known_idioms():
+    """Positive control: the detector catches every idiom it claims to.
+
+    Pins that the guard is not vacuous — these are exactly the escape hatches a
+    #242 implementer might reach for.
+    """
+    sample = "\n".join(
+        [
+            "_MODEL_REGISTRY_PY[k] = v",  # subscript assign
+            "_SCHEMA_IR_BY_MODEL[names[0]] = v",  # nested-subscript key
+            "_SCHEMA_IR_BY_MODEL[name]['payload'] = v",  # in-place mutation
+            "_MODEL_REGISTRY_PY.setdefault(k, v)",
+            "_MODEL_REGISTRY_PY.update(other)",
+            "_MODEL_REGISTRY_PY.pop(k, None)",
+            "_SCHEMA_IR_BY_MODEL.popitem()",
+            "_SCHEMA_IR_FINGERPRINT_BY_MODEL.clear()",
+            "del _MODEL_REGISTRY_PY[k]",
+            "_MODEL_REGISTRY_PY |= other",
+            "ferro_state._MODEL_REGISTRY_PY[k] = v",  # attribute-qualified access
+            "ferro_state._SCHEMA_IR_BY_MODEL.pop(k, None)",
+            "_MODEL_REGISTRY_PY[\n    k\n] = v",  # multi-line statement
+        ]
+    )
+    # Each statement is one logical write; the multi-line one spans 3 source
+    # lines but is a single hit.
+    assert len(_store_write_linenos(sample)) == 13
+
+    clean = "\n".join(
+        [
+            "value = _MODEL_REGISTRY_PY[k]",  # read
+            "snapshot = list(_MODEL_REGISTRY_PY.items())",  # iteration
+            "found = _SCHEMA_IR_BY_MODEL.get(k)",  # get
+            "present = k in _MODEL_REGISTRY_PY",  # membership
+            "source_model = _MODEL_REGISTRY_PY[name]",  # RHS subscript read
+        ]
+    )
+    assert _store_write_linenos(clean) == []

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -19,10 +19,10 @@ class SessionMarker(ferro.Model):
 
 @pytest.fixture(autouse=True)
 def _ensure_models_registered():
-    from ferro.state import _MODEL_REGISTRY_PY
+    from ferro.state import register_model
 
     SessionMarker._reregister_ferro()
-    _MODEL_REGISTRY_PY[SessionMarker.__name__] = SessionMarker
+    register_model(SessionMarker.__name__, SessionMarker)
     yield
 
 


### PR DESCRIPTION
## Summary

Prefactor with **zero behavior change** (parent PRD #242, ADR `docs/adr/0001-resolved-epoch-registration.md`). Centralizes every per-model registry/envelope write and eviction behind single entrypoints so the later slices (#244/#245 — generation counter, bulk install) have one site to hook.

- New entrypoints in `ferro.state` (the store-owning layer):
  - `register_model(key, cls)` — sole `_MODEL_REGISTRY_PY` writer.
  - `persist_model_envelope(name, envelope)` — sole `_SCHEMA_IR_BY_MODEL` + fingerprint writer; the fingerprint is derived from the envelope internally so the stored pair can never drift.
  - `evict_model_envelope(name)` — envelope-only eviction (join-table cleanup path).
  - `deregister_model(name)` — full per-model eviction (registry + envelope caches).
- Routed the metaclass, IR compiler (`_persist_schema_ir_envelope`, and the shared `ir_fingerprint`/`canonical_ir_json` now single-sourced in `state`), and the relationship-resolution / `_reregister_ferro` envelope paths through them. No direct `_MODEL_REGISTRY_PY` / `_SCHEMA_IR_BY_MODEL` writes remain in `src/` — pinned by an AST-based single-writer guard test with a positive control.
- Migrated add/remove test fixtures — including the autouse `_ferro_registry_isolation` (conftest) and `_isolate_relation_state` (`test_fk_target_pk`) teardowns — to `deregister_model`, so function-local models no longer leave the registry and envelope caches disagreeing.
- `clear_registry()` now evicts join-table envelopes from the per-model envelope cache (envelope-only, leaving the model registry intact per its cold-rehydration promise), so the two stores the **#153** stale-join-table guard depends on can never diverge.
- Shared `clean_registry` fixture promoted to `conftest.py` and reused (removes a hand-rolled copy in `test_ir_vectors_contract`).

Respects AGENTS.md invariants: I-1 (assembled modelset unchanged — IR-vector snapshots pass), I-4, I-6, I-10 (no `CHANGELOG.md` edits).

Note on review item 6 (bare-`__name__` marker fixtures): normalizing those keys to `__ferro_identity__` was evaluated and **declined for this slice** — `test_named_connections_smoke_matrix_sqlite` deliberately calls the raw FFI `delete_record("NamedSmokeMarker", ...)` with the bare name, which only resolves because that bare key propagates into the pushed Rust modelset. Changing it is an observable behavior change, out of scope for a no-behavior-change prefactor; the entrypoint takes the key explicitly to preserve the existing behavior exactly.

## Test plan

- [x] `pytest` — 864 passed, 50 skipped (Postgres; no provider locally), 1 xfailed
- [x] `cargo test --no-default-features --features testing` — 124 passed
- [x] New `tests/test_registry_entrypoints.py`: register/deregister/evict behavior, `persist_model_envelope` fingerprint pairing, `clear_registry()` join-envelope eviction + model-registry survival (#153 guard), AST single-writer guard + positive control
- [ ] CI Postgres matrix (where the #153 failure actually manifests) runs on this PR

## Exit steps

- [x] Issue status updated: PR body closes the scoped issue (I-9)
- [ ] Confirm CI green (incl. Postgres matrix) before merge

Closes #243