### PR TITLE
refactor: canonicalize registry keys — derive register_model key from model identity

### DIFF
--- a/src/ferro/metaclass.py
+++ b/src/ferro/metaclass.py
@@ -421,7 +421,7 @@ class ModelMetaclass(type(BaseModel)):
                     "models cannot share a table. Set __ferro_table__ on one of "
                     "them to give it a distinct table name."
                 )
-        register_model(identity, cls)
+        register_model(cls)
         cls.ferro_relations = local_relations
 
         # Queryable-column set for build-time predicate validation (FF-F F-2):

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -99,22 +99,25 @@ def ir_fingerprint(value: dict[str, Any]) -> str:
     return hashlib.sha256(canonical_ir_json(value).encode("utf-8")).hexdigest()
 
 
-def register_model(key: str, cls: type) -> None:
+def register_model(cls: type) -> None:
     """Record a model class in the Python registry (provisional registration).
 
     Single entrypoint for every per-model ``_MODEL_REGISTRY_PY`` write. Today the
-    writers are the metaclass (class-body registration, keyed by
-    ``__ferro_identity__``) and a handful of test fixtures that re-add models
-    after a registry wipe. Centralizing the write is the prefactor (#243) that
-    lets a later slice (#242) hook one site — e.g. a generation counter —
-    instead of chasing scattered dict assignments. Idempotent by construction.
+    writers are the metaclass (class-body registration) and a handful of test
+    fixtures that re-add models after a registry wipe. Centralizing the write is
+    the prefactor (#243) that lets a later slice (#242) hook one site — e.g. a
+    generation counter — instead of chasing scattered dict assignments.
+    Idempotent by construction.
 
-    ``key`` is passed explicitly rather than derived from ``cls`` so behavior is
-    identical to the direct writes this replaced (some marker-model fixtures
-    deliberately register under a bare ``__name__`` that a raw-FFI test relies
-    on); normalizing that key is a behavior change out of scope for this slice.
+    The key is the model's canonical identity (``__ferro_identity__``), derived
+    from ``cls`` here rather than caller-supplied (#249). Deriving it in one
+    place makes the registry key a pure function of the model: callers can no
+    longer register a model under a divergent bare ``__name__`` that a lookup by
+    canonical identity would miss (the "Model 'X' not found" footgun). Every
+    other emitter — the Rust runtime registry, the raw-FFI operations — keys the
+    same model by this identity, so there is exactly one name for a model.
     """
-    _MODEL_REGISTRY_PY[key] = cls
+    _MODEL_REGISTRY_PY[cls.__ferro_identity__] = cls
 
 
 def persist_model_envelope(name: str, envelope: dict[str, Any]) -> None:

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -35,8 +35,25 @@ def _ensure_active_session(session: SessionLike | None) -> None:
     if session is not None and session.session_id is None:
         raise RuntimeError(_SESSION_CLOSED_MESSAGE)
 
+class FerroModelClass(Protocol):
+    """Structural type for a registrable Ferro model class.
+
+    The registry keys by ``__ferro_identity__`` (what ``register_model``
+    derives its key from) and resolves bare references against ``__name__`` /
+    ``__qualname__``. Typed as a ``Protocol`` rather than ``type[Model]`` so
+    ``state`` — which ``models`` and ``metaclass`` import — does not import back
+    into them (circular import); a non-Ferro class handed to ``register_model``
+    is then a type error at the call site instead of a raw ``AttributeError``
+    at runtime.
+    """
+
+    __ferro_identity__: str
+    __name__: str
+    __qualname__: str
+
+
 # Global registry for models (Python side)
-_MODEL_REGISTRY_PY = {}
+_MODEL_REGISTRY_PY: dict[str, FerroModelClass] = {}
 
 _UNSET = object()
 
@@ -99,7 +116,7 @@ def ir_fingerprint(value: dict[str, Any]) -> str:
     return hashlib.sha256(canonical_ir_json(value).encode("utf-8")).hexdigest()
 
 
-def register_model(cls: type) -> None:
+def register_model(cls: FerroModelClass) -> None:
     """Record a model class in the Python registry (provisional registration).
 
     Single entrypoint for every per-model ``_MODEL_REGISTRY_PY`` write. Today the
@@ -150,6 +167,12 @@ def deregister_model(name: str) -> None:
     Single deregistration entrypoint: removes the class-registry entry plus the
     compiled SchemaIR envelope and its fingerprint. Idempotent — absent keys are
     ignored — so it is safe for teardown paths and re-runs.
+
+    Takes a ``name`` (the canonical identity) rather than a class, unlike
+    :func:`register_model` which derives the key from ``cls``. The asymmetry is
+    deliberate: teardown paths iterate registry keys (e.g. evicting every
+    function-local model added during a test) and hold the identity string, not
+    the class object.
     """
     _MODEL_REGISTRY_PY.pop(name, None)
     evict_model_envelope(name)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -20,7 +20,7 @@ def _ensure_models_registered():
     from ferro.state import register_model
 
     ConnectionRouteMarker._reregister_ferro()
-    register_model(ConnectionRouteMarker.__name__, ConnectionRouteMarker)
+    register_model(ConnectionRouteMarker)
     yield
 
 

--- a/tests/test_documentation_features.py
+++ b/tests/test_documentation_features.py
@@ -104,7 +104,7 @@ def _ensure_models_registered():
     from ferro.state import _PENDING_RELATIONS, register_model
 
     for model_cls in (DocUser, DocPost, Comment, Tag, DocProduct):
-        register_model(model_cls.__ferro_identity__, model_cls)
+        register_model(model_cls)
 
     # Some tests clear private relationship state to model fresh imports. These
     # module-level models must restore both schemas and descriptors afterward.

--- a/tests/test_enum_cold_hydration.py
+++ b/tests/test_enum_cold_hydration.py
@@ -29,7 +29,7 @@ def cleanup():
     registered_before = set(_MODEL_REGISTRY_PY)
     # Other tests (e.g. test_sqlite_alembic_reconnect_hydration) clear the Python registry.
     if BillingRow.__ferro_identity__ not in _MODEL_REGISTRY_PY:
-        register_model(BillingRow.__ferro_identity__, BillingRow)
+        register_model(BillingRow)
     reset_engine()
     clear_registry()
     yield

--- a/tests/test_named_connections_integration.py
+++ b/tests/test_named_connections_integration.py
@@ -53,7 +53,7 @@ def _ensure_models_registered():
     from ferro.state import register_model
 
     NamedSmokeMarker._reregister_ferro()
-    register_model(NamedSmokeMarker.__name__, NamedSmokeMarker)
+    register_model(NamedSmokeMarker)
     yield
 
 
@@ -110,12 +110,16 @@ async def test_named_connections_smoke_matrix_sqlite(tmp_path):
         # (and its D4 conflict check) entirely, so no session is needed. FF-D
         # D3 collapsed the tx_id/using/session_id triple into one resolved
         # RouteHandle; build it directly since this deliberately skips
-        # resolve_operation_scope.
+        # resolve_operation_scope. The model name is the canonical identity the
+        # runtime registry keys by (#249) — the same name every ORM op passes,
+        # not a bare ``__name__``.
         from ferro._core import RouteHandle, delete_record
 
         assert (
             await delete_record(
-                "NamedSmokeMarker", "1", RouteHandle(connection_name="service")
+                NamedSmokeMarker.__ferro_identity__,
+                "1",
+                RouteHandle(connection_name="service"),
             )
             is True
         )

--- a/tests/test_registry_entrypoints.py
+++ b/tests/test_registry_entrypoints.py
@@ -42,7 +42,7 @@ def test_register_model_is_the_single_registry_write(clean_registry):
     assert identity in ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL
 
 
-def test_register_model_records_under_given_key(clean_registry):
+def test_register_model_keys_by_canonical_identity(clean_registry):
     from ferro import state as ferro_state
     from ferro.state import register_model
 
@@ -50,9 +50,12 @@ def test_register_model_records_under_given_key(clean_registry):
         id: Annotated[int | None, FerroField(primary_key=True)] = None
 
     ferro_state._MODEL_REGISTRY_PY.clear()
-    register_model(Marker.__ferro_identity__, Marker)
+    # #249: the key is derived from the model's canonical identity, never
+    # caller-supplied. A bare ``__name__`` must never become a registry key.
+    register_model(Marker)
 
     assert ferro_state._MODEL_REGISTRY_PY[Marker.__ferro_identity__] is Marker
+    assert Marker.__name__ not in ferro_state._MODEL_REGISTRY_PY
 
 
 def test_persist_model_envelope_fingerprint_matches_envelope(clean_registry):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -22,7 +22,7 @@ def _ensure_models_registered():
     from ferro.state import register_model
 
     SessionMarker._reregister_ferro()
-    register_model(SessionMarker.__name__, SessionMarker)
+    register_model(SessionMarker)
     yield
 
 


### PR DESCRIPTION
## What & why

`register_model` no longer accepts a caller-supplied key. It now derives the registry key from the model's **canonical identity** (`__ferro_identity__`), so the key is a pure function of the model:

```python
# before
register_model(SomeModel.__name__, SomeModel)   # or __ferro_identity__ — caller's choice
# after
register_model(SomeModel)
```

This closes the correctness footgun called out in #249: the metaclass keyed by `__ferro_identity__` while some fixtures registered under a bare `__name__`. When the two diverge, a lookup by canonical identity misses a model registered under its bare name — the "Model 'X' not found" class of failure. Latent today only because the divergent cases happened to be self-consistent.

## The FFI reconciliation

The one load-bearing bare-`__name__` dependency was the raw-FFI `delete_record("NamedSmokeMarker", ...)` path in `tests/test_named_connections_integration.py`. Tracing it:

- The Rust runtime registry (`MODEL_REGISTRY`) and `delete_record` look models up by **exact key = canonical identity** — the same name every ORM operation already passes.
- A bare Python-registry key only resolved because `resolve_relationships()` (run by `connect`/`create_tables`) re-registers each model into the Rust registry keyed by its **Python dict key**. A bare Python key therefore leaked a bare Rust key.

Fix is on the FFI caller, not the registry key: with canonical keying there is exactly one name for a model, and the raw call now passes `NamedSmokeMarker.__ferro_identity__`. No fuzzy bare-name fallback was added to the runtime (that would reintroduce the ambiguity this removes — I-6).

## Changes

- `register_model(cls)` derives the key from `__ferro_identity__` (`src/ferro/state.py`).
- Metaclass call site updated (`src/ferro/metaclass.py`).
- Every `register_model(key, cls)` call site migrated to `register_model(cls)` (`test_session`, `test_connection`, `test_named_connections_integration`, `test_enum_cold_hydration`, `test_documentation_features`).
- Raw-FFI `delete_record` in `test_named_connections_integration` uses the canonical identity.
- Dedicated entrypoint test rewritten to pin the canonical-key contract (and that a bare `__name__` never becomes a key).

Prerequisite for #245.

## Validation

- `pytest`: 864 passed, 50 skipped, 1 xfailed.
- `cargo test --no-default-features --features testing` (with `PYO3_PYTHON` set): 124 passed.

## Exit steps (I-9)

- [x] `register_model(cls)` is the only signature; no call site passes a key.
- [x] Registry key is always the model's canonical identity.
- [x] `tests/test_named_connections_integration.py` (raw-FFI `delete_record`) passes without relying on a bare-`__name__` key.
- [x] Full `pytest` + `cargo test` green.
- [x] Issue closure encoded in PR body: Closes #249.
- [x] `CHANGELOG.md` untouched (I-10).

Closes #249

Made with [Cursor](https://cursor.com)