### PR TITLE
feat: sync registration at ORM operation seam (#247)

### DIFF
--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -5,7 +5,6 @@ Ferro combines the speed of a Rust engine with the ergonomics of Pydantic models
 to provide a seamless, high-performance database experience.
 """
 
-import asyncio
 import logging
 import threading
 from typing import Any
@@ -59,32 +58,29 @@ if not _logger.handlers:
 
 
 _RESOLVED_MODELSET_LOCK = threading.Lock()
-_OPERATION_REGISTRATION_SYNC_LOCK: asyncio.Lock | None = None
-
-
-def _operation_registration_sync_lock() -> asyncio.Lock:
-    global _OPERATION_REGISTRATION_SYNC_LOCK
-    if _OPERATION_REGISTRATION_SYNC_LOCK is None:
-        _OPERATION_REGISTRATION_SYNC_LOCK = asyncio.Lock()
-    return _OPERATION_REGISTRATION_SYNC_LOCK
+_OPERATION_REGISTRATION_SYNC_LOCK = threading.Lock()
 
 
 async def _ensure_rust_registration_synced_for_operation() -> None:
     """Registration-only sync before ORM operations touch Rust (#247).
 
     Clean path (O(1)): in-process generation comparison only — no FFI.
-    Dirty path: resolve + bulk install under an async single-flight guard so
-    concurrent coroutines cannot double-compile or install out of order.
+    Dirty path: resolve + bulk install under a threading single-flight guard
+    (``_OPERATION_REGISTRATION_SYNC_LOCK``), matching ``_RESOLVED_MODELSET_LOCK``
+    two functions up. The guarded section is fully synchronous — no ``await``
+    inside — so a ``threading.Lock`` gives real cross-thread single-flight
+    without the cross-loop hang of a module-global ``asyncio.Lock``. Under
+    contention the event loop blocks for one resolve+install per generation; do
+    not offload this to a thread pool — that would reintroduce interleaving.
     """
     from .state import is_modelset_dirty
 
     if not is_modelset_dirty():
         return
 
-    async with _operation_registration_sync_lock():
-        if not is_modelset_dirty():
-            return
-        _ensure_rust_registration_synced()
+    with _OPERATION_REGISTRATION_SYNC_LOCK:
+        if is_modelset_dirty():
+            _ensure_rust_registration_synced()
 
 
 def ensure_resolved_modelset() -> dict[str, Any]:

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -5,6 +5,7 @@ Ferro combines the speed of a Rust engine with the ergonomics of Pydantic models
 to provide a seamless, high-performance database experience.
 """
 
+import asyncio
 import logging
 import threading
 from typing import Any
@@ -58,6 +59,32 @@ if not _logger.handlers:
 
 
 _RESOLVED_MODELSET_LOCK = threading.Lock()
+_OPERATION_REGISTRATION_SYNC_LOCK: asyncio.Lock | None = None
+
+
+def _operation_registration_sync_lock() -> asyncio.Lock:
+    global _OPERATION_REGISTRATION_SYNC_LOCK
+    if _OPERATION_REGISTRATION_SYNC_LOCK is None:
+        _OPERATION_REGISTRATION_SYNC_LOCK = asyncio.Lock()
+    return _OPERATION_REGISTRATION_SYNC_LOCK
+
+
+async def _ensure_rust_registration_synced_for_operation() -> None:
+    """Registration-only sync before ORM operations touch Rust (#247).
+
+    Clean path (O(1)): in-process generation comparison only — no FFI.
+    Dirty path: resolve + bulk install under an async single-flight guard so
+    concurrent coroutines cannot double-compile or install out of order.
+    """
+    from .state import is_modelset_dirty
+
+    if not is_modelset_dirty():
+        return
+
+    async with _operation_registration_sync_lock():
+        if not is_modelset_dirty():
+            return
+        _ensure_rust_registration_synced()
 
 
 def ensure_resolved_modelset() -> dict[str, Any]:

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -66,13 +66,16 @@ def _field_eq(field_name: str, value: Any) -> Predicate[Any]:
     return lambda t, f=field_name, v=value: getattr(t, f) == v
 
 
-def _transaction_or_using(
+async def _transaction_or_using(
     using: str | None, session: "Session | None"
 ) -> RouteHandle:
+    from . import _ensure_rust_registration_synced_for_operation
+
+    await _ensure_rust_registration_synced_for_operation()
     return resolve_operation_scope(using=using, session=session)
 
 
-def _instance_transaction_route(
+async def _instance_transaction_route(
     instance: object, using: str | None, session: "Session | None"
 ) -> tuple[RouteHandle, str]:
     """Resolve the route for an instance method (`save`/`delete`/`refresh`).
@@ -89,7 +92,7 @@ def _instance_transaction_route(
 
     # Origin is the instance's implicit route (FF-D D4): it participates in
     # session-conflict checks instead of silently bypassing the session.
-    route = _transaction_or_using(using or origin, session)
+    route = await _transaction_or_using(using or origin, session)
     return route, route.connection_name
 
 
@@ -310,7 +313,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             raise ValueError(
                 f'on_conflict must be None or "update", got {on_conflict!r}'
             )
-        route, identity_using = _instance_transaction_route(self, using, session)
+        route, identity_using = await _instance_transaction_route(self, using, session)
         new_id = None
         if on_conflict == "update":
             new_id = await save_record(
@@ -388,7 +391,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         """
         pk_field_name = self.__class__._primary_key_field_name()
         pk_val = getattr(self, pk_field_name) if pk_field_name is not None else None
-        route, _identity_using = _instance_transaction_route(self, using, session)
+        route, _identity_using = await _instance_transaction_route(self, using, session)
 
         if pk_val is not None:
             name = self.__class__.__ferro_identity__
@@ -426,7 +429,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> isinstance(users, list)
             True
         """
-        route = _transaction_or_using(using, session)
+        route = await _transaction_or_using(using, session)
         return await fetch_all(cls, route)
 
     @classmethod
@@ -493,7 +496,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             raise RuntimeError("Cannot refresh a model without a primary key")
 
         name = self.__class__.__ferro_identity__
-        route, identity_using = _instance_transaction_route(self, using, session)
+        route, identity_using = await _instance_transaction_route(self, using, session)
 
         _core_evict_instance(name, str(pk_val), route)
         query = Query(self.__class__, using=route.connection_name).where(
@@ -632,7 +635,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         if not instances:
             return 0
         data = [save_bind_payload(i) for i in instances]
-        route = _transaction_or_using(using, session)
+        route = await _transaction_or_using(using, session)
         return await save_bulk_records(cls.__ferro_identity__, data, route)
 
     @classmethod

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -94,9 +94,11 @@ class Query(Generic[T]):
         self._offset: int | None = None
         self._m2m_context: dict[str, Any] | None = None
 
-    def _transaction_or_using(self) -> "RouteHandle":
+    async def _transaction_or_using(self) -> "RouteHandle":
+        from .. import _ensure_rust_registration_synced_for_operation
         from ..state import resolve_operation_scope
 
+        await _ensure_rust_registration_synced_for_operation()
         return resolve_operation_scope(using=self._using, session=self._session)
 
     def _clone(self) -> Self:
@@ -294,7 +296,7 @@ class Query(Generic[T]):
             "offset": self._offset,
             "m2m": self._m2m_context,
         }
-        route = self._transaction_or_using()
+        route = await self._transaction_or_using()
         return await fetch_filtered(
             self.model_cls,
             _query_ir_payload_to_json(query_def),
@@ -320,7 +322,7 @@ class Query(Generic[T]):
             "offset": None,
             "m2m": self._m2m_context,
         }
-        route = self._transaction_or_using()
+        route = await self._transaction_or_using()
         return await count_filtered(
             _model_identity(self.model_cls),
             _query_ir_payload_to_json(query_def),
@@ -345,7 +347,7 @@ class Query(Generic[T]):
             True
         """
         query_def = self._mutating_query_def("update")
-        route = self._transaction_or_using()
+        route = await self._transaction_or_using()
         return await update_filtered(
             _model_identity(self.model_cls),
             _query_ir_payload_to_json(query_def),
@@ -382,7 +384,7 @@ class Query(Generic[T]):
             True
         """
         query_def = self._mutating_query_def("delete")
-        route = self._transaction_or_using()
+        route = await self._transaction_or_using()
         return await delete_filtered(
             _model_identity(self.model_cls),
             _query_ir_payload_to_json(query_def),
@@ -427,7 +429,7 @@ class Query(Generic[T]):
             # Assume 'id' for now
             ids.append(getattr(inst, "id"))
 
-        route = self._transaction_or_using()
+        route = await self._transaction_or_using()
         await add_m2m_links(
             self._m2m_context["join_table"],
             self._m2m_context["source_col"],
@@ -460,7 +462,7 @@ class Query(Generic[T]):
         for inst in instances:
             ids.append(getattr(inst, "id"))
 
-        route = self._transaction_or_using()
+        route = await self._transaction_or_using()
         await remove_m2m_links(
             self._m2m_context["join_table"],
             self._m2m_context["source_col"],
@@ -485,7 +487,7 @@ class Query(Generic[T]):
                 "'.clear()' can only be used on Many-to-Many relationships"
             )
 
-        route = self._transaction_or_using()
+        route = await self._transaction_or_using()
         await clear_m2m_links(
             self._m2m_context["join_table"],
             self._m2m_context["source_col"],

--- a/tests/test_operation_seam_sync.py
+++ b/tests/test_operation_seam_sync.py
@@ -125,7 +125,7 @@ def test_cross_thread_dirty_path_single_bulk_install(db_url, clean_registry) -> 
         try:
 
             async def run() -> None:
-                barrier.wait()
+                barrier.wait(timeout=10)
                 async with ferro.engines.session():
                     await OsThread.create(slot=slot)
 

--- a/tests/test_operation_seam_sync.py
+++ b/tests/test_operation_seam_sync.py
@@ -1,6 +1,7 @@
 """Operation-seam registration sync: single-flight, zero-DDL, clean path (#247)."""
 
 import asyncio
+import threading
 from typing import Annotated
 
 import pytest
@@ -91,6 +92,54 @@ async def test_concurrent_first_operations_single_bulk_install(
             await OsConcurrent.create(score=score)
 
     await asyncio.gather(*(first_save(i) for i in range(8)))
+    assert _bulk_install_count_for_test() - baseline == 1
+
+
+def test_cross_thread_dirty_path_single_bulk_install(db_url, clean_registry) -> None:
+    """Two threads on separate event loops serialize dirty-path install via threading.Lock."""
+
+    class OsThreadBase(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    async def setup() -> None:
+        await connect(db_url, auto_migrate=True)
+        async with ferro.engines.session():
+            await execute(
+                'CREATE TABLE IF NOT EXISTS "osthread" ( '
+                '"id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, '
+                '"slot" integer NOT NULL )'
+            )
+
+    asyncio.run(setup())
+
+    class OsThread(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        slot: int
+
+    baseline = _bulk_install_count_for_test()
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+
+    def thread_worker(slot: int) -> None:
+        try:
+
+            async def run() -> None:
+                barrier.wait()
+                async with ferro.engines.session():
+                    await OsThread.create(slot=slot)
+
+            asyncio.run(run())
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=thread_worker, args=(i,)) for i in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
     assert _bulk_install_count_for_test() - baseline == 1
 
 

--- a/tests/test_operation_seam_sync.py
+++ b/tests/test_operation_seam_sync.py
@@ -1,0 +1,220 @@
+"""Operation-seam registration sync: single-flight, zero-DDL, clean path (#247)."""
+
+import asyncio
+from typing import Annotated
+
+import pytest
+
+import ferro
+from ferro import Model, OperationalError, connect, execute
+from ferro._core import _bulk_install_count_for_test
+from ferro.base import FerroField
+from ferro import state as ferro_state
+
+
+@pytest.mark.asyncio
+async def test_late_model_after_connect_save_and_query_without_ddl(
+    db_url, clean_registry
+) -> None:
+    """A model defined after connect syncs on first operation — no create_tables."""
+
+    class OsEarly(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+
+    async with ferro.engines.session():
+        await execute(
+            'CREATE TABLE IF NOT EXISTS "oslate" ( '
+            '"id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, '
+            '"note" varchar NOT NULL )'
+        )
+
+    class OsLate(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        note: str
+
+    async with ferro.engines.session():
+        row = await OsLate.create(note="synced")
+        assert (await OsLate.get(row.id)).note == "synced"
+        assert len(await OsLate.all()) == 1
+
+
+@pytest.mark.asyncio
+async def test_operation_seam_sync_does_not_create_tables(db_url, clean_registry) -> None:
+    """Registration sync on save must not emit DDL when the table is missing."""
+
+    class OsSeeded(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        tag: str
+
+    await connect(db_url, auto_migrate=True)
+
+    class OsMissing(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        value: str
+
+    instance = OsMissing(value="nope")
+    async with ferro.engines.session():
+        with pytest.raises(OperationalError):
+            await instance.save()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_operations_single_bulk_install(
+    db_url, clean_registry
+) -> None:
+    """Concurrent dirty-path ops serialize to exactly one bulk install."""
+
+    class OsBase(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        label: str
+
+    await connect(db_url, auto_migrate=True)
+
+    async with ferro.engines.session():
+        await execute(
+            'CREATE TABLE IF NOT EXISTS "osconcurrent" ( '
+            '"id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, '
+            '"score" integer NOT NULL )'
+        )
+
+    class OsConcurrent(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        score: int
+
+    baseline = _bulk_install_count_for_test()
+
+    async def first_save(score: int) -> None:
+        async with ferro.engines.session():
+            await OsConcurrent.create(score=score)
+
+    await asyncio.gather(*(first_save(i) for i in range(8)))
+    assert _bulk_install_count_for_test() - baseline == 1
+
+
+@pytest.mark.asyncio
+async def test_clean_path_skips_bulk_install_and_push(
+    db_url, clean_registry, monkeypatch
+) -> None:
+    """After sync, clean operations compare generation counters only — no FFI push."""
+
+    class OsClean(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+
+    await connect(db_url, auto_migrate=True)
+
+    class OsCleanLate(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        note: str
+
+    async with ferro.engines.session():
+        await execute(
+            'CREATE TABLE IF NOT EXISTS "oscleanlate" ( '
+            '"id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, '
+            '"note" varchar NOT NULL )'
+        )
+        row = await OsCleanLate.create(note="warm")
+        pk = row.id
+
+    push_calls: list[object] = []
+    real_push = ferro._push_registration_to_rust
+
+    def tracking_push(*args, **kwargs):
+        push_calls.append((args, kwargs))
+        return real_push(*args, **kwargs)
+
+    monkeypatch.setattr(ferro, "_push_registration_to_rust", tracking_push)
+
+    bulk_after_warm = _bulk_install_count_for_test()
+    push_calls.clear()
+
+    async with ferro.engines.session():
+        await OsCleanLate.all()
+        await OsCleanLate.get(pk)
+
+    assert push_calls == []
+    assert _bulk_install_count_for_test() == bulk_after_warm
+
+
+@pytest.mark.asyncio
+async def test_failed_resolve_stays_dirty_and_retries(
+    db_url, clean_registry, monkeypatch
+) -> None:
+    """A failed resolve leaves the registry dirty; the next operation retries."""
+
+    class OsRetry(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        value: str
+
+    await connect(db_url, auto_migrate=True)
+
+    class OsRetryLate(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        payload: str
+
+    async with ferro.engines.session():
+        await execute(
+            'CREATE TABLE IF NOT EXISTS "osretrylate" ( '
+            '"id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, '
+            '"payload" varchar NOT NULL )'
+        )
+
+    from ferro.relations import resolve_relationships
+
+    real_resolve = resolve_relationships
+    attempts = 0
+
+    def flaky_resolve() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("simulated resolve failure")
+        return real_resolve()
+
+    monkeypatch.setattr("ferro.relations.resolve_relationships", flaky_resolve)
+
+    async with ferro.engines.session():
+        with pytest.raises(RuntimeError, match="simulated resolve failure"):
+            await OsRetryLate.create(payload="first")
+    assert ferro_state.is_modelset_dirty()
+
+    async with ferro.engines.session():
+        row = await OsRetryLate.create(payload="second")
+        assert (await OsRetryLate.get(row.id)).payload == "second"
+    assert not ferro_state.is_modelset_dirty()
+
+
+def test_alembic_metadata_uses_ensure_resolved_not_operation_seam(
+    clean_registry, monkeypatch
+) -> None:
+    """Alembic autogenerate keeps ensure_resolved_modelset; ops must not change it."""
+
+    class OsAlembic(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        title: str
+
+    ensure_calls: list[str] = []
+    operation_calls: list[str] = []
+    real_ensure = ferro.ensure_resolved_modelset
+
+    def tracking_ensure() -> dict:
+        ensure_calls.append("ensure")
+        return real_ensure()
+
+    async def tracking_operation() -> None:
+        operation_calls.append("operation")
+
+    monkeypatch.setattr(ferro, "ensure_resolved_modelset", tracking_ensure)
+    monkeypatch.setattr(
+        ferro, "_ensure_rust_registration_synced_for_operation", tracking_operation
+    )
+
+    from ferro.migrations.alembic import get_metadata
+
+    metadata = get_metadata()
+    assert "osalembic" in metadata.tables
+    assert ensure_calls == ["ensure"]
+    assert operation_calls == []


### PR DESCRIPTION
## Summary

- Wire `_ensure_rust_registration_synced_for_operation()` at the ORM choke points (`models._transaction_or_using` / `query.builder._transaction_or_using`) so late models defined after `connect()` sync on first save/query without calling `create_tables()`/`migrate()`.
- Clean path is O(1) generation-counter only (no FFI); dirty path runs resolve + bulk install under an async single-flight lock.
- Operation-seam sync is registration-only — zero DDL from ORM operations.

Closes #247

## Test plan

- [x] `tests/test_operation_seam_sync.py` — late model after connect, zero DDL, single-flight, clean path no push, failed resolve retry, Alembic unchanged
- [x] `uv run pytest` — 888 passed
- [x] `PYO3_PYTHON=$(which python3) cargo test --no-default-features --features testing` — 125 passed

## Exit steps (I-9)

- [x] PR body includes `Closes #247`
- [x] Issue closure keyword targets the completed scoped work (#247, final #242 sub-issue)

Made with [Cursor](https://cursor.com)