### PR TITLE
ci(release): custom highlights atop the GitHub Release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: boolean
         default: false
+      highlights:
+        description: 'Markdown prepended to the top of the GitHub Release body'
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   group: release-${{ github.workflow }}-${{ github.ref }}
@@ -184,6 +189,20 @@ jobs:
 
           echo "release_ref=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo "Using release ref: $RELEASE_TAG"
+
+      - name: Prepend highlights to GitHub Release
+        if: steps.verify_release.outputs.release_created == 'true' && inputs.highlights != ''
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          # Passed via env (not inline ${{ }}) so backticks, $, and quotes in the
+          # prose can't break the script or inject shell.
+          HIGHLIGHTS: ${{ inputs.highlights }}
+        shell: bash
+        run: |
+          TAG="${{ steps.release_ref.outputs.release_ref }}"
+          BODY="$(gh release view "$TAG" --json body -q .body)"
+          { printf '%s\n' "$HIGHLIGHTS"; printf '\n---\n\n'; printf '%s\n' "$BODY"; } > /tmp/notes.md
+          gh release edit "$TAG" --notes-file /tmp/notes.md
 
       - name: Release summary
         if: always()

--- a/justfile
+++ b/justfile
@@ -1,8 +1,14 @@
-release:
-    gh workflow run release.yml
+# Cut a release. Pass optional markdown to prepend to the top of the GitHub
+# Release body (the auto-generated changelog stays beneath it):
+#
+#   just release "## Query joins have landed 🎉  See the [guide](https://…)."
+#   just release "$(cat /tmp/notes.md)"
+#   just release $'## Query joins\n\nTraverse relations in `where()` …\n\nDocs: https://…'
+release notes="":
+    gh workflow run release.yml -f highlights={{ quote(notes) }}
 
-prerelease:
-    gh workflow run release.yml -f prerelease=true
+prerelease notes="":
+    gh workflow run release.yml -f prerelease=true -f highlights={{ quote(notes) }}
 
 docs:
     gh workflow run publish-docs.yml


### PR DESCRIPTION
## What

Adds an optional way to prepend a bloggy, human-written intro to the top of the **GitHub Release** body when cutting a release — without touching `CHANGELOG.md`, and without tracking anything in git (the prose lives permanently on the GitHub Release).

Today the release body is rendered by python-semantic-release from its `.release_notes.md.j2` template, which reuses the same component that builds `CHANGELOG.md` — so the release notes are ~identical to the changelog. This lets you add a descriptive preamble (features, examples, doc links) above that changelog.

## How

- New optional `highlights` `workflow_dispatch` input on `release.yml`.
- `just release` / `just prerelease` now take an optional `notes` argument, shell-quoted with `quote()` and forwarded as `-f highlights=…`.
- A new `Prepend highlights to GitHub Release` step runs after the release/tag is created: it reads the auto-generated body with `gh release view`, prepends the highlights and a `---` divider, and writes it back with `gh release edit`. Skipped when no highlights are passed.
- The prose is passed through an **env var** (`HIGHLIGHTS`), not inline `${{ }}`, so backticks/`$`/quotes in the text can't break the shell step or inject.

Result on the GitHub Release: your prose → `---` → the untouched auto-generated changelog.

## Usage

```bash
just release "## Query joins have landed 🎉  See the [guide](https://…)."
just release "$(cat /tmp/notes.md)"
just release $'## Query joins\n\nTraverse relations in `where()` …\n\nDocs: https://…'
```

## Notes

- `workflow_dispatch` inputs are read from the workflow file on `main`, so this input only becomes usable once this PR is merged.
- Combined `workflow_dispatch` inputs cap at ~65 KB — plenty for release prose.