### PR TITLE
feat: query-time joins — relation traversal for filter and sort (stage 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,9 +249,12 @@ Rules:
   checking (`User.age >= 18` types as `bool`; `where()` expects
   `QueryNode | Predicate`). Docs say so explicitly wherever the style is
   shown.
-- **`order_by` is not a predicate** and keeps attribute style
-  (`order_by(User.age, "desc")`). Passing a lambda to `order_by` silently
-  produces a junk column name — never show it.
+- **`order_by` is not a predicate**, but its lambda selector
+  (`order_by(lambda u: u.age, "desc")`) is validated and is the documented
+  style — and it is the ONLY way to order by a related column
+  (`order_by(lambda t: t.account.label)`), which relation traversal requires.
+  Attribute style is not accepted — `order_by` takes a column-name string or
+  a lambda selector (anything else raises `TypeError`).
 
 The canonical comparisons live in `docs/pages/guide/queries.md`
 ("Predicate Styles") and `docs/pages/concepts/query-typing.md`; everywhere

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -328,6 +328,8 @@ mod tests {
         // The joins section must actually carry the multi-hop path.
         assert_eq!(envelope.payload.joins.len(), 2);
         assert_eq!(envelope.payload.joins[1].path.len(), 2);
+        // An order_by entry carrying a relation path (#271) survives round-trip too.
+        assert_eq!(envelope.payload.order_by[0].path, vec!["account".to_string()]);
         let encoded = serde_json::to_value(&envelope).expect("query traversal IR must serialize");
         assert_eq!(encoded, ir, "query traversal round-trip must not drift");
     }

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -311,6 +311,28 @@ mod tests {
     }
 
     #[test]
+    fn query_traversal_fixture_roundtrip() {
+        // Multi-hop `joins` section + path-carrying leaves must survive a
+        // deserialize/serialize round-trip without drift (#270 wire stability).
+        let fixture = include_str!(
+            "../../../tests/fixtures/ir_vectors/query_transaction_traversal_v2.json"
+        );
+        let parsed: serde_json::Value =
+            serde_json::from_str(fixture).expect("query traversal fixture must parse");
+        let ir = parsed
+            .get("ir")
+            .cloned()
+            .expect("fixture must contain ir envelope");
+        let envelope: IrEnvelope<QueryIrPayload> =
+            serde_json::from_value(ir.clone()).expect("query traversal IR must deserialize");
+        // The joins section must actually carry the multi-hop path.
+        assert_eq!(envelope.payload.joins.len(), 2);
+        assert_eq!(envelope.payload.joins[1].path.len(), 2);
+        let encoded = serde_json::to_value(&envelope).expect("query traversal IR must serialize");
+        assert_eq!(encoded, ir, "query traversal round-trip must not drift");
+    }
+
+    #[test]
     fn codec_fixture_roundtrip() {
         let fixture =
             include_str!("../../../tests/fixtures/ir_vectors/codec_registry_core_v1.json");

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -134,7 +134,11 @@ pub struct SchemaCheck {
     pub values: Vec<String>,
 }
 
-/// Query IR: filter, sort, pagination, and optional M2M join context.
+/// Query IR: filter, sort, pagination, joins, and optional M2M join context.
+///
+/// `ir_version: 2` (unconditional, no v1 emitted anywhere — #269). `joins` is
+/// required and always present (`[]` until #270 renders real JOINs); every leaf
+/// and `order_by` entry carries a `path` (required, `[]` = root model).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueryIrPayload {
     /// Model class name the query targets.
@@ -150,6 +154,30 @@ pub struct QueryIrPayload {
     pub offset: Option<u64>,
     /// Many-to-many join metadata JSON, deserialized into [`M2mContext`] downstream.
     pub m2m: Option<Value>,
+    /// Relation joins collected from traversal (`[]` until #270 renders them).
+    pub joins: Vec<QueryJoin>,
+}
+
+/// One relation JOIN collected from query-time traversal (#270 lands rendering).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueryJoin {
+    /// `"inner"` (default traversal semantics) or `"left"` (`.left_join`).
+    pub join_type: String,
+    /// Relation hops from the root model to the joined table, in traversal order.
+    pub path: Vec<QueryJoinHop>,
+}
+
+/// One hop in a [`QueryJoin`] path: a single FK edge between two tables.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueryJoinHop {
+    /// Relation field name on the source side of this hop.
+    pub relation: String,
+    /// Local column the hop joins from (shadow `*_id` for `ForeignKey`).
+    pub from_column: String,
+    /// Table this hop joins into.
+    pub to_table: String,
+    /// Column on `to_table` the hop joins against (usually the target PK).
+    pub to_column: String,
 }
 
 /// One `ORDER BY` term.
@@ -159,6 +187,9 @@ pub struct QueryOrderBy {
     pub column: String,
     /// Sort direction (`"asc"` or `"desc"`, case-insensitive in the planner).
     pub direction: String,
+    /// Relation field names from the root model to the ordered column's table;
+    /// `[]` = root model (#269 requires this empty until #270 renders joins).
+    pub path: Vec<String>,
 }
 
 /// Predicate tree node in query IR (leaf comparison or compound AND/OR).
@@ -174,6 +205,9 @@ pub enum QueryNode {
         column: String,
         /// Typed right-hand value.
         value: QueryValue,
+        /// Relation field names from the root model to `column`'s table;
+        /// `[]` = root model (#269 requires this empty until #270 renders joins).
+        path: Vec<String>,
     },
     /// Binary boolean combination of two child nodes.
     #[serde(rename = "compound")]
@@ -263,7 +297,7 @@ mod tests {
     #[test]
     fn query_fixture_roundtrip() {
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_user_compound_v1.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_user_compound_v2.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query fixture must parse");
         let ir = parsed

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -335,6 +335,33 @@ mod tests {
     }
 
     #[test]
+    fn query_left_join_fixture_roundtrip() {
+        // A LEFT-marked path plus a deeper INNER entry sharing its prefix
+        // (mixed LEFT-prefix/INNER-suffix, #272) must survive a
+        // deserialize/serialize round-trip without drift, and the join_type
+        // tokens must reach Rust exactly as written on the wire.
+        let fixture =
+            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_left_join_v2.json");
+        let parsed: serde_json::Value =
+            serde_json::from_str(fixture).expect("query left_join fixture must parse");
+        let ir = parsed
+            .get("ir")
+            .cloned()
+            .expect("fixture must contain ir envelope");
+        let envelope: IrEnvelope<QueryIrPayload> =
+            serde_json::from_value(ir.clone()).expect("query left_join IR must deserialize");
+        // The wire carries the mixed edge types: a "left" 1-hop prefix and an
+        // "inner" 2-hop entry sharing it.
+        assert_eq!(envelope.payload.joins.len(), 2);
+        assert_eq!(envelope.payload.joins[0].join_type, "left");
+        assert_eq!(envelope.payload.joins[0].path.len(), 1);
+        assert_eq!(envelope.payload.joins[1].join_type, "inner");
+        assert_eq!(envelope.payload.joins[1].path.len(), 2);
+        let encoded = serde_json::to_value(&envelope).expect("query left_join IR must serialize");
+        assert_eq!(encoded, ir, "query left_join round-trip must not drift");
+    }
+
+    #[test]
     fn codec_fixture_roundtrip() {
         let fixture =
             include_str!("../../../tests/fixtures/ir_vectors/codec_registry_core_v1.json");

--- a/docs/examples/traversal.py
+++ b/docs/examples/traversal.py
@@ -1,0 +1,302 @@
+"""Runnable companion to the "Querying Across Relationships" guide section
+(docs/pages/guide/queries.md).
+
+Seeds a small ledger domain (Ledger <- Account -> Owner, with Transactions and
+Notes hanging off Account) plus self-contained schemas for the two-FK, self-FK,
+and many-to-many patterns, then runs every traversal query the guide shows and
+asserts the exact rows that come back.
+"""
+
+import asyncio
+from typing import Annotated
+
+from ferro import BackRef, Field, ForeignKey, ManyToMany, Model, Relation, connect, engines
+
+
+# --8<-- [start:schema]
+class Ledger(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    accounts: Relation[list["Account"]] = BackRef()
+
+
+class Owner(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    email: str
+    accounts: Relation[list["Account"]] = BackRef()
+
+
+class Account(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    label: str
+    ledger: Annotated[Ledger, ForeignKey(related_name="accounts")]
+    owner: Annotated[Owner, ForeignKey(related_name="accounts")]
+    transactions: Relation[list["Transaction"]] = BackRef()
+    notes: Relation[list["Note"]] = BackRef()
+
+
+class Transaction(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    amount: int
+    account: Annotated[Account, ForeignKey(related_name="transactions")]
+# --8<-- [end:schema]
+
+
+# --8<-- [start:note-model]
+class Note(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    body: str
+    account: Annotated[Account | None, ForeignKey(related_name="notes")] = None
+# --8<-- [end:note-model]
+
+
+# --8<-- [start:two-fk-model]
+class Airport(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    code: str
+    departures: Relation[list["Flight"]] = BackRef()
+    arrivals: Relation[list["Flight"]] = BackRef()
+
+
+class Flight(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    origin: Annotated[Airport, ForeignKey(related_name="departures")]
+    destination: Annotated[Airport, ForeignKey(related_name="arrivals")]
+# --8<-- [end:two-fk-model]
+
+
+# --8<-- [start:self-fk-model]
+class Employee(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    manager: Annotated["Employee", ForeignKey(related_name="reports", nullable=True)] = None
+    reports: Relation[list["Employee"]] = BackRef()
+# --8<-- [end:self-fk-model]
+
+
+# --8<-- [start:m2m-model]
+class Author(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    role: str
+    tags: Relation[list["Tag"]] = BackRef()
+
+
+class Tag(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    created_by: Annotated[Author, ForeignKey(related_name="tags")]
+    posts: Relation[list["Post"]] = BackRef()
+
+
+class Post(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    title: str
+    tags: Relation[list["Tag"]] = ManyToMany(related_name="posts")
+# --8<-- [end:m2m-model]
+
+
+async def _seed_ledger() -> None:
+    """Two ledgers, two owners, three accounts, six fan-in transactions.
+
+    Ledger A holds a1 (owner o1) and a2 (owner o2); Ledger B holds b1 (owner o1).
+    Transactions: a1 has 10/20/30, a2 has 40, b1 has 50/60.
+    """
+    la, lb = Ledger(id=1, name="ledger-a"), Ledger(id=2, name="ledger-b")
+    o1, o2 = Owner(id=1, email="o1@ferro.dev"), Owner(id=2, email="o2@ferro.dev")
+    for row in (la, lb, o1, o2):
+        await row.save()
+
+    a1 = Account(id=1, label="a1", ledger=la, owner=o1)
+    a2 = Account(id=2, label="a2", ledger=la, owner=o2)
+    b1 = Account(id=3, label="b1", ledger=lb, owner=o1)
+    for row in (a1, a2, b1):
+        await row.save()
+
+    for txn in (
+        Transaction(id=1, amount=10, account=a1),
+        Transaction(id=2, amount=20, account=a1),
+        Transaction(id=3, amount=30, account=a1),
+        Transaction(id=4, amount=40, account=a2),
+        Transaction(id=5, amount=50, account=b1),
+        Transaction(id=6, amount=60, account=b1),
+    ):
+        await txn.save()
+
+    # One note attached to a1, one orphan (nullable FK left NULL).
+    await Note(id=1, body="attached", account=a1).save()
+    await Note(id=2, body="orphan", account=None).save()
+
+
+async def main() -> None:
+    await connect("sqlite::memory:", auto_migrate=True)
+
+    async with engines.session():
+        await _seed_ledger()
+
+        ledger_a = await Ledger.get(1)
+        owner_o2 = await Owner.get(2)
+        account_a1 = await Account.get(1)
+
+        # --8<-- [start:basic]
+        # Every transaction whose account belongs to ledger A.
+        rows = await Transaction.where(
+            lambda transaction: transaction.account.ledger_id == ledger_a.id
+        ).all()
+        # --8<-- [end:basic]
+        assert {r.id for r in rows} == {1, 2, 3, 4}
+
+        # --8<-- [start:pinch]
+        top = await (
+            Transaction.where(lambda transaction: transaction.account.ledger_id == ledger_a.id)
+            .where(lambda transaction: transaction.amount >= 20)
+            .order_by(lambda transaction: transaction.amount, "desc")
+            .limit(2)
+            .all()
+        )
+        # --8<-- [end:pinch]
+        assert [r.amount for r in top] == [40, 30]
+
+        # --8<-- [start:multi-hop]
+        rows = await Transaction.where(
+            lambda transaction: transaction.account.owner.email == "o2@ferro.dev"
+        ).all()
+        # --8<-- [end:multi-hop]
+        assert {r.id for r in rows} == {4}
+
+        # --8<-- [start:inner-narrows]
+        # Filtering through note.account drops the orphan note (NULL account FK).
+        ledger_a_notes = await Note.where(
+            lambda note: note.account.ledger_id == ledger_a.id
+        ).all()
+        # --8<-- [end:inner-narrows]
+        assert {r.id for r in ledger_a_notes} == {1}
+
+        # --8<-- [start:count]
+        ledger_a_count = await Transaction.where(
+            lambda transaction: transaction.account.ledger_id == ledger_a.id
+        ).count()
+        # --8<-- [end:count]
+        assert ledger_a_count == 4
+
+        # --8<-- [start:order-by]
+        ordered = await (
+            Transaction.select()
+            .order_by(lambda transaction: transaction.account.label)
+            .order_by(lambda transaction: transaction.id)
+            .all()
+        )
+        # --8<-- [end:order-by]
+        assert [r.id for r in ordered] == [1, 2, 3, 4, 5, 6]
+
+        # --8<-- [start:instance-eq]
+        # `== instance` filters by the shadow FK column, with no join.
+        on_a1 = await Transaction.where(
+            lambda transaction: transaction.account == account_a1
+        ).all()
+        not_on_a1 = await Transaction.where(
+            lambda transaction: transaction.account != account_a1
+        ).all()
+        # --8<-- [end:instance-eq]
+        assert {r.id for r in on_a1} == {1, 2, 3}
+        assert {r.id for r in not_on_a1} == {4, 5, 6}
+
+        # --8<-- [start:deep-instance-eq]
+        owned_by_o2 = await Transaction.where(
+            lambda transaction: transaction.account.owner == owner_o2
+        ).all()
+        # --8<-- [end:deep-instance-eq]
+        assert {r.id for r in owned_by_o2} == {4}
+
+        # --8<-- [start:is-null]
+        # Join-free IS NULL / IS NOT NULL on the shadow FK.
+        orphans = await Note.where(lambda note: note.account == None).all()  # noqa: E711
+        attached = await Note.where(lambda note: note.account != None).all()  # noqa: E711
+        # --8<-- [end:is-null]
+        assert {r.id for r in orphans} == {2}
+        assert {r.id for r in attached} == {1}
+
+        # --8<-- [start:existence]
+        # Bare .join() keeps only rows whose nullable relation exists.
+        with_account = await Note.select().join(lambda note: note.account).all()
+        # --8<-- [end:existence]
+        assert {r.id for r in with_account} == {1}
+
+        # --8<-- [start:left-join]
+        # .left_join() keeps the orphan row that traversal would drop.
+        all_notes = await Note.select().left_join(lambda note: note.account).all()
+        # --8<-- [end:left-join]
+        assert {r.id for r in all_notes} == {1, 2}
+
+        # --8<-- [start:mutate-limitation]
+        # Traversed predicates cannot mutate — fetch primary keys first...
+        ids = [
+            note.id
+            for note in await Note.where(
+                lambda note: note.account.ledger_id == ledger_a.id
+            ).all()
+        ]
+        # ...then delete by that key set with a join-free predicate.
+        await Note.where(lambda note: note.id.in_(ids)).delete()
+        # --8<-- [end:mutate-limitation]
+        assert await Note.where(lambda note: note.id.in_(ids)).count() == 0
+        # Restore the note for later assertions in this script.
+        await Note(id=1, body="attached", account=account_a1).save()
+
+        await _run_two_fk()
+        await _run_self_fk()
+        await _run_m2m()
+
+    print("traversal example ran successfully")
+
+
+async def _run_two_fk() -> None:
+    jfk = await Airport.create(id=1, code="JFK")
+    lax = await Airport.create(id=2, code="LAX")
+    await Flight.create(id=1, origin=jfk, destination=lax)
+    await Flight.create(id=2, origin=lax, destination=jfk)
+
+    # --8<-- [start:two-fk-query]
+    # Each FK is its own relation path, so each traversal is its own join —
+    # no aliases to name.
+    departing_jfk = await Flight.where(lambda flight: flight.origin.code == "JFK").all()
+    arriving_jfk = await Flight.where(
+        lambda flight: flight.destination.code == "JFK"
+    ).all()
+    # --8<-- [end:two-fk-query]
+    assert {f.id for f in departing_jfk} == {1}
+    assert {f.id for f in arriving_jfk} == {2}
+
+
+async def _run_self_fk() -> None:
+    boss = await Employee.create(id=1, name="boss", manager=None)
+    await Employee.create(id=2, name="alice", manager=boss)
+    await Employee.create(id=3, name="bob", manager=boss)
+
+    # --8<-- [start:self-fk-query]
+    boss_reports = await Employee.where(
+        lambda employee: employee.manager.name == "boss"
+    ).all()
+    # --8<-- [end:self-fk-query]
+    assert {e.name for e in boss_reports} == {"alice", "bob"}
+
+
+async def _run_m2m() -> None:
+    admin = await Author.create(id=1, role="admin")
+    member = await Author.create(id=2, role="member")
+    urgent = await Tag.create(id=1, name="urgent", created_by=admin)
+    chill = await Tag.create(id=2, name="chill", created_by=member)
+    post = await Post.create(id=1, title="launch")
+    await post.tags.add(urgent, chill)
+
+    # --8<-- [start:m2m-query]
+    # The association context (post.tags) and forward-FK traversal on the tag
+    # compose in one statement.
+    admin_tags = await post.tags.where(
+        lambda tag: tag.created_by.role == "admin"
+    ).all()
+    # --8<-- [end:m2m-query]
+    assert {t.id for t in admin_tags} == {1}
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/examples/traversal_annotated.py
+++ b/docs/examples/traversal_annotated.py
@@ -1,0 +1,115 @@
+"""Annotated-style companion to traversal.py (AGENTS.md I-7).
+
+Field options move into ``Annotated[...]``. The relationship declarations are
+identical in both styles: forward FKs are always ``Annotated[Target,
+ForeignKey(...)]`` and ``BackRef()``/``ManyToMany()`` are always assignments.
+The queries themselves declare no fields, so they live only in traversal.py.
+"""
+
+import asyncio
+from typing import Annotated
+
+from ferro import BackRef, Field, ForeignKey, ManyToMany, Model, Relation, connect, engines
+
+
+# --8<-- [start:schema]
+class Ledger(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    name: str
+    accounts: Relation[list["Account"]] = BackRef()
+
+
+class Owner(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    email: str
+    accounts: Relation[list["Account"]] = BackRef()
+
+
+class Account(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    label: str
+    ledger: Annotated[Ledger, ForeignKey(related_name="accounts")]
+    owner: Annotated[Owner, ForeignKey(related_name="accounts")]
+    transactions: Relation[list["Transaction"]] = BackRef()
+    notes: Relation[list["Note"]] = BackRef()
+
+
+class Transaction(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    amount: int
+    account: Annotated[Account, ForeignKey(related_name="transactions")]
+# --8<-- [end:schema]
+
+
+# --8<-- [start:note-model]
+class Note(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    body: str
+    account: Annotated[Account | None, ForeignKey(related_name="notes")] = None
+# --8<-- [end:note-model]
+
+
+# --8<-- [start:two-fk-model]
+class Airport(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    code: str
+    departures: Relation[list["Flight"]] = BackRef()
+    arrivals: Relation[list["Flight"]] = BackRef()
+
+
+class Flight(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    origin: Annotated[Airport, ForeignKey(related_name="departures")]
+    destination: Annotated[Airport, ForeignKey(related_name="arrivals")]
+# --8<-- [end:two-fk-model]
+
+
+# --8<-- [start:self-fk-model]
+class Employee(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    name: str
+    manager: Annotated["Employee", ForeignKey(related_name="reports", nullable=True)] = None
+    reports: Relation[list["Employee"]] = BackRef()
+# --8<-- [end:self-fk-model]
+
+
+# --8<-- [start:m2m-model]
+class Author(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    role: str
+    tags: Relation[list["Tag"]] = BackRef()
+
+
+class Tag(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    name: str
+    created_by: Annotated[Author, ForeignKey(related_name="tags")]
+    posts: Relation[list["Post"]] = BackRef()
+
+
+class Post(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    title: str
+    tags: Relation[list["Tag"]] = ManyToMany(related_name="posts")
+# --8<-- [end:m2m-model]
+
+
+async def main() -> None:
+    await connect("sqlite::memory:", auto_migrate=True)
+
+    async with engines.session():
+        la = await Ledger.create(id=1, name="ledger-a")
+        o1 = await Owner.create(id=1, email="o1@ferro.dev")
+        a1 = await Account.create(id=1, label="a1", ledger=la, owner=o1)
+        await Transaction.create(id=1, amount=10, account=a1)
+
+        rows = await Transaction.where(
+            lambda transaction: transaction.account.ledger_id == la.id
+        ).all()
+        assert {r.id for r in rows} == {1}
+
+    print("traversal_annotated example ran successfully")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/pages/api/queries.md
+++ b/docs/pages/api/queries.md
@@ -2,6 +2,8 @@
 
 `Model.where(...)` and `Model.select()` return a `Query` — an immutable, chainable builder that executes when awaited via `all()`, `first()`, `count()`, `exists()`, `update()`, or `delete()`. Predicates are lambda-only (`User.where(lambda user: user.age >= 18)`) — a fresh `QueryProxy` validates column names against the model at build time.
 
+`where()` and `order_by()` lambdas may **traverse** a forward-FK relation (`lambda t: t.account.ledger_id == 1`): each hop renders one INNER join, deduplicated by relation path (ADR-0006). `join()` forces a join on a relation path (a bare `join()` is an existence filter on a nullable relation), and `left_join()` marks the whole path LEFT to keep relation-less rows. See the [Querying Across Relationships](../guide/queries.md#querying-across-relationships) guide for worked examples.
+
 ::: ferro.query.builder.Query
 
 ::: ferro.query.QueryProxy

--- a/docs/pages/concepts/query-typing.md
+++ b/docs/pages/concepts/query-typing.md
@@ -38,6 +38,16 @@ What isn't checked yet is the *right-hand side* of a comparison: the proxy attri
 published = await author.posts.where(lambda post: post.published == True).all()
 ```
 
+## Traversing Relations
+
+Reaching through a foreign key inside a predicate — `lambda transaction: transaction.account.ledger_id == 1` — type-checks as a predicate for the same reason a plain comparison does: attribute access on the proxy keeps returning a chainable proxy, and the terminal comparison returns `QueryNode`. The checker sees a valid `Predicate[Transaction]`; the [Queries guide](../guide/queries.md#querying-across-relationships) covers what the traversal *means* (one INNER join per relation path).
+
+The static gate checks the **shape** of the predicate, not the **names** in it:
+
+- **A traversal that ends in a comparison type-checks.** `transaction.account.ledger_id == 1` is a `QueryNode`, so it satisfies `where()`.
+- **A bare relation as a predicate fails the checker.** `lambda transaction: transaction.account` returns a proxy, not a `QueryNode`, so it is a type error — the same failure mode as `lambda user: True`.
+- **Name typos are caught at build time, not by the checker.** A misspelled hop (`transaction.accont`, `account.emial`) is `FieldProxy[Any]` to the type checker, so it type-checks; at build time the proxy validates every hop against the real model and raises `AttributeError` with a did-you-mean naming that hop's model. The static gate guarantees shape; the runtime proxy guarantees names.
+
 ## What This Doesn't Change
 
 - Your model annotations. `archived: bool = False` stays exactly as it is.

--- a/docs/pages/guide/queries.md
+++ b/docs/pages/guide/queries.md
@@ -216,6 +216,8 @@ The practical consequence of INNER-everywhere: **traversing a relation narrows t
 
 This is deliberate and stable. A hop's nullability never changes the join type, so making a foreign key nullable later never silently rewrites the meaning of an existing query, and an N-hop path is trivial to reason about — no hop poisons the ones after it. Keeping the relation-less rows is an explicit opt-in (`left_join`, below).
 
+The narrowing is query-wide, not per-clause: the join is rendered once for the whole statement, so a traversal branch inside an `|` still narrows the entire result. `(note.account.ledger_id == 1) | (note.body == "orphan")` drops every relation-less note — the INNER `account` join removes it before the `OR` is ever evaluated, so the `body == "orphan"` branch can never rescue it. Reach for `left_join` when a traversal branch of an `|` must keep relation-less rows.
+
 `count()` and the other terminals see exactly this narrowed set — a many-to-one join never multiplies root rows, so `.count()` equals the number of matching transactions, not the number of joined pairs:
 
 ```python

--- a/docs/pages/guide/queries.md
+++ b/docs/pages/guide/queries.md
@@ -148,13 +148,212 @@ Queries are lazy — nothing hits the database until you await a terminal:
 
 ## Querying Across Relationships
 
-Every `ForeignKey` field gets a shadow `*_id` column you can filter on like any scalar:
+A `where()` or `order_by()` lambda can reach *through* a `ForeignKey` to a column on the related model. Write the relation field, then keep going:
+
+```python
+ledger_a = await Ledger.get(1)
+
+rows = await Transaction.where(
+    lambda transaction: transaction.account.ledger_id == ledger_a.id
+).all()
+```
+
+That is one SQL statement — a `SELECT` over `transactions` with a join to `accounts` — and it returns the transactions whose account belongs to ledger A. You never write the join; the relation you traverse (`transaction.account`) *is* the join.
+
+The examples below use this schema — a `Transaction` points at an `Account`, and an `Account` points at both a `Ledger` and an `Owner`:
+
+=== "Assignment"
+
+    ```python
+    --8<-- "docs/examples/traversal.py:schema"
+    ```
+
+=== "Annotated"
+
+    ```python
+    --8<-- "docs/examples/traversal_annotated.py:schema"
+    ```
+
+### Traversing at any depth
+
+Each hop resolves against the related model, so you can chain as many as the schema allows. `transaction.account.owner.email` walks `Transaction → Account → Owner` in a single statement with two joins:
+
+```python
+--8<-- "docs/examples/traversal.py:multi-hop"
+```
+
+Every hop is validated when you build the query — before anything reaches the database. A misspelled column or relation raises `AttributeError` naming the model at that hop and the closest match, and the suggestion pool spans both columns *and* relations:
+
+```text
+>>> Transaction.where(lambda transaction: transaction.accont.ledger_id == 1)
+AttributeError: Transaction has no queryable column 'accont'. Did you mean 'account'? Valid columns: account_id, amount, id. Valid relations: account.
+
+>>> Transaction.where(lambda transaction: transaction.account.owner.emial == "x")
+AttributeError: Owner has no queryable column 'emial'. Did you mean 'email'? Valid columns: email, id.
+```
+
+### Every traversed hop is an INNER join
+
+Traversal always renders an **INNER** join, at every hop, no matter whether the foreign key is nullable (ADR-0006). To see what that means for nullable relations, the narrowing examples in this and the following sections add a `Note` model whose `account` relation is **optional** — a note may or may not be attached to an account:
+
+=== "Assignment"
+
+    ```python
+    --8<-- "docs/examples/traversal.py:note-model"
+    ```
+
+=== "Annotated"
+
+    ```python
+    --8<-- "docs/examples/traversal_annotated.py:note-model"
+    ```
+
+The practical consequence of INNER-everywhere: **traversing a relation narrows the result to rows where that relation exists**. A `Note` whose `account` FK is `NULL` simply does not appear in a query that filters through `note.account`:
+
+```python
+--8<-- "docs/examples/traversal.py:inner-narrows"
+```
+
+This is deliberate and stable. A hop's nullability never changes the join type, so making a foreign key nullable later never silently rewrites the meaning of an existing query, and an N-hop path is trivial to reason about — no hop poisons the ones after it. Keeping the relation-less rows is an explicit opt-in (`left_join`, below).
+
+`count()` and the other terminals see exactly this narrowed set — a many-to-one join never multiplies root rows, so `.count()` equals the number of matching transactions, not the number of joined pairs:
+
+```python
+--8<-- "docs/examples/traversal.py:count"
+```
+
+### Ordering by a related column
+
+`order_by()` traverses the same way, to any depth, and shares its joins with `where()`:
+
+```python
+--8<-- "docs/examples/traversal.py:order-by"
+```
+
+Because the sort join is INNER too, ordering by a related column drops relation-less rows — the same narrowing as `where()`. (Use `left_join` to keep them; see below.)
+
+### One join per relation path
+
+The relation path is the join's identity. Reference the same path in two `where()` calls, in an `&`/`|` tree, or across `where()` and `order_by()`, and it renders as **one** join. Distinct paths — even to the same table — render as distinct joins. There is no alias to name and none to manage; the path does that job.
+
+That is what lets a traversal filter compose cleanly with plain root-column clauses — the motivating query pairs one `account` join with a root-column filter, ordering, and a limit, all in a single statement:
+
+```python
+--8<-- "docs/examples/traversal.py:pinch"
+```
+
+### Comparing to a related instance
+
+Every `ForeignKey` also exposes a shadow `{fk}_id` column, so you can filter by a related row's primary key directly — no join at all:
 
 ```python
 posts = await Post.where(lambda post: post.author_id == user.id).all()
 ```
 
-Reverse relations (`BackRef`) are chainable queries themselves — filter, order, and slice them before executing:
+Comparing the relation itself to a **persisted** instance is sugar for exactly that shadow-column check — still join-free:
+
+```python
+--8<-- "docs/examples/traversal.py:instance-eq"
+```
+
+Deep instance equality compares the shadow column of the *last* hop under the prefix join: `transaction.account.owner == some_owner` filters `owner_id` on the joined `accounts` row.
+
+```python
+--8<-- "docs/examples/traversal.py:deep-instance-eq"
+```
+
+Comparing an **unpersisted** instance is a build-time error naming the model (`cannot compare relation 'account' to an unpersisted Account instance …`) — there is no primary key to match on yet.
+
+### Testing for existence or absence
+
+A bare `.join()` with no predicate is a meaningful **existence filter** on a nullable relation — it narrows to rows where the relation is present (the same INNER narrowing traversal gives you, expressed directly):
+
+```python
+--8<-- "docs/examples/traversal.py:existence"
+```
+
+For the opposite question — "has *no* related row" — compare the relation to `None`. `relation == None` / `!= None` lower to `IS NULL` / `IS NOT NULL` on the shadow column, join-free, so "has no account" needs no `left_join`:
+
+```python
+--8<-- "docs/examples/traversal.py:is-null"
+```
+
+### Keeping rows that have no relation
+
+When you want the relation-less rows *kept* rather than filtered out, opt into a `left_join`. It marks **every edge of its path** LEFT (the whole-path rule), so a left-marked two-hop path retains rows missing the relation at either hop:
+
+```python
+--8<-- "docs/examples/traversal.py:left-join"
+```
+
+A bare `left_join` on a path also traversed by `where()` lifts the shared edge to LEFT — an explicit LEFT always beats an implicit INNER on the same edge (declaring `join` **and** `left_join` on one edge is a build-time `ValueError`).
+
+!!! note "NULL ordering diverges by dialect under `left_join`"
+    Once relation-less rows survive into an `order_by` on a related column, their `NULL` sort key lands in a dialect-specific spot: **PostgreSQL sorts `NULL`s last on an ascending sort; SQLite sorts them first.** This divergence only appears because you opted into `left_join` — plain INNER traversal drops those rows, so it never surfaces (ADR-0006).
+
+### Two foreign keys to the same table
+
+Distinct relation paths are distinct joins even when they point at the same table, so two FKs to one model just work — no alias ceremony:
+
+=== "Assignment"
+
+    ```python
+    --8<-- "docs/examples/traversal.py:two-fk-model"
+    ```
+
+=== "Annotated"
+
+    ```python
+    --8<-- "docs/examples/traversal_annotated.py:two-fk-model"
+    ```
+
+```python
+--8<-- "docs/examples/traversal.py:two-fk-query"
+```
+
+### Self-referential traversal
+
+A self-referencing FK traverses like any other — the join target is the same table, reached by a distinct path:
+
+=== "Assignment"
+
+    ```python
+    --8<-- "docs/examples/traversal.py:self-fk-model"
+    ```
+
+=== "Annotated"
+
+    ```python
+    --8<-- "docs/examples/traversal_annotated.py:self-fk-model"
+    ```
+
+```python
+--8<-- "docs/examples/traversal.py:self-fk-query"
+```
+
+### Traversing from a many-to-many
+
+An association query (`post.tags`) composes with forward-FK traversal on the target model: the association join and the traversal join coexist in one statement.
+
+=== "Assignment"
+
+    ```python
+    --8<-- "docs/examples/traversal.py:m2m-model"
+    ```
+
+=== "Annotated"
+
+    ```python
+    --8<-- "docs/examples/traversal_annotated.py:m2m-model"
+    ```
+
+```python
+--8<-- "docs/examples/traversal.py:m2m-query"
+```
+
+### Filtering reverse relations
+
+Reverse relations (`BackRef`) are chainable queries in their own right — filter, order, and slice them before executing, and their predicates can traverse too:
 
 ```python
 published = await author.posts.where(lambda post: post.published == True).all()  # noqa: E712
@@ -162,7 +361,31 @@ latest = await author.posts.order_by(lambda post: post.created_at, "desc").limit
 n = await author.posts.count()
 ```
 
-Joins across relations inside a single `where()` are not supported — filter on shadow FK columns or use the reverse-relation query. See [Relationships](relationships.md) for the full picture.
+### Results are plain root instances
+
+A traversed query is **shape-preserving**: filtering `Transaction` through `transaction.account.ledger_id` still returns `Transaction` instances, no matter how deep the predicate reaches. Traversal does *not* pre-load the related rows onto the results — `await transaction.account` still issues its own query, exactly as it does without any traversal. (Eager loading is separate future work; see [Not Yet Supported](#not-yet-supported).)
+
+### `update()` and `delete()` cannot traverse
+
+Portable SQL has no `UPDATE … JOIN` / `DELETE … JOIN`, so a traversed predicate on `update()`/`delete()` is rejected **before any SQL runs**:
+
+```text
+>>> await Transaction.where(lambda transaction: transaction.account.label == "a1").delete()
+ValueError: delete() does not support relation traversal: portable SQL has no DELETE ... JOIN. Fetch primary keys via the joined query first, then delete by primary-key set. (A join-free relation filter like `t.account == instance` is allowed.)
+```
+
+Do the two-step: fetch the primary keys with the joined query, then mutate by that key set (a join-free `relation == instance` or `== None` filter *is* allowed on mutations):
+
+```python
+--8<-- "docs/examples/traversal.py:mutate-limitation"
+```
+
+### Guardrails
+
+- A predicate lambda that returns a **bare relation** (`lambda transaction: transaction.account`) is meaningless as a filter and raises `TypeError` pointing you at `== None`, `== an instance`, or a column comparison. The same bare relation in `order_by()` is likewise rejected.
+- Combining predicates with Python's `and`/`or` (instead of `&`/`|`) coerces a node to `bool` and raises `TypeError: QueryNode cannot be used in a boolean context; use & / |`. Always parenthesize and use the bitwise operators.
+
+See [Relationships](relationships.md) for the schema-declaration side of foreign keys and reverse relations.
 
 ## Not Yet Supported
 

--- a/docs/pages/guide/relationships.md
+++ b/docs/pages/guide/relationships.md
@@ -35,6 +35,8 @@ The most common shape: a `ForeignKey` on the "child" model, declared as `Annotat
 
 For every `ForeignKey` field (e.g. `team`), Ferro creates a shadow scalar column and matching Pydantic field named `{field}_id` (e.g. `team_id`) holding the related row's primary key. Its Python type follows the target model's primary-key annotation. Read it or filter on it like any other column — `Player.where(lambda t: t.team_id == team.id)` — with no extra query.
 
+To filter or order by a column on the *related* model, a query lambda can traverse the relation itself (`Player.where(lambda player: player.team.name == "Rustaceans")`) — see [Querying Across Relationships](queries.md#querying-across-relationships).
+
 ## One-to-One
 
 Add `unique=True` to the `ForeignKey` to enforce at most one child per parent. The reverse side is a plain (non-list) `BackRef` that resolves to a single instance:
@@ -235,6 +237,6 @@ One-to-one relations (`unique=True`) already get an index; for multi-column inde
 ## See Also
 
 - [Models & Fields](models-and-fields.md) — field declaration styles and constraints
-- [Queries](queries.md) — filtering on shadow FK columns and reverse relations
+- [Queries](queries.md) — filtering on shadow FK columns, traversing relations, and reverse relations
 - [Mutations](mutations.md) — creating related records, cascade implications
 - [Schema Migrations](migrations.md) — how relationships appear in Alembic metadata

--- a/src/ferro/columns.py
+++ b/src/ferro/columns.py
@@ -23,13 +23,38 @@ from ._annotation_utils import (
 from ._shadow_fk_types import _scalar_part_of_annotation
 from .base import ForeignKey, foreign_key_allows_none
 
-__all__ = ["ColumnSpec", "ForeignKeyRef", "build_column_specs", "fk_shadow_spec", "pk_spec"]
+__all__ = [
+    "ColumnSpec",
+    "ForeignKeyRef",
+    "RelationSpec",
+    "build_column_specs",
+    "build_relation_specs",
+    "fk_shadow_spec",
+    "pk_spec",
+]
 
 
 @dataclass(frozen=True, slots=True)
 class ForeignKeyRef:
     to_table: str
     on_delete: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RelationSpec:
+    """One declared forward-FK relation's traversal facts (#268).
+
+    Built alongside ``ColumnSpec`` at the same compile choke point
+    (``compile_model_schema_ir``) and exposed as
+    ``cls.__ferro_relation_specs__``. Relation-traversal query planning (PRD
+    #267) resolves an attribute access like ``t.account`` to its target model
+    and shadow FK column via this lookup, hop by hop.
+    """
+
+    field_name: str
+    target: type
+    shadow_column: str
+    nullable: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -367,6 +392,47 @@ def build_column_specs(model_cls: type[Any]) -> dict[str, ColumnSpec]:
             db_type_explicit=bool(db_type),
             db_check=db_check,
             foreign_key=fk_ref,
+        )
+    return specs
+
+
+def build_relation_specs(
+    model_cls: type[Any], columns: dict[str, ColumnSpec]
+) -> dict[str, RelationSpec]:
+    """Build one RelationSpec per declared forward-FK relation (#268).
+
+    Reads ``ferro_relations`` (the same class-body-registered relation
+    metadata ``build_column_specs`` reads via ``fk_by_shadow``) and pairs each
+    entry with its already-compiled shadow ``{field}_id`` ColumnSpec — the
+    single-source nullability derivation lives there, not here (design pin:
+    do not re-derive). ``ManyToManyRelation`` and BackRef entries in
+    ``ferro_relations`` are not ``ForeignKey`` instances and are skipped.
+
+    A relation whose target hasn't been resolved to a concrete class yet
+    (provisional, class-body time, before ``resolve_relationships()``) is
+    omitted here; the resolved second pass recompiles with real targets so
+    the lookup is complete once resolution finishes.
+
+    Callers store the result on ``cls.__ferro_relation_specs__`` and must
+    replace, never mutate — same convention as ``__ferro_columns__``.
+    """
+    ferro_relations = getattr(model_cls, "ferro_relations", {}) or {}
+    specs: dict[str, RelationSpec] = {}
+    for field_name, meta in ferro_relations.items():
+        if not isinstance(meta, ForeignKey):
+            continue
+        target = meta.to
+        if not isinstance(target, type):
+            continue
+        shadow_column = f"{field_name}_id"
+        shadow_spec = columns.get(shadow_column)
+        if shadow_spec is None:
+            continue
+        specs[field_name] = RelationSpec(
+            field_name=field_name,
+            target=target,
+            shadow_column=shadow_column,
+            nullable=shadow_spec.nullable,
         )
     return specs
 

--- a/src/ferro/ir/compiler.py
+++ b/src/ferro/ir/compiler.py
@@ -19,7 +19,7 @@ from .._core import (
     _ddl_single_index_name,
     _ddl_single_unique_name,
 )
-from ..columns import ColumnSpec, build_column_specs
+from ..columns import ColumnSpec, build_column_specs, build_relation_specs
 from ..composite_indexes import drop_overlap_with_uniques, normalized_composite_indexes
 from ..composite_uniques import normalized_composite_uniques
 from ..state import (
@@ -318,6 +318,11 @@ def compile_model_schema_ir(
     # "``__ferro_columns__`` can never go stale relative to the envelope"
     # invariant, made atomic.
     model_cls.__ferro_columns__ = specs
+    # Same choke point compiles relation-traversal facts (#268): every
+    # ``__ferro_columns__`` refresh (provisional class-body registration and
+    # the resolved second pass) refreshes ``__ferro_relation_specs__`` too, so
+    # the latter is never stale relative to the former.
+    model_cls.__ferro_relation_specs__ = build_relation_specs(model_cls, specs)
     return envelope
 
 

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -11,7 +11,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from .columns import ColumnSpec
+    from .columns import ColumnSpec, RelationSpec
     from .query import Predicate
     from .session import Session
 
@@ -210,6 +210,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
     __ferro_composite_uniques__: ClassVar[tuple[tuple[str, ...], ...]] = ()
     __ferro_composite_indexes__: ClassVar[tuple[tuple[str, ...], ...]] = ()
     __ferro_columns__: ClassVar[dict[str, "ColumnSpec"]] = {}
+    __ferro_relation_specs__: ClassVar[dict[str, "RelationSpec"]] = {}
     _enum_fields: ClassVar[dict[str, type[Enum]]] = {}
 
     @classmethod

--- a/src/ferro/query/__init__.py
+++ b/src/ferro/query/__init__.py
@@ -1,7 +1,7 @@
 """Expose query-building primitives used by Ferro models"""
 
 from .builder import Query, Relation
-from .nodes import FieldProxy, Predicate, QueryNode, QueryProxy
+from .nodes import FieldProxy, Predicate, QueryNode, QueryProxy, RelationProxy
 
 __all__ = [
     "FieldProxy",
@@ -10,4 +10,5 @@ __all__ = [
     "QueryNode",
     "QueryProxy",
     "Relation",
+    "RelationProxy",
 ]

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -90,6 +90,51 @@ def _register_join_paths(node: QueryNode, joins: dict[tuple[str, ...], str]) -> 
         joins.setdefault(tuple(node.path), "inner")
 
 
+def _resolve_join_selector(
+    selector: "Callable[[QueryProxy[Any]], Any]", model_cls: type
+) -> tuple[str, ...]:
+    """Resolve a join-chainer selector into a relation path (#272).
+
+    ``selector`` is a lambda receiving a validating :class:`QueryProxy` and
+    naming a RELATION path (``lambda t: t.account``, ``lambda t: t.account.owner``)
+    — i.e. it must return a :class:`RelationProxy`. Each hop is validated against
+    the relevant model at build time (the proxy raises ``AttributeError`` with a
+    did-you-mean for a bad hop, same as ``where()``).
+
+    Returns:
+        The relation ``path`` tuple the selector names (length ≥ 1).
+
+    Raises:
+        TypeError: If ``selector`` is not callable, resolves to a column
+            (:class:`FieldProxy`) rather than a relation, or returns any other
+            non-relation value — a join selector names a relation path, not a
+            column.
+    """
+    if not callable(selector):
+        raise TypeError(
+            "join()/left_join() expected a selector callable "
+            f"(e.g. `lambda t: t.account`), got {type(selector).__name__}"
+        )
+    result = selector(QueryProxy(model_cls))
+    if isinstance(result, FieldProxy):
+        raise TypeError(
+            "join()/left_join() selector resolved to a column, not a relation "
+            "(e.g. `lambda t: t.account.name`); a join selector names a relation "
+            "path (e.g. `lambda t: t.account`)."
+        )
+    if not isinstance(result, RelationProxy):
+        raise TypeError(
+            "join()/left_join() selector must return a relation path "
+            f"(e.g. `lambda t: t.account`), got {type(result).__name__}"
+        )
+    return result._path
+
+
+def _path_edges(path: tuple[str, ...]) -> list[tuple[str, ...]]:
+    """Every edge (prefix of length ≥ 1) of a relation ``path`` (#272)."""
+    return [path[:i] for i in range(1, len(path) + 1)]
+
+
 def _target_pk_column(model_cls: type) -> str:
     """Return the single primary-key column name of a relation target (#270).
 
@@ -177,10 +222,19 @@ class Query(Generic[T]):
         self._limit: int | None = None
         self._offset: int | None = None
         self._m2m_context: dict[str, Any] | None = None
-        # Relation paths traversed by where() predicates, insertion-ordered
-        # (path tuple -> join_type; always "inner" this slice). Serialized into
-        # the QueryIR ``joins`` section by all()/count() (#270).
+        # Relation paths that must render a join, insertion-ordered (full path
+        # tuple -> registered join_type). Populated by where()/order_by()
+        # traversal ("inner") and by the explicit join()/left_join() chainers
+        # ("inner"/"left"). Serialized into the QueryIR ``joins`` section by
+        # all()/count() (#270, #272).
         self._joins: dict[tuple[str, ...], str] = {}
+        # Edges (path prefixes, length ≥ 1) whose join type was fixed by an
+        # explicit chainer, insertion-ordered (edge tuple -> "inner"|"left").
+        # ``.left_join`` marks every edge of its path "left" (whole-path rule,
+        # ADR-0006); ``.join`` marks them "inner". The single source of truth
+        # for LEFT on the wire — implicit where()/order_by() traversal never
+        # touches this, so explicit always beats implicit (#272).
+        self._explicit_edges: dict[tuple[str, ...], str] = {}
 
     async def _transaction_or_using(self) -> "RouteHandle":
         from .. import _ensure_rust_registration_synced_for_operation
@@ -203,6 +257,7 @@ class Query(Generic[T]):
             dict(self._m2m_context) if self._m2m_context is not None else None
         )
         new._joins = dict(self._joins)
+        new._explicit_edges = dict(self._explicit_edges)
         return new
 
     def _m2m(
@@ -344,6 +399,97 @@ class Query(Generic[T]):
             new._joins.setdefault(path, "inner")
         return new
 
+    def join(self, selector: "Callable[[QueryProxy[T]], Any]") -> Self:
+        """Force an INNER join on a relation path and return a new query.
+
+        ``selector`` is a lambda naming a RELATION path
+        (``lambda t: t.account``, ``lambda t: t.account.owner``) — the same
+        traversal syntax as ``where()``, but resolving to the relation itself,
+        not a column on it. A bare ``.join(lambda t: t.account)`` with no
+        predicate is a meaningful **existence filter** on a nullable relation:
+        it narrows the result to rows where the relation exists (ADR-0006).
+
+        Every edge of the path is marked explicit-INNER; combining it with an
+        explicit ``.left_join`` on the same edge is a build-time error (see
+        :meth:`left_join`).
+
+        Args:
+            selector: A lambda receiving a :class:`QueryProxy` and returning a
+                relation path (a ``RelationProxy``).
+
+        Returns:
+            A new ``Query`` with the join registered; ``self`` is unchanged.
+
+        Raises:
+            TypeError: If ``selector`` is not callable or does not resolve to a
+                relation path (a column selector is rejected — join names a
+                relation, not a column).
+            ValueError: If an edge of the path is already marked explicit-LEFT.
+
+        Examples:
+            >>> with_account = QJTransaction.select().join(lambda t: t.account)
+        """
+        return self._add_explicit_join(selector, "inner")
+
+    def left_join(self, selector: "Callable[[QueryProxy[T]], Any]") -> Self:
+        """Mark a relation path LEFT (whole-path) and return a new query.
+
+        ``selector`` names a RELATION path exactly like :meth:`join`. Every edge
+        of the path is marked LEFT (the **whole-path rule**, ADR-0006), so a
+        left-marked 2-hop path retains rows missing the relation at either hop.
+        Relation-less rows are retained (NULL retention), observable both in
+        ordered results and in traversal predicates on related columns (e.g.
+        ``where(lambda t: t.account.name == None)``).
+
+        Conflict rules: an explicit LEFT beats implicit ``where()``/``order_by()``
+        traversal on a shared edge (the path renders LEFT); an explicit ``.join``
+        plus an explicit ``.left_join`` on the same edge is a build-time error.
+
+        Args:
+            selector: A lambda receiving a :class:`QueryProxy` and returning a
+                relation path (a ``RelationProxy``).
+
+        Returns:
+            A new ``Query`` with the LEFT join registered; ``self`` is unchanged.
+
+        Raises:
+            TypeError: If ``selector`` is not callable or does not resolve to a
+                relation path.
+            ValueError: If an edge of the path is already marked explicit-INNER.
+
+        Examples:
+            >>> keep_orphans = QJNote.select().left_join(lambda n: n.account)
+        """
+        return self._add_explicit_join(selector, "left")
+
+    def _add_explicit_join(
+        self, selector: "Callable[[QueryProxy[T]], Any]", join_type: str
+    ) -> Self:
+        """Shared body of :meth:`join`/:meth:`left_join` (#272).
+
+        Resolves the selector to a relation path, checks every edge for a
+        contradictory explicit mark (INNER vs LEFT), then records the marks and
+        registers the full path so it renders. Re-marking an edge the same
+        direction is idempotent.
+        """
+        path = _resolve_join_selector(selector, self.model_cls)
+        edges = _path_edges(path)
+        new = self._clone()
+        for edge in edges:
+            existing = new._explicit_edges.get(edge)
+            if existing is not None and existing != join_type:
+                relation_path = ".".join(edge)
+                raise ValueError(
+                    f"conflicting explicit join types on relation edge "
+                    f"{relation_path!r}: already marked {existing!r} by a prior "
+                    f"join()/left_join(), cannot re-mark {join_type!r}. Use one "
+                    "join type per edge."
+                )
+        for edge in edges:
+            new._explicit_edges[edge] = join_type
+        new._joins.setdefault(path, join_type)
+        return new
+
     def limit(self, value: int) -> Self:
         """Limit the number of records returned
 
@@ -387,11 +533,31 @@ class Query(Generic[T]):
         carrying its ordered hop facts (:func:`_resolve_join_hops`). The Rust
         SELECT walkers assign deterministic ``j{i}_{relation}`` aliases and
         dedup shared prefixes at render time (#270).
+
+        The wire ``join_type`` is resolved from ``_explicit_edges`` at the EDGE
+        level so it is already unambiguous (#272): an entry is ``"left"`` iff
+        ALL of its edges are explicitly LEFT-marked, else ``"inner"``. Because
+        ``.left_join`` is whole-path and the only source of LEFT, a proper
+        prefix of a longer path can be LEFT while the deeper hop is INNER — that
+        prefix is itself a registered ``_joins`` entry (``left_join`` registers
+        its full path) and is emitted as its own ``"left"`` entry; the longer
+        entry is emitted ``"inner"``. The Rust edge resolver then renders the
+        prefix edges LEFT and the deeper edges INNER (a pure double-check of
+        this wire). This also makes "explicit LEFT beats implicit INNER on a
+        shared edge" visible in the IR itself.
         """
-        return [
-            {"join_type": join_type, "path": _resolve_join_hops(self.model_cls, path)}
-            for path, join_type in self._joins.items()
-        ]
+        entries: list[dict[str, Any]] = []
+        for path in self._joins:
+            is_left = all(
+                self._explicit_edges.get(edge) == "left" for edge in _path_edges(path)
+            )
+            entries.append(
+                {
+                    "join_type": "left" if is_left else "inner",
+                    "path": _resolve_join_hops(self.model_cls, path),
+                }
+            )
+        return entries
 
     def _mutating_query_def(self, operation: str) -> dict[str, Any]:
         """Build the QueryIR payload for a mutating operation (update/delete).

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -688,7 +688,12 @@ class Query(Generic[T]):
             The number of records updated.
 
         Raises:
-            ValueError: If ``limit()`` or ``offset()`` was set on this query.
+            ValueError: If ``limit()`` or ``offset()`` was set on this query, or
+                if the query traverses a relation (a ``where()`` predicate on a
+                related column, or an explicit ``join()``/``left_join()``) —
+                multi-table mutation has no portable SQL. Filter by a column on
+                the target model, or resolve the related primary keys first and
+                update by primary-key set.
 
         Examples:
             >>> updated = await User.where(lambda user: user.id == 1).update(name="Taylor")
@@ -725,7 +730,12 @@ class Query(Generic[T]):
             The number of records deleted.
 
         Raises:
-            ValueError: If ``limit()`` or ``offset()`` was set on this query.
+            ValueError: If ``limit()`` or ``offset()`` was set on this query, or
+                if the query traverses a relation (a ``where()`` predicate on a
+                related column, or an explicit ``join()``/``left_join()``) —
+                multi-table mutation has no portable SQL. Filter by a column on
+                the target model, or resolve the related primary keys first and
+                delete by primary-key set.
 
         Examples:
             >>> deleted = await User.where(lambda user: user.disabled == True).delete()  # noqa: E712

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -61,6 +61,13 @@ def _resolve_where_node(predicate: "Predicate[Any]", model_cls: type) -> QueryNo
             f"(e.g. `lambda user: user.age >= 18`), got {type(predicate).__name__}"
         )
     result = predicate(QueryProxy(model_cls))
+    if isinstance(result, RelationProxy):
+        relation = result._path[-1]
+        raise TypeError(
+            f"where() predicate returned the bare relation {relation!r}; compare "
+            f"a column (e.g. t.{relation}.<column> == ...) or use == None / "
+            "== an instance to filter by the relation."
+        )
     if not isinstance(result, QueryNode):
         raise TypeError(
             "where() predicate callable must return QueryNode, "
@@ -88,6 +95,20 @@ def _register_join_paths(node: QueryNode, joins: dict[tuple[str, ...], str]) -> 
         return
     if node.path:
         joins.setdefault(tuple(node.path), "inner")
+
+
+def _where_node_traverses(node: QueryNode) -> bool:
+    """True if any leaf under ``node`` carries a non-empty relation path (#273).
+
+    Used by :meth:`Query._mutating_query_def` to reject relation traversal on
+    ``update()``/``delete()``. A join-free shadow-FK leaf (``t.account ==
+    instance`` desugars to ``path=()``) is NOT traversal and stays allowed.
+    """
+    if node.is_compound:
+        return (node.left is not None and _where_node_traverses(node.left)) or (
+            node.right is not None and _where_node_traverses(node.right)
+        )
+    return bool(node.path)
 
 
 def _resolve_join_selector(
@@ -369,10 +390,11 @@ class Query(Generic[T]):
             # walker cannot render. Ordering by a related COLUMN (a FieldProxy
             # with a non-empty path) is valid traversal (#271).
             if isinstance(selected, RelationProxy):
+                relation = selected._path[-1]
                 raise TypeError(
-                    "order_by() selector resolved to a relation, not a column "
-                    "(e.g. `lambda t: t.account`); order by a column on the "
-                    "relation instead (e.g. `lambda t: t.account.name`)."
+                    f"order_by() selector returned the bare relation {relation!r}, "
+                    "not a column; order by a column on it instead "
+                    f"(e.g. t.{relation}.<column>)."
                 )
             if not isinstance(selected, FieldProxy):
                 raise TypeError(
@@ -567,7 +589,13 @@ class Query(Generic[T]):
         rejected loudly instead of being silently ignored.
 
         Raises:
-            ValueError: If ``limit()`` or ``offset()`` was set on this query.
+            ValueError: If ``limit()``/``offset()`` was set, or if the query
+                traverses a relation (a joined/explicit-edge path, or a
+                where-clause leaf carrying a non-empty path). Portable SQL has
+                no ``UPDATE/DELETE ... JOIN``; a join-free shadow-FK filter
+                (``t.account == instance``) stays allowed. Rejected here, before
+                any DB round-trip (the Rust guard from #270 stays as boundary
+                defense).
         """
         if self._limit is not None or self._offset is not None:
             raise ValueError(
@@ -575,6 +603,18 @@ class Query(Generic[T]):
                 f"no {operation.upper()} ... LIMIT. Remove the .limit()/.offset() "
                 f"call, or fetch primary keys first and {operation} by "
                 "primary-key set."
+            )
+        if (
+            self._joins
+            or self._explicit_edges
+            or any(_where_node_traverses(node) for node in self.where_clause)
+        ):
+            raise ValueError(
+                f"{operation}() does not support relation traversal: portable SQL "
+                f"has no {operation.upper()} ... JOIN. Fetch primary keys via the "
+                f"joined query first, then {operation} by primary-key set. "
+                "(A join-free relation filter like `t.account == instance` is "
+                "allowed.)"
             )
         return {
             "model_name": _model_identity(self.model_cls),

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -274,6 +274,15 @@ class Query(Generic[T]):
         column-name string (``order_by("created_at", "desc")``). Both forms are
         validated against the model's queryable columns at build time.
 
+        A lambda selector may traverse a declared forward-FK relation
+        (``order_by(lambda t: t.account.name)``) exactly like ``where()``: each
+        hop resolves against the related model, and the traversed path renders
+        one INNER join (ADR-0006), shared with any ``where()`` traversal of the
+        same path in the same query — the same path referenced in both yields
+        exactly one join. String selectors do not traverse: ``"account.name"``
+        is looked up as a literal (unqualified) column name on the queried
+        model.
+
         Args:
             field: Column selector — lambda receiving a :class:`QueryProxy`,
                 or a column-name string.
@@ -285,7 +294,8 @@ class Query(Generic[T]):
         Raises:
             AttributeError: If the column is not a queryable column.
             TypeError: If a lambda selector returns something other than a
-                single column reference.
+                single column reference (a bare relation, e.g.
+                ``lambda t: t.account``, is meaningless as a sort key).
             ValueError: If ``direction`` is not ``"asc"`` or ``"desc"``.
 
         Examples:
@@ -294,31 +304,28 @@ class Query(Generic[T]):
         if direction.lower() not in ("asc", "desc"):
             raise ValueError("direction must be 'asc' or 'desc'")
 
+        path: tuple[str, ...] = ()
         if isinstance(field, str):
             col_name = validate_query_column(self.model_cls, field)
         elif callable(field):
             selected = field(QueryProxy(self.model_cls))
-            # Relation-traversal ordering (a RelationProxy, or a FieldProxy with
-            # a non-empty relation path) is slice #271 — reject it loudly now
-            # rather than emitting an order_by the SELECT walker cannot render.
+            # Ordering by a bare relation (no column selected) is meaningless —
+            # reject it loudly rather than emitting an order_by the SELECT
+            # walker cannot render. Ordering by a related COLUMN (a FieldProxy
+            # with a non-empty path) is valid traversal (#271).
             if isinstance(selected, RelationProxy):
                 raise TypeError(
-                    "order_by() does not support relation traversal yet "
-                    "(ordering by a related column arrives in a later release); "
-                    "order by a column on the queried model instead."
+                    "order_by() selector resolved to a relation, not a column "
+                    "(e.g. `lambda t: t.account`); order by a column on the "
+                    "relation instead (e.g. `lambda t: t.account.name`)."
                 )
             if not isinstance(selected, FieldProxy):
                 raise TypeError(
                     "order_by() selector must return a FieldProxy "
                     f"(e.g. `lambda u: u.created_at`), got {type(selected).__name__}"
                 )
-            if selected.path:
-                raise TypeError(
-                    "order_by() does not support relation traversal yet "
-                    "(ordering by a related column arrives in a later release); "
-                    "order by a column on the queried model instead."
-                )
             col_name = selected.column
+            path = selected.path
         else:
             raise TypeError(
                 "order_by() expected a column-name string or a lambda selector, "
@@ -327,8 +334,14 @@ class Query(Generic[T]):
 
         new = self._clone()
         new.order_by_clause.append(
-            {"column": col_name, "direction": direction.lower(), "path": []}
+            {
+                "column": col_name,
+                "direction": direction.lower(),
+                "path": list(path),
+            }
         )
+        if path:
+            new._joins.setdefault(path, "inner")
         return new
 
     def limit(self, value: int) -> Self:

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -30,13 +30,18 @@ E = TypeVar("E")
 
 
 def _query_ir_payload_to_json(query_payload: dict[str, Any]) -> str:
-    """Serialize a QueryIR payload into a versioned IR envelope JSON string."""
+    """Serialize a QueryIR payload into a versioned IR envelope JSON string.
+
+    Always emits ``ir_version: 2`` (#269 — unconditional bump; there is no v1
+    envelope left anywhere). Python and Rust ship in one wheel, so a single
+    supported version is the whole contract (#267 Implementation Decisions).
+    """
     import json
 
     return json.dumps(
         {
             "ir_kind": "query",
-            "ir_version": 1,
+            "ir_version": 2,
             "payload": _serialize_query_value(query_payload),
         }
     )
@@ -89,7 +94,7 @@ class Query(Generic[T]):
         self._using = using
         self._session = session
         self.where_clause: list["QueryNode"] = []
-        self.order_by_clause: list[dict[str, str]] = []
+        self.order_by_clause: list[dict[str, Any]] = []
         self._limit: int | None = None
         self._offset: int | None = None
         self._m2m_context: dict[str, Any] | None = None
@@ -214,7 +219,9 @@ class Query(Generic[T]):
             )
 
         new = self._clone()
-        new.order_by_clause.append({"column": col_name, "direction": direction.lower()})
+        new.order_by_clause.append(
+            {"column": col_name, "direction": direction.lower(), "path": []}
+        )
         return new
 
     def limit(self, value: int) -> Self:
@@ -275,6 +282,7 @@ class Query(Generic[T]):
             "where": [node.to_ir_dict() for node in self.where_clause],
             "order_by": [],
             "m2m": None,
+            "joins": [],
         }
 
     async def all(self) -> list[T]:
@@ -295,6 +303,7 @@ class Query(Generic[T]):
             "limit": self._limit,
             "offset": self._offset,
             "m2m": self._m2m_context,
+            "joins": [],
         }
         route = await self._transaction_or_using()
         return await fetch_filtered(
@@ -321,6 +330,7 @@ class Query(Generic[T]):
             "limit": None,
             "offset": None,
             "m2m": self._m2m_context,
+            "joins": [],
         }
         route = await self._transaction_or_using()
         return await count_filtered(

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -18,6 +18,7 @@ from .nodes import (
     Predicate,
     QueryNode,
     QueryProxy,
+    RelationProxy,
     _serialize_query_value,
     validate_query_column,
 )
@@ -68,6 +69,84 @@ def _resolve_where_node(predicate: "Predicate[Any]", model_cls: type) -> QueryNo
     return result
 
 
+def _register_join_paths(node: QueryNode, joins: dict[tuple[str, ...], str]) -> None:
+    """Register every relation path a resolved WHERE node references (#270).
+
+    Walks the node tree depth-first, left-to-right; each leaf with a non-empty
+    ``path`` registers that FULL path once (``setdefault`` keeps the first
+    occurrence's order). Only full paths are stored — the Rust walker dedups
+    shared prefixes when it renders JOINs, so a ``["account", "owner"]`` leaf
+    and an ``["account"]`` leaf still yield exactly two JOINs. Dedup across
+    ``&``/``|`` trees and across multiple ``where()`` calls falls out of the
+    dict.
+    """
+    if node.is_compound:
+        if node.left is not None:
+            _register_join_paths(node.left, joins)
+        if node.right is not None:
+            _register_join_paths(node.right, joins)
+        return
+    if node.path:
+        joins.setdefault(tuple(node.path), "inner")
+
+
+def _target_pk_column(model_cls: type) -> str:
+    """Return the single primary-key column name of a relation target (#270).
+
+    Raises:
+        ValueError: If ``model_cls`` has zero or multiple primary-key columns —
+            relation traversal joins against exactly one PK column, so an
+            ambiguous target is a loud error naming the model, never a guess.
+    """
+    pks = [
+        name
+        for name, spec in getattr(model_cls, "__ferro_columns__", {}).items()
+        if spec.primary_key
+    ]
+    if len(pks) != 1:
+        raise ValueError(
+            f"Relation traversal into {model_cls.__name__!r} requires exactly one "
+            f"primary-key column, found {len(pks)}: {sorted(pks)}."
+        )
+    return pks[0]
+
+
+def _resolve_join_hops(
+    model_cls: type, path: tuple[str, ...]
+) -> list[dict[str, str]]:
+    """Resolve a relation path into ordered hop facts for the QueryIR ``joins``.
+
+    Each hop's ``relation``/``from_column``/``to_table``/``to_column`` is read
+    from the relation-spec chain starting at ``model_cls`` — ``from_column`` is
+    the shadow FK column on the source side, ``to_column`` the target's PK.
+
+    Raises:
+        ValueError: If a path element is not a declared relation of the current
+            model (should not happen — proxies validate at build time), or the
+            target has no single primary key (:func:`_target_pk_column`).
+    """
+    hops: list[dict[str, str]] = []
+    current = model_cls
+    for relation in path:
+        specs = getattr(current, "__ferro_relation_specs__", None) or {}
+        spec = specs.get(relation)
+        if spec is None:
+            raise ValueError(
+                f"{current.__name__!r} has no relation {relation!r} for traversal."
+            )
+        target = spec.target
+        hops.append(
+            {
+                "relation": relation,
+                "from_column": spec.shadow_column,
+                "to_table": target.__ferro_table__,
+                "to_column": _target_pk_column(target),
+            }
+        )
+        current = target
+    return hops
+
+
 class Query(Generic[T]):
     """Build and execute fluent ORM queries.
 
@@ -98,6 +177,10 @@ class Query(Generic[T]):
         self._limit: int | None = None
         self._offset: int | None = None
         self._m2m_context: dict[str, Any] | None = None
+        # Relation paths traversed by where() predicates, insertion-ordered
+        # (path tuple -> join_type; always "inner" this slice). Serialized into
+        # the QueryIR ``joins`` section by all()/count() (#270).
+        self._joins: dict[tuple[str, ...], str] = {}
 
     async def _transaction_or_using(self) -> "RouteHandle":
         from .. import _ensure_rust_registration_synced_for_operation
@@ -119,6 +202,7 @@ class Query(Generic[T]):
         new._m2m_context = (
             dict(self._m2m_context) if self._m2m_context is not None else None
         )
+        new._joins = dict(self._joins)
         return new
 
     def _m2m(
@@ -149,6 +233,12 @@ class Query(Generic[T]):
         ``AttributeError`` naming the closest valid match, before any query
         is sent to the database.
 
+        Attribute access on a declared forward-FK field traverses the relation
+        (``lambda t: t.account.ledger_id == lid``): each hop resolves against
+        the related model, and every distinct traversed path renders one INNER
+        join (ADR-0006) when the query runs. Every hop is validated at build
+        time with the same did-you-mean naming the hop's model.
+
         Args:
             predicate: A callable that takes a :class:`QueryProxy` and
                 returns a :class:`QueryNode`.
@@ -167,7 +257,9 @@ class Query(Generic[T]):
             True
         """
         new = self._clone()
-        new.where_clause.append(_resolve_where_node(predicate, self.model_cls))
+        node = _resolve_where_node(predicate, self.model_cls)
+        new.where_clause.append(node)
+        _register_join_paths(node, new._joins)
         return new
 
     def order_by(
@@ -206,10 +298,25 @@ class Query(Generic[T]):
             col_name = validate_query_column(self.model_cls, field)
         elif callable(field):
             selected = field(QueryProxy(self.model_cls))
+            # Relation-traversal ordering (a RelationProxy, or a FieldProxy with
+            # a non-empty relation path) is slice #271 — reject it loudly now
+            # rather than emitting an order_by the SELECT walker cannot render.
+            if isinstance(selected, RelationProxy):
+                raise TypeError(
+                    "order_by() does not support relation traversal yet "
+                    "(ordering by a related column arrives in a later release); "
+                    "order by a column on the queried model instead."
+                )
             if not isinstance(selected, FieldProxy):
                 raise TypeError(
                     "order_by() selector must return a FieldProxy "
                     f"(e.g. `lambda u: u.created_at`), got {type(selected).__name__}"
+                )
+            if selected.path:
+                raise TypeError(
+                    "order_by() does not support relation traversal yet "
+                    "(ordering by a related column arrives in a later release); "
+                    "order by a column on the queried model instead."
                 )
             col_name = selected.column
         else:
@@ -260,6 +367,19 @@ class Query(Generic[T]):
         new._offset = value
         return new
 
+    def _serialize_joins(self) -> list[dict[str, Any]]:
+        """Serialize collected relation paths into QueryIR ``joins`` entries.
+
+        Emits one entry per registered full path, in insertion order, each
+        carrying its ordered hop facts (:func:`_resolve_join_hops`). The Rust
+        SELECT walkers assign deterministic ``j{i}_{relation}`` aliases and
+        dedup shared prefixes at render time (#270).
+        """
+        return [
+            {"join_type": join_type, "path": _resolve_join_hops(self.model_cls, path)}
+            for path, join_type in self._joins.items()
+        ]
+
     def _mutating_query_def(self, operation: str) -> dict[str, Any]:
         """Build the QueryIR payload for a mutating operation (update/delete).
 
@@ -303,7 +423,7 @@ class Query(Generic[T]):
             "limit": self._limit,
             "offset": self._offset,
             "m2m": self._m2m_context,
-            "joins": [],
+            "joins": self._serialize_joins(),
         }
         route = await self._transaction_or_using()
         return await fetch_filtered(
@@ -330,7 +450,7 @@ class Query(Generic[T]):
             "limit": None,
             "offset": None,
             "m2m": self._m2m_context,
-            "joins": [],
+            "joins": self._serialize_joins(),
         }
         route = await self._transaction_or_using()
         return await count_filtered(

--- a/src/ferro/query/nodes.py
+++ b/src/ferro/query/nodes.py
@@ -37,6 +37,7 @@ class QueryNode:
         left: "QueryNode | None" = None,
         right: "QueryNode | None" = None,
         is_compound: bool = False,
+        path: tuple[str, ...] = (),
     ):
         """Initialize a query expression node
 
@@ -47,6 +48,10 @@ class QueryNode:
             left: Left child node for compound expressions.
             right: Right child node for compound expressions.
             is_compound: Set to True for logical expressions with child nodes.
+            path: Relation field names from the root model to ``column``'s
+                table; empty (default) means the root model. Plumbed through
+                so relation traversal (#270) can populate it — this slice
+                never produces a non-empty path.
         """
         self.column = column
         self.operator = operator
@@ -54,6 +59,7 @@ class QueryNode:
         self.left = left
         self.right = right
         self.is_compound = is_compound
+        self.path = path
 
     def __or__(self, other: "QueryNode") -> "QueryNode":
         """Combine two nodes with logical OR
@@ -103,6 +109,7 @@ class QueryNode:
                 "column": self.column,
                 "operator": self.operator,
                 "value": {"kind": _query_value_kind(serialized), "value": serialized},
+                "path": list(self.path),
             }
         return {
             "node_kind": "compound",
@@ -167,41 +174,46 @@ class FieldProxy(Generic[TField]):
         True
     """
 
-    def __init__(self, column: str):
+    def __init__(self, column: str, path: tuple[str, ...] = ()):
         """Initialize a field proxy for a specific column
 
         Args:
             column: Database column name to target in expressions.
+            path: Relation field names from the root model to this column's
+                table; empty (default) means the root model. Plumbed through
+                so relation traversal (#270) can populate it — this slice
+                never produces a non-empty path.
         """
         self.column = column
+        self.path = path
 
     def __eq__(  # type: ignore[override]  # ty: ignore[invalid-method-override]
         self, other: "TField | FieldProxy[TField]"
     ) -> QueryNode:
         """Build an equality comparison node"""
-        return QueryNode(self.column, "==", other)
+        return QueryNode(self.column, "==", other, path=self.path)
 
     def __ne__(  # type: ignore[override]  # ty: ignore[invalid-method-override]
         self, other: "TField | FieldProxy[TField]"
     ) -> QueryNode:
         """Build an inequality comparison node"""
-        return QueryNode(self.column, "!=", other)
+        return QueryNode(self.column, "!=", other, path=self.path)
 
     def __lt__(self, other: "TField | FieldProxy[TField]") -> QueryNode:
         """Build a less-than comparison node"""
-        return QueryNode(self.column, "<", other)
+        return QueryNode(self.column, "<", other, path=self.path)
 
     def __le__(self, other: "TField | FieldProxy[TField]") -> QueryNode:
         """Build a less-than-or-equal comparison node"""
-        return QueryNode(self.column, "<=", other)
+        return QueryNode(self.column, "<=", other, path=self.path)
 
     def __gt__(self, other: "TField | FieldProxy[TField]") -> QueryNode:
         """Build a greater-than comparison node"""
-        return QueryNode(self.column, ">", other)
+        return QueryNode(self.column, ">", other, path=self.path)
 
     def __ge__(self, other: "TField | FieldProxy[TField]") -> QueryNode:
         """Build a greater-than-or-equal comparison node"""
-        return QueryNode(self.column, ">=", other)
+        return QueryNode(self.column, ">=", other, path=self.path)
 
     def in_(
         self, other: "list[TField] | tuple[TField, ...] | set[TField]"
@@ -226,7 +238,7 @@ class FieldProxy(Generic[TField]):
             raise TypeError(
                 f"The 'in_' operator expects a list, tuple, or set, got {type(other).__name__}"
             )
-        return QueryNode(self.column, "IN", list(other))
+        return QueryNode(self.column, "IN", list(other), path=self.path)
 
     def like(self: "FieldProxy[str]", pattern: str) -> QueryNode:
         """Build a ``LIKE`` comparison node
@@ -246,7 +258,7 @@ class FieldProxy(Generic[TField]):
             >>> email_filter.operator
             'LIKE'
         """
-        return QueryNode(self.column, "LIKE", pattern)
+        return QueryNode(self.column, "LIKE", pattern, path=self.path)
 
     def __lshift__(
         self, other: "list[TField] | tuple[TField, ...] | set[TField]"

--- a/src/ferro/query/nodes.py
+++ b/src/ferro/query/nodes.py
@@ -113,10 +113,31 @@ class QueryNode:
             }
         return {
             "node_kind": "compound",
+            # Identity checks, never truthiness: ``__bool__`` raises to catch
+            # ``and``/``or`` misuse, so every internal test of a QueryNode uses
+            # ``is (not) None`` (audited for #273).
             "operator": self.operator,
-            "left": self.left.to_ir_dict() if self.left else None,
-            "right": self.right.to_ir_dict() if self.right else None,
+            "left": self.left.to_ir_dict() if self.left is not None else None,
+            "right": self.right.to_ir_dict() if self.right is not None else None,
         }
+
+    def __bool__(self) -> bool:
+        """Reject boolean coercion of a query node (#273).
+
+        Python evaluates ``and``/``or`` by calling ``bool()`` on the operands,
+        so ``(u.age >= 18) and (u.active == True)`` would silently collapse to
+        one branch instead of building a compound predicate. Raising here turns
+        that mistake into a pointed error at build time; combine predicates with
+        the bitwise ``&`` / ``|`` operators instead.
+
+        Raises:
+            TypeError: Always — a ``QueryNode`` has no truth value.
+        """
+        raise TypeError(
+            "QueryNode cannot be used in a boolean context; use & / | to "
+            "combine predicates, not and/or "
+            "(e.g. (u.age >= 18) & (u.active == True))."
+        )
 
     def __repr__(self):
         """Return a developer-friendly representation of the node"""
@@ -397,8 +418,13 @@ class RelationProxy:
       did-you-mean suggestion (same style as :func:`validate_query_column`).
 
     A bare ``RelationProxy`` returned from a ``where()`` lambda is not a
-    :class:`QueryNode`; ``where()`` rejects it. Comparison/misuse sugar on a
-    relation (``== instance``, ``== None``) is a later slice (#273).
+    :class:`QueryNode`; ``where()`` rejects it. Equality sugar against a
+    persisted target instance or ``None`` desugars **join-free** to a
+    shadow-FK comparison (#273): ``t.account == acct`` builds
+    ``QueryNode(column="account_id", operator="==", value=<acct.pk>, path=())``
+    — the shadow column of the LAST hop, with the proxy path MINUS that hop, so
+    a deep proxy (``t.account.owner == o``) compares ``owner_id`` under the
+    ``("account",)`` prefix joins only.
 
     Examples:
         >>> proxy = QueryProxy(Transaction)  # doctest: +SKIP
@@ -424,6 +450,109 @@ class RelationProxy:
             return RelationProxy(self._root_model, self._path + (name,), spec.target)
         validate_query_column(self._target, name)
         return FieldProxy(name, path=self._path)
+
+    def _relation_name(self) -> str:
+        """The last-hop relation field name (the one being compared)."""
+        return self._path[-1]
+
+    def _last_hop_shadow_column(self) -> str:
+        """Shadow FK column of the LAST hop, resolved along the spec chain.
+
+        For ``t.account`` this is ``account_id`` on the root table; for
+        ``t.account.owner`` it is ``owner_id`` on the hop-1 (account) table.
+        """
+        current = self._root_model
+        spec = None
+        for name in self._path:
+            specs = getattr(current, "__ferro_relation_specs__", None) or {}
+            spec = specs[name]
+            current = spec.target
+        assert spec is not None  # a RelationProxy always has ≥ 1 hop
+        return spec.shadow_column
+
+    def _instance_comparison(self, other: object, operator: str) -> QueryNode:
+        """Desugar ``== instance`` / ``== None`` to a shadow-FK leaf (#273).
+
+        The node targets the last hop's shadow FK column with the proxy path
+        MINUS that hop, so it registers only the PREFIX joins (none for a
+        one-hop proxy — genuinely join-free).
+
+        Raises:
+            ValueError: If ``other`` is a target-model instance whose primary
+                key is unset (unpersisted) — naming the model, save-first.
+            TypeError: If ``other`` is neither the target model nor ``None`` —
+                the relation-vs-scalar guardrail, suggesting a column compare.
+        """
+        relation = self._relation_name()
+        shadow = self._last_hop_shadow_column()
+        prefix_path = self._path[:-1]
+        if other is None:
+            return QueryNode(
+                column=shadow, operator=operator, value=None, path=prefix_path
+            )
+        if isinstance(other, self._target):
+            # Reuse the Task 3 PK resolver (loud on zero/multiple PKs); local
+            # import avoids a builder <-> nodes import cycle at module load.
+            from .builder import _target_pk_column
+
+            pk_column = _target_pk_column(self._target)
+            pk_value = getattr(other, pk_column, None)
+            if pk_value is None:
+                raise ValueError(
+                    f"cannot compare relation {relation!r} to an unpersisted "
+                    f"{self._target.__name__} instance (primary key not set); "
+                    "save it first"
+                )
+            return QueryNode(
+                column=shadow, operator=operator, value=pk_value, path=prefix_path
+            )
+        raise TypeError(
+            f"cannot compare relation {relation!r} to {other!r}: expected a "
+            f"{self._target.__name__} instance or None. To filter by a column, "
+            f"compare it directly (e.g. t.{relation}.<column> == ...)."
+        )
+
+    def __eq__(  # type: ignore[override]  # ty: ignore[invalid-method-override]
+        self, other: object
+    ) -> QueryNode:
+        """Desugar ``t.<relation> == instance`` / ``== None`` (join-free, #273)."""
+        return self._instance_comparison(other, "==")
+
+    def __ne__(  # type: ignore[override]  # ty: ignore[invalid-method-override]
+        self, other: object
+    ) -> QueryNode:
+        """Desugar ``t.<relation> != instance`` / ``!= None`` (join-free, #273)."""
+        return self._instance_comparison(other, "!=")
+
+    def _reject_operator(self, symbol: str) -> "QueryNode":
+        """Reject a non-equality operator on a bare relation (#273)."""
+        relation = self._relation_name()
+        raise TypeError(
+            f"relation {relation!r} supports only == / != against a "
+            f"{self._target.__name__} instance or None; to compare a column use "
+            f"t.{relation}.<column> (e.g. t.{relation}.<column> {symbol} ...)."
+        )
+
+    def __lt__(self, other: object) -> "QueryNode":
+        return self._reject_operator("<")
+
+    def __le__(self, other: object) -> "QueryNode":
+        return self._reject_operator("<=")
+
+    def __gt__(self, other: object) -> "QueryNode":
+        return self._reject_operator(">")
+
+    def __ge__(self, other: object) -> "QueryNode":
+        return self._reject_operator(">=")
+
+    def in_(self, other: object) -> "QueryNode":
+        return self._reject_operator("in_")
+
+    def like(self, other: object) -> "QueryNode":
+        return self._reject_operator("like")
+
+    def __lshift__(self, other: object) -> "QueryNode":
+        return self._reject_operator("<<")
 
     def __repr__(self) -> str:
         joined = ".".join(self._path)

--- a/src/ferro/query/nodes.py
+++ b/src/ferro/query/nodes.py
@@ -4,7 +4,7 @@ import difflib
 import uuid
 from collections.abc import Callable
 from decimal import Decimal
-from typing import Any, Generic, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar
 
 TField = TypeVar("TField")
 TModel = TypeVar("TModel")
@@ -187,6 +187,21 @@ class FieldProxy(Generic[TField]):
         self.column = column
         self.path = path
 
+    if TYPE_CHECKING:
+
+        def __getattr__(self, name: str) -> "FieldProxy[Any]":
+            """Statically model relation-traversal chaining (#270).
+
+            Only visible to type checkers: ``t.account.ledger_id`` types each
+            hop as ``FieldProxy[Any]`` so a traversal comparison still yields a
+            ``QueryNode`` while a *bare* proxy (``lambda t: t.account``) stays a
+            non-``QueryNode`` and fails predicate typing. At runtime the actual
+            resolution lives on :class:`QueryProxy` / :class:`RelationProxy`
+            (relation → deeper proxy, column → this ``FieldProxy``); this
+            declaration is never executed.
+            """
+            ...
+
     def __eq__(  # type: ignore[override]  # ty: ignore[invalid-method-override]
         self, other: "TField | FieldProxy[TField]"
     ) -> QueryNode:
@@ -289,8 +304,9 @@ def validate_query_column(model_cls: type, name: str) -> str:
     Raises:
         AttributeError: If ``name`` is not a declared field or shadow
             ``{fk}_id`` column of ``model_cls``. The message names the bad
-            column, suggests the closest valid one, and lists all valid
-            columns.
+            column, suggests the closest valid one across BOTH columns and
+            declared forward-relation names (#270), and lists the valid
+            columns and relations.
     """
     valid = getattr(model_cls, "__ferro_query_columns__", None)
     if valid is None:
@@ -300,11 +316,19 @@ def validate_query_column(model_cls: type, name: str) -> str:
         )
     if name in valid:
         return name
-    close = difflib.get_close_matches(name, sorted(valid), n=1)
+    # A valid relation name never reaches here (proxies resolve relations
+    # before column validation), but relation field names still enrich the
+    # did-you-mean pool so a typo close to a relation gets the right hint.
+    relations = getattr(model_cls, "__ferro_relation_specs__", None) or {}
+    suggestions = sorted(set(valid) | set(relations))
+    close = difflib.get_close_matches(name, suggestions, n=1)
     hint = f" Did you mean {close[0]!r}?" if close else ""
+    relation_note = (
+        f" Valid relations: {', '.join(sorted(relations))}." if relations else ""
+    )
     raise AttributeError(
         f"{model_cls.__name__} has no queryable column {name!r}.{hint} "
-        f"Valid columns: {', '.join(sorted(valid))}."
+        f"Valid columns: {', '.join(sorted(valid))}.{relation_note}"
     )
 
 
@@ -334,9 +358,76 @@ class QueryProxy(Generic[TModel]):
         self._model_cls = model_cls
 
     def __getattr__(self, name: str) -> "FieldProxy[Any]":
-        """Validate ``name`` and return a ``FieldProxy`` for it."""
+        """Resolve ``name`` on the root model.
+
+        Relation specs are consulted FIRST (#270): a declared forward-FK field
+        name yields a :class:`RelationProxy` for traversal (``t.account`` →
+        proxy → ``.ledger_id``); every other name falls through to column
+        validation and returns a :class:`FieldProxy`.
+        """
+        relations = getattr(self._model_cls, "__ferro_relation_specs__", None) or {}
+        spec = relations.get(name)
+        if spec is not None:
+            # Statically typed as FieldProxy[Any] (chainable shape) even though a
+            # relation resolves to a RelationProxy at runtime — a bare relation
+            # proxy is intentionally not a QueryNode, so predicate typing still
+            # rejects `lambda t: t.account` (design pin, PRD #267).
+            return RelationProxy(  # ty: ignore[invalid-return-type]
+                self._model_cls, (name,), spec.target
+            )
         validate_query_column(self._model_cls, name)
         return FieldProxy(name)
+
+
+class RelationProxy:
+    """Traversal proxy for a declared forward-FK relation path (#270).
+
+    Returned by attribute access on a :class:`QueryProxy` (or a deeper
+    ``RelationProxy``) when the accessed name is a declared forward relation.
+    It carries the *root* model, the relation ``path`` walked so far (a tuple
+    of relation field names), and the ``target`` model that path resolves to.
+
+    Attribute access resolves against the CURRENT TARGET model, recursively at
+    any depth:
+
+    - a relation name yields a deeper ``RelationProxy`` (``path + (name,)``);
+    - a column name yields a :class:`FieldProxy` carrying this proxy's ``path``,
+      so ``t.account.ledger_id == lid`` builds a path-qualified comparison node;
+    - an unknown name raises ``AttributeError`` naming the hop's model with a
+      did-you-mean suggestion (same style as :func:`validate_query_column`).
+
+    A bare ``RelationProxy`` returned from a ``where()`` lambda is not a
+    :class:`QueryNode`; ``where()`` rejects it. Comparison/misuse sugar on a
+    relation (``== instance``, ``== None``) is a later slice (#273).
+
+    Examples:
+        >>> proxy = QueryProxy(Transaction)  # doctest: +SKIP
+        >>> node = (proxy.account.ledger_id == 7)  # doctest: +SKIP
+        >>> node.path  # doctest: +SKIP
+        ('account',)
+    """
+
+    __slots__ = ("_root_model", "_path", "_target")
+
+    def __init__(
+        self, root_model: type, path: tuple[str, ...], target: type
+    ) -> None:
+        self._root_model = root_model
+        self._path = path
+        self._target = target
+
+    def __getattr__(self, name: str) -> "RelationProxy | FieldProxy[Any]":
+        """Resolve ``name`` against the current target model (one hop deeper)."""
+        relations = getattr(self._target, "__ferro_relation_specs__", None) or {}
+        spec = relations.get(name)
+        if spec is not None:
+            return RelationProxy(self._root_model, self._path + (name,), spec.target)
+        validate_query_column(self._target, name)
+        return FieldProxy(name, path=self._path)
+
+    def __repr__(self) -> str:
+        joined = ".".join(self._path)
+        return f"RelationProxy(path={joined!r}, target={self._target.__name__!r})"
 
 
 Predicate: TypeAlias = Callable[[QueryProxy[TModel]], QueryNode]

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -242,11 +242,23 @@ fn tx_remove(session_id: Option<&str>, tx_id: &str) -> PyResult<Option<Transacti
     Ok(TRANSACTION_REGISTRY.remove(tx_id).map(|(_, handle)| handle))
 }
 
+/// The only QueryIR version this build accepts (#269, #267 Implementation Decisions).
+///
+/// Python and Rust ship in one wheel, so there is exactly one supported version at any
+/// time — no negotiation, no fallback. A mismatch can only mean a mixed build (a stale
+/// `.so` next to a rebuilt Python package, or vice versa).
+const SUPPORTED_QUERY_IR_VERSION: u32 = 2;
+
+/// Envelope shell used only to read `ir_kind`/`ir_version` before committing to a strict
+/// [`QueryIrPayload`] parse. `payload` is deliberately raw JSON: a real v1 payload (no
+/// `joins`/`path` fields) must fail on the version check below with an actionable
+/// message, not on a generic "missing field" serde error from parsing a payload shape
+/// this build no longer understands.
 #[derive(Debug, Clone, Deserialize)]
 struct QueryIrEnvelope {
     ir_kind: String,
     ir_version: u32,
-    payload: QueryIrPayload,
+    payload: serde_json::Value,
 }
 
 fn query_plan_from_ir_json(query_ir_json: &str) -> PyResult<QueryPlan> {
@@ -259,21 +271,32 @@ fn query_plan_from_ir_json(query_ir_json: &str) -> PyResult<QueryPlan> {
             envelope.ir_kind
         )));
     }
-    if envelope.ir_version != 1 {
+    if envelope.ir_version != SUPPORTED_QUERY_IR_VERSION {
         return Err(pyo3::exceptions::PyValueError::new_err(format!(
-            "Unsupported QueryIR version {}; expected 1",
-            envelope.ir_version
+            "Unsupported QueryIR version {}: this build of ferro accepts only version {}. \
+             Python and Rust ship in one wheel, so a version mismatch means mixed builds — \
+             reinstall/rebuild ferro so the Python package and the compiled extension match.",
+            envelope.ir_version, SUPPORTED_QUERY_IR_VERSION
         )));
     }
-    QueryPlan::from_ir_payload(envelope.payload)
+    let payload: QueryIrPayload = serde_json::from_value(envelope.payload).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("Invalid QueryIR JSON: {}", e))
+    })?;
+    QueryPlan::from_ir_payload(payload)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid QueryIR: {e}")))
 }
 
+/// Build a SeaQuery `Condition` from `plan`'s `where_clause`.
+///
+/// `qualify_with`: `Some(root_table)` qualifies every column as `root_table.column`
+/// (required for SELECT — see [`crate::query::QueryPlan::to_condition_for_backend`]);
+/// `None` leaves columns unqualified (today's `UPDATE`/`DELETE ... WHERE` behavior).
 fn query_condition_for_backend(
     plan: &QueryPlan,
     backend: Dialect,
+    qualify_with: Option<&str>,
 ) -> PyResult<Condition> {
-    plan.to_condition_for_backend(backend)
+    plan.to_condition_for_backend(backend, qualify_with)
         .map_err(pyo3::exceptions::PyValueError::new_err)
 }
 
@@ -1595,9 +1618,18 @@ pub fn fetch_filtered<'py>(
                 ));
             }
 
-            select.cond_where(query_condition_for_backend(&plan, backend)?);
+            // SELECT columns are qualified by the root table alias (#269): every leaf
+            // and order_by path is guaranteed empty (root model) by
+            // `QueryPlan::from_ir_payload`'s defensive-loudness check, so qualifying
+            // here is always correct — #270 will thread real join paths through
+            // instead of the root table for non-root references.
+            select.cond_where(query_condition_for_backend(
+                &plan,
+                backend,
+                Some(&table_name),
+            )?);
             for order in &plan.order_by {
-                let col = Alias::new(&order.column);
+                let col = (Alias::new(&table_name), Alias::new(&order.column));
                 let dir = if order.direction.to_lowercase() == "desc" {
                     Order::Desc
                 } else {
@@ -1754,7 +1786,13 @@ pub fn count_filtered(
                 select.from(Alias::new(&table_name));
             }
 
-            select.cond_where(query_condition_for_backend(&plan, backend)?);
+            // Qualified by the root table alias (#269) — see the matching comment in
+            // `fetch_filtered` for why this is always correct in this slice.
+            select.cond_where(query_condition_for_backend(
+                &plan,
+                backend,
+                Some(&table_name),
+            )?);
             sea_query_build_for_backend!(select, backend)
         };
 
@@ -1923,9 +1961,17 @@ pub fn delete_filtered(
         // ... sql ...
         let (sql, bind_values) = {
             let mut delete = Query::delete();
+            // Qualified by the root table alias (#269): both dialects accept
+            // `table.column` in `DELETE ... WHERE`, and uniform qualification across
+            // every walker avoids retrofitting the mutating paths when joins reach
+            // them later.
             delete
                 .from_table(Alias::new(&table_name))
-                .cond_where(query_condition_for_backend(&plan, backend)?);
+                .cond_where(query_condition_for_backend(
+                    &plan,
+                    backend,
+                    Some(&table_name),
+                )?);
             sea_query_build_for_backend!(delete, backend)
         };
 
@@ -1989,9 +2035,16 @@ pub fn update_filtered<'py>(
         plan.postgres_enum_udt = enum_udt.clone();
         // ... sql ...
         let (sql, bind_values) = {
+            // Qualified by the root table alias (#269) — same rationale as
+            // `delete_filtered` above. SET columns stay bare: SQL forbids
+            // qualified column names on the left of `SET` assignments.
             let mut update = UpdateStatement::new()
                 .table(Alias::new(&table_name))
-                .cond_where(query_condition_for_backend(&plan, backend)?)
+                .cond_where(query_condition_for_backend(
+                    &plan,
+                    backend,
+                    Some(&table_name),
+                )?)
                 .to_owned();
             for (key, input) in &update_inputs {
                 update.value(
@@ -3468,17 +3521,19 @@ mod mutation_pagination_guard_tests {
     fn envelope_without_pagination_keys() -> String {
         serde_json::json!({
             "ir_kind": "query",
-            "ir_version": 1,
+            "ir_version": 2,
             "payload": {
                 "model_name": "Widget",
                 "where": [{
                     "node_kind": "leaf",
                     "operator": "==",
                     "column": "name",
-                    "value": {"kind": "string", "value": "a"}
+                    "value": {"kind": "string", "value": "a"},
+                    "path": []
                 }],
                 "order_by": [],
-                "m2m": null
+                "m2m": null,
+                "joins": []
             }
         })
         .to_string()
@@ -3529,6 +3584,174 @@ mod mutation_pagination_guard_tests {
                 "message should name the operation and offset: {msg}"
             );
         });
+    }
+}
+
+#[cfg(test)]
+mod query_ir_version_gate_tests {
+    use super::query_plan_from_ir_json;
+
+    fn v2_envelope() -> serde_json::Value {
+        serde_json::json!({
+            "ir_kind": "query",
+            "ir_version": 2,
+            "payload": {
+                "model_name": "Widget",
+                "where": [],
+                "order_by": [],
+                "limit": null,
+                "offset": null,
+                "m2m": null,
+                "joins": []
+            }
+        })
+    }
+
+    #[test]
+    fn accepts_version_2() {
+        query_plan_from_ir_json(&v2_envelope().to_string())
+            .expect("a well-formed v2 envelope must be accepted");
+    }
+
+    /// Contract test (#269 acceptance criteria): a v1 envelope — including one
+    /// that predates the `joins`/`path` fields entirely, as any real v1 emitter
+    /// would produce — must be rejected with a message naming the version
+    /// actually received, this build's supported version, and that Python/Rust
+    /// ship in one wheel (so a mismatch means mixed builds).
+    #[test]
+    fn rejects_v1_envelope_with_actionable_message() {
+        let v1_envelope = serde_json::json!({
+            "ir_kind": "query",
+            "ir_version": 1,
+            "payload": {
+                "model_name": "Widget",
+                "where": [],
+                "order_by": [],
+                "limit": null,
+                "offset": null,
+                "m2m": null
+            }
+        });
+
+        let err = query_plan_from_ir_json(&v1_envelope.to_string())
+            .expect_err("a v1 envelope must be rejected");
+        pyo3::Python::attach(|py| {
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+        });
+        let msg = err.to_string();
+        assert!(
+            msg.contains('1'),
+            "message should name the received version: {msg}"
+        );
+        assert!(
+            msg.contains('2'),
+            "message should name the supported version: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("one wheel"),
+            "message should explain Python/Rust ship in one wheel: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("reinstall") || msg.to_lowercase().contains("rebuild"),
+            "message should tell the caller how to fix a mismatch: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_future_version() {
+        let mut envelope = v2_envelope();
+        envelope["ir_version"] = serde_json::json!(3);
+
+        let err = query_plan_from_ir_json(&envelope.to_string())
+            .expect_err("an unsupported future version must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains('3'),
+            "message should name the received version: {msg}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod mutation_qualification_tests {
+    //! Pin root-alias qualification in mutating WHERE clauses (#269).
+    //!
+    //! `update_filtered`/`delete_filtered` assemble their statements inside async
+    //! pyfunctions with no directly callable seam, so these tests rebuild the same
+    //! statement shape (`Query::delete()` / `UpdateStatement` +
+    //! `query_condition_for_backend(.., Some(&table_name))`) and assert the rendered
+    //! SQL qualifies the WHERE column on both dialects.
+
+    use super::{query_condition_for_backend, query_plan_from_ir_json};
+    use crate::state::Dialect;
+    use sea_query::{Alias, PostgresQueryBuilder, Query, SqliteQueryBuilder, UpdateStatement};
+
+    fn widget_plan() -> crate::query::QueryPlan {
+        query_plan_from_ir_json(
+            &serde_json::json!({
+                "ir_kind": "query",
+                "ir_version": 2,
+                "payload": {
+                    "model_name": "Widget",
+                    "where": [{
+                        "node_kind": "leaf",
+                        "operator": "==",
+                        "column": "name",
+                        "value": {"kind": "string", "value": "a"},
+                        "path": []
+                    }],
+                    "order_by": [],
+                    "m2m": null,
+                    "joins": []
+                }
+            })
+            .to_string(),
+        )
+        .expect("v2 envelope parses")
+    }
+
+    #[test]
+    fn delete_where_column_is_root_qualified_on_both_dialects() {
+        let plan = widget_plan();
+        for backend in [Dialect::Sqlite, Dialect::Postgres] {
+            let mut delete = Query::delete();
+            delete
+                .from_table(Alias::new("widget"))
+                .cond_where(query_condition_for_backend(&plan, backend, Some("widget")).unwrap());
+            let sql = match backend {
+                Dialect::Postgres => delete.to_string(PostgresQueryBuilder),
+                Dialect::Sqlite => delete.to_string(SqliteQueryBuilder),
+            };
+            assert!(
+                sql.contains("\"widget\".\"name\"") || sql.contains("`widget`.`name`"),
+                "DELETE WHERE column must be root-qualified on {backend:?}: {sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn update_where_column_is_root_qualified_on_both_dialects() {
+        let plan = widget_plan();
+        for backend in [Dialect::Sqlite, Dialect::Postgres] {
+            let mut update = UpdateStatement::new()
+                .table(Alias::new("widget"))
+                .cond_where(query_condition_for_backend(&plan, backend, Some("widget")).unwrap())
+                .to_owned();
+            update.value(Alias::new("name"), "b");
+            let sql = match backend {
+                Dialect::Postgres => update.to_string(PostgresQueryBuilder),
+                Dialect::Sqlite => update.to_string(SqliteQueryBuilder),
+            };
+            assert!(
+                sql.contains("\"widget\".\"name\" =") || sql.contains("`widget`.`name` ="),
+                "UPDATE WHERE column must be root-qualified on {backend:?}: {sql}"
+            );
+            // SET assignment column must stay bare (SQL forbids qualified SET targets).
+            assert!(
+                sql.contains("SET \"name\"") || sql.contains("SET `name`"),
+                "UPDATE SET column must stay unqualified on {backend:?}: {sql}"
+            );
+        }
     }
 }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -6,7 +6,7 @@
 use crate::backend::{
     EngineBindValue, EngineHandle, EngineRow, EngineValue, NullKind, TableCatalog,
 };
-use crate::query::QueryPlan;
+use crate::query::{JoinPlan, QueryPlan};
 use crate::state::{
     Dialect, TRANSACTION_REGISTRY,
     TransactionConnection, TransactionHandle, connection_for_route, ensure_session_idle_for_close,
@@ -16,8 +16,9 @@ use dashmap::DashMap;
 use ferro_schema_ir::QueryIrPayload;
 use pyo3::prelude::*;
 use sea_query::{
-    Alias, Condition, Expr, Iden, InsertStatement, OnConflict, Order, PostgresQueryBuilder, Query,
-    SimpleExpr, SqliteQueryBuilder, UpdateStatement, Value as SeaValue,
+    Alias, Condition, Expr, Iden, InsertStatement, JoinType, OnConflict, Order,
+    PostgresQueryBuilder, Query, SelectStatement, SimpleExpr, SqliteQueryBuilder, UpdateStatement,
+    Value as SeaValue,
 };
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
@@ -289,8 +290,11 @@ fn query_plan_from_ir_json(query_ir_json: &str) -> PyResult<QueryPlan> {
 /// Build a SeaQuery `Condition` from `plan`'s `where_clause`.
 ///
 /// `qualify_with`: `Some(root_table)` qualifies every column as `root_table.column`
-/// (required for SELECT — see [`crate::query::QueryPlan::to_condition_for_backend`]);
-/// `None` leaves columns unqualified (today's `UPDATE`/`DELETE ... WHERE` behavior).
+/// (see [`crate::query::QueryPlan::to_condition_for_backend`]). All four filtered
+/// walkers qualify with the root alias in production — the mutating `UPDATE`/`DELETE
+/// ... WHERE` paths pass `Some(root_table)` here, and the SELECT paths use
+/// [`query_condition_with_joins`] instead. `None` leaves columns unqualified and is
+/// exercised only by unit tests.
 fn query_condition_for_backend(
     plan: &QueryPlan,
     backend: Dialect,
@@ -298,6 +302,68 @@ fn query_condition_for_backend(
 ) -> PyResult<Condition> {
     plan.to_condition_for_backend(backend, qualify_with)
         .map_err(pyo3::exceptions::PyValueError::new_err)
+}
+
+/// Build the relation-JOIN plan for a SELECT walker (#270).
+///
+/// `reserved` names (the M2M association table, when present) are protected from
+/// alias collisions alongside the root table. Errors map planner `String`s to
+/// `PyValueError` (unknown `join_type`).
+fn query_join_plan(plan: &QueryPlan, root_table: &str, reserved: &[&str]) -> PyResult<JoinPlan> {
+    plan.build_join_plan(root_table, reserved)
+        .map_err(pyo3::exceptions::PyValueError::new_err)
+}
+
+/// Build the WHERE `Condition` with columns qualified by their relation-path
+/// JOIN alias (SELECT walkers, #270).
+fn query_condition_with_joins(
+    plan: &QueryPlan,
+    backend: Dialect,
+    root_table: &str,
+    join_plan: &JoinPlan,
+) -> PyResult<Condition> {
+    plan.to_condition_with_joins(backend, root_table, join_plan)
+        .map_err(pyo3::exceptions::PyValueError::new_err)
+}
+
+/// Render a [`JoinPlan`]'s edges onto a SELECT as aliased INNER/LEFT joins.
+///
+/// Each edge emits `<join> <to_table> AS <alias> ON
+/// <prev_alias>.<from_column> = <alias>.<to_column>`; the join type is validated
+/// (`"inner"`/`"left"`), so an unknown type is a loud error, never a mis-render.
+fn apply_relation_joins(select: &mut SelectStatement, join_plan: &JoinPlan) -> PyResult<()> {
+    for edge in &join_plan.renders {
+        let join_type = match edge.join_type.as_str() {
+            "inner" => JoinType::InnerJoin,
+            "left" => JoinType::LeftJoin,
+            other => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "unsupported join_type {other:?} while rendering relation joins"
+                )));
+            }
+        };
+        select.join_as(
+            join_type,
+            Alias::new(&edge.to_table),
+            Alias::new(&edge.alias),
+            Expr::col((Alias::new(&edge.prev_alias), Alias::new(&edge.from_column)))
+                .equals((Alias::new(&edge.alias), Alias::new(&edge.to_column))),
+        );
+    }
+    Ok(())
+}
+
+/// Reject relation traversal on a mutating operation (#270 renders joins in SELECT
+/// only). The Python builder never emits joins on a mutating payload, so a `joins`
+/// list or a path-carrying WHERE leaf here is misuse — fail loud.
+fn reject_traversal_on_mutation(plan: &QueryPlan, operation: &str) -> PyResult<()> {
+    plan.ensure_no_traversal().map_err(|detail| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "{operation}() does not support relation traversal: {detail}. \
+             Filter by a column on the target model, or resolve the related \
+             primary keys first and {operation} by primary-key set."
+        ))
+    })
 }
 
 /// Reject `limit`/`offset` on mutating operations (FF-A A1, #171).
@@ -1595,6 +1661,7 @@ pub fn fetch_filtered<'py>(
             select.column((Alias::new(&table_name), sea_query::Asterisk));
             select.from(Alias::new(&table_name));
 
+            let m2m_join_table = plan.m2m.as_ref().map(|m2m| m2m.join_table.clone());
             if let Some(m2m) = &plan.m2m {
                 let join_table = Alias::new(&m2m.join_table);
                 let source_col = Alias::new(&m2m.source_col);
@@ -1618,15 +1685,20 @@ pub fn fetch_filtered<'py>(
                 ));
             }
 
-            // SELECT columns are qualified by the root table alias (#269): every leaf
-            // and order_by path is guaranteed empty (root model) by
-            // `QueryPlan::from_ir_payload`'s defensive-loudness check, so qualifying
-            // here is always correct — #270 will thread real join paths through
-            // instead of the root table for non-root references.
-            select.cond_where(query_condition_for_backend(
+            // Relation-traversal JOINs (#270): the M2M association table (when
+            // present) is reserved so a relation alias can never collide with it.
+            let reserved: Vec<&str> = m2m_join_table.as_deref().into_iter().collect();
+            let join_plan = query_join_plan(&plan, &table_name, &reserved)?;
+            apply_relation_joins(&mut select, &join_plan)?;
+
+            // WHERE columns are qualified by their relation-path alias (root leaf ->
+            // root table, path leaf -> its JOIN alias). A path with no matching join
+            // entry is a loud error, never a silently unqualified column.
+            select.cond_where(query_condition_with_joins(
                 &plan,
                 backend,
-                Some(&table_name),
+                &table_name,
+                &join_plan,
             )?);
             for order in &plan.order_by {
                 let col = (Alias::new(&table_name), Alias::new(&order.column));
@@ -1756,6 +1828,7 @@ pub fn count_filtered(
             let mut select = Query::select();
             select.expr(Expr::cust("COUNT(*)"));
 
+            let m2m_join_table = plan.m2m.as_ref().map(|m2m| m2m.join_table.clone());
             if let Some(m2m) = &plan.m2m {
                 let join_table = Alias::new(&m2m.join_table);
                 let source_col = Alias::new(&m2m.source_col);
@@ -1786,12 +1859,19 @@ pub fn count_filtered(
                 select.from(Alias::new(&table_name));
             }
 
-            // Qualified by the root table alias (#269) — see the matching comment in
-            // `fetch_filtered` for why this is always correct in this slice.
-            select.cond_where(query_condition_for_backend(
+            // Relation-traversal JOINs render into the COUNT the same as the SELECT
+            // (#270). Plain COUNT(*), no DISTINCT: forward-FK hops are many-to-one and
+            // never multiply root rows, so count() equals the matching root-row count.
+            let reserved: Vec<&str> = m2m_join_table.as_deref().into_iter().collect();
+            let join_plan = query_join_plan(&plan, &table_name, &reserved)?;
+            apply_relation_joins(&mut select, &join_plan)?;
+
+            // WHERE columns qualified by their relation-path alias (see fetch_filtered).
+            select.cond_where(query_condition_with_joins(
                 &plan,
                 backend,
-                Some(&table_name),
+                &table_name,
+                &join_plan,
             )?);
             sea_query_build_for_backend!(select, backend)
         };
@@ -1946,6 +2026,7 @@ pub fn delete_filtered(
 ) -> PyResult<Bound<'_, PyAny>> {
     let mut plan = query_plan_from_ir_json(&query_ir_json)?;
     reject_pagination_on_mutation(&plan, "delete")?;
+    reject_traversal_on_mutation(&plan, "delete")?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let r = route.get();
@@ -2020,6 +2101,7 @@ pub fn update_filtered<'py>(
 ) -> PyResult<Bound<'py, PyAny>> {
     let mut plan = query_plan_from_ir_json(&query_ir_json)?;
     reject_pagination_on_mutation(&plan, "update")?;
+    reject_traversal_on_mutation(&plan, "update")?;
     let update_inputs = bind_inputs_from_py(&updates)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -353,6 +353,39 @@ fn apply_relation_joins(select: &mut SelectStatement, join_plan: &JoinPlan) -> P
     Ok(())
 }
 
+/// Resolve, for every table a relation JOIN reaches, the owning model's
+/// registration and native-enum catalog so a traversed WHERE leaf binds against
+/// its OWN model — not the root's codec plan / enum catalog (#270 critical).
+///
+/// Both maps are keyed by physical table name (root and joined columns cannot
+/// collide on the enum-UDT lookup). Registration resolution is route (a):
+/// `MODEL_REGISTRY` is scanned by `table_name` (one model per table, so
+/// unambiguous), and a joined table with NO registration is a loud error — never
+/// a silent fallback to root/generic binds. The enum catalog reuses the
+/// per-table `postgres_table_catalog` cache (one probe per table per schema
+/// epoch), so steady-state traversal queries add no extra round-trips.
+async fn populate_hop_bind_context(
+    plan: &mut QueryPlan,
+    join_plan: &JoinPlan,
+    engine: &EngineHandle,
+    exec: Executor<'_>,
+    backend: Dialect,
+) -> PyResult<()> {
+    for edge in &join_plan.renders {
+        let table = &edge.to_table;
+        if !plan.hop_registrations.contains_key(table) {
+            let registration = crate::state::registration_for_table(table)?;
+            plan.hop_registrations.insert(table.clone(), registration);
+        }
+        if !plan.hop_enum_udt.contains_key(table) {
+            let catalog = postgres_table_catalog(table, engine, exec, backend).await?;
+            plan.hop_enum_udt
+                .insert(table.clone(), catalog.enum_udt.clone());
+        }
+    }
+    Ok(())
+}
+
 /// Reject relation traversal on a mutating operation (#270 renders joins in SELECT
 /// only). The Python builder never emits joins on a mutating payload, so a `joins`
 /// list or a path-carrying WHERE leaf here is misuse — fail loud.
@@ -1653,6 +1686,15 @@ pub fn fetch_filtered<'py>(
         let table_name = schema.table_name.clone();
         let catalog = postgres_table_catalog(&table_name, &engine, exec, backend).await?;
         plan.postgres_enum_udt = catalog.enum_udt.clone();
+
+        // Relation-traversal JOINs (#270): the M2M association table (when
+        // present) is reserved so a relation alias can never collide with it.
+        // The join plan is built up front so each hop table's registration +
+        // enum catalog can be resolved before conditions bind (#270 critical).
+        let m2m_join_table = plan.m2m.as_ref().map(|m2m| m2m.join_table.clone());
+        let reserved: Vec<&str> = m2m_join_table.as_deref().into_iter().collect();
+        let join_plan = query_join_plan(&plan, &table_name, &reserved)?;
+        populate_hop_bind_context(&mut plan, &join_plan, &engine, exec, backend).await?;
         // ...
         let (sql, bind_values, pk_col, schema_for_decode) = {
             let pk = schema.meta.pk_col.clone();
@@ -1661,7 +1703,6 @@ pub fn fetch_filtered<'py>(
             select.column((Alias::new(&table_name), sea_query::Asterisk));
             select.from(Alias::new(&table_name));
 
-            let m2m_join_table = plan.m2m.as_ref().map(|m2m| m2m.join_table.clone());
             if let Some(m2m) = &plan.m2m {
                 let join_table = Alias::new(&m2m.join_table);
                 let source_col = Alias::new(&m2m.source_col);
@@ -1685,10 +1726,6 @@ pub fn fetch_filtered<'py>(
                 ));
             }
 
-            // Relation-traversal JOINs (#270): the M2M association table (when
-            // present) is reserved so a relation alias can never collide with it.
-            let reserved: Vec<&str> = m2m_join_table.as_deref().into_iter().collect();
-            let join_plan = query_join_plan(&plan, &table_name, &reserved)?;
             apply_relation_joins(&mut select, &join_plan)?;
 
             // WHERE columns are qualified by their relation-path alias (root leaf ->
@@ -1834,12 +1871,21 @@ pub fn count_filtered(
             .await?
             .enum_udt
             .clone();
+
+        // Relation-traversal JOINs render into the COUNT the same as the SELECT
+        // (#270). Plain COUNT(*), no DISTINCT: forward-FK hops are many-to-one and
+        // never multiply root rows, so count() equals the matching root-row count.
+        // Build the plan up front and resolve each hop table's registration +
+        // enum catalog before conditions bind (#270 critical).
+        let m2m_join_table = plan.m2m.as_ref().map(|m2m| m2m.join_table.clone());
+        let reserved: Vec<&str> = m2m_join_table.as_deref().into_iter().collect();
+        let join_plan = query_join_plan(&plan, &table_name, &reserved)?;
+        populate_hop_bind_context(&mut plan, &join_plan, &engine, exec, backend).await?;
         // ... sql ...
         let (sql, bind_values) = {
             let mut select = Query::select();
             select.expr(Expr::cust("COUNT(*)"));
 
-            let m2m_join_table = plan.m2m.as_ref().map(|m2m| m2m.join_table.clone());
             if let Some(m2m) = &plan.m2m {
                 let join_table = Alias::new(&m2m.join_table);
                 let source_col = Alias::new(&m2m.source_col);
@@ -1870,11 +1916,6 @@ pub fn count_filtered(
                 select.from(Alias::new(&table_name));
             }
 
-            // Relation-traversal JOINs render into the COUNT the same as the SELECT
-            // (#270). Plain COUNT(*), no DISTINCT: forward-FK hops are many-to-one and
-            // never multiply root rows, so count() equals the matching root-row count.
-            let reserved: Vec<&str> = m2m_join_table.as_deref().into_iter().collect();
-            let join_plan = query_join_plan(&plan, &table_name, &reserved)?;
             apply_relation_joins(&mut select, &join_plan)?;
 
             // WHERE columns qualified by their relation-path alias (see fetch_filtered).
@@ -3896,7 +3937,21 @@ mod select_join_render_tests {
 
     #[test]
     fn rendered_select_pins_join_clause_and_dedups_shared_where_order_by_path() {
-        let plan = shared_path_plan();
+        let mut plan = shared_path_plan();
+        // The walkers resolve each joined table's registration + enum catalog
+        // before building conditions; mirror that for the traversed `label` leaf
+        // (path [account] -> table "account").
+        plan.hop_registrations.insert(
+            "account".to_string(),
+            crate::state::RegisteredModel::new_for_test(
+                serde_json::json!({
+                    "properties": {"label": {"type": "string"}, "name": {"type": "string"}}
+                }),
+                "account".to_string(),
+            ),
+        );
+        plan.hop_enum_udt
+            .insert("account".to_string(), std::collections::HashMap::new());
         let join_plan = query_join_plan(&plan, "transaction", &[]).expect("join plan");
 
         let mut select = SelectStatement::new();

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -3974,6 +3974,55 @@ mod select_join_render_tests {
         .expect("v2 envelope parses")
     }
 
+    /// `t.account == instance` desugars to a shadow-FK leaf (`account_id`) with
+    /// an EMPTY path and NO joins entry — the join-free proof (#273). The
+    /// rendered SELECT must contain no JOIN and a WHERE qualified by the ROOT
+    /// table's `account_id`, never a relation alias.
+    #[test]
+    fn rendered_select_instance_equality_is_join_free() {
+        let plan = query_plan_from_ir_json(
+            &serde_json::json!({
+                "ir_kind": "query",
+                "ir_version": 2,
+                "payload": {
+                    "model_name": "Transaction",
+                    "where": [{
+                        "node_kind": "leaf",
+                        "operator": "==",
+                        "column": "account_id",
+                        "value": {"kind": "int", "value": 7},
+                        "path": []
+                    }],
+                    "order_by": [], "limit": null, "offset": null, "m2m": null,
+                    "joins": []
+                }
+            })
+            .to_string(),
+        )
+        .expect("v2 envelope parses");
+
+        let join_plan = query_join_plan(&plan, "transaction", &[]).expect("join plan");
+        let mut select = SelectStatement::new();
+        select
+            .column((Alias::new("transaction"), sea_query::Asterisk))
+            .from(Alias::new("transaction"));
+        apply_relation_joins(&mut select, &join_plan).expect("joins render");
+        select.cond_where(
+            query_condition_with_joins(&plan, Dialect::Postgres, "transaction", &join_plan)
+                .expect("condition builds"),
+        );
+        let sql = select.to_string(PostgresQueryBuilder);
+
+        assert!(
+            !sql.contains("JOIN"),
+            "instance equality must be join-free: {sql}"
+        );
+        assert!(
+            sql.contains("WHERE \"transaction\".\"account_id\""),
+            "WHERE must filter the ROOT-qualified shadow FK: {sql}"
+        );
+    }
+
     /// A `.left_join(t.account)` renders a LEFT JOIN clause (#272 NULL retention).
     #[test]
     fn rendered_select_pins_left_join_clause() {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -3943,6 +3943,137 @@ mod select_join_render_tests {
             "ORDER BY must qualify by the shared join alias: {sql}"
         );
     }
+
+    /// Build a plain `SELECT * FROM <root>` with the plan's relation joins
+    /// rendered — the exact seam both `fetch_filtered` and `count_filtered`
+    /// call (`apply_relation_joins`), so a rendered-SQL pin here covers both.
+    fn render_joined_select(plan: &crate::query::QueryPlan, root_table: &str) -> String {
+        let join_plan = query_join_plan(plan, root_table, &[]).expect("join plan");
+        let mut select = SelectStatement::new();
+        select
+            .column((Alias::new(root_table), sea_query::Asterisk))
+            .from(Alias::new(root_table));
+        apply_relation_joins(&mut select, &join_plan).expect("joins render");
+        select.to_string(PostgresQueryBuilder)
+    }
+
+    fn joined_plan(joins: serde_json::Value, model_name: &str) -> crate::query::QueryPlan {
+        query_plan_from_ir_json(
+            &serde_json::json!({
+                "ir_kind": "query",
+                "ir_version": 2,
+                "payload": {
+                    "model_name": model_name,
+                    "where": [], "order_by": [],
+                    "limit": null, "offset": null, "m2m": null,
+                    "joins": joins
+                }
+            })
+            .to_string(),
+        )
+        .expect("v2 envelope parses")
+    }
+
+    /// A `.left_join(t.account)` renders a LEFT JOIN clause (#272 NULL retention).
+    #[test]
+    fn rendered_select_pins_left_join_clause() {
+        let plan = joined_plan(
+            serde_json::json!([
+                {"join_type": "left", "path": [
+                    {"relation": "account", "from_column": "account_id",
+                     "to_table": "account", "to_column": "id"}
+                ]}
+            ]),
+            "Note",
+        );
+        let sql = render_joined_select(&plan, "note");
+        let expected = "LEFT JOIN \"account\" AS \"j1_account\" ON \
+             \"note\".\"account_id\" = \"j1_account\".\"id\"";
+        assert!(
+            sql.contains(expected),
+            "expected LEFT JOIN clause, got: {sql}"
+        );
+        assert_eq!(sql.matches("LEFT JOIN").count(), 1, "one LEFT JOIN: {sql}");
+        assert_eq!(sql.matches("INNER JOIN").count(), 0, "no INNER JOIN: {sql}");
+    }
+
+    /// Whole-path LEFT: a 2-hop `.left_join` renders BOTH edges LEFT (#272).
+    #[test]
+    fn rendered_select_whole_path_left_renders_both_hops_left() {
+        let plan = joined_plan(
+            serde_json::json!([
+                {"join_type": "left", "path": [
+                    {"relation": "account", "from_column": "account_id",
+                     "to_table": "account", "to_column": "id"},
+                    {"relation": "owner", "from_column": "owner_id",
+                     "to_table": "owner", "to_column": "id"}
+                ]}
+            ]),
+            "Transaction",
+        );
+        let sql = render_joined_select(&plan, "transaction");
+        assert!(
+            sql.contains("LEFT JOIN \"account\" AS \"j1_account\""),
+            "hop-1 LEFT JOIN: {sql}"
+        );
+        assert!(
+            sql.contains(
+                "LEFT JOIN \"owner\" AS \"j2_owner\" ON \
+                 \"j1_account\".\"owner_id\" = \"j2_owner\".\"id\""
+            ),
+            "hop-2 LEFT JOIN chained off hop-1 alias: {sql}"
+        );
+        assert_eq!(sql.matches("LEFT JOIN").count(), 2, "two LEFT JOINs: {sql}");
+        assert_eq!(sql.matches("INNER JOIN").count(), 0, "no INNER JOIN: {sql}");
+    }
+
+    /// Mixed case (#272 pin): a `"left"` `[account]` entry and an `"inner"`
+    /// `[account, owner]` entry render TWO joins (shared prefix dedups) — the
+    /// account edge LEFT, the owner edge INNER — regardless of entry order.
+    #[test]
+    fn rendered_select_mixed_left_prefix_inner_suffix_is_order_independent() {
+        let left_first = serde_json::json!([
+            {"join_type": "left", "path": [
+                {"relation": "account", "from_column": "account_id",
+                 "to_table": "account", "to_column": "id"}
+            ]},
+            {"join_type": "inner", "path": [
+                {"relation": "account", "from_column": "account_id",
+                 "to_table": "account", "to_column": "id"},
+                {"relation": "owner", "from_column": "owner_id",
+                 "to_table": "owner", "to_column": "id"}
+            ]}
+        ]);
+        let inner_first = serde_json::json!([
+            {"join_type": "inner", "path": [
+                {"relation": "account", "from_column": "account_id",
+                 "to_table": "account", "to_column": "id"},
+                {"relation": "owner", "from_column": "owner_id",
+                 "to_table": "owner", "to_column": "id"}
+            ]},
+            {"join_type": "left", "path": [
+                {"relation": "account", "from_column": "account_id",
+                 "to_table": "account", "to_column": "id"}
+            ]}
+        ]);
+        for joins in [left_first, inner_first] {
+            let plan = joined_plan(joins, "Transaction");
+            let sql = render_joined_select(&plan, "transaction");
+            assert_eq!(
+                sql.matches(" JOIN ").count(),
+                2,
+                "shared prefix dedups to exactly two joins: {sql}"
+            );
+            assert!(
+                sql.contains("LEFT JOIN \"account\" AS \"j1_account\""),
+                "account edge LEFT: {sql}"
+            );
+            assert!(
+                sql.contains("INNER JOIN \"owner\" AS \"j2_owner\""),
+                "owner edge INNER: {sql}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1700,14 +1700,25 @@ pub fn fetch_filtered<'py>(
                 &table_name,
                 &join_plan,
             )?);
+            // ORDER BY terms are qualified the same way as WHERE leaves: an empty
+            // path qualifies by the root table, a relation path by its JOIN alias
+            // (#271). A path with no matching join entry is a loud error — the
+            // Python builder always registers the join for an order_by path, so
+            // this is defense-in-depth, never reachable in normal use.
             for order in &plan.order_by {
-                let col = (Alias::new(&table_name), Alias::new(&order.column));
+                let col = crate::query::qualify_column_with_joins(
+                    &table_name,
+                    &join_plan,
+                    &order.column,
+                    &order.path,
+                )
+                .map_err(pyo3::exceptions::PyValueError::new_err)?;
                 let dir = if order.direction.to_lowercase() == "desc" {
                     Order::Desc
                 } else {
                     Order::Asc
                 };
-                select.order_by(col, dir);
+                select.order_by_expr(col.into(), dir);
             }
             if let Some(limit) = plan.limit {
                 select.limit(limit);
@@ -3834,6 +3845,103 @@ mod mutation_qualification_tests {
                 "UPDATE SET column must stay unqualified on {backend:?}: {sql}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod select_join_render_tests {
+    //! Pin the FULL rendered SELECT SQL for a joined query (#271) — including the
+    //! `INNER JOIN <table> AS <alias> ON <prev>.<from_column> = <alias>.<to_column>`
+    //! clause text `apply_relation_joins` renders. Task 3 (#270) only pinned the
+    //! `JoinPlan` struct's alias fields at the unit level; the reviewer flagged the
+    //! missing rendered-SQL pin, closed here since this slice extends the exact
+    //! same SELECT-walker seam to `ORDER BY`.
+
+    use super::{
+        apply_relation_joins, query_condition_with_joins, query_join_plan, query_plan_from_ir_json,
+    };
+    use crate::state::Dialect;
+    use sea_query::{Alias, Order, PostgresQueryBuilder, SelectStatement};
+
+    /// `Transaction -> account` traversed by BOTH a `where()` leaf and an
+    /// `order_by` term on the same path — the one-join acceptance criterion.
+    fn shared_path_plan() -> crate::query::QueryPlan {
+        query_plan_from_ir_json(
+            &serde_json::json!({
+                "ir_kind": "query",
+                "ir_version": 2,
+                "payload": {
+                    "model_name": "Transaction",
+                    "where": [{
+                        "node_kind": "leaf",
+                        "operator": "==",
+                        "column": "label",
+                        "value": {"kind": "string", "value": "a1"},
+                        "path": ["account"]
+                    }],
+                    "order_by": [{"column": "name", "direction": "asc", "path": ["account"]}],
+                    "limit": null, "offset": null, "m2m": null,
+                    "joins": [
+                        {"join_type": "inner", "path": [
+                            {"relation": "account", "from_column": "account_id",
+                             "to_table": "account", "to_column": "id"}
+                        ]}
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .expect("v2 envelope parses")
+    }
+
+    #[test]
+    fn rendered_select_pins_join_clause_and_dedups_shared_where_order_by_path() {
+        let plan = shared_path_plan();
+        let join_plan = query_join_plan(&plan, "transaction", &[]).expect("join plan");
+
+        let mut select = SelectStatement::new();
+        select
+            .column((Alias::new("transaction"), sea_query::Asterisk))
+            .from(Alias::new("transaction"));
+        apply_relation_joins(&mut select, &join_plan).expect("joins render");
+        select.cond_where(
+            query_condition_with_joins(&plan, Dialect::Postgres, "transaction", &join_plan)
+                .expect("condition builds"),
+        );
+        for order in &plan.order_by {
+            let col = crate::query::qualify_column_with_joins(
+                "transaction",
+                &join_plan,
+                &order.column,
+                &order.path,
+            )
+            .expect("order_by column qualifies by its join alias");
+            select.order_by_expr(col.into(), Order::Asc);
+        }
+
+        let sql = select.to_string(PostgresQueryBuilder);
+
+        let expected_join = "INNER JOIN \"account\" AS \"j1_account\" ON \
+             \"transaction\".\"account_id\" = \"j1_account\".\"id\"";
+        assert!(
+            sql.contains(expected_join),
+            "expected the exact rendered JOIN clause, got: {sql}"
+        );
+        // Same relation path referenced by both the WHERE leaf and the order_by
+        // term must still render exactly ONE join (#270/#271 acceptance).
+        assert_eq!(
+            sql.matches("INNER JOIN").count(),
+            1,
+            "shared where()/order_by path must render exactly one JOIN: {sql}"
+        );
+        assert!(
+            sql.contains("WHERE \"j1_account\".\"label\""),
+            "WHERE leaf must qualify by the shared join alias: {sql}"
+        );
+        assert!(
+            sql.contains("ORDER BY \"j1_account\".\"name\""),
+            "ORDER BY must qualify by the shared join alias: {sql}"
+        );
     }
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -48,9 +48,12 @@ enum ColumnQualifier<'a> {
     /// Qualify every column with `root_table.column` (all paths must be empty).
     RootTable(&'a str),
     /// Qualify by JOIN alias: empty path -> `root_table`, else the path's alias.
+    /// Carries the whole [`JoinPlan`] so a traversed leaf can resolve BOTH its
+    /// alias (`prefix_alias`) and its owning table (`prefix_table`) for typed
+    /// binds against the hop's model (#270).
     Joined {
         root_table: &'a str,
-        prefix_alias: &'a HashMap<Vec<String>, String>,
+        join_plan: &'a JoinPlan,
     },
 }
 
@@ -72,7 +75,7 @@ pub fn qualify_column_with_joins(
 ) -> Result<Expr, String> {
     let qualifier = ColumnQualifier::Joined {
         root_table,
-        prefix_alias: &join_plan.prefix_alias,
+        join_plan,
     };
     qualify_leaf_column(&qualifier, column, path)
 }
@@ -104,6 +107,10 @@ pub struct JoinPlan {
     /// Full relation path -> alias, for qualifying path-carrying WHERE leaves
     /// and `ORDER BY` terms.
     pub prefix_alias: HashMap<Vec<String>, String>,
+    /// Full relation path -> the hop's physical table, for resolving a
+    /// traversed leaf's typed bind against its OWNING model's codec plan and
+    /// native-enum catalog (#270). Same key set as `prefix_alias`.
+    pub prefix_table: HashMap<Vec<String>, String>,
 }
 
 /// Validate a join_type token from the IR (`"inner"`/`"left"`), erroring loudly
@@ -150,12 +157,12 @@ fn qualify_leaf_column(
         }
         ColumnQualifier::Joined {
             root_table,
-            prefix_alias,
+            join_plan,
         } => {
             if path.is_empty() {
                 return Ok(Expr::col((Alias::new(*root_table), Alias::new(column))));
             }
-            let alias = prefix_alias.get(path).ok_or_else(|| {
+            let alias = join_plan.prefix_alias.get(path).ok_or_else(|| {
                 format!(
                     "column {column:?} carries relation path {path:?} with no \
                      matching join entry"
@@ -208,6 +215,19 @@ pub struct QueryPlan {
     /// per query from `MODEL_REGISTRY` — no per-value registry locks. `None`
     /// when the model is not registered (fallback generic binds).
     pub registration: Option<std::sync::Arc<crate::state::RegisteredModel>>,
+    /// Per-joined-table registration for typed binds on TRAVERSED columns
+    /// (#270), keyed by physical table name. Populated by the SELECT walkers
+    /// (`fetch_filtered`/`count_filtered`) once per distinct joined table from
+    /// `MODEL_REGISTRY` (table→model is unambiguous). A traversed leaf resolves
+    /// its codec plan from here — never from the root `registration`. Empty for
+    /// non-traversal queries.
+    pub hop_registrations: HashMap<String, std::sync::Arc<crate::state::RegisteredModel>>,
+    /// Per-joined-table native-enum UDT catalog for TRAVERSED columns (#270),
+    /// keyed by physical table name. Populated by the SELECT walkers from each
+    /// joined table's `postgres_table_catalog` so a root and a joined column
+    /// sharing a name cannot collide on the enum-UDT lookup. Empty for
+    /// non-traversal queries (and always empty on SQLite).
+    pub hop_enum_udt: HashMap<String, HashMap<String, String>>,
 }
 
 impl QueryPlan {
@@ -248,6 +268,8 @@ impl QueryPlan {
             m2m,
             postgres_enum_udt: HashMap::new(),
             registration,
+            hop_registrations: HashMap::new(),
+            hop_enum_udt: HashMap::new(),
         })
     }
 
@@ -310,6 +332,7 @@ impl QueryPlan {
         }
 
         let mut prefix_alias: HashMap<Vec<String>, String> = HashMap::new();
+        let mut prefix_table: HashMap<Vec<String>, String> = HashMap::new();
         let mut used: HashSet<String> = HashSet::new();
         used.insert(root_table.to_string());
         for name in reserved {
@@ -338,6 +361,7 @@ impl QueryPlan {
                 }
                 used.insert(alias.clone());
                 prefix_alias.insert(prefix.clone(), alias.clone());
+                prefix_table.insert(prefix.clone(), hop.to_table.clone());
                 renders.push(JoinRender {
                     join_type: edge_join_type.to_string(),
                     to_table: hop.to_table.clone(),
@@ -352,6 +376,7 @@ impl QueryPlan {
         Ok(JoinPlan {
             renders,
             prefix_alias,
+            prefix_table,
         })
     }
 
@@ -401,7 +426,7 @@ impl QueryPlan {
     ) -> Result<Condition, String> {
         let qualifier = ColumnQualifier::Joined {
             root_table,
-            prefix_alias: &join_plan.prefix_alias,
+            join_plan,
         };
         self.build_condition(backend, &qualifier)
     }
@@ -445,47 +470,34 @@ impl QueryPlan {
                 path,
             } => {
                 let col = qualify_leaf_column(qualifier, column, path)?;
+                // A traversed leaf binds against its OWNING model's codec plan and
+                // native-enum catalog — resolved by the hop's table, never the
+                // root's (#270). An empty path resolves the root context.
+                let (codec_plan, enum_udt) = self.leaf_bind_context(qualifier, path)?;
                 // IR always carries a value object; JSON null arrives as
                 // `QueryValue { kind: "null", value: Value::Null }`. SQL
                 // `col = NULL` is never true — use `IS NULL` / `IS NOT NULL`
                 // for `== None` / `!= None`.
                 let rhs_is_json_null = value.value.is_null();
                 let val = &value.value;
+                let bind = |v: &Value| {
+                    self.value_rhs_with_context(column, v, false, backend, codec_plan, enum_udt)
+                };
                 let expr: SimpleExpr = match operator.as_str() {
                     "==" if rhs_is_json_null => col.is_null(),
                     "!=" if rhs_is_json_null => col.is_not_null(),
-                    "==" => {
-                        col.eq(self.value_rhs_simple_expr_for_backend(column, val, false, backend))
-                    }
-                    "!=" => {
-                        col.ne(self.value_rhs_simple_expr_for_backend(column, val, false, backend))
-                    }
-                    "<" => {
-                        col.lt(self.value_rhs_simple_expr_for_backend(column, val, false, backend))
-                    }
-                    "<=" => {
-                        col.lte(self.value_rhs_simple_expr_for_backend(column, val, false, backend))
-                    }
-                    ">" => {
-                        col.gt(self.value_rhs_simple_expr_for_backend(column, val, false, backend))
-                    }
-                    ">=" => {
-                        col.gte(self.value_rhs_simple_expr_for_backend(column, val, false, backend))
-                    }
+                    "==" => col.eq(bind(val)),
+                    "!=" => col.ne(bind(val)),
+                    "<" => col.lt(bind(val)),
+                    "<=" => col.lte(bind(val)),
+                    ">" => col.gt(bind(val)),
+                    ">=" => col.gte(bind(val)),
                     "IN" => {
                         if let Some(vals) = val.as_array() {
-                            let rhs: Vec<SimpleExpr> = vals
-                                .iter()
-                                .map(|v| {
-                                    self.value_rhs_simple_expr_for_backend(
-                                        column, v, false, backend,
-                                    )
-                                })
-                                .collect();
+                            let rhs: Vec<SimpleExpr> = vals.iter().map(&bind).collect();
                             col.is_in(rhs)
                         } else {
-                            col.eq(self
-                                .value_rhs_simple_expr_for_backend(column, val, false, backend))
+                            col.eq(bind(val))
                         }
                     }
                     "LIKE" => {
@@ -495,9 +507,7 @@ impl QueryPlan {
                         };
                         col.like(pattern)
                     }
-                    _ => {
-                        col.eq(self.value_rhs_simple_expr_for_backend(column, val, false, backend))
-                    }
+                    _ => col.eq(bind(val)),
                 };
                 Ok(Condition::all().add(expr))
             }
@@ -528,14 +538,95 @@ impl QueryPlan {
         infer_uuid_without_schema: bool,
         backend: Dialect,
     ) -> SimpleExpr {
-        crate::codec::query_bind_expr(
-            self.registration.as_ref().map(|m| &m.codec_plan),
+        self.value_rhs_with_context(
             col_name,
             val,
             infer_uuid_without_schema,
             backend,
+            self.registration.as_ref().map(|m| &m.codec_plan),
             &self.postgres_enum_udt,
         )
+    }
+
+    /// Right-hand side bind for a comparison, against an EXPLICIT codec plan and
+    /// native-enum catalog rather than the root's (#270).
+    ///
+    /// The condition builder resolves `codec_plan`/`enum_udt` per leaf from its
+    /// relation path (root context for an empty path, the traversed hop's model
+    /// otherwise) via [`QueryPlan::leaf_bind_context`], so a traversed column can
+    /// never be typed by the root model's rule for a same-named column.
+    fn value_rhs_with_context(
+        &self,
+        col_name: &str,
+        val: &Value,
+        infer_uuid_without_schema: bool,
+        backend: Dialect,
+        codec_plan: Option<&crate::codec_plan::ModelCodecPlan>,
+        enum_udt: &HashMap<String, String>,
+    ) -> SimpleExpr {
+        crate::codec::query_bind_expr(
+            codec_plan,
+            col_name,
+            val,
+            infer_uuid_without_schema,
+            backend,
+            enum_udt,
+        )
+    }
+
+    /// Resolve the codec plan + native-enum UDT catalog that govern a WHERE
+    /// leaf's typed bind, keyed by the leaf's OWNING table (#270 critical).
+    ///
+    /// An empty `path` is a root-model column → the root `registration` /
+    /// `postgres_enum_udt`. A non-empty `path` is a traversed column → the hop
+    /// table's registration (`hop_registrations`) and enum catalog
+    /// (`hop_enum_udt`), looked up by the table the join plan assigns to that
+    /// path. This is the seam that stops a traversed column from being typed by
+    /// the root model's rule for a same-named column.
+    ///
+    /// # Errors
+    /// Returns `Err(String)` when a non-empty path has no join entry, or when
+    /// the SELECT walker did not populate the hop table's registration / enum
+    /// catalog — a loud failure, never a silent fallback to root/generic binds
+    /// (I-6). These are defense-in-depth: the walkers resolve both maps for
+    /// every rendered join before building conditions.
+    fn leaf_bind_context(
+        &self,
+        qualifier: &ColumnQualifier<'_>,
+        path: &[String],
+    ) -> Result<(Option<&crate::codec_plan::ModelCodecPlan>, &HashMap<String, String>), String> {
+        if path.is_empty() {
+            return Ok((
+                self.registration.as_ref().map(|m| &m.codec_plan),
+                &self.postgres_enum_udt,
+            ));
+        }
+        let ColumnQualifier::Joined { join_plan, .. } = qualifier else {
+            return Err(format!(
+                "relation path {path:?} on a statement that renders no joins; \
+                 cannot resolve typed binds"
+            ));
+        };
+        let table = join_plan.prefix_table.get(path).ok_or_else(|| {
+            format!("relation path {path:?} has no matching join entry for typed binds")
+        })?;
+        let codec_plan = self
+            .hop_registrations
+            .get(table)
+            .map(|model| &model.codec_plan)
+            .ok_or_else(|| {
+                format!(
+                    "traversed table {table:?} (path {path:?}) has no registration; \
+                     cannot resolve typed binds for the relation"
+                )
+            })?;
+        let enum_udt = self.hop_enum_udt.get(table).ok_or_else(|| {
+            format!(
+                "traversed table {table:?} (path {path:?}) has no native-enum catalog; \
+                 fetch its postgres_table_catalog before building conditions"
+            )
+        })?;
+        Ok((Some(codec_plan), enum_udt))
     }
 }
 
@@ -562,6 +653,8 @@ mod tests {
             m2m: None,
             postgres_enum_udt: HashMap::new(),
             registration,
+            hop_registrations: HashMap::new(),
+            hop_enum_udt: HashMap::new(),
         }
     }
 
@@ -771,7 +864,18 @@ mod tests {
 
     #[test]
     fn traversal_where_qualifies_leaf_with_join_alias() {
-        let plan = QueryPlan::from_ir_payload(traversal_payload()).expect("plan builds");
+        let mut plan = QueryPlan::from_ir_payload(traversal_payload()).expect("plan builds");
+        // The SELECT walkers resolve a hop table's registration + enum catalog
+        // before building conditions; mirror that for the traversed `email` leaf
+        // (path [account, owner] -> table "owner").
+        plan.hop_registrations.insert(
+            "owner".to_string(),
+            crate::state::RegisteredModel::new_for_test(
+                json!({"properties": {"email": {"type": "string"}}}),
+                "owner".to_string(),
+            ),
+        );
+        plan.hop_enum_udt.insert("owner".to_string(), HashMap::new());
         let join_plan = plan.build_join_plan("transaction", &[]).expect("join plan");
         let sql = plan
             .to_condition_with_joins(Dialect::Postgres, "transaction", &join_plan)
@@ -979,7 +1083,14 @@ mod tests {
         let err = plan
             .to_condition_with_joins(Dialect::Sqlite, "transaction", &join_plan)
             .expect_err("leaf path with no join entry must error");
-        assert!(err.contains("no"), "got {err}");
+        // The message must name the offending column AND its unresolved path, not
+        // just vaguely mention "no".
+        assert!(err.contains("email"), "must name the column: {err}");
+        assert!(err.contains("account"), "must name the path: {err}");
+        assert!(
+            err.contains("no matching join entry"),
+            "must state the failure: {err}"
+        );
     }
 
     #[test]
@@ -1074,7 +1185,13 @@ mod tests {
             &["unregistered".to_string()],
         )
         .expect_err("an order_by path with no matching join entry must error");
-        assert!(err.contains("no"), "got {err}");
+        // The message must name the offending column AND its unresolved path.
+        assert!(err.contains("name"), "must name the column: {err}");
+        assert!(err.contains("unregistered"), "must name the path: {err}");
+        assert!(
+            err.contains("no matching join entry"),
+            "must state the failure: {err}"
+        );
     }
 
     #[test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -11,6 +11,58 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
+/// Reject relation-traversal shape this build cannot render yet (#269 defensive loudness).
+///
+/// Every leaf and `order_by` entry in v2 QueryIR carries a `path` (empty = root model),
+/// and every payload carries a `joins` list (empty for now). Until #270 lands JOIN
+/// rendering in the SELECT walkers, a non-empty `joins` list or any non-empty `path`
+/// describes a query this build cannot lower correctly — silently ignoring it would mean
+/// mis-rendered SQL (dropping a filter the caller believes is applied). Fail loud instead.
+///
+/// # Errors
+/// Returns `Err(String)` naming the unsupported `joins`/`path` content.
+fn reject_unsupported_traversal(payload: &QueryIrPayload) -> Result<(), String> {
+    if !payload.joins.is_empty() {
+        return Err(format!(
+            "QueryIR joins are not yet supported by this build (received {} join(s)); \
+             relation traversal ships in a later release",
+            payload.joins.len()
+        ));
+    }
+    for node in &payload.where_clause {
+        reject_non_empty_leaf_path(node)?;
+    }
+    for order in &payload.order_by {
+        if !order.path.is_empty() {
+            return Err(format!(
+                "QueryIR order_by path is not yet supported by this build (column {:?} \
+                 carries path {:?}); relation traversal ships in a later release",
+                order.column, order.path
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn reject_non_empty_leaf_path(node: &QueryNode) -> Result<(), String> {
+    match node {
+        QueryNode::Leaf { column, path, .. } => {
+            if !path.is_empty() {
+                return Err(format!(
+                    "QueryIR leaf path is not yet supported by this build (column {:?} \
+                     carries path {:?}); relation traversal ships in a later release",
+                    column, path
+                ));
+            }
+            Ok(())
+        }
+        QueryNode::Compound { left, right, .. } => {
+            reject_non_empty_leaf_path(left)?;
+            reject_non_empty_leaf_path(right)
+        }
+    }
+}
+
 /// Many-to-many join context for filtered relation loads.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct M2mContext {
@@ -63,8 +115,12 @@ impl QueryPlan {
     /// from catalog before building SQL) and the model registration resolved.
     ///
     /// # Errors
-    /// Returns `Err(String)` when the `m2m` JSON blob cannot deserialize into [`M2mContext`].
+    /// Returns `Err(String)` when the `m2m` JSON blob cannot deserialize into [`M2mContext`],
+    /// or when the payload carries relation-traversal shape (`joins`, or a `path` on any leaf
+    /// or `order_by` entry) that this build cannot render yet (see
+    /// [`reject_unsupported_traversal`]).
     pub fn from_ir_payload(payload: QueryIrPayload) -> Result<QueryPlan, String> {
+        reject_unsupported_traversal(&payload)?;
         let m2m: Option<M2mContext> = match payload.m2m {
             Some(value) => serde_json::from_value(value)
                 .map(Some)
@@ -91,6 +147,12 @@ impl QueryPlan {
     ///
     /// # Arguments
     /// * `backend` — Dialect for typed binds and operator lowering.
+    /// * `qualify_with` — When `Some(root_table)`, every column reference is qualified
+    ///   as `root_table.column` (sea_query `Expr::col((Alias::new(root_table),
+    ///   Alias::new(column)))`) — required for SELECT (`fetch_filtered`/`count_filtered`)
+    ///   so bare columns can't collide with a future JOINed table (#270). `None` leaves
+    ///   columns unqualified, which mutating statements (`UPDATE`/`DELETE ... WHERE`) use
+    ///   today (single-table target, no JOIN to disambiguate against).
     ///
     /// # Returns
     /// `Condition::all()` with each `where_clause` node applied.
@@ -100,10 +162,12 @@ impl QueryPlan {
     pub fn to_condition_for_backend(
         &self,
         backend: Dialect,
+        qualify_with: Option<&str>,
     ) -> Result<Condition, String> {
         let mut condition = Condition::all();
         for node in &self.where_clause {
-            condition = condition.add(self.node_to_condition_for_backend(node, backend)?);
+            condition =
+                condition.add(self.node_to_condition_for_backend(node, backend, qualify_with)?);
         }
         Ok(condition)
     }
@@ -112,6 +176,7 @@ impl QueryPlan {
         &self,
         node: &QueryNode,
         backend: Dialect,
+        qualify_with: Option<&str>,
     ) -> Result<Condition, String> {
         match node {
             QueryNode::Compound {
@@ -119,8 +184,9 @@ impl QueryPlan {
                 left,
                 right,
             } => {
-                let left_cond = self.node_to_condition_for_backend(left, backend)?;
-                let right_cond = self.node_to_condition_for_backend(right, backend)?;
+                let left_cond = self.node_to_condition_for_backend(left, backend, qualify_with)?;
+                let right_cond =
+                    self.node_to_condition_for_backend(right, backend, qualify_with)?;
                 Ok(match operator.as_str() {
                     "OR" => Condition::any().add(left_cond).add(right_cond),
                     "AND" => Condition::all().add(left_cond).add(right_cond),
@@ -131,8 +197,15 @@ impl QueryPlan {
                 operator,
                 column,
                 value,
+                // Always `[]` here: `from_ir_payload` rejects a non-empty leaf `path`
+                // before a `QueryPlan` ever exists (#269 defensive loudness; #270
+                // will thread this into JOIN-qualified column lowering).
+                path: _,
             } => {
-                let col = Expr::col(Alias::new(column));
+                let col = match qualify_with {
+                    Some(root_table) => Expr::col((Alias::new(root_table), Alias::new(column))),
+                    None => Expr::col(Alias::new(column)),
+                };
                 // IR always carries a value object; JSON null arrives as
                 // `QueryValue { kind: "null", value: Value::Null }`. SQL
                 // `col = NULL` is never true — use `IS NULL` / `IS NOT NULL`
@@ -267,15 +340,15 @@ mod tests {
             "model_name": "Pending",
             "where": [
                 {"node_kind": "leaf", "column": "attached_at", "operator": "==",
-                 "value": {"kind": "null", "value": null}},
+                 "value": {"kind": "null", "value": null}, "path": []},
                 {"node_kind": "compound", "operator": "OR",
                  "left": {"node_kind": "leaf", "column": "age", "operator": ">=",
-                          "value": {"kind": "int", "value": 18}},
+                          "value": {"kind": "int", "value": 18}, "path": []},
                  "right": {"node_kind": "leaf", "column": "name", "operator": "LIKE",
-                           "value": {"kind": "string", "value": "a%"}}}
+                           "value": {"kind": "string", "value": "a%"}, "path": []}}
             ],
-            "order_by": [{"column": "age", "direction": "desc"}],
-            "limit": 10, "offset": 5, "m2m": null
+            "order_by": [{"column": "age", "direction": "desc", "path": []}],
+            "limit": 10, "offset": 5, "m2m": null, "joins": []
         }))
         .expect("payload deserializes");
         let plan = super::QueryPlan::from_ir_payload(payload).expect("plan builds");
@@ -284,10 +357,14 @@ mod tests {
 
         let mut select = Query::select();
         select.from(Alias::new("pending")).cond_where(
-            plan.to_condition_for_backend(Dialect::Sqlite).expect("valid"),
+            plan.to_condition_for_backend(Dialect::Sqlite, None)
+                .expect("valid"),
         );
         let sql = select.to_string(SqliteQueryBuilder).to_lowercase();
-        assert!(sql.contains("is null"), "IR null eq must lower to IS NULL: {sql}");
+        assert!(
+            sql.contains("is null"),
+            "IR null eq must lower to IS NULL: {sql}"
+        );
         assert!(!sql.contains("= null"), "must not emit = NULL: {sql}");
         assert!(sql.contains("or"), "compound OR preserved: {sql}");
     }
@@ -298,22 +375,182 @@ mod tests {
             "model_name": "Pending",
             "where": [
                 {"node_kind": "leaf", "column": "payload", "operator": "!=",
-                 "value": {"kind": "null", "value": null}}
+                 "value": {"kind": "null", "value": null}, "path": []}
             ],
             "order_by": [],
-            "limit": null, "offset": null, "m2m": null
+            "limit": null, "offset": null, "m2m": null, "joins": []
         }))
         .expect("payload deserializes");
         let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
         let mut select = Query::select();
         select.from(Alias::new("pending")).cond_where(
-            plan.to_condition_for_backend(Dialect::Sqlite)
+            plan.to_condition_for_backend(Dialect::Sqlite, None)
                 .expect("valid test query"),
         );
         let sql = select.to_string(SqliteQueryBuilder).to_lowercase();
         assert!(
             sql.contains("is not null"),
             "expected IS NOT NULL, got {sql}"
+        );
+    }
+
+    #[test]
+    fn to_condition_for_backend_qualifies_column_with_root_table_when_requested() {
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Pending",
+            "where": [
+                {"node_kind": "leaf", "column": "age", "operator": ">=",
+                 "value": {"kind": "int", "value": 18}, "path": []}
+            ],
+            "order_by": [],
+            "limit": null, "offset": null, "m2m": null, "joins": []
+        }))
+        .expect("payload deserializes");
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+
+        let mut select = Query::select();
+        select.from(Alias::new("pending")).cond_where(
+            plan.to_condition_for_backend(Dialect::Sqlite, Some("pending"))
+                .expect("valid test query"),
+        );
+        let sql = select.to_string(SqliteQueryBuilder).to_lowercase();
+        assert!(
+            sql.contains("\"pending\".\"age\"") || sql.contains("`pending`.`age`"),
+            "expected the root table alias to qualify the WHERE column, got {sql}"
+        );
+    }
+
+    /// Same qualification, rendered through the Postgres builder (acceptance criteria:
+    /// "Rendered SQL qualifies all column references by the root alias on both backends").
+    #[test]
+    fn to_condition_for_backend_qualifies_column_with_root_table_on_postgres() {
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Pending",
+            "where": [
+                {"node_kind": "leaf", "column": "age", "operator": ">=",
+                 "value": {"kind": "int", "value": 18}, "path": []}
+            ],
+            "order_by": [],
+            "limit": null, "offset": null, "m2m": null, "joins": []
+        }))
+        .expect("payload deserializes");
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+
+        let mut select = Query::select();
+        select.from(Alias::new("pending")).cond_where(
+            plan.to_condition_for_backend(Dialect::Postgres, Some("pending"))
+                .expect("valid test query"),
+        );
+        let sql = select.to_string(PostgresQueryBuilder).to_lowercase();
+        assert!(
+            sql.contains("\"pending\".\"age\""),
+            "expected the root table alias to qualify the WHERE column on Postgres, got {sql}"
+        );
+    }
+
+    #[test]
+    fn to_condition_for_backend_leaves_column_unqualified_without_root_table() {
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Pending",
+            "where": [
+                {"node_kind": "leaf", "column": "age", "operator": ">=",
+                 "value": {"kind": "int", "value": 18}, "path": []}
+            ],
+            "order_by": [],
+            "limit": null, "offset": null, "m2m": null, "joins": []
+        }))
+        .expect("payload deserializes");
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+
+        let mut select = Query::select();
+        select.from(Alias::new("pending")).cond_where(
+            plan.to_condition_for_backend(Dialect::Sqlite, None)
+                .expect("valid test query"),
+        );
+        let sql = select.to_string(SqliteQueryBuilder).to_lowercase();
+        assert!(
+            !sql.contains("\"pending\".\"age\"") && !sql.contains("`pending`.`age`"),
+            "unqualified request must not qualify the WHERE column, got {sql}"
+        );
+    }
+
+    #[test]
+    fn from_ir_payload_rejects_non_empty_joins() {
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Pending",
+            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+            "joins": [{"join_type": "inner", "path": [
+                {"relation": "account", "from_column": "account_id",
+                 "to_table": "account", "to_column": "id"}
+            ]}]
+        }))
+        .expect("payload deserializes");
+
+        let err = QueryPlan::from_ir_payload(payload)
+            .expect_err("non-empty joins must be rejected until #270 renders them");
+        assert!(
+            err.contains("join"),
+            "error should mention joins are unsupported: {err}"
+        );
+    }
+
+    #[test]
+    fn from_ir_payload_rejects_non_empty_leaf_path() {
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Pending",
+            "where": [
+                {"node_kind": "leaf", "column": "name", "operator": "==",
+                 "value": {"kind": "string", "value": "a"}, "path": ["account"]}
+            ],
+            "order_by": [], "limit": null, "offset": null, "m2m": null, "joins": []
+        }))
+        .expect("payload deserializes");
+
+        let err = QueryPlan::from_ir_payload(payload)
+            .expect_err("a non-empty leaf path must be rejected until #270 renders joins");
+        assert!(
+            err.contains("path"),
+            "error should mention the unsupported path: {err}"
+        );
+    }
+
+    #[test]
+    fn from_ir_payload_rejects_non_empty_leaf_path_nested_in_compound() {
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Pending",
+            "where": [
+                {"node_kind": "compound", "operator": "AND",
+                 "left": {"node_kind": "leaf", "column": "active", "operator": "==",
+                          "value": {"kind": "bool", "value": true}, "path": []},
+                 "right": {"node_kind": "leaf", "column": "name", "operator": "==",
+                           "value": {"kind": "string", "value": "a"}, "path": ["account"]}}
+            ],
+            "order_by": [], "limit": null, "offset": null, "m2m": null, "joins": []
+        }))
+        .expect("payload deserializes");
+
+        let err = QueryPlan::from_ir_payload(payload)
+            .expect_err("a non-empty path nested in a compound node must be rejected");
+        assert!(
+            err.contains("path"),
+            "error should mention the unsupported path: {err}"
+        );
+    }
+
+    #[test]
+    fn from_ir_payload_rejects_non_empty_order_by_path() {
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Pending",
+            "where": [], "limit": null, "offset": null, "m2m": null, "joins": [],
+            "order_by": [{"column": "name", "direction": "asc", "path": ["account"]}]
+        }))
+        .expect("payload deserializes");
+
+        let err = QueryPlan::from_ir_payload(payload)
+            .expect_err("a non-empty order_by path must be rejected until #270 renders joins");
+        assert!(
+            err.contains("path"),
+            "error should mention the unsupported path: {err}"
         );
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -267,7 +267,8 @@ impl QueryPlan {
         Ok(())
     }
 
-    /// Assign deterministic aliases and build the ordered JOIN render plan (#270).
+    /// Assign deterministic aliases and build the ordered JOIN render plan (#270,
+    /// with per-edge LEFT/INNER resolution #272).
     ///
     /// Walks each `joins` entry's hops in order, keeping a `prefix -> alias` map so
     /// the first-unseen prefix emits exactly one edge and shared prefixes across
@@ -277,6 +278,15 @@ impl QueryPlan {
     /// `reserved` name (the M2M association table), or an already-assigned alias
     /// appends `_x` until unique.
     ///
+    /// Each rendered edge's join type is resolved at the EDGE level, not per
+    /// entry: an edge is `LEFT` iff some `"left"` entry covers it, else `INNER`
+    /// (ADR-0006 whole-path rule — `.left_join` marks its whole path, so every
+    /// prefix of a `"left"` entry is a LEFT edge). Resolving before render keeps
+    /// the rendered type independent of entry order and of which entry first
+    /// materializes a shared prefix; e.g. a `"left"` `[account]` entry and an
+    /// `"inner"` `[account, owner]` entry render the `account` edge LEFT and the
+    /// `owner` edge INNER regardless of their order on the wire (#272).
+    ///
     /// # Errors
     /// Returns `Err(String)` for an unknown `join_type` (see [`validate_join_type`]).
     pub fn build_join_plan(
@@ -284,6 +294,21 @@ impl QueryPlan {
         root_table: &str,
         reserved: &[&str],
     ) -> Result<JoinPlan, String> {
+        // Validate every entry's join_type and collect the set of LEFT edges.
+        // A `"left"` entry is whole-path, so every one of its prefixes is a LEFT
+        // edge; an edge is LEFT iff any `"left"` entry contains it.
+        let mut left_edges: HashSet<Vec<String>> = HashSet::new();
+        for join in &self.joins {
+            let join_type = validate_join_type(&join.join_type)?;
+            if join_type == "left" {
+                let mut prefix: Vec<String> = Vec::new();
+                for hop in &join.path {
+                    prefix.push(hop.relation.clone());
+                    left_edges.insert(prefix.clone());
+                }
+            }
+        }
+
         let mut prefix_alias: HashMap<Vec<String>, String> = HashMap::new();
         let mut used: HashSet<String> = HashSet::new();
         used.insert(root_table.to_string());
@@ -293,7 +318,6 @@ impl QueryPlan {
         let mut renders: Vec<JoinRender> = Vec::new();
         let mut next_index = 1usize;
         for join in &self.joins {
-            let join_type = validate_join_type(&join.join_type)?;
             let mut prefix: Vec<String> = Vec::new();
             let mut prev_alias = root_table.to_string();
             for hop in &join.path {
@@ -302,6 +326,11 @@ impl QueryPlan {
                     prev_alias = existing.clone();
                     continue;
                 }
+                let edge_join_type = if left_edges.contains(&prefix) {
+                    "left"
+                } else {
+                    "inner"
+                };
                 let mut alias = format!("j{}_{}", next_index, hop.relation);
                 next_index += 1;
                 while used.contains(&alias) {
@@ -310,7 +339,7 @@ impl QueryPlan {
                 used.insert(alias.clone());
                 prefix_alias.insert(prefix.clone(), alias.clone());
                 renders.push(JoinRender {
-                    join_type: join_type.to_string(),
+                    join_type: edge_join_type.to_string(),
                     to_table: hop.to_table.clone(),
                     alias: alias.clone(),
                     prev_alias: prev_alias.clone(),
@@ -826,6 +855,110 @@ mod tests {
             .build_join_plan("thing", &[])
             .expect_err("unknown join_type must be rejected");
         assert!(err.contains("join_type"), "got {err}");
+    }
+
+    #[test]
+    fn build_join_plan_marks_single_left_edge() {
+        // A lone `"left"` 1-hop entry renders its edge LEFT (#272).
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Note",
+            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+            "joins": [
+                {"join_type": "left", "path": [
+                    {"relation": "account", "from_column": "account_id",
+                     "to_table": "account", "to_column": "id"}
+                ]}
+            ]
+        }))
+        .expect("payload deserializes");
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+        let join_plan = plan.build_join_plan("note", &[]).expect("join plan");
+        assert_eq!(join_plan.renders.len(), 1);
+        assert_eq!(join_plan.renders[0].join_type, "left");
+        assert_eq!(join_plan.renders[0].alias, "j1_account");
+    }
+
+    #[test]
+    fn build_join_plan_marks_whole_path_left_at_every_hop() {
+        // Whole-path rule: a `"left"` 2-hop entry marks BOTH edges LEFT (#272).
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Transaction",
+            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+            "joins": [
+                {"join_type": "left", "path": [
+                    {"relation": "account", "from_column": "account_id",
+                     "to_table": "account", "to_column": "id"},
+                    {"relation": "owner", "from_column": "owner_id",
+                     "to_table": "owner", "to_column": "id"}
+                ]}
+            ]
+        }))
+        .expect("payload deserializes");
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+        let join_plan = plan.build_join_plan("transaction", &[]).expect("join plan");
+        assert_eq!(join_plan.renders.len(), 2);
+        assert_eq!(join_plan.renders[0].join_type, "left", "hop-1 edge LEFT");
+        assert_eq!(join_plan.renders[1].join_type, "left", "hop-2 edge LEFT");
+    }
+
+    #[test]
+    fn build_join_plan_mixed_left_prefix_inner_suffix_is_order_independent() {
+        // The pinned mixed case (#272): a `"left"` `[account]` entry shares its
+        // prefix with an `"inner"` `[account, owner]` entry. Edge-level
+        // resolution yields the account edge LEFT and the owner edge INNER — and
+        // that verdict must not depend on entry order on the wire.
+        let left_first = json!([
+            {"join_type": "left", "path": [
+                {"relation": "account", "from_column": "account_id",
+                 "to_table": "account", "to_column": "id"}
+            ]},
+            {"join_type": "inner", "path": [
+                {"relation": "account", "from_column": "account_id",
+                 "to_table": "account", "to_column": "id"},
+                {"relation": "owner", "from_column": "owner_id",
+                 "to_table": "owner", "to_column": "id"}
+            ]}
+        ]);
+        let inner_first = json!([
+            {"join_type": "inner", "path": [
+                {"relation": "account", "from_column": "account_id",
+                 "to_table": "account", "to_column": "id"},
+                {"relation": "owner", "from_column": "owner_id",
+                 "to_table": "owner", "to_column": "id"}
+            ]},
+            {"join_type": "left", "path": [
+                {"relation": "account", "from_column": "account_id",
+                 "to_table": "account", "to_column": "id"}
+            ]}
+        ]);
+        for joins in [left_first, inner_first] {
+            let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+                "model_name": "Transaction",
+                "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+                "joins": joins
+            }))
+            .expect("payload deserializes");
+            let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+            let join_plan = plan.build_join_plan("transaction", &[]).expect("join plan");
+            // Two edges total (shared account prefix dedups).
+            assert_eq!(
+                join_plan.renders.len(),
+                2,
+                "shared prefix dedups to 2 edges"
+            );
+            let account = join_plan
+                .renders
+                .iter()
+                .find(|r| r.alias == "j1_account" || r.to_table == "account")
+                .expect("account edge rendered");
+            let owner = join_plan
+                .renders
+                .iter()
+                .find(|r| r.to_table == "owner")
+                .expect("owner edge rendered");
+            assert_eq!(account.join_type, "left", "account edge is LEFT");
+            assert_eq!(owner.join_type, "inner", "owner edge is INNER");
+        }
     }
 
     #[test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -5,38 +5,27 @@
 //! null/UUID/enum binds via [`crate::codec`].
 
 use crate::state::Dialect;
-use ferro_schema_ir::{QueryIrPayload, QueryNode, QueryOrderBy};
+use ferro_schema_ir::{QueryIrPayload, QueryJoin, QueryNode, QueryOrderBy};
 use sea_query::{Alias, Condition, Expr, SimpleExpr};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-/// Reject relation-traversal shape this build cannot render yet (#269 defensive loudness).
+/// Reject `order_by` relation traversal, which no query shape can render yet.
 ///
-/// Every leaf and `order_by` entry in v2 QueryIR carries a `path` (empty = root model),
-/// and every payload carries a `joins` list (empty for now). Until #270 lands JOIN
-/// rendering in the SELECT walkers, a non-empty `joins` list or any non-empty `path`
-/// describes a query this build cannot lower correctly — silently ignoring it would mean
-/// mis-rendered SQL (dropping a filter the caller believes is applied). Fail loud instead.
+/// WHERE traversal (leaf `path`s and the `joins` list) renders in the SELECT
+/// walkers as of #270, but ordering by a related column is a later slice (#271):
+/// there is no Python surface to emit it, so a non-empty `order_by` path here can
+/// only be misuse. Silently dropping it would mis-render the ORDER BY — fail loud.
 ///
 /// # Errors
-/// Returns `Err(String)` naming the unsupported `joins`/`path` content.
-fn reject_unsupported_traversal(payload: &QueryIrPayload) -> Result<(), String> {
-    if !payload.joins.is_empty() {
-        return Err(format!(
-            "QueryIR joins are not yet supported by this build (received {} join(s)); \
-             relation traversal ships in a later release",
-            payload.joins.len()
-        ));
-    }
-    for node in &payload.where_clause {
-        reject_non_empty_leaf_path(node)?;
-    }
+/// Returns `Err(String)` naming the unsupported `order_by` path content.
+fn reject_unsupported_order_by(payload: &QueryIrPayload) -> Result<(), String> {
     for order in &payload.order_by {
         if !order.path.is_empty() {
             return Err(format!(
                 "QueryIR order_by path is not yet supported by this build (column {:?} \
-                 carries path {:?}); relation traversal ships in a later release",
+                 carries path {:?}); order-by relation traversal ships in a later release",
                 order.column, order.path
             ));
         }
@@ -44,13 +33,19 @@ fn reject_unsupported_traversal(payload: &QueryIrPayload) -> Result<(), String> 
     Ok(())
 }
 
+/// Reject any relation-traversal shape on a WHERE tree (used by mutating walkers).
+///
+/// UPDATE/DELETE with relation joins would need multi-table mutation semantics no
+/// backend portably supports, so the Python builder never emits `joins` on a
+/// mutating payload. A leaf carrying a relation `path` here (or a non-empty `joins`
+/// list, checked by the caller) can only be misuse — fail loud rather than silently
+/// drop the traversal filter.
 fn reject_non_empty_leaf_path(node: &QueryNode) -> Result<(), String> {
     match node {
         QueryNode::Leaf { column, path, .. } => {
             if !path.is_empty() {
                 return Err(format!(
-                    "QueryIR leaf path is not yet supported by this build (column {:?} \
-                     carries path {:?}); relation traversal ships in a later release",
+                    "WHERE column {:?} carries relation path {:?}",
                     column, path
                 ));
             }
@@ -59,6 +54,112 @@ fn reject_non_empty_leaf_path(node: &QueryNode) -> Result<(), String> {
         QueryNode::Compound { left, right, .. } => {
             reject_non_empty_leaf_path(left)?;
             reject_non_empty_leaf_path(right)
+        }
+    }
+}
+
+/// How to qualify a WHERE column reference when lowering to SeaQuery.
+///
+/// SELECT walkers use [`ColumnQualifier::Joined`] so a root-model column gets the
+/// root table alias and a relation-path leaf gets its JOIN alias; mutating walkers
+/// use [`ColumnQualifier::RootTable`] (single-table target, paths rejected upstream);
+/// unit tests use [`ColumnQualifier::Unqualified`].
+enum ColumnQualifier<'a> {
+    /// Leave columns unqualified (bare `column`).
+    Unqualified,
+    /// Qualify every column with `root_table.column` (all paths must be empty).
+    RootTable(&'a str),
+    /// Qualify by JOIN alias: empty path -> `root_table`, else the path's alias.
+    Joined {
+        root_table: &'a str,
+        prefix_alias: &'a HashMap<Vec<String>, String>,
+    },
+}
+
+/// One rendered relation JOIN edge: `<join> <to_table> AS <alias> ON
+/// <prev_alias>.<from_column> = <alias>.<to_column>`.
+#[derive(Debug, Clone)]
+pub struct JoinRender {
+    /// Validated join type token (`"inner"` or `"left"`).
+    pub join_type: String,
+    /// Table this edge joins into.
+    pub to_table: String,
+    /// Deterministic internal alias for `to_table` on this edge.
+    pub alias: String,
+    /// Alias of the previous hop (root table for the first hop).
+    pub prev_alias: String,
+    /// Local column on the previous side of the edge.
+    pub from_column: String,
+    /// Column on `to_table` the edge joins against.
+    pub to_column: String,
+}
+
+/// Resolved JOIN plan for one query: ordered render steps plus a full-path ->
+/// alias map for qualifying WHERE columns (#270).
+#[derive(Debug, Clone, Default)]
+pub struct JoinPlan {
+    /// JOIN edges in first-appearance order (shared prefixes deduped to one edge).
+    pub renders: Vec<JoinRender>,
+    /// Full relation path -> alias, for qualifying path-carrying WHERE leaves.
+    pub prefix_alias: HashMap<Vec<String>, String>,
+}
+
+/// Validate a join_type token from the IR (`"inner"`/`"left"`), erroring loudly
+/// on anything else so an unknown type can never silently mis-render.
+fn validate_join_type(join_type: &str) -> Result<&'static str, String> {
+    match join_type {
+        "inner" => Ok("inner"),
+        "left" => Ok("left"),
+        other => Err(format!(
+            "unsupported QueryIR join_type {other:?}; expected \"inner\" or \"left\""
+        )),
+    }
+}
+
+/// Build the qualified column reference for a WHERE leaf under `qualifier`.
+///
+/// # Errors
+/// Returns `Err(String)` when a non-`Joined` qualifier meets a path-carrying leaf
+/// (paths are rejected upstream for those statements), or when a `Joined` leaf's
+/// relation `path` has no assigned JOIN alias — never silently unqualified.
+fn qualify_leaf_column(
+    qualifier: &ColumnQualifier<'_>,
+    column: &str,
+    path: &[String],
+) -> Result<Expr, String> {
+    match qualifier {
+        ColumnQualifier::Unqualified => {
+            if !path.is_empty() {
+                return Err(format!(
+                    "WHERE column {column:?} carries relation path {path:?} but this \
+                     statement renders no joins"
+                ));
+            }
+            Ok(Expr::col(Alias::new(column)))
+        }
+        ColumnQualifier::RootTable(root_table) => {
+            if !path.is_empty() {
+                return Err(format!(
+                    "WHERE column {column:?} carries relation path {path:?} but this \
+                     statement renders no joins"
+                ));
+            }
+            Ok(Expr::col((Alias::new(*root_table), Alias::new(column))))
+        }
+        ColumnQualifier::Joined {
+            root_table,
+            prefix_alias,
+        } => {
+            if path.is_empty() {
+                return Ok(Expr::col((Alias::new(*root_table), Alias::new(column))));
+            }
+            let alias = prefix_alias.get(path).ok_or_else(|| {
+                format!(
+                    "WHERE column {column:?} carries relation path {path:?} with no \
+                     matching join entry"
+                )
+            })?;
+            Ok(Expr::col((Alias::new(alias.as_str()), Alias::new(column))))
         }
     }
 }
@@ -93,6 +194,9 @@ pub struct QueryPlan {
     pub limit: Option<u64>,
     /// `OFFSET` clause.
     pub offset: Option<u64>,
+    /// Relation JOINs collected from WHERE traversal, in registration order.
+    /// Empty for non-traversal queries; rendered by the SELECT walkers (#270).
+    pub joins: Vec<QueryJoin>,
     /// M2M join filter when loading through an association table.
     pub m2m: Option<M2mContext>,
     /// Populated from `pg_catalog` before building filter SQL. Not part of the
@@ -116,11 +220,12 @@ impl QueryPlan {
     ///
     /// # Errors
     /// Returns `Err(String)` when the `m2m` JSON blob cannot deserialize into [`M2mContext`],
-    /// or when the payload carries relation-traversal shape (`joins`, or a `path` on any leaf
-    /// or `order_by` entry) that this build cannot render yet (see
-    /// [`reject_unsupported_traversal`]).
+    /// or when an `order_by` entry carries a relation `path` — order-by traversal ships in a
+    /// later release (see [`reject_unsupported_order_by`]). WHERE `path`s and the `joins` list
+    /// are accepted here and rendered by the SELECT walkers (#270); mutating walkers reject
+    /// them separately via [`QueryPlan::ensure_no_traversal`].
     pub fn from_ir_payload(payload: QueryIrPayload) -> Result<QueryPlan, String> {
-        reject_unsupported_traversal(&payload)?;
+        reject_unsupported_order_by(&payload)?;
         let m2m: Option<M2mContext> = match payload.m2m {
             Some(value) => serde_json::from_value(value)
                 .map(Some)
@@ -137,9 +242,85 @@ impl QueryPlan {
             order_by: payload.order_by,
             limit: payload.limit,
             offset: payload.offset,
+            joins: payload.joins,
             m2m,
             postgres_enum_udt: HashMap::new(),
             registration,
+        })
+    }
+
+    /// Reject any relation traversal on this plan (mutating-walker guard, #270).
+    ///
+    /// # Errors
+    /// Returns `Err(String)` if the plan carries `joins` or any WHERE leaf with a
+    /// non-empty relation `path`. UPDATE/DELETE render a single-table statement, so
+    /// traversal here is misuse; the error detail names the offending shape.
+    pub fn ensure_no_traversal(&self) -> Result<(), String> {
+        if !self.joins.is_empty() {
+            return Err(format!("query carries {} relation join(s)", self.joins.len()));
+        }
+        for node in &self.where_clause {
+            reject_non_empty_leaf_path(node)?;
+        }
+        Ok(())
+    }
+
+    /// Assign deterministic aliases and build the ordered JOIN render plan (#270).
+    ///
+    /// Walks each `joins` entry's hops in order, keeping a `prefix -> alias` map so
+    /// the first-unseen prefix emits exactly one edge and shared prefixes across
+    /// entries (e.g. `[account, owner]` and `[account]`) dedup to one JOIN each.
+    /// Aliases are `j{i}_{relation}` (`i` = 1-based order of first appearance,
+    /// `relation` = the prefix's last hop); a collision with `root_table`, a
+    /// `reserved` name (the M2M association table), or an already-assigned alias
+    /// appends `_x` until unique.
+    ///
+    /// # Errors
+    /// Returns `Err(String)` for an unknown `join_type` (see [`validate_join_type`]).
+    pub fn build_join_plan(
+        &self,
+        root_table: &str,
+        reserved: &[&str],
+    ) -> Result<JoinPlan, String> {
+        let mut prefix_alias: HashMap<Vec<String>, String> = HashMap::new();
+        let mut used: HashSet<String> = HashSet::new();
+        used.insert(root_table.to_string());
+        for name in reserved {
+            used.insert((*name).to_string());
+        }
+        let mut renders: Vec<JoinRender> = Vec::new();
+        let mut next_index = 1usize;
+        for join in &self.joins {
+            let join_type = validate_join_type(&join.join_type)?;
+            let mut prefix: Vec<String> = Vec::new();
+            let mut prev_alias = root_table.to_string();
+            for hop in &join.path {
+                prefix.push(hop.relation.clone());
+                if let Some(existing) = prefix_alias.get(&prefix) {
+                    prev_alias = existing.clone();
+                    continue;
+                }
+                let mut alias = format!("j{}_{}", next_index, hop.relation);
+                next_index += 1;
+                while used.contains(&alias) {
+                    alias.push_str("_x");
+                }
+                used.insert(alias.clone());
+                prefix_alias.insert(prefix.clone(), alias.clone());
+                renders.push(JoinRender {
+                    join_type: join_type.to_string(),
+                    to_table: hop.to_table.clone(),
+                    alias: alias.clone(),
+                    prev_alias: prev_alias.clone(),
+                    from_column: hop.from_column.clone(),
+                    to_column: hop.to_column.clone(),
+                });
+                prev_alias = alias;
+            }
+        }
+        Ok(JoinPlan {
+            renders,
+            prefix_alias,
         })
     }
 
@@ -149,10 +330,12 @@ impl QueryPlan {
     /// * `backend` — Dialect for typed binds and operator lowering.
     /// * `qualify_with` — When `Some(root_table)`, every column reference is qualified
     ///   as `root_table.column` (sea_query `Expr::col((Alias::new(root_table),
-    ///   Alias::new(column)))`) — required for SELECT (`fetch_filtered`/`count_filtered`)
-    ///   so bare columns can't collide with a future JOINed table (#270). `None` leaves
-    ///   columns unqualified, which mutating statements (`UPDATE`/`DELETE ... WHERE`) use
-    ///   today (single-table target, no JOIN to disambiguate against).
+    ///   Alias::new(column)))`). All four filtered walkers qualify with the root alias
+    ///   in production — SELECT (`fetch_filtered`/`count_filtered`) to disambiguate
+    ///   against JOINed tables (#270), and `UPDATE`/`DELETE ... WHERE` for uniformity
+    ///   (both dialects accept `table.column` on a single-table mutation). `None`
+    ///   leaves columns unqualified and is exercised only by unit tests; production
+    ///   SELECTs that carry joins use [`QueryPlan::to_condition_with_joins`] instead.
     ///
     /// # Returns
     /// `Condition::all()` with each `where_clause` node applied.
@@ -164,10 +347,42 @@ impl QueryPlan {
         backend: Dialect,
         qualify_with: Option<&str>,
     ) -> Result<Condition, String> {
+        let qualifier = match qualify_with {
+            Some(root_table) => ColumnQualifier::RootTable(root_table),
+            None => ColumnQualifier::Unqualified,
+        };
+        self.build_condition(backend, &qualifier)
+    }
+
+    /// Combine root predicates into a `Condition`, qualifying each column by its
+    /// relation path against `join_plan` (SELECT walkers, #270): a root-model
+    /// column (empty path) gets `root_table`, a path-carrying leaf gets its JOIN
+    /// alias.
+    ///
+    /// # Errors
+    /// Returns `Err(String)` for unsupported compound operators, or a leaf whose
+    /// relation `path` has no matching JOIN entry (never silently unqualified).
+    pub fn to_condition_with_joins(
+        &self,
+        backend: Dialect,
+        root_table: &str,
+        join_plan: &JoinPlan,
+    ) -> Result<Condition, String> {
+        let qualifier = ColumnQualifier::Joined {
+            root_table,
+            prefix_alias: &join_plan.prefix_alias,
+        };
+        self.build_condition(backend, &qualifier)
+    }
+
+    fn build_condition(
+        &self,
+        backend: Dialect,
+        qualifier: &ColumnQualifier<'_>,
+    ) -> Result<Condition, String> {
         let mut condition = Condition::all();
         for node in &self.where_clause {
-            condition =
-                condition.add(self.node_to_condition_for_backend(node, backend, qualify_with)?);
+            condition = condition.add(self.node_to_condition_for_backend(node, backend, qualifier)?);
         }
         Ok(condition)
     }
@@ -176,7 +391,7 @@ impl QueryPlan {
         &self,
         node: &QueryNode,
         backend: Dialect,
-        qualify_with: Option<&str>,
+        qualifier: &ColumnQualifier<'_>,
     ) -> Result<Condition, String> {
         match node {
             QueryNode::Compound {
@@ -184,9 +399,8 @@ impl QueryPlan {
                 left,
                 right,
             } => {
-                let left_cond = self.node_to_condition_for_backend(left, backend, qualify_with)?;
-                let right_cond =
-                    self.node_to_condition_for_backend(right, backend, qualify_with)?;
+                let left_cond = self.node_to_condition_for_backend(left, backend, qualifier)?;
+                let right_cond = self.node_to_condition_for_backend(right, backend, qualifier)?;
                 Ok(match operator.as_str() {
                     "OR" => Condition::any().add(left_cond).add(right_cond),
                     "AND" => Condition::all().add(left_cond).add(right_cond),
@@ -197,15 +411,9 @@ impl QueryPlan {
                 operator,
                 column,
                 value,
-                // Always `[]` here: `from_ir_payload` rejects a non-empty leaf `path`
-                // before a `QueryPlan` ever exists (#269 defensive loudness; #270
-                // will thread this into JOIN-qualified column lowering).
-                path: _,
+                path,
             } => {
-                let col = match qualify_with {
-                    Some(root_table) => Expr::col((Alias::new(root_table), Alias::new(column))),
-                    None => Expr::col(Alias::new(column)),
-                };
+                let col = qualify_leaf_column(qualifier, column, path)?;
                 // IR always carries a value object; JSON null arrives as
                 // `QueryValue { kind: "null", value: Value::Null }`. SQL
                 // `col = NULL` is never true — use `IS NULL` / `IS NOT NULL`
@@ -319,6 +527,7 @@ mod tests {
             order_by: Vec::new(),
             limit: None,
             offset: None,
+            joins: Vec::new(),
             m2m: None,
             postgres_enum_udt: HashMap::new(),
             registration,
@@ -474,67 +683,193 @@ mod tests {
         );
     }
 
-    #[test]
-    fn from_ir_payload_rejects_non_empty_joins() {
-        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
-            "model_name": "Pending",
-            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
-            "joins": [{"join_type": "inner", "path": [
-                {"relation": "account", "from_column": "account_id",
-                 "to_table": "account", "to_column": "id"}
-            ]}]
+    /// A multi-hop `joins` payload plus a path-carrying leaf now builds a plan and
+    /// renders INNER JOINs (#270 replaces the slice-2 blanket rejection). Pins the
+    /// alias scheme, prefix dedup, and path-qualified WHERE column in one SQL string.
+    fn traversal_payload() -> ferro_schema_ir::QueryIrPayload {
+        serde_json::from_value(json!({
+            "model_name": "Transaction",
+            "where": [
+                {"node_kind": "compound", "operator": "AND",
+                 "left": {"node_kind": "leaf", "column": "email", "operator": "==",
+                          "value": {"kind": "string", "value": "a@b.com"},
+                          "path": ["account", "owner"]},
+                 "right": {"node_kind": "leaf", "column": "amount", "operator": ">=",
+                           "value": {"kind": "int", "value": 100}, "path": []}}
+            ],
+            "order_by": [{"column": "id", "direction": "asc", "path": []}],
+            "limit": 50, "offset": 0, "m2m": null,
+            "joins": [
+                {"join_type": "inner", "path": [
+                    {"relation": "account", "from_column": "account_id",
+                     "to_table": "account", "to_column": "id"}
+                ]},
+                {"join_type": "inner", "path": [
+                    {"relation": "account", "from_column": "account_id",
+                     "to_table": "account", "to_column": "id"},
+                    {"relation": "owner", "from_column": "owner_id",
+                     "to_table": "owner", "to_column": "id"}
+                ]}
+            ]
         }))
-        .expect("payload deserializes");
+        .expect("payload deserializes")
+    }
 
-        let err = QueryPlan::from_ir_payload(payload)
-            .expect_err("non-empty joins must be rejected until #270 renders them");
-        assert!(
-            err.contains("join"),
-            "error should mention joins are unsupported: {err}"
+    #[test]
+    fn build_join_plan_assigns_aliases_and_dedups_shared_prefix() {
+        let plan = QueryPlan::from_ir_payload(traversal_payload()).expect("plan builds");
+        let join_plan = plan.build_join_plan("transaction", &[]).expect("join plan");
+
+        // A 1-hop path and a 2-hop path sharing its prefix produce exactly two edges.
+        assert_eq!(join_plan.renders.len(), 2, "shared prefix must dedup to 2 JOINs");
+        assert_eq!(join_plan.renders[0].alias, "j1_account");
+        assert_eq!(join_plan.renders[0].prev_alias, "transaction");
+        assert_eq!(join_plan.renders[1].alias, "j2_owner");
+        assert_eq!(join_plan.renders[1].prev_alias, "j1_account");
+        assert_eq!(
+            join_plan.prefix_alias.get(&vec!["account".to_string()]),
+            Some(&"j1_account".to_string())
+        );
+        assert_eq!(
+            join_plan
+                .prefix_alias
+                .get(&vec!["account".to_string(), "owner".to_string()]),
+            Some(&"j2_owner".to_string())
         );
     }
 
     #[test]
-    fn from_ir_payload_rejects_non_empty_leaf_path() {
+    fn traversal_where_qualifies_leaf_with_join_alias() {
+        let plan = QueryPlan::from_ir_payload(traversal_payload()).expect("plan builds");
+        let join_plan = plan.build_join_plan("transaction", &[]).expect("join plan");
+        let sql = plan
+            .to_condition_with_joins(Dialect::Postgres, "transaction", &join_plan)
+            .and_then(|cond| {
+                let mut select = Query::select();
+                select.from(Alias::new("transaction")).cond_where(cond);
+                Ok(select.to_string(PostgresQueryBuilder).to_lowercase())
+            })
+            .expect("condition builds");
+        // Path leaf qualified by its hop alias; root leaf by the root table.
+        assert!(sql.contains("\"j2_owner\".\"email\""), "got {sql}");
+        assert!(sql.contains("\"transaction\".\"amount\""), "got {sql}");
+    }
+
+    #[test]
+    fn build_join_plan_two_paths_to_one_table_get_distinct_aliases() {
+        // Transfer(from_account, to_account) -> two FKs into the same table.
         let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
-            "model_name": "Pending",
+            "model_name": "Transfer",
+            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+            "joins": [
+                {"join_type": "inner", "path": [
+                    {"relation": "from_account", "from_column": "from_account_id",
+                     "to_table": "account", "to_column": "id"}
+                ]},
+                {"join_type": "inner", "path": [
+                    {"relation": "to_account", "from_column": "to_account_id",
+                     "to_table": "account", "to_column": "id"}
+                ]}
+            ]
+        }))
+        .expect("payload deserializes");
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+        let join_plan = plan.build_join_plan("transfer", &[]).expect("join plan");
+        assert_eq!(join_plan.renders.len(), 2);
+        assert_eq!(join_plan.renders[0].alias, "j1_from_account");
+        assert_eq!(join_plan.renders[1].alias, "j2_to_account");
+        assert_ne!(join_plan.renders[0].alias, join_plan.renders[1].alias);
+        // Both edges target the same physical table under distinct aliases.
+        assert_eq!(join_plan.renders[0].to_table, "account");
+        assert_eq!(join_plan.renders[1].to_table, "account");
+    }
+
+    #[test]
+    fn build_join_plan_uniquifies_alias_colliding_with_reserved_name() {
+        // A join into a table whose alias would collide with the M2M association
+        // table name gets `_x` appended until unique.
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Thing",
+            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+            "joins": [
+                {"join_type": "inner", "path": [
+                    {"relation": "account", "from_column": "account_id",
+                     "to_table": "account", "to_column": "id"}
+                ]}
+            ]
+        }))
+        .expect("payload deserializes");
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+        let join_plan = plan
+            .build_join_plan("thing", &["j1_account"])
+            .expect("join plan");
+        assert_eq!(join_plan.renders[0].alias, "j1_account_x");
+    }
+
+    #[test]
+    fn build_join_plan_rejects_unknown_join_type() {
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Thing",
+            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+            "joins": [
+                {"join_type": "cross", "path": [
+                    {"relation": "account", "from_column": "account_id",
+                     "to_table": "account", "to_column": "id"}
+                ]}
+            ]
+        }))
+        .expect("payload deserializes");
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+        let err = plan
+            .build_join_plan("thing", &[])
+            .expect_err("unknown join_type must be rejected");
+        assert!(err.contains("join_type"), "got {err}");
+    }
+
+    #[test]
+    fn to_condition_with_joins_errors_on_leaf_path_without_join_entry() {
+        // A path-carrying leaf whose path was never registered as a join entry is a
+        // loud error, never a silently unqualified column.
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Transaction",
             "where": [
-                {"node_kind": "leaf", "column": "name", "operator": "==",
+                {"node_kind": "leaf", "column": "email", "operator": "==",
                  "value": {"kind": "string", "value": "a"}, "path": ["account"]}
             ],
             "order_by": [], "limit": null, "offset": null, "m2m": null, "joins": []
         }))
         .expect("payload deserializes");
-
-        let err = QueryPlan::from_ir_payload(payload)
-            .expect_err("a non-empty leaf path must be rejected until #270 renders joins");
-        assert!(
-            err.contains("path"),
-            "error should mention the unsupported path: {err}"
-        );
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+        let join_plan = plan.build_join_plan("transaction", &[]).expect("join plan");
+        let err = plan
+            .to_condition_with_joins(Dialect::Sqlite, "transaction", &join_plan)
+            .expect_err("leaf path with no join entry must error");
+        assert!(err.contains("no"), "got {err}");
     }
 
     #[test]
-    fn from_ir_payload_rejects_non_empty_leaf_path_nested_in_compound() {
+    fn ensure_no_traversal_rejects_joins_and_leaf_paths() {
+        let plan = QueryPlan::from_ir_payload(traversal_payload()).expect("plan builds");
+        let err = plan
+            .ensure_no_traversal()
+            .expect_err("mutation guard must reject joins");
+        assert!(err.contains("join"), "got {err}");
+
+        // Leaf path with no joins list is also rejected (mutating payloads set joins=[]).
         let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
-            "model_name": "Pending",
+            "model_name": "Transaction",
             "where": [
-                {"node_kind": "compound", "operator": "AND",
-                 "left": {"node_kind": "leaf", "column": "active", "operator": "==",
-                          "value": {"kind": "bool", "value": true}, "path": []},
-                 "right": {"node_kind": "leaf", "column": "name", "operator": "==",
-                           "value": {"kind": "string", "value": "a"}, "path": ["account"]}}
+                {"node_kind": "leaf", "column": "email", "operator": "==",
+                 "value": {"kind": "string", "value": "a"}, "path": ["account"]}
             ],
             "order_by": [], "limit": null, "offset": null, "m2m": null, "joins": []
         }))
         .expect("payload deserializes");
-
-        let err = QueryPlan::from_ir_payload(payload)
-            .expect_err("a non-empty path nested in a compound node must be rejected");
-        assert!(
-            err.contains("path"),
-            "error should mention the unsupported path: {err}"
-        );
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+        let err = plan
+            .ensure_no_traversal()
+            .expect_err("mutation guard must reject leaf paths");
+        assert!(err.contains("path"), "got {err}");
     }
 
     #[test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -11,28 +11,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 
-/// Reject `order_by` relation traversal, which no query shape can render yet.
-///
-/// WHERE traversal (leaf `path`s and the `joins` list) renders in the SELECT
-/// walkers as of #270, but ordering by a related column is a later slice (#271):
-/// there is no Python surface to emit it, so a non-empty `order_by` path here can
-/// only be misuse. Silently dropping it would mis-render the ORDER BY — fail loud.
-///
-/// # Errors
-/// Returns `Err(String)` naming the unsupported `order_by` path content.
-fn reject_unsupported_order_by(payload: &QueryIrPayload) -> Result<(), String> {
-    for order in &payload.order_by {
-        if !order.path.is_empty() {
-            return Err(format!(
-                "QueryIR order_by path is not yet supported by this build (column {:?} \
-                 carries path {:?}); order-by relation traversal ships in a later release",
-                order.column, order.path
-            ));
-        }
-    }
-    Ok(())
-}
-
 /// Reject any relation-traversal shape on a WHERE tree (used by mutating walkers).
 ///
 /// UPDATE/DELETE with relation joins would need multi-table mutation semantics no
@@ -76,6 +54,29 @@ enum ColumnQualifier<'a> {
     },
 }
 
+/// Qualify a column reference (a WHERE leaf or an `ORDER BY` term) by its
+/// relation path's JOIN alias (SELECT walkers, #270/#271): an empty `path`
+/// qualifies by `root_table`, a non-empty `path` resolves through `join_plan`'s
+/// prefix map. Shared by WHERE lowering and the `ORDER BY` render loop so both
+/// clauses qualify identically against the same join plan.
+///
+/// # Errors
+/// Returns `Err(String)` when `path` has no matching JOIN entry — never
+/// silently unqualified (the Python builder always registers the join for a
+/// path-carrying `order_by` entry, same as `where()`; this is defense-in-depth).
+pub fn qualify_column_with_joins(
+    root_table: &str,
+    join_plan: &JoinPlan,
+    column: &str,
+    path: &[String],
+) -> Result<Expr, String> {
+    let qualifier = ColumnQualifier::Joined {
+        root_table,
+        prefix_alias: &join_plan.prefix_alias,
+    };
+    qualify_leaf_column(&qualifier, column, path)
+}
+
 /// One rendered relation JOIN edge: `<join> <to_table> AS <alias> ON
 /// <prev_alias>.<from_column> = <alias>.<to_column>`.
 #[derive(Debug, Clone)]
@@ -100,7 +101,8 @@ pub struct JoinRender {
 pub struct JoinPlan {
     /// JOIN edges in first-appearance order (shared prefixes deduped to one edge).
     pub renders: Vec<JoinRender>,
-    /// Full relation path -> alias, for qualifying path-carrying WHERE leaves.
+    /// Full relation path -> alias, for qualifying path-carrying WHERE leaves
+    /// and `ORDER BY` terms.
     pub prefix_alias: HashMap<Vec<String>, String>,
 }
 
@@ -155,7 +157,7 @@ fn qualify_leaf_column(
             }
             let alias = prefix_alias.get(path).ok_or_else(|| {
                 format!(
-                    "WHERE column {column:?} carries relation path {path:?} with no \
+                    "column {column:?} carries relation path {path:?} with no \
                      matching join entry"
                 )
             })?;
@@ -219,13 +221,13 @@ impl QueryPlan {
     /// from catalog before building SQL) and the model registration resolved.
     ///
     /// # Errors
-    /// Returns `Err(String)` when the `m2m` JSON blob cannot deserialize into [`M2mContext`],
-    /// or when an `order_by` entry carries a relation `path` — order-by traversal ships in a
-    /// later release (see [`reject_unsupported_order_by`]). WHERE `path`s and the `joins` list
-    /// are accepted here and rendered by the SELECT walkers (#270); mutating walkers reject
-    /// them separately via [`QueryPlan::ensure_no_traversal`].
+    /// Returns `Err(String)` when the `m2m` JSON blob cannot deserialize into
+    /// [`M2mContext`]. WHERE `path`s, `order_by` `path`s, and the `joins` list are all
+    /// accepted here and rendered by the SELECT walkers (#270 WHERE traversal, #271
+    /// `order_by` traversal); mutating walkers reject WHERE traversal separately via
+    /// [`QueryPlan::ensure_no_traversal`] (the Python builder never emits a path-carrying
+    /// `order_by` entry on a mutating payload, so no equivalent guard is needed there).
     pub fn from_ir_payload(payload: QueryIrPayload) -> Result<QueryPlan, String> {
-        reject_unsupported_order_by(&payload)?;
         let m2m: Option<M2mContext> = match payload.m2m {
             Some(value) => serde_json::from_value(value)
                 .map(Some)
@@ -873,20 +875,73 @@ mod tests {
     }
 
     #[test]
-    fn from_ir_payload_rejects_non_empty_order_by_path() {
+    fn from_ir_payload_accepts_non_empty_order_by_path() {
+        // #271 lifts the blanket order_by-path rejection: a path-carrying order_by
+        // entry now builds a plan like any other (the SELECT walkers render it).
         let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
             "model_name": "Pending",
-            "where": [], "limit": null, "offset": null, "m2m": null, "joins": [],
+            "where": [], "limit": null, "offset": null, "m2m": null, "joins": [
+                {"join_type": "inner", "path": [
+                    {"relation": "account", "from_column": "account_id",
+                     "to_table": "account", "to_column": "id"}
+                ]}
+            ],
             "order_by": [{"column": "name", "direction": "asc", "path": ["account"]}]
         }))
         .expect("payload deserializes");
 
-        let err = QueryPlan::from_ir_payload(payload)
-            .expect_err("a non-empty order_by path must be rejected until #270 renders joins");
-        assert!(
-            err.contains("path"),
-            "error should mention the unsupported path: {err}"
-        );
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+        assert_eq!(plan.order_by[0].path, vec!["account".to_string()]);
+    }
+
+    /// `qualify_column_with_joins` is the render-time seam shared by WHERE and
+    /// `ORDER BY` (#271): an empty path qualifies by the root table, a registered
+    /// path qualifies by its JOIN alias, and an unregistered path is a loud error.
+    #[test]
+    fn qualify_column_with_joins_qualifies_order_by_path_by_join_alias() {
+        let plan = QueryPlan::from_ir_payload(traversal_payload()).expect("plan builds");
+        let join_plan = plan.build_join_plan("transaction", &[]).expect("join plan");
+
+        let root_col = super::qualify_column_with_joins(
+            "transaction",
+            &join_plan,
+            "id",
+            &[],
+        )
+        .expect("root column qualifies");
+        let sql = Query::select()
+            .expr(root_col)
+            .to_string(PostgresQueryBuilder)
+            .to_lowercase();
+        assert!(sql.contains("\"transaction\".\"id\""), "got {sql}");
+
+        let path_col = super::qualify_column_with_joins(
+            "transaction",
+            &join_plan,
+            "email",
+            &["account".to_string(), "owner".to_string()],
+        )
+        .expect("path column qualifies by its join alias");
+        let sql = Query::select()
+            .expr(path_col)
+            .to_string(PostgresQueryBuilder)
+            .to_lowercase();
+        assert!(sql.contains("\"j2_owner\".\"email\""), "got {sql}");
+    }
+
+    #[test]
+    fn qualify_column_with_joins_errors_on_order_by_path_without_join_entry() {
+        let plan = QueryPlan::from_ir_payload(traversal_payload()).expect("plan builds");
+        let join_plan = plan.build_join_plan("transaction", &[]).expect("join plan");
+
+        let err = super::qualify_column_with_joins(
+            "transaction",
+            &join_plan,
+            "name",
+            &["unregistered".to_string()],
+        )
+        .expect_err("an order_by path with no matching join entry must error");
+        assert!(err.contains("no"), "got {err}");
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -119,6 +119,34 @@ pub fn registered_model(name: &str) -> PyResult<Arc<RegisteredModel>> {
         })
 }
 
+/// Look up the registration whose physical table is `table_name` (#270 relation
+/// traversal): the owning model of a joined hop table, for typed binds on
+/// traversed columns.
+///
+/// Models cannot share a table — the metaclass enforces one table per model — so
+/// a table→registration resolution is unambiguous. Used once per distinct joined
+/// table per query (not per value), mirroring [`registered_model`]'s single
+/// resolution for the root.
+///
+/// # Errors
+/// `PyRuntimeError` when the registry lock fails or no registered model owns the
+/// table (a loud error — a traversed hop must never fall back to root/generic
+/// binds).
+pub fn registration_for_table(table_name: &str) -> PyResult<Arc<RegisteredModel>> {
+    MODEL_REGISTRY
+        .read()
+        .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("Failed to lock Model Registry"))?
+        .values()
+        .find(|model| model.table_name == table_name)
+        .cloned()
+        .ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "No registered model owns table '{table_name}'; cannot resolve typed \
+                 binds for a traversed relation"
+            ))
+        })
+}
+
 /// Python-compiled SchemaIR modelset pushed by the `connect`/`migrate` wrappers.
 ///
 /// Populated before `internal_migrate` runs so the runtime diff can consume the

--- a/tests/fixtures/ir_vectors/README.md
+++ b/tests/fixtures/ir_vectors/README.md
@@ -27,9 +27,13 @@ Each vector is one JSON file with this envelope:
 Rules:
 
 - `domain` and `ir.ir_kind` must match.
-- `ir.ir_version` must equal `1` for Phase 0 vectors.
+- `ir.ir_version` must equal `1` for `schema` and `codec` vectors. `query`
+  vectors are on `ir_version: 2` (#269 — unconditional bump, path-qualified
+  column references, empty `joins: []` until #270 renders real JOINs); there
+  is no v1 `query` vector left.
 - `expect_valid` currently supports only `true` fixtures (negative vectors can be added later).
-- Fixture file names use `<domain>_<scenario>_v1.json`.
+- Fixture file names use `<domain>_<scenario>_v<version>.json` (matching that
+  domain's current `ir_version`).
 
 ## Coverage requirements (Phase 0 minimum)
 

--- a/tests/fixtures/ir_vectors/query_transaction_left_join_v2.json
+++ b/tests/fixtures/ir_vectors/query_transaction_left_join_v2.json
@@ -1,0 +1,58 @@
+{
+  "vector_name": "query_transaction_left_join_v2",
+  "domain": "query",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "query",
+    "ir_version": 2,
+    "payload": {
+      "model_name": "Transaction",
+      "where": [
+        {
+          "node_kind": "leaf",
+          "column": "email",
+          "operator": "==",
+          "value": {
+            "kind": "string",
+            "value": "owner@ferro.dev"
+          },
+          "path": ["account", "owner"]
+        }
+      ],
+      "order_by": [],
+      "limit": null,
+      "offset": null,
+      "m2m": null,
+      "joins": [
+        {
+          "join_type": "left",
+          "path": [
+            {
+              "relation": "account",
+              "from_column": "account_id",
+              "to_table": "account",
+              "to_column": "id"
+            }
+          ]
+        },
+        {
+          "join_type": "inner",
+          "path": [
+            {
+              "relation": "account",
+              "from_column": "account_id",
+              "to_table": "account",
+              "to_column": "id"
+            },
+            {
+              "relation": "owner",
+              "from_column": "owner_id",
+              "to_table": "owner",
+              "to_column": "id"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/ir_vectors/query_transaction_traversal_v2.json
+++ b/tests/fixtures/ir_vectors/query_transaction_traversal_v2.json
@@ -1,0 +1,78 @@
+{
+  "vector_name": "query_transaction_traversal_v2",
+  "domain": "query",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "query",
+    "ir_version": 2,
+    "payload": {
+      "model_name": "Transaction",
+      "where": [
+        {
+          "node_kind": "compound",
+          "operator": "AND",
+          "left": {
+            "node_kind": "leaf",
+            "column": "email",
+            "operator": "==",
+            "value": {
+              "kind": "string",
+              "value": "owner@ferro.dev"
+            },
+            "path": ["account", "owner"]
+          },
+          "right": {
+            "node_kind": "leaf",
+            "column": "amount",
+            "operator": ">=",
+            "value": {
+              "kind": "int",
+              "value": 100
+            },
+            "path": []
+          }
+        }
+      ],
+      "order_by": [
+        {
+          "column": "id",
+          "direction": "asc",
+          "path": []
+        }
+      ],
+      "limit": 50,
+      "offset": 0,
+      "m2m": null,
+      "joins": [
+        {
+          "join_type": "inner",
+          "path": [
+            {
+              "relation": "account",
+              "from_column": "account_id",
+              "to_table": "account",
+              "to_column": "id"
+            }
+          ]
+        },
+        {
+          "join_type": "inner",
+          "path": [
+            {
+              "relation": "account",
+              "from_column": "account_id",
+              "to_table": "account",
+              "to_column": "id"
+            },
+            {
+              "relation": "owner",
+              "from_column": "owner_id",
+              "to_table": "owner",
+              "to_column": "id"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/ir_vectors/query_transaction_traversal_v2.json
+++ b/tests/fixtures/ir_vectors/query_transaction_traversal_v2.json
@@ -35,6 +35,11 @@
       ],
       "order_by": [
         {
+          "column": "name",
+          "direction": "asc",
+          "path": ["account"]
+        },
+        {
           "column": "id",
           "direction": "asc",
           "path": []

--- a/tests/fixtures/ir_vectors/query_user_compound_v2.json
+++ b/tests/fixtures/ir_vectors/query_user_compound_v2.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_user_compound_v1",
+  "vector_name": "query_user_compound_v2",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 1,
+    "ir_version": 2,
     "payload": {
       "model_name": "User",
       "where": [
@@ -18,7 +18,8 @@
             "value": {
               "kind": "bool",
               "value": true
-            }
+            },
+            "path": []
           },
           "right": {
             "node_kind": "compound",
@@ -30,7 +31,8 @@
               "value": {
                 "kind": "string",
                 "value": "%@ferro.dev"
-              }
+              },
+              "path": []
             },
             "right": {
               "node_kind": "leaf",
@@ -39,7 +41,8 @@
               "value": {
                 "kind": "list",
                 "value": ["admin", "owner"]
-              }
+              },
+              "path": []
             }
           }
         }
@@ -47,12 +50,14 @@
       "order_by": [
         {
           "column": "id",
-          "direction": "asc"
+          "direction": "asc",
+          "path": []
         }
       ],
       "limit": 100,
       "offset": 0,
-      "m2m": null
+      "m2m": null,
+      "joins": []
     }
   }
 }

--- a/tests/static_fixtures/bad_predicates.py
+++ b/tests/static_fixtures/bad_predicates.py
@@ -6,7 +6,7 @@ diagnostics -- if it starts passing, the static gate has stopped biting.
 
 from typing import Annotated
 
-from ferro import FerroField, Model
+from ferro import FerroField, ForeignKey, Model
 from ferro.query import Predicate
 
 
@@ -17,3 +17,29 @@ class BadUser(Model):
 
 bad_bool: Predicate[BadUser] = lambda u: True          # bool is not QueryNode
 bad_value: Predicate[BadUser] = lambda u: u.age        # FieldProxy is not QueryNode
+
+
+# Relation-proxy guardrails (#273). Attribute access on the QueryProxy is
+# statically `FieldProxy[Any]` (the chainable shape — a relation only resolves
+# to a RelationProxy at runtime), so:
+class BadAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+
+
+class BadTxn(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    account: Annotated[BadAccount, ForeignKey(related_name="txns")]
+
+
+# Bare relation as a predicate: `t.account` is a relation, not a QueryNode.
+# Types as FieldProxy[Any], so the assignment fails with invalid-assignment —
+# the same static failure mode as `bad_value` above.
+bad_bare_relation: Predicate[BadTxn] = lambda t: t.account
+
+# Relation-vs-scalar comparison: `t.account == 5` type-checks (FieldProxy.__eq__
+# returns QueryNode under the shape-only static promise, PRD #267). Its
+# guardrail is a RUNTIME TypeError raised by RelationProxy.__eq__ (a relation
+# compares only to a target instance or None), exercised by test_query_joins.
+# Pinned here to document that relation-misuse is a build-time (runtime) error,
+# not a static one — this line does NOT produce a diagnostic.
+bad_relation_scalar: Predicate[BadTxn] = lambda t: t.account == 5

--- a/tests/static_fixtures/good_predicates.py
+++ b/tests/static_fixtures/good_predicates.py
@@ -3,7 +3,7 @@
 from typing import Annotated, assert_type
 
 from ferro import FerroField, ForeignKey, Model
-from ferro.query import FieldProxy, Predicate, QueryNode, QueryProxy
+from ferro.query import FieldProxy, Predicate, Query, QueryNode, QueryProxy
 
 
 class GoodUser(Model):
@@ -48,3 +48,12 @@ pred_hop_compound: Predicate[GoodTxn] = lambda t: (t.account.ledger_id == 1) & (
     t.account.owner.email == "a@b.com"
 )
 assert_type(pred_hop1(QueryProxy[GoodTxn](GoodTxn)), QueryNode)
+
+
+# Explicit join()/left_join() chainers (#272): the selector names a RELATION
+# path (`lambda t: t.account`) using the same chainable proxy shape, and the
+# chainers return a Query of the same row type.
+join_query: Query[GoodTxn] = GoodTxn.select().join(lambda t: t.account)
+left_join_query: Query[GoodTxn] = GoodTxn.select().left_join(lambda t: t.account.owner)
+assert_type(join_query, Query[GoodTxn])
+assert_type(left_join_query, Query[GoodTxn])

--- a/tests/static_fixtures/good_predicates.py
+++ b/tests/static_fixtures/good_predicates.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated, assert_type
 
-from ferro import FerroField, Model
+from ferro import FerroField, ForeignKey, Model
 from ferro.query import FieldProxy, Predicate, QueryNode, QueryProxy
 
 
@@ -18,3 +18,33 @@ pred_in: Predicate[GoodUser] = lambda u: u.age.in_([1, 2, 3])
 
 assert_type(pred_compare(QueryProxy[GoodUser](GoodUser)), QueryNode)
 assert_type(FieldProxy("age") >= 18, QueryNode)
+
+
+# Relation traversal (#270): attribute access on a forward-FK field is
+# statically chainable, and a comparison at any hop still yields a QueryNode.
+class GoodLedger(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+
+
+class GoodOwner(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    email: str = ""
+
+
+class GoodAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    ledger: Annotated[GoodLedger, ForeignKey(related_name="accounts")]
+    owner: Annotated[GoodOwner, ForeignKey(related_name="accounts")]
+
+
+class GoodTxn(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    account: Annotated[GoodAccount, ForeignKey(related_name="txns")]
+
+
+pred_hop1: Predicate[GoodTxn] = lambda t: t.account.ledger_id == 1
+pred_hop_multi: Predicate[GoodTxn] = lambda t: t.account.owner.email == "a@b.com"
+pred_hop_compound: Predicate[GoodTxn] = lambda t: (t.account.ledger_id == 1) & (
+    t.account.owner.email == "a@b.com"
+)
+assert_type(pred_hop1(QueryProxy[GoodTxn](GoodTxn)), QueryNode)

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -11,7 +11,9 @@ from ferro import BackRef, Field, ManyToMany, Model, Relation, clear_registry
 
 VECTORS_DIR = Path(__file__).parent / "fixtures" / "ir_vectors"
 SUPPORTED_DOMAINS = {"schema", "query", "codec"}
-SUPPORTED_IR_VERSION = 1
+# `query` is on ir_version 2 (#269 — unconditional bump, path-qualified column
+# references); `schema`/`codec` remain v1.
+SUPPORTED_IR_VERSIONS = {"schema": 1, "query": 2, "codec": 1}
 QUERY_OPERATORS = {"==", "!=", "<", "<=", ">", ">=", "IN", "LIKE", "AND", "OR"}
 
 
@@ -40,13 +42,14 @@ def _validate_query_node(node: dict[str, Any], label: str) -> None:
     assert operator in QUERY_OPERATORS, f"{label}.operator invalid: {operator!r}"
 
     if node_kind == "leaf":
-        _require_keys(node, {"column", "value"}, label)
+        _require_keys(node, {"column", "value", "path"}, label)
         assert isinstance(node["column"], str) and node["column"], (
             f"{label}.column must be non-empty string"
         )
         value = node["value"]
         assert isinstance(value, dict), f"{label}.value must be object"
         _require_keys(value, {"kind", "value"}, f"{label}.value")
+        assert isinstance(node["path"], list), f"{label}.path must be a list"
         return
 
     _require_keys(node, {"left", "right"}, label)
@@ -83,7 +86,11 @@ def _validate_schema_payload(payload: dict[str, Any], label: str) -> None:
 
 
 def _validate_query_payload(payload: dict[str, Any], label: str) -> None:
-    _require_keys(payload, {"model_name", "where", "order_by", "limit", "offset", "m2m"}, label)
+    _require_keys(
+        payload,
+        {"model_name", "where", "order_by", "limit", "offset", "m2m", "joins"},
+        label,
+    )
     assert isinstance(payload["model_name"], str) and payload["model_name"], (
         f"{label}.model_name must be non-empty string"
     )
@@ -94,6 +101,11 @@ def _validate_query_payload(payload: dict[str, Any], label: str) -> None:
         assert isinstance(node, dict), f"{node_label} must be object"
         _validate_query_node(node, node_label)
     assert isinstance(payload["order_by"], list), f"{label}.order_by must be list"
+    for i, order in enumerate(payload["order_by"]):
+        order_label = f"{label}.order_by[{i}]"
+        assert isinstance(order, dict), f"{order_label} must be object"
+        _require_keys(order, {"column", "direction", "path"}, order_label)
+        assert isinstance(order["path"], list), f"{order_label}.path must be a list"
     if payload["limit"] is not None:
         assert isinstance(payload["limit"], int) and payload["limit"] >= 0, (
             f"{label}.limit must be null or non-negative int"
@@ -104,6 +116,16 @@ def _validate_query_payload(payload: dict[str, Any], label: str) -> None:
         )
     if payload["m2m"] is not None:
         assert isinstance(payload["m2m"], dict), f"{label}.m2m must be null or object"
+    joins = payload["joins"]
+    assert isinstance(joins, list), f"{label}.joins must be a list"
+    for i, join in enumerate(joins):
+        join_label = f"{label}.joins[{i}]"
+        assert isinstance(join, dict), f"{join_label} must be object"
+        _require_keys(join, {"join_type", "path"}, join_label)
+        assert join["join_type"] in {"inner", "left"}, (
+            f"{join_label}.join_type invalid: {join['join_type']!r}"
+        )
+        assert isinstance(join["path"], list), f"{join_label}.path must be a list"
 
 
 def _validate_codec_payload(payload: dict[str, Any], label: str) -> None:
@@ -202,8 +224,9 @@ def test_ir_vectors_match_phase0_contract_envelope() -> None:
         assert ir["ir_kind"] == vector["domain"], (
             f"{label}.ir.ir_kind ({ir['ir_kind']!r}) must match domain ({vector['domain']!r})"
         )
-        assert ir["ir_version"] == SUPPORTED_IR_VERSION, (
-            f"{label}.ir.ir_version must equal {SUPPORTED_IR_VERSION}"
+        expected_version = SUPPORTED_IR_VERSIONS[vector["domain"]]
+        assert ir["ir_version"] == expected_version, (
+            f"{label}.ir.ir_version must equal {expected_version} for domain {vector['domain']!r}"
         )
         assert isinstance(ir["payload"], dict), f"{label}.ir.payload must be object"
         _validate_domain_payload(vector["domain"], ir["payload"], f"{label}.ir.payload")

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -126,6 +126,16 @@ def _validate_query_payload(payload: dict[str, Any], label: str) -> None:
             f"{join_label}.join_type invalid: {join['join_type']!r}"
         )
         assert isinstance(join["path"], list), f"{join_label}.path must be a list"
+        for h, hop in enumerate(join["path"]):
+            hop_label = f"{join_label}.path[{h}]"
+            assert isinstance(hop, dict), f"{hop_label} must be object"
+            _require_keys(
+                hop,
+                {"relation", "from_column", "to_table", "to_column"},
+                hop_label,
+            )
+            for key in ("relation", "from_column", "to_table", "to_column"):
+                assert isinstance(hop[key], str), f"{hop_label}.{key} must be a str"
 
 
 def _validate_codec_payload(payload: dict[str, Any], label: str) -> None:

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -64,6 +64,7 @@ def test_query_ir_payload_to_json_serializes_m2m_context_without_mutating_query_
         "limit": None,
         "offset": None,
         "m2m": query._m2m_context,
+        "joins": [],
     }
 
     query_json = _query_ir_payload_to_json(query_def)
@@ -72,7 +73,7 @@ def test_query_ir_payload_to_json_serializes_m2m_context_without_mutating_query_
     assert query._m2m_context["source_id"] == source_id
     assert isinstance(query._m2m_context["source_id"], uuid.UUID)
     assert payload["ir_kind"] == "query"
-    assert payload["ir_version"] == 1
+    assert payload["ir_version"] == 2
     assert payload["payload"]["m2m"]["source_id"] == str(source_id)
 
 
@@ -92,6 +93,28 @@ def test_query_node_to_ir_dict_uses_query_ir_shape():
     assert payload["column"] == "age"
     assert payload["operator"] == ">="
     assert payload["value"] == {"kind": "int", "value": 18}
+    assert payload["path"] == []
+
+
+def test_query_node_to_ir_dict_emits_field_proxy_path():
+    """A leaf built from a ``FieldProxy`` carries its ``path`` into IR (#269);
+    this slice only ever emits ``[]`` (root model) — #270 populates it via
+    relation traversal."""
+    node = FieldProxy("age", path=("account",)) >= 18
+    payload = node.to_ir_dict()
+
+    assert payload["path"] == ["account"]
+
+
+def test_query_node_to_ir_dict_compound_node_has_no_path_key():
+    left = FieldProxy("age") >= 18
+    right = FieldProxy("name") == "a"
+    compound = left & right
+
+    payload = compound.to_ir_dict()
+
+    assert payload["node_kind"] == "compound"
+    assert "path" not in payload
 
 
 def test_field_proxy_operator_overloading():

--- a/tests/test_query_column_validation.py
+++ b/tests/test_query_column_validation.py
@@ -86,7 +86,9 @@ class TestOrderByValidation:
             created_at: str = ""
 
         q = ObUser.select().order_by(lambda u: u.created_at, "desc")
-        assert q.order_by_clause == [{"column": "created_at", "direction": "desc"}]
+        assert q.order_by_clause == [
+            {"column": "created_at", "direction": "desc", "path": []}
+        ]
 
     def test_order_by_string_is_validated(self):
         class ObUser2(Model):
@@ -94,7 +96,7 @@ class TestOrderByValidation:
             age: int = 0
 
         q = ObUser2.select().order_by("age")
-        assert q.order_by_clause == [{"column": "age", "direction": "asc"}]
+        assert q.order_by_clause == [{"column": "age", "direction": "asc", "path": []}]
 
     def test_order_by_misspelled_string_raises(self):
         class ObUser3(Model):

--- a/tests/test_query_immutability.py
+++ b/tests/test_query_immutability.py
@@ -48,7 +48,7 @@ class TestImmutableChaining:
         assert (q1._limit, q1._offset, q1.order_by_clause) == (None, None, [])
         assert q2._limit == 5 and q2._offset is None
         assert q3._offset == 10
-        assert q4.order_by_clause == [{"column": "age", "direction": "desc"}]
+        assert q4.order_by_clause == [{"column": "age", "direction": "desc", "path": []}]
         assert q3.order_by_clause == []
 
     def test_m2m_context_is_not_shared_between_clones(self):

--- a/tests/test_query_joins.py
+++ b/tests/test_query_joins.py
@@ -10,7 +10,11 @@ composition, query immutability, and order_by traversal sharing joins with
 where() (#271).
 """
 
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import StrEnum
 from typing import Annotated
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -124,6 +128,77 @@ class QJMPost(Model):
     id: Annotated[int | None, FerroField(primary_key=True)] = None
     title: str = ""
     tags: Relation[list["QJMTag"]] = ManyToMany(related_name="posts")
+
+
+# Typed-bind matrix (#270 critical): a related model carrying datetime, uuid,
+# decimal, native-enum, and nullable columns, reached by traversal from a root
+# model whose `tag` column collides by NAME with the related `tag` but is a
+# DIFFERENT type (native enum on the root, plain text on the related). These pin
+# that a traversed leaf's typed bind resolves against its OWN table's model, not
+# the root's codec plan / enum catalog.
+
+
+class QJTBTier(StrEnum):
+    FREE = "free"
+    PRO = "pro"
+
+
+class QJTBProfile(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    created_at: datetime
+    external_id: UUID
+    balance: Decimal | None = None
+    tier: QJTBTier = QJTBTier.FREE
+    nickname: str | None = None
+    # Plain-text column; collides by name with QJTBUser.tag (a native enum).
+    tag: str = ""
+    users: Relation[list["QJTBUser"]] = BackRef()
+
+
+class QJTBUser(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    # Native-enum column named identically to the related plain-text QJTBProfile.tag.
+    tag: QJTBTier = QJTBTier.FREE
+    profile: Annotated[QJTBProfile, ForeignKey(related_name="users")]
+
+
+_TB_T1 = datetime(2020, 1, 1, tzinfo=timezone.utc)
+_TB_T2 = datetime(2030, 6, 15, tzinfo=timezone.utc)
+_TB_UID1 = UUID("11111111-1111-1111-1111-111111111111")
+_TB_UID2 = UUID("22222222-2222-2222-2222-222222222222")
+
+
+async def _seed_typed_bind_matrix():
+    """Two profiles with distinct typed values, each owned by one user.
+
+    P1 (user U1): created_at=T1, external_id=UID1, balance=100, tier=PRO,
+        nickname="alice", tag="vip".
+    P2 (user U2): created_at=T2, external_id=UID2, balance=10, tier=FREE,
+        nickname=None, tag="basic".
+    """
+    p1 = QJTBProfile(
+        id=1,
+        created_at=_TB_T1,
+        external_id=_TB_UID1,
+        balance=Decimal("100.00"),
+        tier=QJTBTier.PRO,
+        nickname="alice",
+        tag="vip",
+    )
+    p2 = QJTBProfile(
+        id=2,
+        created_at=_TB_T2,
+        external_id=_TB_UID2,
+        balance=Decimal("10.00"),
+        tier=QJTBTier.FREE,
+        nickname=None,
+        tag="basic",
+    )
+    for row in (p1, p2):
+        await row.save()
+    await QJTBUser(id=1, tag=QJTBTier.PRO, profile=p1).save()
+    await QJTBUser(id=2, tag=QJTBTier.FREE, profile=p2).save()
+    return {"p1": p1, "p2": p2}
 
 
 async def _seed_core():
@@ -268,6 +343,30 @@ async def test_join_dedup_across_where_calls_and_boolean_tree(db_url):
         assert list(q_and._joins) == [("account",)]
         rows_and = await q_and.all()
         assert {r.id for r in rows_and} == {1, 2, 3}
+
+
+@pytest.mark.asyncio
+async def test_or_composition_still_renders_inner_join_narrowing_query_wide(db_url):
+    """ADR-0006 narrowing is query-wide: a traversal branch inside an ``|`` still
+    renders the INNER join, so a relation-less row is dropped even when the OTHER
+    branch (a root-column predicate) would have matched it."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        core = await _seed_core()
+        await QJNote(id=1, body="attached", account=core["a1"]).save()
+        await QJNote(id=2, body="orphan", account=None).save()
+
+        rows = await QJNote.where(
+            lambda n: (n.account.ledger_id == 1) | (n.body == "orphan")
+        ).all()
+        # The INNER account join drops the NULL-FK orphan BEFORE the WHERE, so it
+        # never reaches the `n.body == "orphan"` branch — only the attached note
+        # (ledger 1) survives.
+        assert {r.id for r in rows} == {1}
+        count = await QJNote.where(
+            lambda n: (n.account.ledger_id == 1) | (n.body == "orphan")
+        ).count()
+        assert count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -694,6 +793,16 @@ class TestExplicitJoinChainers:
                 lambda t: t.account.owner
             )
 
+    def test_contradictory_join_types_overlapping_paths_raise_reverse_order(self):
+        """Mirror of the overlap conflict: ``.left_join(t.account.owner)`` THEN
+        ``.join(t.account)`` conflicts on the same shared ``account`` edge — the
+        whole-path LEFT mark and the later INNER mark disagree regardless of which
+        chainer ran first (#272)."""
+        with pytest.raises(ValueError, match="account"):
+            Query(QJTransaction).left_join(lambda t: t.account.owner).join(
+                lambda t: t.account
+            )
+
     def test_remarking_same_direction_is_idempotent(self):
         q = Query(QJTransaction).join(lambda t: t.account).join(lambda t: t.account)
         assert q._explicit_edges == {("account",): "inner"}
@@ -955,3 +1064,114 @@ async def test_m2m_context_composes_with_forward_fk_traversal(db_url):
         assert (
             await post.tags.where(lambda t: t.created_by.role == "admin").count() == 1
         )
+
+
+# ---------------------------------------------------------------------------
+# Typed binds on TRAVERSED columns (#270 critical): a filter on a related
+# datetime / uuid / decimal / native-enum column must bind against the traversed
+# hop's model, not the root's codec plan / enum catalog. Before the fix these
+# resolved every leaf against the root model and failed on Postgres (e.g.
+# `operator does not exist: timestamp with time zone >= text`).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_traversed_datetime_filter_binds_against_hop_model(db_url):
+    """`u.profile.created_at >= dt` casts the bind to the hop table's temporal
+    type — the RED case: on Postgres the root-keyed bug sent an un-cast `text`."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_typed_bind_matrix()
+
+        rows = await QJTBUser.where(
+            lambda u: u.profile.created_at >= datetime(2025, 1, 1, tzinfo=timezone.utc)
+        ).all()
+        # Only P2 (created_at=T2, 2030) is at/after 2025 -> its user U2.
+        assert {r.id for r in rows} == {2}
+        assert (
+            await QJTBUser.where(
+                lambda u: u.profile.created_at
+                >= datetime(2025, 1, 1, tzinfo=timezone.utc)
+            ).count()
+            == 1
+        )
+
+
+@pytest.mark.asyncio
+async def test_traversed_uuid_filter_binds_against_hop_model(db_url):
+    """`u.profile.external_id == uuid` sends a typed uuid bind for the hop table
+    (root-keyed bug: `operator does not exist: uuid = text`)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_typed_bind_matrix()
+
+        rows = await QJTBUser.where(
+            lambda u: u.profile.external_id == _TB_UID1
+        ).all()
+        assert {r.id for r in rows} == {1}
+
+
+@pytest.mark.asyncio
+async def test_traversed_decimal_filter_binds_against_hop_model(db_url):
+    """`u.profile.balance >= Decimal(...)` casts the bind to numeric for the hop
+    table (root-keyed bug: `operator does not exist: numeric >= text`)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_typed_bind_matrix()
+
+        rows = await QJTBUser.where(
+            lambda u: u.profile.balance >= Decimal("50.00")
+        ).all()
+        # Only P1 (balance=100) clears 50 -> user U1.
+        assert {r.id for r in rows} == {1}
+
+
+@pytest.mark.asyncio
+async def test_traversed_native_enum_filter_binds_against_hop_model(db_url):
+    """`u.profile.tier == QJTBTier.PRO` casts to the hop table's native enum UDT
+    (root-keyed bug: no UDT cast -> `operator does not exist: qjtbtier = text`)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_typed_bind_matrix()
+
+        rows = await QJTBUser.where(lambda u: u.profile.tier == QJTBTier.PRO).all()
+        assert {r.id for r in rows} == {1}
+
+
+@pytest.mark.asyncio
+async def test_traversed_typed_null_filter_binds_against_hop_model(db_url):
+    """`u.profile.nickname == None` lowers to IS NULL on the hop alias column and
+    returns exactly the rows whose related nickname is NULL."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_typed_bind_matrix()
+
+        rows = await QJTBUser.where(
+            lambda u: u.profile.nickname == None  # noqa: E711
+        ).all()
+        # Only P2 has nickname NULL -> user U2.
+        assert {r.id for r in rows} == {2}
+
+
+@pytest.mark.asyncio
+async def test_name_collision_root_and_traversed_column_bind_independently(db_url):
+    """`tag` names a NATIVE ENUM on the root (QJTBUser) and PLAIN TEXT on the
+    related (QJTBProfile). Both must bind against their OWN table: the root-keyed
+    bug applied the root's enum-UDT cast to the traversed text column
+    (`invalid input value for enum qjtbtier: "vip"`)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_typed_bind_matrix()
+
+        # Root enum column: filters by the native-enum bind.
+        root_rows = await QJTBUser.where(lambda u: u.tag == QJTBTier.PRO).all()
+        assert {r.id for r in root_rows} == {1}
+
+        # Traversed text column of the SAME name: plain-text bind, no enum cast.
+        traversed_rows = await QJTBUser.where(lambda u: u.profile.tag == "vip").all()
+        assert {r.id for r in traversed_rows} == {1}
+
+        # A value that is NOT a valid enum label must simply not match (never
+        # blow up as an enum cast against the text column).
+        empty = await QJTBUser.where(lambda u: u.profile.tag == "nope").all()
+        assert empty == []

--- a/tests/test_query_joins.py
+++ b/tests/test_query_joins.py
@@ -15,8 +15,9 @@ from typing import Annotated
 import pytest
 
 import ferro
-from ferro import BackRef, FerroField, ForeignKey, Model, Relation
-from ferro.query import Query
+from ferro import BackRef, FerroField, ForeignKey, ManyToMany, Model, Relation
+from ferro.query import Query, QueryNode
+from ferro.query.nodes import FieldProxy, QueryProxy
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -99,6 +100,30 @@ class QJDoc(Model):
     id: Annotated[int | None, FerroField(primary_key=True)] = None
     title: str = ""
     folder: Annotated[QJFolder | None, ForeignKey(related_name="docs")] = None
+
+
+# M2M pair whose TARGET model carries a forward FK, so an M2M association
+# query can traverse it: `post.tags.where(lambda t: t.created_by.role == ...)`
+# (#273 M2M-composition acceptance criterion).
+
+
+class QJMAuthor(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    role: str = ""
+    tags: Relation[list["QJMTag"]] = BackRef()
+
+
+class QJMTag(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str = ""
+    created_by: Annotated[QJMAuthor, ForeignKey(related_name="tags")]
+    posts: Relation[list["QJMPost"]] = BackRef()
+
+
+class QJMPost(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    title: str = ""
+    tags: Relation[list["QJMTag"]] = ManyToMany(related_name="posts")
 
 
 async def _seed_core():
@@ -443,16 +468,147 @@ async def test_order_by_related_column_drops_null_fk_rows(db_url):
 
 def test_order_by_bare_relation_proxy_is_rejected():
     """A bare relation (no column selected) is meaningless as a sort key —
-    rejected at build time (comparison sugar is slice #273's scope)."""
-    with pytest.raises(TypeError, match="relation"):
+    rejected at build time with a pointed message naming the relation (#273)."""
+    with pytest.raises(
+        TypeError, match="order_by.*bare relation 'account'.*t.account.<column>"
+    ):
         Query(QJTransaction).order_by(lambda t: t.account)  # type: ignore[arg-type,return-value]
 
 
 def test_bare_relation_proxy_predicate_is_rejected():
-    """A where() lambda returning a bare relation (no comparison) is not a
-    QueryNode — rejected at build time (comparison sugar is slice #273)."""
-    with pytest.raises(TypeError, match="must return QueryNode"):
+    """A where() lambda returning a bare relation is not a QueryNode — rejected
+    at build time with a pointed message naming the relation (#273)."""
+    with pytest.raises(
+        TypeError, match="bare relation 'account'.*== None / == an instance"
+    ):
         Query(QJTransaction).where(lambda t: t.account)  # type: ignore[arg-type,return-value]
+
+
+# ---------------------------------------------------------------------------
+# Relation-proxy sugar and guardrails (#273): build-time desugaring, error
+# taxonomy, boolean-coercion trap, and update()/delete() traversal rejection.
+# These are build-time-only (no DB round-trip).
+# ---------------------------------------------------------------------------
+
+
+def _persisted_account(pk: int = 7) -> QJAccount:
+    return QJAccount(id=pk, label="x", ledger=QJLedger(id=1), owner=QJOwner(id=1))
+
+
+class TestRelationProxySugar:
+    def _proxy(self) -> QueryProxy:
+        return QueryProxy(QJTransaction)
+
+    def test_instance_equality_desugars_to_shadow_fk_join_free(self):
+        node = self._proxy().account == _persisted_account(7)
+        assert isinstance(node, QueryNode)
+        assert node.column == "account_id"
+        assert node.operator == "=="
+        assert node.value == 7
+        assert node.path == ()  # genuinely join-free (path minus last hop)
+
+    def test_instance_inequality_operator(self):
+        node = self._proxy().account != _persisted_account(7)
+        assert node.operator == "!="
+        assert node.column == "account_id"
+        assert node.value == 7
+        assert node.path == ()
+
+    def test_deep_instance_equality_uses_last_hop_shadow_and_prefix_path(self):
+        owner = QJOwner(id=3, email="o@ferro.dev")
+        node = self._proxy().account.owner == owner
+        # Shadow column of the LAST hop (owner_id, on the account table), with
+        # the proxy path MINUS that hop -> the ("account",) prefix join only.
+        assert node.column == "owner_id"
+        assert node.value == 3
+        assert node.path == ("account",)
+
+    def test_equals_none_builds_null_leaf_join_free(self):
+        node = self._proxy().account == None  # noqa: E711
+        assert node.column == "account_id"
+        assert node.value is None
+        assert node.operator == "=="
+        assert node.path == ()
+
+    def test_not_equals_none_operator(self):
+        node = self._proxy().account != None  # noqa: E711
+        assert node.operator == "!="
+        assert node.value is None
+        assert node.path == ()
+
+    def test_unpersisted_instance_raises_value_error_naming_model(self):
+        unsaved = QJAccount(label="x", ledger=QJLedger(id=1), owner=QJOwner(id=1))
+        with pytest.raises(
+            ValueError, match="unpersisted QJAccount instance .primary key not set"
+        ):
+            self._proxy().account == unsaved
+
+    def test_wrong_model_instance_raises_type_error(self):
+        with pytest.raises(
+            TypeError, match="relation 'account'.*expected a QJAccount instance or None"
+        ):
+            self._proxy().account == QJLedger(id=1)
+
+    def test_scalar_comparison_raises_type_error(self):
+        with pytest.raises(
+            TypeError, match="relation 'account'.*expected a QJAccount instance or None"
+        ):
+            self._proxy().account == 5
+
+    def test_non_equality_operators_are_rejected(self):
+        proxy = self._proxy()
+        for build in (
+            lambda: proxy.account < 5,
+            lambda: proxy.account <= 5,
+            lambda: proxy.account > 5,
+            lambda: proxy.account >= 5,
+            lambda: proxy.account.in_([1, 2]),
+            lambda: proxy.account.like("x"),
+            lambda: proxy.account << [1, 2],
+        ):
+            with pytest.raises(TypeError, match="supports only == / !="):
+                build()
+
+
+def test_query_node_boolean_coercion_raises():
+    """`and`/`or` misuse coerces a QueryNode to bool; that raises pointedly."""
+    node = FieldProxy("age") >= 18
+    with pytest.raises(TypeError, match="boolean context.*use & / |"):
+        bool(node)
+    with pytest.raises(TypeError, match="use & / |"):
+        _ = (FieldProxy("age") >= 18) and (FieldProxy("age") <= 30)
+
+
+class TestMutatingTraversalRejection:
+    """update()/delete() reject relation traversal at the shared choke point
+    (:meth:`Query._mutating_query_def`), before any serialization or DB."""
+
+    def test_traversed_predicate_rejected_for_update_and_delete(self):
+        q = Query(QJTransaction).where(lambda t: t.account.label == "a1")
+        for operation in ("update", "delete"):
+            with pytest.raises(ValueError, match="does not support relation traversal"):
+                q._mutating_query_def(operation)
+
+    def test_explicit_join_rejected(self):
+        q = Query(QJTransaction).join(lambda t: t.account)
+        with pytest.raises(ValueError, match="relation traversal"):
+            q._mutating_query_def("update")
+
+    def test_join_free_relation_filter_is_allowed(self):
+        q = Query(QJTransaction).where(lambda t: t.account == _persisted_account(1))
+        payload = q._mutating_query_def("update")  # must NOT raise
+        assert payload["where"][0]["column"] == "account_id"
+        assert payload["where"][0]["path"] == []
+
+
+@pytest.mark.asyncio
+async def test_update_and_delete_reject_traversal_before_db():
+    """The rejection fires before any DB round-trip — no connection is made."""
+    q = Query(QJTransaction).where(lambda t: t.account.owner.email == "x@y.z")
+    with pytest.raises(ValueError, match="relation traversal"):
+        await q.update(amount=0)
+    with pytest.raises(ValueError, match="relation traversal"):
+        await q.delete()
 
 
 # ---------------------------------------------------------------------------
@@ -720,3 +876,82 @@ async def test_explicit_left_plus_implicit_traversal_renders_left(db_url):
             .all()
         )
         assert {r.id for r in rows} == {2}
+
+
+# ---------------------------------------------------------------------------
+# Relation-proxy equality sugar — behavioral (#273): instance-eq filters by the
+# shadow FK join-free; == None / != None lower to IS NULL / IS NOT NULL; the
+# M2M association context composes with forward-FK traversal on the target.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_instance_equality_filters_by_shadow_fk(db_url):
+    """`t.account == a1` filters by `account_id` join-free; `!=` complements."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        core = await _seed_core()
+        a1 = core["a1"]
+
+        eq_rows = await QJTransaction.where(lambda t: t.account == a1).all()
+        assert {r.id for r in eq_rows} == {1, 2, 3}
+        assert await QJTransaction.where(lambda t: t.account == a1).count() == 3
+
+        ne_rows = await QJTransaction.where(lambda t: t.account != a1).all()
+        assert {r.id for r in ne_rows} == {4, 5, 6}
+
+
+@pytest.mark.asyncio
+async def test_deep_instance_equality_traverses_prefix_join(db_url):
+    """`t.account.owner == o2` compares `owner_id` under the account prefix join
+    (the shadow column lives one hop up, not the final target's PK column)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        core = await _seed_core()
+        o2 = core["o2"]
+
+        rows = await QJTransaction.where(lambda t: t.account.owner == o2).all()
+        # Only account a2 has owner o2; a2 has one transaction (id=4).
+        assert {r.id for r in rows} == {4}
+
+
+@pytest.mark.asyncio
+async def test_relation_equals_none_renders_is_null(db_url):
+    """`n.account == None` / `!= None` lower to IS NULL / IS NOT NULL on the
+    shadow FK, join-free."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        core = await _seed_core()
+        await _seed_notes(core)
+
+        null_rows = await QJNote.where(lambda n: n.account == None).all()  # noqa: E711
+        assert {r.id for r in null_rows} == {2}
+
+        present_rows = await QJNote.where(
+            lambda n: n.account != None  # noqa: E711
+        ).all()
+        assert {r.id for r in present_rows} == {1}
+
+
+@pytest.mark.asyncio
+async def test_m2m_context_composes_with_forward_fk_traversal(db_url):
+    """An M2M association query (`post.tags`) whose where() traverses a forward
+    FK on the target model composes: the association join and the traversal join
+    coexist in one statement (#273)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        admin = await QJMAuthor.create(id=1, role="admin")
+        member = await QJMAuthor.create(id=2, role="member")
+        tag_admin = await QJMTag.create(id=1, name="urgent", created_by=admin)
+        tag_member = await QJMTag.create(id=2, name="chill", created_by=member)
+        post = await QJMPost.create(id=1, title="p1")
+        await post.tags.add(tag_admin, tag_member)
+
+        # Sanity: the unfiltered association returns both tags.
+        assert {t.id for t in await post.tags.all()} == {1, 2}
+
+        admin_tags = await post.tags.where(lambda t: t.created_by.role == "admin").all()
+        assert {t.id for t in admin_tags} == {1}
+        assert (
+            await post.tags.where(lambda t: t.created_by.role == "admin").count() == 1
+        )

--- a/tests/test_query_joins.py
+++ b/tests/test_query_joins.py
@@ -1,11 +1,13 @@
-"""Backend-matrix integration tests for relation traversal in where() (#270).
+"""Backend-matrix integration tests for relation traversal in where() and
+order_by() (#270, #271).
 
 Declares FK-related models, inserts rows, and asserts result sets against real
 SQLite and isolated-schema Postgres backends — no SQL-string snapshots at this
 layer (the rendered-SQL pins live in the Rust walker unit tests). Covers the
 motivating Pinch query, multi-hop traversal, per-hop did-you-mean, INNER-drops-
 NULL semantics (ADR-0006), join dedup, two-FKs-to-one-target, self-FK, verb
-composition, and query immutability.
+composition, query immutability, and order_by traversal sharing joins with
+where() (#271).
 """
 
 from typing import Annotated
@@ -324,14 +326,106 @@ async def test_query_immutability_with_joins(db_url):
         assert {r.id for r in branched_rows} == {5, 6}
 
 
+# ---------------------------------------------------------------------------
+# order_by() relation traversal (#271): shares joins with where(), any depth,
+# asc/desc, INNER-drops-NULL, and a same-path dedup with where().
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_order_by_related_column_asc_and_desc(db_url):
+    """1-hop `order_by(lambda t: t.account.label)`, both directions, with a
+    root-column tiebreaker so ties can never make the assertion flaky."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        asc_rows = await (
+            QJTransaction.select()
+            .order_by(lambda t: t.account.label)
+            .order_by(lambda t: t.id)
+            .all()
+        )
+        # Labels ascending a1 < a2 < b1; ties broken by id.
+        assert [r.id for r in asc_rows] == [1, 2, 3, 4, 5, 6]
+
+        desc_rows = await (
+            QJTransaction.select()
+            .order_by(lambda t: t.account.label, "desc")
+            .order_by(lambda t: t.id)
+            .all()
+        )
+        # Labels descending b1 > a2 > a1; ties broken by id ascending within
+        # each label group — proves the sort key is the related column, not id.
+        assert [r.id for r in desc_rows] == [5, 6, 4, 1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_order_by_multi_hop_shares_join_with_where_same_path(db_url):
+    """`order_by(lambda t: t.account.owner.email)` composed with a `where()`
+    traversal of the SAME path -> exactly one join entry, and correct rows."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        q = (
+            QJTransaction.where(lambda t: t.account.owner.email == "o1@ferro.dev")
+            .order_by(lambda t: t.account.owner.email)
+            .order_by(lambda t: t.id)
+        )
+        # Behavioral half of the one-join acceptance criterion.
+        assert list(q._joins) == [("account", "owner")]
+
+        rows = await q.all()
+        # Owner o1 owns a1 (txns 1,2,3) and b1 (txns 5,6); ordered by email
+        # (constant "o1@ferro.dev" within this filtered set) then id.
+        assert [r.id for r in rows] == [1, 2, 3, 5, 6]
+
+
+@pytest.mark.asyncio
+async def test_order_by_related_column_composed_with_where_different_path(db_url):
+    """`where()` traversing one path and `order_by()` traversing a DIFFERENT
+    path -> two distinct join entries, both effective on the result."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        q = (
+            QJTransaction.where(lambda t: t.account.ledger_id == 1)
+            .order_by(lambda t: t.account.owner.email)
+            .order_by(lambda t: t.id)
+        )
+        assert list(q._joins) == [("account",), ("account", "owner")]
+
+        rows = await q.all()
+        # Ledger A -> accounts a1 (owner o1, txns 1,2,3), a2 (owner o2, txn 4).
+        # Owner email ascending (o1 < o2) with id tiebreaker.
+        assert [r.id for r in rows] == [1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_order_by_related_column_drops_null_fk_rows(db_url):
+    """INNER ordering drops relation-less rows (nullable FK left NULL) — the
+    same ADR-0006 semantics `where()` traversal already has, now for order_by."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        core = await _seed_core()
+        await QJNote(id=1, body="attached", account=core["a1"]).save()
+        await QJNote(id=2, body="orphan", account=None).save()
+
+        rows = await QJNote.select().order_by(lambda n: n.account.label).all()
+        assert [r.id for r in rows] == [1]
+
+
+def test_order_by_bare_relation_proxy_is_rejected():
+    """A bare relation (no column selected) is meaningless as a sort key —
+    rejected at build time (comparison sugar is slice #273's scope)."""
+    with pytest.raises(TypeError, match="relation"):
+        Query(QJTransaction).order_by(lambda t: t.account)  # type: ignore[arg-type,return-value]
+
+
 def test_bare_relation_proxy_predicate_is_rejected():
     """A where() lambda returning a bare relation (no comparison) is not a
     QueryNode — rejected at build time (comparison sugar is slice #273)."""
     with pytest.raises(TypeError, match="must return QueryNode"):
         Query(QJTransaction).where(lambda t: t.account)  # type: ignore[arg-type,return-value]
-
-
-def test_order_by_relation_traversal_is_rejected():
-    """order_by relation traversal is slice #271 — a clear build-time error now."""
-    with pytest.raises(TypeError, match="relation traversal"):
-        Query(QJTransaction).order_by(lambda t: t.account.owner.email)

--- a/tests/test_query_joins.py
+++ b/tests/test_query_joins.py
@@ -1,0 +1,337 @@
+"""Backend-matrix integration tests for relation traversal in where() (#270).
+
+Declares FK-related models, inserts rows, and asserts result sets against real
+SQLite and isolated-schema Postgres backends — no SQL-string snapshots at this
+layer (the rendered-SQL pins live in the Rust walker unit tests). Covers the
+motivating Pinch query, multi-hop traversal, per-hop did-you-mean, INNER-drops-
+NULL semantics (ADR-0006), join dedup, two-FKs-to-one-target, self-FK, verb
+composition, and query immutability.
+"""
+
+from typing import Annotated
+
+import pytest
+
+import ferro
+from ferro import BackRef, FerroField, ForeignKey, Model, Relation
+from ferro.query import Query
+
+pytestmark = pytest.mark.backend_matrix
+
+
+# ---------------------------------------------------------------------------
+# Schema: Transaction -> Account -> {Ledger, Owner}; plus Transfer (two FKs to
+# Account), Employee (self-FK), and a nullable-FK Note.
+# ---------------------------------------------------------------------------
+
+
+class QJLedger(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str = ""
+    accounts: Relation[list["QJAccount"]] = BackRef()
+
+
+class QJOwner(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    email: str = ""
+    accounts: Relation[list["QJAccount"]] = BackRef()
+
+
+class QJAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    label: str = ""
+    ledger: Annotated[QJLedger, ForeignKey(related_name="accounts")]
+    owner: Annotated[QJOwner, ForeignKey(related_name="accounts")]
+    transactions: Relation[list["QJTransaction"]] = BackRef()
+    transfers_out: Relation[list["QJTransfer"]] = BackRef()
+    transfers_in: Relation[list["QJTransfer"]] = BackRef()
+    notes: Relation[list["QJNote"]] = BackRef()
+
+
+class QJTransaction(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    amount: int = 0
+    account: Annotated[QJAccount, ForeignKey(related_name="transactions")]
+
+
+class QJTransfer(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    from_account: Annotated[QJAccount, ForeignKey(related_name="transfers_out")]
+    to_account: Annotated[QJAccount, ForeignKey(related_name="transfers_in")]
+
+
+class QJEmployee(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str = ""
+    manager: Annotated["QJEmployee", ForeignKey(related_name="reports", nullable=True)] = (
+        None
+    )
+    reports: Relation[list["QJEmployee"]] = BackRef()
+
+
+class QJNote(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    body: str = ""
+    account: Annotated[QJAccount | None, ForeignKey(related_name="notes")] = None
+
+
+async def _seed_core():
+    """Two ledgers, two owners, accounts, and fan-in transactions.
+
+    Ledger A has accounts a1 (owner o1) and a2 (owner o2) with 3 + 1 = 4
+    transactions; Ledger B has account b1 (owner o1) with 2 transactions.
+    """
+    la, lb = QJLedger(id=1, name="ledger-a"), QJLedger(id=2, name="ledger-b")
+    o1, o2 = QJOwner(id=1, email="o1@ferro.dev"), QJOwner(id=2, email="o2@ferro.dev")
+    for row in (la, lb, o1, o2):
+        await row.save()
+
+    a1 = QJAccount(id=1, label="a1", ledger=la, owner=o1)
+    a2 = QJAccount(id=2, label="a2", ledger=la, owner=o2)
+    b1 = QJAccount(id=3, label="b1", ledger=lb, owner=o1)
+    for row in (a1, a2, b1):
+        await row.save()
+
+    # Ledger A: 4 transactions (a1 x3, a2 x1); Ledger B: 2 transactions (b1).
+    for txn in (
+        QJTransaction(id=1, amount=10, account=a1),
+        QJTransaction(id=2, amount=20, account=a1),
+        QJTransaction(id=3, amount=30, account=a1),
+        QJTransaction(id=4, amount=40, account=a2),
+        QJTransaction(id=5, amount=50, account=b1),
+        QJTransaction(id=6, amount=60, account=b1),
+    ):
+        await txn.save()
+    return {"la": la, "lb": lb, "o1": o1, "o2": o2, "a1": a1, "a2": a2, "b1": b1}
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: the motivating Pinch query + multi-hop.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pinch_query_filters_through_relation(db_url):
+    """`t.account.ledger_id == lid` composed with a root-column range filter,
+    ordered by a root column, limited — one statement, right rows, right order."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        rows = await (
+            QJTransaction.where(lambda t: t.account.ledger_id == 1)
+            .where(lambda t: t.amount >= 20)
+            .order_by(lambda t: t.amount, "desc")
+            .limit(2)
+            .all()
+        )
+        # Ledger A transactions with amount >= 20: 40, 30, 20 -> desc, top 2.
+        assert [r.amount for r in rows] == [40, 30]
+
+
+@pytest.mark.asyncio
+async def test_multi_hop_traversal(db_url):
+    """`t.account.owner.email == x` traverses two hops in one statement."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        rows = await QJTransaction.where(
+            lambda t: t.account.owner.email == "o2@ferro.dev"
+        ).all()
+        # Only account a2 has owner o2, and a2 has one transaction (id=4).
+        assert {r.id for r in rows} == {4}
+
+
+# ---------------------------------------------------------------------------
+# Per-hop did-you-mean (build time, no DB round-trip).
+# ---------------------------------------------------------------------------
+
+
+class TestPerHopDidYouMean:
+    def test_misspelled_relation_at_root(self):
+        with pytest.raises(AttributeError) as exc:
+            QJTransaction.where(lambda t: t.accont.ledger_id == 1)
+        msg = str(exc.value)
+        assert "QJTransaction" in msg and "account" in msg
+
+    def test_misspelled_column_at_hop_one(self):
+        with pytest.raises(AttributeError) as exc:
+            QJTransaction.where(lambda t: t.account.labl == "x")
+        msg = str(exc.value)
+        # Error names the hop's model (Account) and suggests the real column.
+        assert "QJAccount" in msg and "label" in msg
+
+    def test_misspelled_anything_at_hop_two(self):
+        with pytest.raises(AttributeError) as exc:
+            QJTransaction.where(lambda t: t.account.owner.emial == "x")
+        msg = str(exc.value)
+        assert "QJOwner" in msg and "email" in msg
+
+
+# ---------------------------------------------------------------------------
+# INNER at every hop regardless of nullability (ADR-0006): NULL FK rows drop.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inner_join_drops_null_fk_rows(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        core = await _seed_core()
+        # One note with an account, one without (nullable FK left NULL).
+        await QJNote(id=1, body="attached", account=core["a1"]).save()
+        await QJNote(id=2, body="orphan", account=None).save()
+
+        rows = await QJNote.where(lambda n: n.account.ledger_id == 1).all()
+        assert {r.id for r in rows} == {1}
+        # count() agrees with the INNER-narrowed result set.
+        count = await QJNote.where(lambda n: n.account.ledger_id == 1).count()
+        assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# Join dedup: same path twice / within one &/| tree -> one join (behavioral).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_join_dedup_across_where_calls_and_boolean_tree(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        # Same relation path referenced in two where() calls.
+        q_two_calls = QJTransaction.where(
+            lambda t: t.account.ledger_id == 1
+        ).where(lambda t: t.account.owner.email == "o1@ferro.dev")
+        assert list(q_two_calls._joins) == [("account",), ("account", "owner")]
+        rows = await q_two_calls.all()
+        # Ledger A + owner o1 -> account a1 -> transactions 1,2,3.
+        assert {r.id for r in rows} == {1, 2, 3}
+
+        # Same path twice within one & tree registers once.
+        q_and = QJTransaction.where(
+            lambda t: (t.account.ledger_id == 1) & (t.account.label == "a1")
+        )
+        assert list(q_and._joins) == [("account",)]
+        rows_and = await q_and.all()
+        assert {r.id for r in rows_and} == {1, 2, 3}
+
+
+# ---------------------------------------------------------------------------
+# Two FKs to one target (transfer pair) — distinct joins, no alias ceremony.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_fks_to_one_target(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        core = await _seed_core()
+        # a1 -> ledger A, b1 -> ledger B.
+        await QJTransfer(id=1, from_account=core["a1"], to_account=core["b1"]).save()
+        await QJTransfer(id=2, from_account=core["b1"], to_account=core["a1"]).save()
+
+        out_of_a = await QJTransfer.where(
+            lambda tr: tr.from_account.ledger_id == 1
+        ).all()
+        assert {r.id for r in out_of_a} == {1}
+
+        into_a = await QJTransfer.where(lambda tr: tr.to_account.ledger_id == 1).all()
+        assert {r.id for r in into_a} == {2}
+
+
+# ---------------------------------------------------------------------------
+# Self-FK: Employee.manager traversal.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_self_fk_traversal(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        boss = QJEmployee(id=1, name="boss", manager=None)
+        await boss.save()
+        alice = QJEmployee(id=2, name="alice", manager=boss)
+        await alice.save()
+        await QJEmployee(id=3, name="bob", manager=boss).save()
+        await QJEmployee(id=4, name="carol", manager=alice).save()
+
+        managed_by_boss = await QJEmployee.where(
+            lambda e: e.manager.name == "boss"
+        ).all()
+        assert {e.name for e in managed_by_boss} == {"alice", "bob"}
+
+
+# ---------------------------------------------------------------------------
+# Verb composition + count() equals the matching root-row count.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verbs_compose_and_count_is_root_row_count(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        base = QJTransaction.where(lambda t: t.account.ledger_id == 1)
+
+        # Ledger A has 4 transactions (fan-in: 3 on a1, 1 on a2). A naive
+        # row-multiplying join would over-count; INNER many-to-one does not.
+        assert await base.count() == 4
+        assert await base.exists() is True
+
+        all_rows = await base.order_by(lambda t: t.id).all()
+        assert [r.id for r in all_rows] == [1, 2, 3, 4]
+
+        first = await base.order_by(lambda t: t.id).first()
+        assert first is not None and first.id == 1
+
+        page = await base.order_by(lambda t: t.id).limit(2).offset(1).all()
+        assert [r.id for r in page] == [2, 3]
+
+        empty = QJTransaction.where(lambda t: t.account.owner.email == "nobody@x")
+        assert await empty.count() == 0
+        assert await empty.exists() is False
+
+
+# ---------------------------------------------------------------------------
+# Immutability: branching a joined query never mutates the base.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_immutability_with_joins(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        base = QJTransaction.where(lambda t: t.amount >= 30)
+        branched = base.where(lambda t: t.account.ledger_id == 2)
+
+        # _joins isolation: the base never acquires the branch's join.
+        assert base._joins == {}
+        assert list(branched._joins) == [("account",)]
+        assert base._joins is not branched._joins
+
+        base_rows = await base.all()
+        # Base is a plain root-column filter: amount >= 30 -> ids 3,4,5,6.
+        assert {r.id for r in base_rows} == {3, 4, 5, 6}
+
+        branched_rows = await branched.all()
+        # amount >= 30 AND ledger B (b1: 50,60) -> ids 5,6.
+        assert {r.id for r in branched_rows} == {5, 6}
+
+
+def test_bare_relation_proxy_predicate_is_rejected():
+    """A where() lambda returning a bare relation (no comparison) is not a
+    QueryNode — rejected at build time (comparison sugar is slice #273)."""
+    with pytest.raises(TypeError, match="must return QueryNode"):
+        Query(QJTransaction).where(lambda t: t.account)  # type: ignore[arg-type,return-value]
+
+
+def test_order_by_relation_traversal_is_rejected():
+    """order_by relation traversal is slice #271 — a clear build-time error now."""
+    with pytest.raises(TypeError, match="relation traversal"):
+        Query(QJTransaction).order_by(lambda t: t.account.owner.email)

--- a/tests/test_query_joins.py
+++ b/tests/test_query_joins.py
@@ -77,6 +77,30 @@ class QJNote(Model):
     account: Annotated[QJAccount | None, ForeignKey(related_name="notes")] = None
 
 
+# Nullable-FK chain at BOTH hops (Doc -> Folder -> FolderOwner) so whole-path
+# LEFT retention is observable for rows missing the relation at either hop
+# (#272 acceptance criterion 3).
+
+
+class QJFolderOwner(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str = ""
+    folders: Relation[list["QJFolder"]] = BackRef()
+
+
+class QJFolder(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    label: str = ""
+    owner: Annotated[QJFolderOwner | None, ForeignKey(related_name="folders")] = None
+    docs: Relation[list["QJDoc"]] = BackRef()
+
+
+class QJDoc(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    title: str = ""
+    folder: Annotated[QJFolder | None, ForeignKey(related_name="docs")] = None
+
+
 async def _seed_core():
     """Two ledgers, two owners, accounts, and fan-in transactions.
 
@@ -429,3 +453,270 @@ def test_bare_relation_proxy_predicate_is_rejected():
     QueryNode — rejected at build time (comparison sugar is slice #273)."""
     with pytest.raises(TypeError, match="must return QueryNode"):
         Query(QJTransaction).where(lambda t: t.account)  # type: ignore[arg-type,return-value]
+
+
+# ---------------------------------------------------------------------------
+# Explicit join()/left_join() chainers (#272): state model, conflict rules,
+# the pinned mixed LEFT-prefix/INNER-suffix serialization, and immutability.
+# These are build-time-only (no DB round-trip).
+# ---------------------------------------------------------------------------
+
+
+def _serialized_join_types(query) -> list[tuple[tuple[str, ...], str]]:
+    """(path, join_type) for each serialized ``joins`` entry, in wire order."""
+    return [
+        (tuple(hop["relation"] for hop in entry["path"]), entry["join_type"])
+        for entry in query._serialize_joins()
+    ]
+
+
+class TestExplicitJoinChainers:
+    def test_join_marks_edges_inner_and_registers_path(self):
+        q = Query(QJTransaction).join(lambda t: t.account)
+        assert q._explicit_edges == {("account",): "inner"}
+        assert list(q._joins) == [("account",)]
+        assert _serialized_join_types(q) == [(("account",), "inner")]
+
+    def test_left_join_marks_whole_path_left(self):
+        q = Query(QJTransaction).left_join(lambda t: t.account.owner)
+        # Whole-path rule: BOTH edges are LEFT-marked (ADR-0006).
+        assert q._explicit_edges == {
+            ("account",): "left",
+            ("account", "owner"): "left",
+        }
+        assert list(q._joins) == [("account", "owner")]
+        assert _serialized_join_types(q) == [(("account", "owner"), "left")]
+
+    def test_left_join_prefix_inner_suffix_serializes_mixed_edges(self):
+        """The pinned mixed case: ``left_join(t.account)`` + a deeper INNER
+        traversal ``where(t.account.owner.email == x)`` → wire entries
+        ``["account"]→left`` and ``["account","owner"]→inner`` (#272)."""
+        q = (
+            Query(QJTransaction)
+            .left_join(lambda t: t.account)
+            .where(lambda t: t.account.owner.email == "o1@ferro.dev")
+        )
+        assert q._explicit_edges == {("account",): "left"}
+        assert list(q._joins) == [("account",), ("account", "owner")]
+        assert _serialized_join_types(q) == [
+            (("account",), "left"),
+            (("account", "owner"), "inner"),
+        ]
+
+    def test_explicit_left_beats_implicit_inner_same_path(self):
+        """A where()-registered INNER path re-marked LEFT by left_join renders
+        LEFT — regardless of chainer order (#272)."""
+        after = (
+            Query(QJTransaction)
+            .where(lambda t: t.account.label == "a1")
+            .left_join(lambda t: t.account)
+        )
+        assert _serialized_join_types(after) == [(("account",), "left")]
+
+        before = (
+            Query(QJTransaction)
+            .left_join(lambda t: t.account)
+            .where(lambda t: t.account.label == "a1")
+        )
+        assert _serialized_join_types(before) == [(("account",), "left")]
+
+    def test_contradictory_join_types_same_edge_raise(self):
+        with pytest.raises(ValueError, match="conflicting explicit join"):
+            Query(QJTransaction).join(lambda t: t.account).left_join(
+                lambda t: t.account
+            )
+        with pytest.raises(ValueError, match="conflicting explicit join"):
+            Query(QJTransaction).left_join(lambda t: t.account).join(
+                lambda t: t.account
+            )
+
+    def test_contradictory_join_types_overlapping_paths_raise(self):
+        """``.join(t.account)`` + ``.left_join(t.account.owner)`` conflict on the
+        shared ``account`` edge (whole-path LEFT marks it) — build-time error."""
+        with pytest.raises(ValueError, match="account"):
+            Query(QJTransaction).join(lambda t: t.account).left_join(
+                lambda t: t.account.owner
+            )
+
+    def test_remarking_same_direction_is_idempotent(self):
+        q = Query(QJTransaction).join(lambda t: t.account).join(lambda t: t.account)
+        assert q._explicit_edges == {("account",): "inner"}
+        assert list(q._joins) == [("account",)]
+
+    def test_join_selector_rejecting_column_and_non_relation(self):
+        with pytest.raises(TypeError, match="not a relation"):
+            Query(QJTransaction).join(lambda t: t.account.label)  # type: ignore[arg-type,return-value]
+        with pytest.raises(TypeError, match="must return a relation path"):
+            Query(QJTransaction).left_join(lambda t: 5)  # type: ignore[arg-type,return-value]
+
+    def test_chainers_are_immutable(self):
+        base = Query(QJTransaction).where(lambda t: t.amount >= 10)
+        branched = base.left_join(lambda t: t.account)
+        assert base._joins == {}
+        assert base._explicit_edges == {}
+        assert list(branched._joins) == [("account",)]
+        assert branched._explicit_edges == {("account",): "left"}
+        assert base._explicit_edges is not branched._explicit_edges
+
+
+# ---------------------------------------------------------------------------
+# Explicit join()/left_join() behavior against real backends (#272): existence
+# filtering, NULL retention in ordered results and traversal predicates, and
+# whole-path LEFT retaining rows missing the relation at either hop.
+# ---------------------------------------------------------------------------
+
+
+async def _seed_notes(core):
+    """One note attached to a1, one orphan (nullable FK left NULL)."""
+    await QJNote(id=1, body="attached", account=core["a1"]).save()
+    await QJNote(id=2, body="orphan", account=None).save()
+
+
+@pytest.mark.asyncio
+async def test_bare_join_is_existence_filter(db_url):
+    """``.join(lambda n: n.account)`` with no predicate narrows to rows where
+    the nullable relation exists; count() agrees."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        core = await _seed_core()
+        await _seed_notes(core)
+
+        rows = await QJNote.select().join(lambda n: n.account).all()
+        assert {r.id for r in rows} == {1}
+        count = await QJNote.select().join(lambda n: n.account).count()
+        assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_left_join_retains_relation_less_rows(db_url):
+    """A bare ``.left_join`` retains the orphan row (NULL-FK), unlike ``.join``."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        core = await _seed_core()
+        await _seed_notes(core)
+
+        rows = await QJNote.select().left_join(lambda n: n.account).all()
+        assert {r.id for r in rows} == {1, 2}
+        assert await QJNote.select().left_join(lambda n: n.account).count() == 2
+
+
+@pytest.mark.asyncio
+async def test_left_join_null_retention_in_ordered_results(db_url):
+    """left_join + order_by on a RELATED column retains the NULL-FK row. NULL
+    placement diverges by dialect (ADR-0006: Postgres NULLs last on ASC, SQLite
+    first), so assert the full row set + the non-NULL order per-backend."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        core = await _seed_core()
+        # Two attached notes (a1 "a1", a2 "a2") + one orphan → non-NULL order a1,a2.
+        await QJNote(id=1, body="attached-a1", account=core["a1"]).save()
+        await QJNote(id=2, body="attached-a2", account=core["a2"]).save()
+        await QJNote(id=3, body="orphan", account=None).save()
+
+        rows = await (
+            QJNote.select()
+            .left_join(lambda n: n.account)
+            .order_by(lambda n: n.account.label)
+            .all()
+        )
+        ids = [r.id for r in rows]
+        # Full set retained (orphan kept by LEFT join).
+        assert set(ids) == {1, 2, 3}
+        # Non-NULL rows keep their relative order (label a1 < a2 → id 1 before 2).
+        assert ids.index(1) < ids.index(2)
+        # NULL-FK row's position is dialect-specific but deterministic.
+        if db_url.startswith("postgres"):
+            assert ids == [1, 2, 3]  # NULLs last on ASC
+        else:
+            assert ids == [3, 1, 2]  # SQLite sorts NULLs first
+
+
+@pytest.mark.asyncio
+async def test_left_join_null_retention_in_traversal_predicate(db_url):
+    """left_join + ``where(n.account.name == None)`` returns exactly the
+    relation-less rows (IS NULL on the joined alias column)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        core = await _seed_core()
+        await _seed_notes(core)
+
+        rows = await (
+            QJNote.select()
+            .left_join(lambda n: n.account)
+            .where(lambda n: n.account.label == None)  # noqa: E711
+            .all()
+        )
+        assert {r.id for r in rows} == {2}
+
+
+async def _seed_docs():
+    """Three docs spanning every hole a 2-hop path can have.
+
+    Doc 1 -> folder f1 -> owner ow (relation present at both hops);
+    doc 2 -> no folder (missing at hop 1);
+    doc 3 -> folder f2 whose owner FK is NULL (missing at hop 2).
+    """
+    ow = QJFolderOwner(id=1, name="ow")
+    await ow.save()
+    f1 = QJFolder(id=1, label="owned", owner=ow)
+    f2 = QJFolder(id=2, label="ownerless", owner=None)
+    await f1.save()
+    await f2.save()
+    await QJDoc(id=1, title="both-hops", folder=f1).save()
+    await QJDoc(id=2, title="no-folder", folder=None).save()
+    await QJDoc(id=3, title="folder-no-owner", folder=f2).save()
+
+
+@pytest.mark.asyncio
+async def test_whole_path_left_retains_rows_missing_at_either_hop(db_url):
+    """A left-marked 2-hop path retains rows missing the relation at hop 1 AND
+    rows missing at hop 2 (whole-path LEFT, ADR-0006)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_docs()
+
+        rows = await QJDoc.select().left_join(lambda d: d.folder.owner).all()
+        # Whole-path LEFT: both edges LEFT → the hop-1-missing doc (no folder)
+        # AND the hop-2-missing doc (folder without owner) are retained.
+        assert {r.id for r in rows} == {1, 2, 3}
+        count = await QJDoc.select().left_join(lambda d: d.folder.owner).count()
+        assert count == 3
+
+
+@pytest.mark.asyncio
+async def test_whole_path_left_traversal_predicate_matches_either_hop_holes(db_url):
+    """left_join(2-hop) + ``where(d.folder.owner.name == None)`` returns exactly
+    the rows missing the relation at either hop (IS NULL on the hop-2 alias)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_docs()
+
+        rows = await (
+            QJDoc.select()
+            .left_join(lambda d: d.folder.owner)
+            .where(lambda d: d.folder.owner.name == None)  # noqa: E711
+            .all()
+        )
+        # Missing at hop 1 (doc 2) and missing at hop 2 (doc 3); doc 1 resolves
+        # a non-NULL owner name and is excluded.
+        assert {r.id for r in rows} == {2, 3}
+
+
+@pytest.mark.asyncio
+async def test_explicit_left_plus_implicit_traversal_renders_left(db_url):
+    """Explicit ``.left_join`` on a path also traversed implicitly by ``where``
+    renders LEFT — the IS NULL predicate keeps the NULL-FK row (#272)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        core = await _seed_core()
+        await _seed_notes(core)
+
+        # where() alone would render INNER and drop the orphan; left_join lifts
+        # the shared edge to LEFT so the IS NULL match survives.
+        rows = await (
+            QJNote.select()
+            .where(lambda n: n.account.label == None)  # noqa: E711
+            .left_join(lambda n: n.account)
+            .all()
+        )
+        assert {r.id for r in rows} == {2}

--- a/tests/test_relation_specs.py
+++ b/tests/test_relation_specs.py
@@ -1,0 +1,175 @@
+"""RelationSpec: forward-FK traversal facts at resolved registration (#268).
+
+Prefactor for query-time joins (PRD #267 stage 1) — a per-model lookup of
+declared forward-FK relations (field name -> target model, shadow FK column,
+nullability), authoritative once ``resolve_relationships()`` has run. Zero
+behavior change: this only adds ``cls.__ferro_relation_specs__`` alongside the
+existing ``__ferro_columns__``.
+"""
+
+from typing import Annotated
+
+from ferro import BackRef, ForeignKey, ManyToMany, Model, Relation
+from ferro.base import FerroField
+from ferro.columns import RelationSpec
+
+
+class TestRelationSpecBasics:
+    def test_single_fk_produces_relation_spec(self, clean_registry):
+        class Account(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            entries: Relation[list["Entry"]] = BackRef()
+
+        class Entry(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            account: Annotated[Account, ForeignKey(related_name="entries")]
+
+        specs = Entry.__ferro_relation_specs__
+        assert set(specs) == {"account"}
+        spec = specs["account"]
+        assert spec.field_name == "account"
+        assert spec.target is Account
+        assert spec.shadow_column == "account_id"
+        assert isinstance(spec, RelationSpec)
+
+    def test_model_with_no_relations_has_empty_dict(self, clean_registry):
+        class NoRelations(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            name: str
+
+        assert NoRelations.__ferro_relation_specs__ == {}
+
+    def test_every_model_has_the_attribute(self, clean_registry):
+        # No hasattr guards required by consumers (design pin).
+        class Bare(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+
+        assert hasattr(Bare, "__ferro_relation_specs__")
+        assert Bare.__ferro_relation_specs__ == {}
+
+
+class TestNullability:
+    def test_nullable_fk(self, clean_registry):
+        class Org(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            projects: Relation[list["Project"]] = BackRef()
+
+        class Project(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            org: Annotated[Org | None, ForeignKey(related_name="projects")] = None
+
+        assert Project.__ferro_relation_specs__["org"].nullable is True
+
+    def test_non_nullable_fk(self, clean_registry):
+        class Org(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            projects: Relation[list["Project"]] = BackRef()
+
+        class Project(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            org: Annotated[Org, ForeignKey(related_name="projects")]
+
+        assert Project.__ferro_relation_specs__["org"].nullable is False
+
+    def test_nullable_matches_compiled_shadow_column_spec(self, clean_registry):
+        """Single-source: RelationSpec.nullable must equal the shadow ColumnSpec's."""
+
+        class Org(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            projects: Relation[list["Project"]] = BackRef()
+
+        class Project(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            org: Annotated[Org | None, ForeignKey(related_name="projects")] = None
+
+        rel_spec = Project.__ferro_relation_specs__["org"]
+        col_spec = Project.__ferro_columns__[rel_spec.shadow_column]
+        assert rel_spec.nullable == col_spec.nullable
+
+
+class TestMultipleAndSelfReferentialFKs:
+    def test_two_fks_to_same_target_are_distinguishable(self, clean_registry):
+        class Account(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+
+        class Transfer(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            from_account: Annotated[Account, ForeignKey(related_name="transfers_out")]
+            to_account: Annotated[Account, ForeignKey(related_name="transfers_in")]
+
+        specs = Transfer.__ferro_relation_specs__
+        assert set(specs) == {"from_account", "to_account"}
+        assert specs["from_account"].shadow_column == "from_account_id"
+        assert specs["to_account"].shadow_column == "to_account_id"
+        assert specs["from_account"].target is Account
+        assert specs["to_account"].target is Account
+        assert specs["from_account"] != specs["to_account"]
+
+    def test_self_referential_fk(self, clean_registry):
+        from ferro.relations import resolve_relationships
+
+        class Employee(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            manager: Annotated["Employee", ForeignKey(related_name="reports")]
+            reports: Relation[list["Employee"]] = BackRef()
+
+        # A self-FK is necessarily a forward (string) ref at class-body time —
+        # the class doesn't exist yet — so the spec only completes once
+        # resolve_relationships() binds ``rel.to`` to the real class.
+        resolve_relationships()
+
+        specs = Employee.__ferro_relation_specs__
+        assert set(specs) == {"manager"}
+        spec = specs["manager"]
+        assert spec.target is Employee
+        assert spec.shadow_column == "manager_id"
+        assert spec.nullable is False
+
+
+class TestExclusions:
+    def test_many_to_many_field_absent_from_lookup(self, clean_registry):
+        class Tag(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            posts: Relation[list["Post"]] = BackRef()
+
+        class Post(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            tags: Relation[list[Tag]] = ManyToMany(related_name="posts")
+
+        assert Post.__ferro_relation_specs__ == {}
+
+    def test_back_ref_field_absent_from_lookup(self, clean_registry):
+        class Author(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            books: Relation[list["Book"]] = BackRef()
+
+        class Book(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            author: Annotated[Author, ForeignKey(related_name="books")]
+
+        assert "books" not in Author.__ferro_relation_specs__
+
+
+class TestProvisionalVsResolved:
+    def test_forward_ref_fk_is_complete_once_resolved(self, clean_registry):
+        """Before resolve_relationships(), the target may not yet be a real class;
+        after resolution the lookup must be complete and correct (design pin)."""
+        from ferro.relations import resolve_relationships
+
+        class FwdChild(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            parent: Annotated["FwdParent", ForeignKey(related_name="children")]
+
+        class FwdParent(Model):
+            id: Annotated[int | None, FerroField(primary_key=True)] = None
+            children: Relation[list["FwdChild"]] = BackRef()
+
+        # Attribute exists pre-resolution regardless of contents (invariant).
+        assert hasattr(FwdChild, "__ferro_relation_specs__")
+
+        resolve_relationships()
+
+        specs = FwdChild.__ferro_relation_specs__
+        assert set(specs) == {"parent"}
+        assert specs["parent"].target is FwdParent
+        assert specs["parent"].shadow_column == "parent_id"


### PR DESCRIPTION
Stage 1 of query-time joins (#267): lambda predicates learn **relation traversal**, so the value you filter or sort by no longer has to live on the root model.

```python
transactions = await (
    Transaction
    .where(lambda t: (t.account.ledger_id == ledger_id) & (t.date >= since))
    .order_by(lambda t: t.date, "desc")
    .limit(50)
    .all()
)
```

renders one statement — the motivating Pinch tenancy query:

```sql
SELECT "transaction".* FROM "transaction"
INNER JOIN "account" AS "j1_account" ON "transaction"."account_id" = "j1_account"."id"
WHERE "j1_account"."ledger_id" = $1 AND "transaction"."date" >= $2
ORDER BY "transaction"."date" DESC LIMIT 50
```

Traversal is unlimited-depth (`t.account.owner.email`), validates every hop at build time with did-you-mean, and queries stay **shape-preserving**: a query over `Transaction` returns `Transaction` instances, always (stage-2 hydration is separate and blocked on partial materialization — #267 stays open).

## Semantics (ADR-0006)

- **Always INNER, at every hop** — FK nullability never changes join type; traversing a nullable relation narrows to rows where the relation exists.
- **`.left_join(lambda t: t.account)`** is the explicit opt-out and marks **every edge of its path** LEFT; explicit LEFT beats implicit INNER on a shared edge; explicit `.join` + `.left_join` on one edge is a build-time `ValueError`.
- **No alias surface** — the relation path *is* the join identity: same path anywhere in a query = one join; two FKs to one target and self-FKs traverse independently by field name with internal deterministic aliases (`j1_account`, …).
- **Join-free sugar** — `t.account == instance` desugars to a shadow-FK comparison, `t.account == None` to `IS NULL`; unpersisted instances error at build time naming the model.
- **Guardrails** — bare relation misuse raises pointed `TypeError`s; `and`/`or` misuse raises via `QueryNode.__bool__`; `update()`/`delete()` with traversed predicates raise `ValueError` before any SQL.
- **No row multiplication** — forward-FK hops are many-to-one, so `count()` stays plain `COUNT` and equals the matching root-row count.

## Contract

QueryIR envelope bumps to **v2 unconditionally** (single supported version — Python and Rust ship in one wheel): payload gains a `joins` section (join type + ordered hop list per relation path) and every column reference carries a relation path (`[]` = root). Rust rejects v1 with an actionable message. Typed binds and the Postgres enum catalog resolve against each column's **owning hop model** (not the root), so traversed `datetime`/`uuid`/enum/`decimal` filters bind correctly on both backends — including same-name/different-type collisions between root and related columns.

## Commits (one slice per sub-issue, in dependency order)

- `30ce870` #268 — RelationSpec lookup at resolved registration (prefactor, zero behavior change)
- `673e8dd` #269 — QueryIR v2: unconditional bump, path-qualified references, root-alias SQL qualification
- `32a2bf7` #270 — traversal in `where()`: relation proxies, per-hop did-you-mean, INNER join rendering, dedup, static chainable typing
- `c8d4f59` #271 — `order_by` on related columns, join sharing with `where`
- `6dbb5d2` #272 — `join()`/`left_join()` chainers, whole-path LEFT, order-independent per-edge resolution
- `27f5e17` #273 — relation-proxy sugar and guardrails, M2M-context composition
- `bdf6d45` #274 — docs: traversal guide rewrite, typing promise, API chainers
- `452bbcb`/`68da9f1`/`9429723` — final-review fixes: per-hop typed binds + enum catalogs (with matrix pins for traversed datetime/uuid/enum/decimal and name-collision), assertion tightening, AGENTS.md I-8 order_by correction

**Please REBASE-merge** — each commit is conventional, issue-referenced, and drives the changelog.

## Testing

- 105 new tests. Backend matrix (SQLite + isolated-schema Postgres): 1314 passed, 11 skipped, 1 xfailed — includes ~70 traversal integration tests asserting result sets/ordering (two-FK transfer pairs, self-FK, whole-path LEFT retention at either hop, dialect NULL-ordering, M2M+traversal, typed-bind coverage).
- Rust walker unit tests pin rendered SQL: alias assignment, qualification, prefix dedup, LEFT edge resolution (both wire orders), join-free instance-equality.
- Golden v2 IR vectors (multi-hop, LEFT-marked, order-by path) with Rust round-trip pins; v1 rejection contract test.
- Static gate (`ty`): chainable proxy typing, good 1-hop/multi-hop fixtures; bare-relation-as-predicate still fails the gate.
- Docs build green; runnable examples in both declaration styles exercised by the docs test suite.

## Exit steps

- [x] All seven sub-issue acceptance criteria verified per slice (task-scoped reviews) + final whole-branch review
- [x] Full backend matrix, cargo, ty, docs build green at merge tip
- [x] Issue closure encoded below (#267 remains open — stage 2 is blocked on partial materialization)

Closes #268
Closes #269
Closes #270
Closes #271
Closes #272
Closes #273
Closes #274
