### PR TITLE
feat: generation-counter dirty tracking with assemble-not-recompile (#245)

### DIFF
--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -6,6 +6,7 @@ to provide a seamless, high-performance database experience.
 """
 
 import logging
+import threading
 
 from . import _deprecations as _deprecations  # noqa: F401 — enable deprecation visibility
 
@@ -55,6 +56,36 @@ if not _logger.handlers:
     _logger.propagate = False
 
 
+_RESOLVED_MODELSET_LOCK = threading.Lock()
+
+
+def ensure_resolved_modelset() -> dict:
+    """Ensure the SchemaIR modelset reflects the current registry.
+
+    Clean path (O(1)): one in-process generation comparison, then assemble
+    already-compiled envelopes without recompiling. Dirty path: run
+    ``resolve_relationships()`` (which clears the generation counter on success),
+    then assemble (#245).
+    """
+    from .ir.compiler import compile_registry_schema_ir
+    from .relations import resolve_relationships
+    from .state import is_modelset_dirty
+
+    if not is_modelset_dirty():
+        return compile_registry_schema_ir()
+
+    with _RESOLVED_MODELSET_LOCK:
+        if is_modelset_dirty():
+            resolve_relationships()
+        return compile_registry_schema_ir()
+
+
+def _ensure_rust_registration_synced() -> None:
+    """Resolve the modelset if needed, then push it to the Rust runtime."""
+    ensure_resolved_modelset()
+    _push_registration_to_rust()
+
+
 def clear_registry() -> None:
     """Reset the compiled/registered schema state.
 
@@ -90,16 +121,16 @@ def clear_registry() -> None:
 def _push_registration_to_rust() -> None:
     """Assemble the resolved modelset and install it in the Rust runtime.
 
-    The single Rust registration sync seam (#244): compiles the full registry
-    SchemaIR, then hands the assembled modelset plus its fingerprint to the
-    atomic bulk-install FFI. Rust builds the column registry, swaps the
-    registry + modelset + fingerprint under one lock (build-then-swap,
-    retained-last-good on failure), and skips the swap entirely when the
-    fingerprint already matches — so a clean reconnect installs nothing.
+    The single Rust registration sync seam (#244): hands the assembled modelset
+    plus its fingerprint to the atomic bulk-install FFI. Rust builds the column
+    registry, swaps the registry + modelset + fingerprint under one lock
+    (build-then-swap, retained-last-good on failure), and skips the swap
+    entirely when the fingerprint already matches — so a clean reconnect installs
+    nothing.
 
-    Callers must have run ``resolve_relationships()`` first so join tables and
-    shadow FK columns are present in the assembled modelset. (Removing the
-    per-connect recompile in favor of an assemble-only step is slice #245.)
+    Callers must have ensured the modelset is resolved (``ensure_resolved_modelset``
+    or ``_ensure_rust_registration_synced``) so join tables and shadow FK columns
+    are present in the assembled modelset (#245).
     """
     import json as _json
     from .ir.compiler import compile_registry_schema_ir, schema_ir_fingerprint
@@ -190,10 +221,7 @@ async def connect(
     For schema changes beyond these (renames, primary-key changes, complex
     transforms), use the Alembic bridge — see ``docs/guide/migrations.md``.
     """
-    from .relations import resolve_relationships
-
-    resolve_relationships()
-    _push_registration_to_rust()
+    _ensure_rust_registration_synced()
 
     pool_config = pool or PoolConfig()
     await _core_connect(
@@ -222,10 +250,7 @@ async def create_tables(using=None):
     Args:
         using: Named connection to create tables on, or None for the default.
     """
-    from .relations import resolve_relationships
-
-    resolve_relationships()
-    _push_registration_to_rust()
+    _ensure_rust_registration_synced()
     return await _core_create_tables(using=using)
 
 
@@ -241,10 +266,7 @@ async def migrate(using=None, updates=True, destructive=False):
         updates: If True (default), add missing columns and reconcile type/nullability drift.
         destructive: If True, also drop live columns absent from the model. Implies ``updates``.
     """
-    from .relations import resolve_relationships
-
-    resolve_relationships()
-    _push_registration_to_rust()
+    _ensure_rust_registration_synced()
     return await _core_migrate(using=using, updates=updates, destructive=destructive)
 
 
@@ -278,6 +300,7 @@ __all__ = [
     "reset_engine",
     "set_default_connection",
     "clear_registry",
+    "ensure_resolved_modelset",
     "evict_instance",
     "transaction",
     "execute",

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -7,6 +7,7 @@ to provide a seamless, high-performance database experience.
 
 import logging
 import threading
+from typing import Any
 
 from . import _deprecations as _deprecations  # noqa: F401 — enable deprecation visibility
 
@@ -59,13 +60,18 @@ if not _logger.handlers:
 _RESOLVED_MODELSET_LOCK = threading.Lock()
 
 
-def ensure_resolved_modelset() -> dict:
+def ensure_resolved_modelset() -> dict[str, Any]:
     """Ensure the SchemaIR modelset reflects the current registry.
 
     Clean path (O(1)): one in-process generation comparison, then assemble
     already-compiled envelopes without recompiling. Dirty path: run
     ``resolve_relationships()`` (which clears the generation counter on success),
     then assemble (#245).
+
+    Defining model classes concurrently with ``connect``/``create_tables``/``migrate``
+    is unsupported: a registry entry can become visible before its envelope is
+    persisted, producing a transient missing-envelope error on the unlocked fast
+    path.
     """
     from .ir.compiler import compile_registry_schema_ir
     from .relations import resolve_relationships
@@ -82,8 +88,12 @@ def ensure_resolved_modelset() -> dict:
 
 def _ensure_rust_registration_synced() -> None:
     """Resolve the modelset if needed, then push it to the Rust runtime."""
-    ensure_resolved_modelset()
-    _push_registration_to_rust()
+    from . import state as ferro_state
+
+    envelope = ensure_resolved_modelset()
+    _push_registration_to_rust(
+        envelope, fingerprint=ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT
+    )
 
 
 def clear_registry() -> None:
@@ -118,8 +128,12 @@ def clear_registry() -> None:
     _JOIN_TABLE_REGISTRY.clear()
 
 
-def _push_registration_to_rust() -> None:
-    """Assemble the resolved modelset and install it in the Rust runtime.
+def _push_registration_to_rust(
+    envelope: dict[str, Any] | None = None,
+    *,
+    fingerprint: str | None = None,
+) -> None:
+    """Install an assembled modelset in the Rust runtime.
 
     The single Rust registration sync seam (#244): hands the assembled modelset
     plus its fingerprint to the atomic bulk-install FFI. Rust builds the column
@@ -128,15 +142,28 @@ def _push_registration_to_rust() -> None:
     entirely when the fingerprint already matches — so a clean reconnect installs
     nothing.
 
-    Callers must have ensured the modelset is resolved (``ensure_resolved_modelset``
-    or ``_ensure_rust_registration_synced``) so join tables and shadow FK columns
-    are present in the assembled modelset (#245).
+    When called from ``_ensure_rust_registration_synced``, pass the envelope and
+    cached fingerprint returned by ``ensure_resolved_modelset()`` so the clean
+    path performs one assemble and one fingerprint. With no arguments, assembles
+    (or re-assembles) the current registry for direct callers such as tests.
     """
     import json as _json
+
+    from . import state as ferro_state
     from .ir.compiler import compile_registry_schema_ir, schema_ir_fingerprint
 
-    envelope = compile_registry_schema_ir()
-    _install_registration(_json.dumps(envelope), schema_ir_fingerprint(envelope))
+    if envelope is None:
+        envelope = compile_registry_schema_ir()
+    if fingerprint is None:
+        cached = ferro_state._SCHEMA_IR_MODELSET
+        if (
+            cached is envelope
+            and ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT is not None
+        ):
+            fingerprint = ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT
+        else:
+            fingerprint = schema_ir_fingerprint(envelope)
+    _install_registration(_json.dumps(envelope), fingerprint)
 
 
 class PoolConfig(BaseModel):

--- a/src/ferro/ir/compiler.py
+++ b/src/ferro/ir/compiler.py
@@ -451,6 +451,13 @@ def compile_model_schema_ir(
 
 
 def _model_payload_from_envelope(name: str) -> dict[str, Any]:
+    """Return one model's SchemaIR payload object from the envelope cache.
+
+    The returned dict is a live reference into ``_SCHEMA_IR_BY_MODEL`` — the
+    assembled modelset shares these payload objects. Treat them as read-only;
+    in-place mutation corrupts the per-model cache and survives clean-path
+    re-assembles indefinitely (#245).
+    """
     envelope = _SCHEMA_IR_BY_MODEL.get(name)
     if envelope is None:
         raise RuntimeError(

--- a/src/ferro/ir/compiler.py
+++ b/src/ferro/ir/compiler.py
@@ -18,15 +18,29 @@ from .._core import (
     _ddl_fk_name,
     _ddl_single_index_name,
     _ddl_single_unique_name,
-    register_model_schema,
 )
 from ..schema_metadata import build_model_schema
 from ..state import (
     _JOIN_TABLE_REGISTRY,
     _MODEL_REGISTRY_PY,
+    _SCHEMA_IR_BY_MODEL,
 )
 
 _IR_VERSION = 1
+
+# Test-only counter bumped at the single SchemaIR compile choke point (#245).
+_SCHEMA_IR_COMPILE_COUNT_FOR_TEST = 0
+
+
+def schema_ir_compile_count_for_test() -> int:
+    """Return how many per-model SchemaIR compiles have run (test instrument)."""
+    return _SCHEMA_IR_COMPILE_COUNT_FOR_TEST
+
+
+def reset_schema_ir_compile_count_for_test() -> None:
+    """Reset the compile counter (``clean_registry`` fixture)."""
+    global _SCHEMA_IR_COMPILE_COUNT_FOR_TEST
+    _SCHEMA_IR_COMPILE_COUNT_FOR_TEST = 0
 
 
 def _resolve_ref(schema: dict[str, Any], col_info: dict[str, Any]) -> dict[str, Any]:
@@ -363,25 +377,47 @@ def _persist_schema_ir_envelope(model_name: str, envelope: dict[str, Any]) -> No
     ferro_state.persist_model_envelope(model_name, envelope)
 
 
+def _compile_and_persist_model_envelope(
+    model_name: str,
+    schema: dict[str, Any],
+    *,
+    table_name: str | None = None,
+    model_cls: type[Any] | None = None,
+) -> dict[str, Any]:
+    """Compile one model or join table to SchemaIR and persist its envelope.
+
+    Single compile choke point for the test instrument and for every producer
+    of per-model envelopes (#245).
+    """
+    global _SCHEMA_IR_COMPILE_COUNT_FOR_TEST
+    _SCHEMA_IR_COMPILE_COUNT_FOR_TEST += 1
+    resolved_table_name = table_name
+    if resolved_table_name is None and model_cls is not None:
+        resolved_table_name = getattr(model_cls, "__ferro_table__", None)
+    payload = compile_schema_ir_payload(
+        model_name,
+        schema,
+        table_name=resolved_table_name,
+    )
+    envelope = wrap_schema_ir(payload)
+    _persist_schema_ir_envelope(model_name, envelope)
+    return envelope
+
+
 def register_model_with_ir(
     model_name: str,
     schema: dict[str, Any],
     table_name: str,
 ) -> dict[str, Any]:
-    """Compile SchemaIR once, register Rust state, and persist the envelope.
+    """Compile SchemaIR once and persist the envelope.
 
     Single registration bundle for metaclass, relationship resolution, join
-    tables, and ``Model._reregister_ferro`` (#236).
+    tables, and ``Model._reregister_ferro`` (#236). Rust registration is
+    installed only via the bulk push seam (ADR #242 / #245).
     """
-    payload = compile_schema_ir_payload(model_name, schema, table_name=table_name)
-    register_model_schema(
-        model_name,
-        json.dumps(payload["models"][0]["columns"]),
-        table_name,
+    return _compile_and_persist_model_envelope(
+        model_name, schema, table_name=table_name
     )
-    envelope = wrap_schema_ir(payload)
-    _persist_schema_ir_envelope(model_name, envelope)
-    return envelope
 
 
 def wrap_schema_ir(payload: dict[str, Any]) -> dict[str, Any]:
@@ -409,39 +445,34 @@ def compile_model_schema_ir(
     """
     if schema is None:
         schema = build_model_schema(model_cls)
-    payload = compile_schema_ir_payload(
-        model_name,
-        schema,
-        table_name=getattr(model_cls, "__ferro_table__", None),
+    return _compile_and_persist_model_envelope(
+        model_name, schema, model_cls=model_cls
     )
-    envelope = wrap_schema_ir(payload)
-    _persist_schema_ir_envelope(model_name, envelope)
-    return envelope
 
 
-def compile_registry_schema_ir() -> dict[str, Any]:
-    """Compile and persist a deterministic SchemaIR envelope for all models.
+def _model_payload_from_envelope(name: str) -> dict[str, Any]:
+    envelope = _SCHEMA_IR_BY_MODEL.get(name)
+    if envelope is None:
+        raise RuntimeError(
+            f"Missing SchemaIR envelope for '{name}'. "
+            "Compile the model (or run relationship resolution) before assembling "
+            "the modelset."
+        )
+    return envelope["payload"]["models"][0]
 
-    Returns:
-        The compiled model-set SchemaIR envelope, sorted by model name.
-    """
+
+def _assemble_modelset_envelope() -> dict[str, Any]:
+    """Stitch per-model envelopes into one sorted modelset envelope."""
     models: list[dict[str, Any]] = []
-    for model_name, model_cls in sorted(_MODEL_REGISTRY_PY.items(), key=lambda item: item[0]):
-        model_envelope = compile_model_schema_ir(model_name, model_cls)
-        model_payload = model_envelope["payload"]["models"][0]
-        models.append(model_payload)
+    for model_name, _model_cls in sorted(_MODEL_REGISTRY_PY.items(), key=lambda item: item[0]):
+        models.append(_model_payload_from_envelope(model_name))
 
     for table_name, table_schema in sorted(
         _JOIN_TABLE_REGISTRY.items(), key=lambda item: item[0]
     ):
         if not isinstance(table_schema, dict):
             continue
-        join_payload = compile_schema_ir_payload(
-            table_name,
-            table_schema,
-            table_name=table_name,
-        )["models"][0]
-        models.append(join_payload)
+        models.append(_model_payload_from_envelope(table_name))
 
     envelope = {
         "ir_kind": "schema",
@@ -455,6 +486,65 @@ def compile_registry_schema_ir() -> dict[str, Any]:
     ferro_state._SCHEMA_IR_MODELSET = envelope
     ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = ferro_state.ir_fingerprint(envelope)
     return envelope
+
+
+def _missing_registry_envelope_names() -> list[str]:
+    missing: list[str] = []
+    for name in _MODEL_REGISTRY_PY:
+        if name not in _SCHEMA_IR_BY_MODEL:
+            missing.append(name)
+    for table_name, table_schema in _JOIN_TABLE_REGISTRY.items():
+        if isinstance(table_schema, dict) and table_name not in _SCHEMA_IR_BY_MODEL:
+            missing.append(table_name)
+    return missing
+
+
+def _recompile_missing_registry_envelopes() -> None:
+    for model_name in _missing_registry_envelope_names():
+        model_cls = _MODEL_REGISTRY_PY.get(model_name)
+        if model_cls is not None:
+            compile_model_schema_ir(model_name, model_cls)
+            continue
+        table_schema = _JOIN_TABLE_REGISTRY.get(model_name)
+        if isinstance(table_schema, dict):
+            register_model_with_ir(model_name, table_schema, model_name)
+
+
+def _recompile_all_registered_envelopes() -> None:
+    """Recompile every registered model and join-table envelope.
+
+    Used when ``compile_registry_schema_ir()`` is invoked on a dirty registry
+    without going through ``resolve_relationships()`` — direct callers (tests,
+    Alembic-adjacent tooling) historically relied on compile-not-assemble here.
+    The connect/reconnect clean path never hits this (#245).
+    """
+    for model_name, model_cls in sorted(_MODEL_REGISTRY_PY.items(), key=lambda item: item[0]):
+        compile_model_schema_ir(model_name, model_cls)
+    for table_name, table_schema in sorted(
+        _JOIN_TABLE_REGISTRY.items(), key=lambda item: item[0]
+    ):
+        if isinstance(table_schema, dict):
+            register_model_with_ir(table_name, table_schema, table_name)
+
+
+def compile_registry_schema_ir() -> dict[str, Any]:
+    """Assemble and persist a deterministic SchemaIR envelope for all models.
+
+    Stitches already-compiled per-model envelopes from ``_SCHEMA_IR_BY_MODEL``
+    for every entry in ``_MODEL_REGISTRY_PY`` and ``_JOIN_TABLE_REGISTRY``.
+    On a dirty registry, recompiles envelopes first so direct callers that
+    bypass ``resolve_relationships()`` still observe current registry state.
+    After ``ensure_resolved_modelset()`` on the clean path, this is
+    assemble-only (#245).
+
+    Returns:
+        The assembled model-set SchemaIR envelope, sorted by model name.
+    """
+    if ferro_state.is_modelset_dirty():
+        _recompile_all_registered_envelopes()
+    else:
+        _recompile_missing_registry_envelopes()
+    return _assemble_modelset_envelope()
 
 
 def schema_ir_fingerprint(ir_envelope: dict[str, Any]) -> str:

--- a/src/ferro/migrations/alembic.py
+++ b/src/ferro/migrations/alembic.py
@@ -8,7 +8,6 @@ except ImportError:
 
 from .._annotation_utils import _VARCHAR_RE
 from .._core import _ddl_fk_name, _render_check_body, _resolve_storage_type
-from ..ir import compile_registry_schema_ir
 
 #: SQLAlchemy ``naming_convention`` mirroring the Rust emitter's names. IR-backed
 #: metadata names every artifact explicitly; this convention covers any
@@ -50,13 +49,9 @@ def get_metadata() -> "sa.MetaData":
 
     metadata = sa.MetaData(naming_convention=_FERRO_NAMING_CONVENTION)
 
-    # 1. First, ensure all relationships are resolved
-    from ..relations import resolve_relationships
+    from .. import ensure_resolved_modelset
 
-    resolve_relationships()
-
-    # 2. Build SQLAlchemy metadata from SchemaIR modelset only.
-    schema_ir = compile_registry_schema_ir()
+    schema_ir = ensure_resolved_modelset()
     payload = schema_ir.get("payload", {})
     models = payload.get("models", [])
     for model_ir in models:

--- a/src/ferro/relations/__init__.py
+++ b/src/ferro/relations/__init__.py
@@ -1,4 +1,3 @@
-import json
 from typing import ForwardRef
 
 from ..ir import register_model_with_ir
@@ -8,12 +7,12 @@ from .._shadow_fk_types import (
     schema_fragment_for_pk,
 )
 from ..base import ForeignKey, ManyToManyRelation
-from ..ir import compile_registry_schema_ir
 from ..schema_metadata import build_model_schema
 from ..state import (  # noqa: F401
     _JOIN_TABLE_REGISTRY,
     _MODEL_REGISTRY_PY,
     _PENDING_RELATIONS,
+    mark_modelset_resolved,
     resolve_model_reference,
 )
 from .descriptors import RelationshipDescriptor
@@ -34,7 +33,10 @@ def resolve_relationships():
     to_process = list(_PENDING_RELATIONS)
     _PENDING_RELATIONS.clear()
 
+    recompile_targets: set[str] = set()
+
     for model_name, field_name, rel in to_process:
+        recompile_targets.add(model_name)
         # 1. Resolve 'to' model
         if isinstance(rel.to, (str, ForwardRef)):
             to_name = rel.to if isinstance(rel.to, str) else rel.to.__forward_arg__
@@ -47,6 +49,7 @@ def resolve_relationships():
 
         # 2. Cross-validate with declared reverse relation field.
         target_model = rel.to
+        recompile_targets.add(target_model.__ferro_identity__)
         if not hasattr(target_model, rel.related_name):
             raise RuntimeError(
                 f"Model '{model_name}' defines a relationship to '{target_model.__name__}' "
@@ -151,12 +154,16 @@ def resolve_relationships():
             register_model_with_ir(join_table, join_schema, join_table)
             _JOIN_TABLE_REGISTRY[join_table] = join_schema
 
-    reconcile_shadow_fk_types(_MODEL_REGISTRY_PY)
+    rebuilt = reconcile_shadow_fk_types(_MODEL_REGISTRY_PY)
+    for model_cls in rebuilt:
+        recompile_targets.add(model_cls.__ferro_identity__)
 
-    # Second pass: Re-register schemas — loudly (FF-E E4). A model whose
-    # schema fails to rebuild here would otherwise be silently left on its
-    # pre-relationship schema.
-    for model_name, model_cls in _MODEL_REGISTRY_PY.items():
+    # Second pass: recompile only models whose schema changed during resolution
+    # (relationship sources/targets and shadow-FK reconciliation targets).
+    for model_name in sorted(recompile_targets):
+        model_cls = _MODEL_REGISTRY_PY.get(model_name)
+        if model_cls is None:
+            continue
         try:
             schema = build_model_schema(model_cls)
         except Exception as exc:
@@ -168,5 +175,5 @@ def resolve_relationships():
             model_name, schema, model_cls.__ferro_table__
         )
 
-    compile_registry_schema_ir()
+    mark_modelset_resolved()
     _PENDING_RELATIONS.clear()

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -100,6 +100,44 @@ _SCHEMA_IR_MODELSET_FINGERPRINT: str | None = None
 _SCHEMA_IR_BY_MODEL: dict[str, dict[str, Any]] = {}
 _SCHEMA_IR_FINGERPRINT_BY_MODEL: dict[str, str] = {}
 
+# Monotonic generation counter bumped by register/deregister; cleared (matched to
+# resolved) at the end of relationship resolution (#245).
+_REGISTRATION_GENERATION: int = 0
+_RESOLVED_GENERATION: int = 0
+
+
+def registration_generation() -> int:
+    """Return the current registration generation counter (test/diagnostic)."""
+    return _REGISTRATION_GENERATION
+
+
+def resolved_generation() -> int:
+    """Return the generation counter last cleared by relationship resolution."""
+    return _RESOLVED_GENERATION
+
+
+def is_modelset_dirty() -> bool:
+    """True when the registry changed since last resolve or relations are pending."""
+    return _REGISTRATION_GENERATION != _RESOLVED_GENERATION or bool(_PENDING_RELATIONS)
+
+
+def _bump_registration_generation() -> None:
+    global _REGISTRATION_GENERATION
+    _REGISTRATION_GENERATION += 1
+
+
+def mark_modelset_resolved() -> None:
+    """Record that the current registry generation has been resolved."""
+    global _RESOLVED_GENERATION
+    _RESOLVED_GENERATION = _REGISTRATION_GENERATION
+
+
+def reset_registration_generations_for_test() -> None:
+    """Reset generation counters (``clean_registry`` fixture)."""
+    global _REGISTRATION_GENERATION, _RESOLVED_GENERATION
+    _REGISTRATION_GENERATION = 0
+    _RESOLVED_GENERATION = 0
+
 
 def canonical_ir_json(value: dict[str, Any]) -> str:
     """Serialize an IR artifact with deterministic key ordering."""
@@ -135,6 +173,7 @@ def register_model(cls: FerroModelClass) -> None:
     same model by this identity, so there is exactly one name for a model.
     """
     _MODEL_REGISTRY_PY[cls.__ferro_identity__] = cls
+    _bump_registration_generation()
 
 
 def persist_model_envelope(name: str, envelope: dict[str, Any]) -> None:
@@ -174,8 +213,11 @@ def deregister_model(name: str) -> None:
     function-local model added during a test) and hold the identity string, not
     the class object.
     """
+    removed = name in _MODEL_REGISTRY_PY
     _MODEL_REGISTRY_PY.pop(name, None)
     evict_model_envelope(name)
+    if removed:
+        _bump_registration_generation()
 
 
 _NO_ROUTE_MESSAGE = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,6 +232,10 @@ def clean_registry():
         ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL.clear()
         ferro_state._SCHEMA_IR_MODELSET = None
         ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = None
+        ferro_state.reset_registration_generations_for_test()
+        from ferro.ir.compiler import reset_schema_ir_compile_count_for_test
+
+        reset_schema_ir_compile_count_for_test()
 
     _wipe()
     yield

--- a/tests/test_generation_counter_dirty_tracking.py
+++ b/tests/test_generation_counter_dirty_tracking.py
@@ -1,0 +1,143 @@
+"""Generation-counter dirty tracking, assemble-not-recompile, compile counter (#245)."""
+
+from typing import Annotated
+
+import pytest
+
+import ferro
+from ferro import Model, Relation, connect, create_tables, reset_engine
+from ferro._core import _bulk_install_count_for_test
+from ferro.base import FerroField, ForeignKey
+from ferro.fields import BackRef
+from ferro.ir.compiler import (
+    compile_registry_schema_ir,
+    reset_schema_ir_compile_count_for_test,
+    schema_ir_compile_count_for_test,
+)
+from ferro import state as ferro_state
+
+
+def test_register_and_deregister_bump_generation_counter(clean_registry) -> None:
+    assert ferro_state.registration_generation() == 0
+    assert ferro_state.resolved_generation() == 0
+    assert not ferro_state.is_modelset_dirty()
+
+    class GcWidget(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    assert ferro_state.registration_generation() == 1
+    assert ferro_state.is_modelset_dirty()
+
+    ferro_state.deregister_model(GcWidget.__ferro_identity__)
+    assert ferro_state.registration_generation() == 2
+    assert ferro_state.is_modelset_dirty()
+
+
+def test_resolve_clears_dirty_generation(clean_registry) -> None:
+    from ferro.relations import resolve_relationships
+
+    class GcAuthor(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+        posts: Relation[list["GcPost"]] = BackRef()
+
+    class GcPost(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        title: str
+        author: Annotated["GcAuthor", ForeignKey(related_name="posts")]
+
+    assert ferro_state.is_modelset_dirty()
+    resolve_relationships()
+    assert not ferro_state.is_modelset_dirty()
+    assert ferro_state.resolved_generation() == ferro_state.registration_generation()
+
+
+def test_assemble_fails_loudly_on_missing_envelope(clean_registry) -> None:
+    from ferro.relations import resolve_relationships
+
+    class GcOrphan(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+
+    from ferro.ir.compiler import _assemble_modelset_envelope
+
+    resolve_relationships()
+    ferro_state.evict_model_envelope(GcOrphan.__ferro_identity__)
+
+    with pytest.raises(RuntimeError, match="Missing SchemaIR envelope"):
+        _assemble_modelset_envelope()
+
+
+@pytest.mark.asyncio
+async def test_clean_reconnect_zero_compiles_zero_bulk_install(db_url, clean_registry) -> None:
+    """After the first sync, an identical reconnect assembles without recompiling
+    and skips the bulk install fingerprint gate."""
+
+    class GcStable(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    reset_schema_ir_compile_count_for_test()
+    bulk_baseline = _bulk_install_count_for_test()
+
+    await connect(db_url, auto_migrate=False)
+    assert _bulk_install_count_for_test() - bulk_baseline == 1
+
+    reset_engine()
+    reset_schema_ir_compile_count_for_test()
+    after_first = _bulk_install_count_for_test()
+
+    await connect(db_url, auto_migrate=False)
+    assert schema_ir_compile_count_for_test() == 0
+    assert _bulk_install_count_for_test() - after_first == 0
+
+
+def test_dirty_resolve_recompiles_only_affected_subset(clean_registry, monkeypatch) -> None:
+    """Relationship resolution recompiles changed models and shadow-FK targets,
+    not the entire registry."""
+    from ferro.relations import resolve_relationships
+
+    compile_calls: list[str] = []
+    real_compile = ferro.ir.compiler._compile_and_persist_model_envelope
+
+    def tracking_compile(model_name, schema, *, table_name=None, model_cls=None):
+        compile_calls.append(model_name)
+        return real_compile(
+            model_name, schema, table_name=table_name, model_cls=model_cls
+        )
+
+    monkeypatch.setattr(
+        ferro.ir.compiler, "_compile_and_persist_model_envelope", tracking_compile
+    )
+
+    class GcIsland(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        note: str
+        leaves: Relation[list["GcLeaf"]] = BackRef()
+
+    island_identity = GcIsland.__ferro_identity__
+
+    class GcLeaf(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        island_id: int | None = None
+        island: Annotated[GcIsland, ForeignKey(related_name="leaves")]
+
+    compile_calls.clear()
+    resolve_relationships()
+
+    assert island_identity in compile_calls
+    assert GcLeaf.__ferro_identity__ in compile_calls
+    assert len(compile_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_ensure_rust_registration_synced_routes_connect(db_url, clean_registry) -> None:
+    from ferro import ensure_resolved_modelset
+
+    class GcRouted(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        value: str
+
+    await connect(db_url, auto_migrate=True)
+    assert ferro_state._SCHEMA_IR_MODELSET is not None
+    assert ensure_resolved_modelset() == ferro_state._SCHEMA_IR_MODELSET

--- a/tests/test_generation_counter_dirty_tracking.py
+++ b/tests/test_generation_counter_dirty_tracking.py
@@ -5,12 +5,11 @@ from typing import Annotated
 import pytest
 
 import ferro
-from ferro import Model, Relation, connect, create_tables, reset_engine
+from ferro import Model, Relation, connect, reset_engine
 from ferro._core import _bulk_install_count_for_test
 from ferro.base import FerroField, ForeignKey
 from ferro.fields import BackRef
 from ferro.ir.compiler import (
-    compile_registry_schema_ir,
     reset_schema_ir_compile_count_for_test,
     schema_ir_compile_count_for_test,
 )
@@ -139,5 +138,7 @@ async def test_ensure_rust_registration_synced_routes_connect(db_url, clean_regi
         value: str
 
     await connect(db_url, auto_migrate=True)
-    assert ferro_state._SCHEMA_IR_MODELSET is not None
-    assert ensure_resolved_modelset() == ferro_state._SCHEMA_IR_MODELSET
+    reset_schema_ir_compile_count_for_test()
+    modelset = ensure_resolved_modelset()
+    assert schema_ir_compile_count_for_test() == 0
+    assert modelset is ferro_state._SCHEMA_IR_MODELSET

--- a/tests/test_relationship_resolution_errors.py
+++ b/tests/test_relationship_resolution_errors.py
@@ -1,13 +1,15 @@
 """FF-E E4: resolve_relationships' schema re-registration pass fails loudly.
 
-The second pass used to wrap every re-registration in `except Exception:
-pass`, leaving a model that failed to rebuild silently on its
-pre-relationship schema.
+The selective re-registration pass used to wrap every re-registration in
+``except Exception: pass``, leaving a model that failed to rebuild silently
+on its pre-relationship schema.
 """
+
+from typing import Annotated
 
 import pytest
 
-from ferro import Model
+from ferro import BackRef, ForeignKey, Model, Relation
 from ferro.relations import resolve_relationships
 
 
@@ -28,6 +30,12 @@ def test_second_pass_rebuild_failure_aborts_with_model_named(monkeypatch):
     class E4Broken(Model):
         id: int | None = None
         name: str
+        peers: Relation[list["E4Peer"]] = BackRef()
+
+    class E4Peer(Model):
+        id: int | None = None
+        broken_id: int | None = None
+        broken: Annotated[E4Broken, ForeignKey(related_name="peers")]
 
     import ferro.relations as relations_mod
 


### PR DESCRIPTION
## Summary

- Add monotonic registration generation counters (`register_model` / `deregister_model` bump; `resolve_relationships` clears) with O(1) dirty detection via `is_modelset_dirty()`.
- Introduce `ensure_resolved_modelset()` and `_ensure_rust_registration_synced()`; route `connect` / `create_tables` / `migrate` through the composed sync primitive; Alembic bridge calls `ensure_resolved_modelset()` only.
- Rewrite `compile_registry_schema_ir()` to assemble from `_SCHEMA_IR_BY_MODEL` (iterating `_MODEL_REGISTRY_PY` + `_JOIN_TABLE_REGISTRY`, failing loudly on missing envelopes); dirty resolve recompiles only relationship/shadow-FK targets; add Python `schema_ir_compile_count_for_test` instrument.

## Test plan

- [x] `pytest` (874 passed)
- [x] `cargo test --no-default-features --features testing`
- [x] IR-vector snapshot / cross-emitter parity (`tests/test_ir_vectors_contract.py`)
- [x] Clean reconnect: 0 compiles + 0 bulk installs (`tests/test_generation_counter_dirty_tracking.py`)

## Bridge and Schema Impact

- [ ] No Rust/Python bridge changes
- [x] Python model/schema changed
- [ ] Rust core or SQL generation changed
- [ ] `src/ferro/_core.pyi` updated (if needed)
- [x] Integration test added first for new behavior

## Migration / Breaking Changes

- [x] No breaking changes

## Documentation and Changelog

- [x] No docs update needed
- [ ] Docs updated (README/docs/inline docs)
- [ ] Changelog entry needed

## Related Issues

- Closes #245

## Exit Steps (I-9)

- [x] Related completed issues are linked above with Closes/Fixes/Resolves
- [ ] Issue statuses are updated/auto-close on merge

Made with [Cursor](https://cursor.com)