### PR TITLE
feat: partial materialization — QueryIR v3 + partial selects (Rows/Row)

### DIFF
--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -420,6 +420,34 @@ mod tests {
     }
 
     #[test]
+    fn query_record_fixture_roundtrip() {
+        // The record-plan golden vector (#279): a projected query's full
+        // payload — predicate, order, limit, and a two-field record plan —
+        // survives a deserialize/serialize round-trip without drift.
+        let fixture =
+            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_record_v3.json");
+        let parsed: serde_json::Value =
+            serde_json::from_str(fixture).expect("query record fixture must parse");
+        let ir = parsed
+            .get("ir")
+            .cloned()
+            .expect("fixture must contain ir envelope");
+        let envelope: IrEnvelope<QueryIrPayload> =
+            serde_json::from_value(ir.clone()).expect("query record IR must deserialize");
+        let Materialization::Record { fields } = &envelope.payload.materialization else {
+            panic!(
+                "expected a record plan, got {:?}",
+                envelope.payload.materialization
+            );
+        };
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].name, "id");
+        assert_eq!(fields[1].name, "amount");
+        let encoded = serde_json::to_value(&envelope).expect("query record IR must serialize");
+        assert_eq!(encoded, ir, "query record round-trip must not drift");
+    }
+
+    #[test]
     fn record_materialization_roundtrips() {
         // The `record` kind deserializes today (#278) even though the runtime
         // rejects it until #279 builds the record walker: the types are the

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -134,11 +134,14 @@ pub struct SchemaCheck {
     pub values: Vec<String>,
 }
 
-/// Query IR: filter, sort, pagination, joins, and optional M2M join context.
+/// Query IR: filter, sort, pagination, joins, materialization plan, and
+/// optional M2M join context.
 ///
-/// `ir_version: 2` (unconditional, no v1 emitted anywhere — #269). `joins` is
-/// required and always present (`[]` until #270 renders real JOINs); every leaf
-/// and `order_by` entry carries a `path` (required, `[]` = root model).
+/// `ir_version: 3` (unconditional, no v1/v2 emitted anywhere — #269, #278).
+/// `joins` is required and always present (`[]` when the query traverses no
+/// relation); every leaf and `order_by` entry carries a `path` (required,
+/// `[]` = root model); `materialization` is required — the plan travels with
+/// the query as data (ADR-0007), never inferred from a column list.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueryIrPayload {
     /// Model class name the query targets.
@@ -156,6 +159,56 @@ pub struct QueryIrPayload {
     pub m2m: Option<Value>,
     /// Relation joins collected from traversal (`[]` until #270 renders them).
     pub joins: Vec<QueryJoin>,
+    /// What the query's result columns become (required in v3, ADR-0007).
+    pub materialization: Materialization,
+}
+
+/// A query's materialization plan (ADR-0007): what its result columns become.
+///
+/// Every v3 query carries exactly one plan. `root_instances` is complete
+/// root-model rows hydrated into model instances — the default and the only
+/// plan the non-projecting walkers accept. `record` is partial selects: a
+/// typed column subset decoded into projected records (#279). `instances`
+/// (populated instance graphs, joined-row hydration) is declared here so the
+/// hydration ABI grows once, but every walker rejects it loudly until
+/// #267 stage 2 builds it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind")]
+pub enum Materialization {
+    /// Complete root-model instances — one full row per result (the default).
+    #[serde(rename = "root_instances")]
+    RootInstances,
+    /// Projected records: a typed column subset decoded into `Row` records.
+    #[serde(rename = "record")]
+    Record {
+        /// Projected fields in selection order.
+        fields: Vec<RecordField>,
+    },
+    /// Populated instance graphs (joined-row hydration, #267 stage 2).
+    /// Declared-but-rejected until that epic builds it.
+    #[serde(rename = "instances")]
+    Instances,
+}
+
+/// One projected field in a [`Materialization::Record`] plan.
+///
+/// `name` is declared separately from the source `column`, the field carries a
+/// relation `path`, and may later carry an `expr` instead of a column — so
+/// output aliases, traversed projection, and aggregations (#282) extend this
+/// shape additively without reshaping the v3 contract.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RecordField {
+    /// Output field name on the projected record.
+    pub name: String,
+    /// Source column the value reads from (`name == column` until output
+    /// aliases land with #282).
+    pub column: String,
+    /// Relation path from the root model to `column`'s table (`[]` = root
+    /// model; non-empty paths are traversed projection, #282).
+    pub path: Vec<String>,
+    /// Reserved: expression source instead of a column (aggregations, #282).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expr: Option<Value>,
 }
 
 /// One relation JOIN collected from query-time traversal (#270 lands rendering).
@@ -297,7 +350,7 @@ mod tests {
     #[test]
     fn query_fixture_roundtrip() {
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_user_compound_v2.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_user_compound_v3.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query fixture must parse");
         let ir = parsed
@@ -306,6 +359,11 @@ mod tests {
             .expect("fixture must contain ir envelope");
         let envelope: IrEnvelope<QueryIrPayload> =
             serde_json::from_value(ir.clone()).expect("query IR must deserialize");
+        // v3 (#278): the materialization plan travels with the query.
+        assert_eq!(
+            envelope.payload.materialization,
+            Materialization::RootInstances
+        );
         let encoded = serde_json::to_value(&envelope).expect("query IR must serialize");
         assert_eq!(encoded, ir, "query round-trip must not drift");
     }
@@ -315,7 +373,7 @@ mod tests {
         // Multi-hop `joins` section + path-carrying leaves must survive a
         // deserialize/serialize round-trip without drift (#270 wire stability).
         let fixture = include_str!(
-            "../../../tests/fixtures/ir_vectors/query_transaction_traversal_v2.json"
+            "../../../tests/fixtures/ir_vectors/query_transaction_traversal_v3.json"
         );
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query traversal fixture must parse");
@@ -341,7 +399,7 @@ mod tests {
         // deserialize/serialize round-trip without drift, and the join_type
         // tokens must reach Rust exactly as written on the wire.
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_left_join_v2.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_left_join_v3.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query left_join fixture must parse");
         let ir = parsed
@@ -359,6 +417,58 @@ mod tests {
         assert_eq!(envelope.payload.joins[1].path.len(), 2);
         let encoded = serde_json::to_value(&envelope).expect("query left_join IR must serialize");
         assert_eq!(encoded, ir, "query left_join round-trip must not drift");
+    }
+
+    #[test]
+    fn record_materialization_roundtrips() {
+        // The `record` kind deserializes today (#278) even though the runtime
+        // rejects it until #279 builds the record walker: the types are the
+        // contract, the walkers are the implementation.
+        let wire = serde_json::json!({
+            "kind": "record",
+            "fields": [
+                {"name": "id", "column": "id", "path": []},
+                {"name": "amount", "column": "amount", "path": []}
+            ]
+        });
+        let plan: Materialization =
+            serde_json::from_value(wire.clone()).expect("record kind must deserialize");
+        let Materialization::Record { fields } = &plan else {
+            panic!("expected Record, got {plan:?}");
+        };
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].name, "id");
+        assert_eq!(fields[0].column, "id");
+        assert!(fields[0].path.is_empty());
+        assert!(fields[0].expr.is_none(), "expr is reserved and absent");
+        let encoded = serde_json::to_value(&plan).expect("record kind must serialize");
+        assert_eq!(encoded, wire, "record round-trip must not drift");
+    }
+
+    #[test]
+    fn instances_materialization_roundtrips() {
+        // `instances` is declared-but-rejected (#267 stage 2): it must
+        // deserialize so the hydration ABI grows once, and the runtime — not
+        // the type layer — is what rejects it.
+        let wire = serde_json::json!({"kind": "instances"});
+        let plan: Materialization =
+            serde_json::from_value(wire.clone()).expect("instances kind must deserialize");
+        assert_eq!(plan, Materialization::Instances);
+        let encoded = serde_json::to_value(&plan).expect("instances kind must serialize");
+        assert_eq!(encoded, wire, "instances round-trip must not drift");
+    }
+
+    #[test]
+    fn unknown_materialization_kind_is_rejected() {
+        let err =
+            serde_json::from_value::<Materialization>(serde_json::json!({"kind": "row_dicts"}))
+                .expect_err("an unknown materialization kind must fail to deserialize");
+        let msg = err.to_string();
+        assert!(msg.contains("row_dicts"), "must name the bad kind: {msg}");
+        assert!(
+            msg.contains("root_instances") && msg.contains("record") && msg.contains("instances"),
+            "must name the supported kinds: {msg}"
+        );
     }
 
     #[test]

--- a/docs/examples/partial_selects.py
+++ b/docs/examples/partial_selects.py
@@ -1,0 +1,107 @@
+"""Runnable companion to the "Selecting a Column Subset" guide section
+(docs/pages/guide/queries.md).
+
+Seeds a small transactions table, then runs every partial-select query the
+guide shows and asserts the exact records that come back.
+"""
+
+import asyncio
+from typing import Annotated
+
+from ferro import BackRef, Field, ForeignKey, Model, Relation, Rows, connect, engines
+
+
+# --8<-- [start:schema]
+class Account(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    label: str
+    transactions: Relation[list["Transaction"]] = BackRef()
+
+
+class Transaction(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    amount: int
+    memo: str
+    account: Annotated[Account, ForeignKey(related_name="transactions")]
+# --8<-- [end:schema]
+
+
+async def main() -> None:
+    await connect("sqlite::memory:", auto_migrate=True)
+
+    async with engines.session():
+        a1 = await Account.create(id=1, label="a1")
+        b1 = await Account.create(id=2, label="b1")
+        await Transaction.create(id=1, amount=10, memo="coffee", account=a1)
+        await Transaction.create(id=2, amount=20, memo="lunch", account=a1)
+        await Transaction.create(id=3, amount=30, memo="dinner", account=b1)
+
+        # --8<-- [start:basic]
+        rows = await Transaction.select(lambda t: (t.id, t.amount)).all()
+
+        rows[0].amount  # attribute access, like a model
+        rows.model_dump()  # [{"id": 1, "amount": 10}, ...]
+        # --8<-- [end:basic]
+        assert {(r.id, r.amount) for r in rows} == {(1, 10), (2, 20), (3, 30)}
+        assert rows[0].model_dump() == {"id": rows[0].id, "amount": rows[0].amount}
+
+        # --8<-- [start:not-a-model]
+        row = rows[0]
+        assert not isinstance(row, Transaction)  # a Row, not a Transaction
+        assert not hasattr(row, "save")  # records cannot be persisted
+        # --8<-- [end:not-a-model]
+
+        # --8<-- [start:single]
+        amounts = await Transaction.select(lambda t: t.amount).order_by("amount").all()
+        assert [r.amount for r in amounts] == [10, 20, 30]
+        # --8<-- [end:single]
+
+        # --8<-- [start:container]
+        newest = await (
+            Transaction.select(lambda t: (t.id, t.memo)).order_by("id", "desc").all()
+        )
+
+        assert len(newest) == 3  # list-like: len ...
+        assert newest[0].memo == "dinner"  # ... index ...
+        top_two = newest[:2]  # ... and slice (a Rows again)
+        assert isinstance(top_two, Rows)
+        assert top_two.model_dump() == [
+            {"id": 3, "memo": "dinner"},
+            {"id": 2, "memo": "lunch"},
+        ]
+        # --8<-- [end:container]
+
+        # --8<-- [start:strings]
+        rows = await Transaction.select("id", "amount").order_by("id").all()
+        assert rows[0].model_dump() == {"id": 1, "amount": 10}
+        # --8<-- [end:strings]
+
+        # --8<-- [start:compose]
+        # Projection composes with everything a read query can do: traversal
+        # predicates, ordering by unselected columns, limit/offset, first().
+        rows = await (
+            Transaction.select(lambda t: (t.id, t.memo))
+            .where(lambda t: t.account.label == "a1")
+            .order_by("amount", "desc")  # amount is not selected — still sorts
+            .limit(1)
+            .all()
+        )
+        assert rows.model_dump() == [{"id": 2, "memo": "lunch"}]
+
+        row = await Transaction.select(lambda t: t.memo).order_by("id").first()
+        assert row is not None and row.memo == "coffee"
+        # --8<-- [end:compose]
+
+        # --8<-- [start:count]
+        # count()/exists() are unaffected by projection: they measure the
+        # same matching rows a full query would.
+        q = Transaction.select(lambda t: (t.id,)).where(lambda t: t.amount >= 20)
+        assert await q.count() == 2
+        assert await q.exists() is True
+        # --8<-- [end:count]
+
+    print("partial_selects example ran successfully")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/examples/partial_selects_annotated.py
+++ b/docs/examples/partial_selects_annotated.py
@@ -1,0 +1,43 @@
+"""Annotated-style companion to partial_selects.py (AGENTS.md I-7).
+
+Field options move into ``Annotated[...]``. Projection is independent of the
+declaration style — the queries are identical in both — so only the schema and
+one round-trip live here.
+"""
+
+import asyncio
+from typing import Annotated
+
+from ferro import BackRef, Field, ForeignKey, Model, Relation, connect, engines
+
+
+# --8<-- [start:schema]
+class Account(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    label: str
+    transactions: Relation[list["Transaction"]] = BackRef()
+
+
+class Transaction(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    amount: int
+    memo: str
+    account: Annotated[Account, ForeignKey(related_name="transactions")]
+# --8<-- [end:schema]
+
+
+async def main() -> None:
+    await connect("sqlite::memory:", auto_migrate=True)
+
+    async with engines.session():
+        a1 = await Account.create(id=1, label="a1")
+        await Transaction.create(id=1, amount=10, memo="coffee", account=a1)
+
+        rows = await Transaction.select(lambda t: (t.id, t.amount)).all()
+        assert rows.model_dump() == [{"id": 1, "amount": 10}]
+
+    print("partial_selects_annotated example ran successfully")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/pages/api/queries.md
+++ b/docs/pages/api/queries.md
@@ -4,8 +4,28 @@
 
 `where()` and `order_by()` lambdas may **traverse** a forward-FK relation (`lambda t: t.account.ledger_id == 1`): each hop renders one INNER join, deduplicated by relation path (ADR-0006). `join()` forces a join on a relation path (a bare `join()` is an existence filter on a nullable relation), and `left_join()` marks the whole path LEFT to keep relation-less rows. See the [Querying Across Relationships](../guide/queries.md#querying-across-relationships) guide for worked examples.
 
+## `select()` overloads
+
+`select()` has three forms, resolved at build time:
+
+| Call | Returns | Result of `.all()` |
+| :--- | :--- | :--- |
+| `Model.select()` | `Query[Model]` | `list[Model]` — the full query, unchanged. |
+| `Model.select(lambda t: (t.id, t.amount))` | `ProjectedQuery[Model]` | `Rows[Row]` — projected records (single-field form: `select(lambda t: t.amount)`). |
+| `Model.select("id", "amount")` | `ProjectedQuery[Model]` | `Rows[Row]` — `order_by()`'s string contract: root columns only, never mixed with a lambda. |
+
+A `ProjectedQuery` composes like any `Query` (`where()` with traversal, `order_by()` by unselected columns, `limit()`/`offset()`, `first()`, `count()`, `exists()`); `update()`/`delete()` and a second `select()` raise at build time. See [Selecting a Column Subset](../guide/queries.md#selecting-a-column-subset) for worked examples and the complete-instance invariant behind the `Row` result shape.
+
 ::: ferro.query.builder.Query
+
+::: ferro.query.builder.ProjectedQuery
+
+::: ferro.query.Row
+
+::: ferro.query.Rows
 
 ::: ferro.query.QueryProxy
 
 ::: ferro.query.Predicate
+
+::: ferro.query.RowSelector

--- a/docs/pages/concepts/query-typing.md
+++ b/docs/pages/concepts/query-typing.md
@@ -48,6 +48,32 @@ The static gate checks the **shape** of the predicate, not the **names** in it:
 - **A bare relation as a predicate fails the checker.** `lambda transaction: transaction.account` returns a proxy, not a `QueryNode`, so it is a type error — the same failure mode as `lambda user: True`.
 - **Name typos are caught at build time, not by the checker.** A misspelled hop (`transaction.accont`, `account.emial`) is `FieldProxy[Any]` to the type checker, so it type-checks; at build time the proxy validates every hop against the real model and raises `AttributeError` with a did-you-mean naming that hop's model. The static gate guarantees shape; the runtime proxy guarantees names.
 
+## Projected Queries
+
+Partial selects extend the same shape-not-names promise through projection.
+`select(...)` with a selector flips the query's static type from
+`Query[Model]` to `ProjectedQuery[Model]`, so the terminals change shape:
+`.all()` checks as `Rows[Row]` and `.first()` as `Row | None` — never
+`list[Model]`:
+
+```python
+rows = await Transaction.select(lambda t: (t.id, t.amount)).all()  # Rows[Row]
+row = await Transaction.select(lambda t: t.amount).first()  # Row | None
+full = await Transaction.select().all()  # list[Transaction] — bare form unchanged
+```
+
+The gate divides the work exactly like predicates do:
+
+- **Shape is checked statically.** Passing a `Row` where a model instance is
+  expected fails the checker (`list[Transaction] = await
+  Transaction.select(lambda t: (t.id,)).all()` is an `invalid-assignment`),
+  and mutating a projected query (`.update()` / `.delete()`) is a static
+  error at the call site as well as a build-time `ValueError`.
+- **Names are checked at build time.** A selected column is `FieldProxy[Any]`
+  to the checker; a misspelled column raises `AttributeError` with a
+  did-you-mean when the query is built, before any round-trip — the same
+  runtime validation as `where()` and `order_by()`.
+
 ## What This Doesn't Change
 
 - Your model annotations. `archived: bool = False` stays exactly as it is.
@@ -59,6 +85,8 @@ The static gate checks the **shape** of the predicate, not the **names** in it:
 - `ferro.query.QueryProxy` — validating attribute proxy passed to lambda predicates.
 - `ferro.query.Predicate` — `Callable[[QueryProxy[TModel]], QueryNode]`, the type of any lambda predicate.
 - `ferro.query.FieldProxy` — generic over the column's Python type (`FieldProxy[T]`); the mechanism a `QueryProxy` attribute access returns.
+- `ferro.query.RowSelector` — the type of a `select()` lambda selector: a callable returning one column or a tuple of columns.
+- `ferro.query.Row` / `ferro.query.Rows` — projected records and their list-like container, the result shape of a projected query.
 
 ## See Also
 

--- a/docs/pages/guide/queries.md
+++ b/docs/pages/guide/queries.md
@@ -146,6 +146,8 @@ Queries are lazy — nothing hits the database until you await a terminal:
 
 `Model.all()` is shorthand for `Model.select().all()`.
 
+On a **projected** query (`select(lambda t: (t.id, t.amount))`), `.all()` returns `Rows[Row]` and `.first()` returns `Row | None` — records, not model instances; `count()` and `exists()` are unchanged. See [Selecting a Column Subset](#selecting-a-column-subset).
+
 ## Querying Across Relationships
 
 A `where()` or `order_by()` lambda can reach *through* a `ForeignKey` to a column on the related model. Write the relation field, then keep going:
@@ -389,13 +391,99 @@ Do the two-step: fetch the primary keys with the joined query, then mutate by th
 
 See [Relationships](relationships.md) for the schema-declaration side of foreign keys and reverse relations.
 
+## Selecting a Column Subset
+
+Every query so far loads complete rows into complete model instances. When a list view only reads two columns of a wide table, ask for less: pass `select()` a lambda naming the columns, and the query becomes a **projection**:
+
+```python
+--8<-- "docs/examples/partial_selects.py:basic"
+```
+
+The examples in this section use this schema:
+
+=== "Assignment"
+
+    ```python
+    --8<-- "docs/examples/partial_selects.py:schema"
+    ```
+
+=== "Annotated"
+
+    ```python
+    --8<-- "docs/examples/partial_selects_annotated.py:schema"
+    ```
+
+### What you get back — and why it isn't a `Transaction`
+
+A projected query does **not** return `Transaction` instances. In Ferro, **a model instance always carries a complete row** — there is no such thing as a partial or deferred-field model instance, anywhere. If projection handed you a two-column `Transaction`, every `save()`, every refresh, and every helper that takes a model would have to wonder which query produced its argument, and touching an unselected field would blow up far from the query that caused it.
+
+So anything narrower than a full row comes back honestly typed as what it is: a **projected record** — a `Row`, delivered in the list-like `Rows` container:
+
+```python
+--8<-- "docs/examples/partial_selects.py:not-a-model"
+```
+
+A `Row` is read-only in the persistence sense: it has no `save()`, no refresh, and never enters the identity map — a record can never masquerade as a row in the database. It carries exactly the columns you selected, in selection order, decoded by the same machinery as full hydration — a projected `datetime`, `UUID`, enum, or `Decimal` column has the same Python type and value it would have on the model, on both backends. Under the hood the query declares this result shape explicitly (a *materialization plan* travels with the query), which is also why asking for less is never slower per row than asking for everything: records are built on the same zero-validation path as models.
+
+Selecting a single column needs no tuple ceremony:
+
+```python
+--8<-- "docs/examples/partial_selects.py:single"
+```
+
+### `Rows` is a list you can ship
+
+`Rows` behaves like a list — index, slice, iterate, `len()` — and both `Rows` and `Row` are pydantic-shaped: `model_dump()` yields `list[dict]`, and `Rows[Row]` drops straight into a FastAPI `response_model`:
+
+```python
+--8<-- "docs/examples/partial_selects.py:container"
+```
+
+### Column-name strings
+
+Quick scripts can pass column names as strings — the same string contract as `order_by()`: root columns only (shadow `{fk}_id` columns included), validated at build time. The lambda form remains the documented style:
+
+```python
+--8<-- "docs/examples/partial_selects.py:strings"
+```
+
+### Projections compose like any other query
+
+`where()` (relation traversal included), `order_by()` (even by columns the projection does not select), `limit()`/`offset()`, and `first()` all work unchanged; `count()` and `exists()` are unaffected by projection — they measure the same matching rows a full query would:
+
+```python
+--8<-- "docs/examples/partial_selects.py:compose"
+```
+
+```python
+--8<-- "docs/examples/partial_selects.py:count"
+```
+
+### Build-time validation and the loud limits
+
+A misspelled column fails when you build the query, with a did-you-mean — exactly like `where()` and `order_by()`:
+
+```text
+>>> Transaction.select(lambda t: (t.id, t.amonut))
+AttributeError: Transaction has no queryable column 'amonut'. Did you mean 'amount'? Valid columns: account_id, amount, id, memo.
+```
+
+Misuse is loud, never silently ignored:
+
+- **No traversed projection yet.** `select(lambda t: t.account.label)` raises `NotImplementedError` — projecting related columns is designed together with output aliases and aggregations. Dotted strings (`select("account.label")`) are rejected permanently; traversal will be lambda-only when it lands.
+- **No mutations through a projection.** `update()` / `delete()` on a projected query raise `ValueError` at the call, before any SQL — a projection is a read shape, and silently ignoring it would make `select(...)` a no-op on mutations. Mutate through an unprojected query instead.
+- **No double `select()`.** Replacing a projection mid-chain would change the result type; name every column in one call, or start a new query from the model.
+- **No mixing forms.** Strings and a lambda in one `select()` call raise `TypeError`.
+
+Static typing follows the same shape promise as predicates: `select(...)` flips the query's type so `.all()` checks as `Rows[Row]` and `.first()` as `Row | None` — passing a `Row` where a model instance is expected fails the type checker. See [Typed Query Predicates](../concepts/query-typing.md#projected-queries).
+
 ## Not Yet Supported
 
 !!! note "On the roadmap"
     The following query features are **not yet implemented** — see the [Roadmap](../roadmap.md):
 
     - Aggregations beyond `count()` / `exists()` (`sum`, `avg`, `min`, `max`, `GROUP BY`)
-    - Partial selects (selecting specific columns; queries always load all model fields)
+    - Traversed projection and output aliases (`select(lambda t: t.account.name)`) — designed together with aggregations
     - Eager loading (`prefetch_related` / `select_related`) — be mindful of N+1 patterns when looping over relations
     - Case-insensitive `ilike()`
     - `not_in()` (negate with `!=` conditions combined with `&` in the meantime)

--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -4,8 +4,7 @@ Ferro is pre-1.0 and under active development. The items below are known gaps we
 
 ## Query Features
 
-- **Aggregations beyond `count()`/`exists()`** — `sum`, `avg`, `min`, `max` on the query builder. Today you either compute in Python after fetching or drop to raw SQL.
-- **Partial selects** — loading a subset of columns (`User.select(User.id, User.username)`-style) instead of full models, for wide tables and hot read paths.
+- **Aggregations beyond `count()`/`exists()`** — `sum`, `avg`, `min`, `max` on the query builder, plus output aliases and traversed projection (`select(lambda t: t.account.name)`), designed together on the [partial-select](guide/queries.md#selecting-a-column-subset) substrate. Today you either compute in Python after fetching or drop to raw SQL.
 - **Eager loading** — `prefetch_related`/`select_related`-style relationship loading to eliminate N+1 query patterns. Today each awaited relationship attribute is its own query.
 - **`ilike()`** — case-insensitive pattern matching. Workaround: `like()` with normalized case.
 - **`not_in_()`** — NOT IN exclusion lists. Workaround: combine `!=` comparisons with `&`.

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -41,7 +41,7 @@ from .exceptions import (
 )
 from .fields import BackRef, Field, ManyToMany
 from .models import Model, evict_instance, transaction
-from .query import Relation
+from .query import Relation, Row, Rows
 from .raw import Transaction, execute, fetch_all, fetch_one
 from .session import Session, engines
 
@@ -344,6 +344,8 @@ __all__ = [
     "BackRef",
     "ManyToMany",
     "Relation",
+    "Row",
+    "Rows",
     "version",
     "create_tables",
     "migrate",

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -95,6 +95,7 @@ async def fetch_filtered(
     cls: object,
     query_ir_json: str,
     route: RouteHandle,
+    record_cls: type | None = None,
 ) -> list[Any]: ...
 async def count_filtered(
     name: str,

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -539,10 +539,16 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         cls, selector: "RowSelector[Self]", *, session: "Session | None" = None
     ) -> "ProjectedQuery[Self]": ...
 
+    @overload
+    @classmethod
+    def select(
+        cls, *columns: str, session: "Session | None" = None
+    ) -> "ProjectedQuery[Self]": ...
+
     @classmethod
     def select(
         cls,
-        *selectors: "RowSelector[Self]",
+        *selectors: "RowSelector[Self] | str",
         session: "Session | None" = None,
     ) -> "Query[Self] | ProjectedQuery[Self]":
         """Start a fluent query, optionally projected to a column subset.
@@ -553,8 +559,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         ``select(lambda t: t.amount)`` — the query is a projection: its
         results are :class:`~ferro.query.Row` records in the list-like
         :class:`~ferro.query.Rows` container, never model instances
-        (ADR-0007). Selected columns validate at build time with
-        did-you-mean.
+        (ADR-0007). Column-name strings (``select("id", "amount")``) follow
+        ``order_by``'s string contract: root columns only, never mixed with
+        a lambda. Both forms validate at build time with did-you-mean.
 
         Returns:
             A query object scoped to this model class; projected when a

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -8,11 +8,12 @@ from typing import (
     ClassVar,
     Literal,
     Self,
+    overload,
 )
 
 if TYPE_CHECKING:
     from .columns import ColumnSpec, RelationSpec
-    from .query import Predicate
+    from .query import Predicate, ProjectedQuery, RowSelector
     from .session import Session
 
 from pydantic import BaseModel, ConfigDict, model_validator
@@ -528,19 +529,44 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         """
         return Query(cls, session=session).where(predicate)
 
+    @overload
     @classmethod
-    def select(cls, *, session: "Session | None" = None) -> Query[Self]:
-        """Start an empty fluent query for this model class
+    def select(cls, *, session: "Session | None" = None) -> Query[Self]: ...
+
+    @overload
+    @classmethod
+    def select(
+        cls, selector: "RowSelector[Self]", *, session: "Session | None" = None
+    ) -> "ProjectedQuery[Self]": ...
+
+    @classmethod
+    def select(
+        cls,
+        *selectors: "RowSelector[Self]",
+        session: "Session | None" = None,
+    ) -> "Query[Self] | ProjectedQuery[Self]":
+        """Start a fluent query, optionally projected to a column subset.
+
+        Bare ``select()`` starts a full query of complete model instances
+        (unchanged). With a lambda selector —
+        ``select(lambda t: (t.id, t.amount))``, or the single-field form
+        ``select(lambda t: t.amount)`` — the query is a projection: its
+        results are :class:`~ferro.query.Row` records in the list-like
+        :class:`~ferro.query.Rows` container, never model instances
+        (ADR-0007). Selected columns validate at build time with
+        did-you-mean.
 
         Returns:
-            A query object scoped to this model class.
+            A query object scoped to this model class; projected when a
+            selector is given.
 
         Examples:
             >>> query = User.select().limit(5)
             >>> isinstance(query, Query)
             True
+            >>> rows = await Transaction.select(lambda t: (t.id, t.amount)).all()  # doctest: +SKIP
         """
-        return Query(cls, session=session)
+        return Query(cls, session=session).select(*selectors)
 
     @classmethod
     def using(cls, name: str) -> "ModelConnection[Self]":

--- a/src/ferro/query/__init__.py
+++ b/src/ferro/query/__init__.py
@@ -1,14 +1,26 @@
 """Expose query-building primitives used by Ferro models"""
 
-from .builder import Query, Relation
-from .nodes import FieldProxy, Predicate, QueryNode, QueryProxy, RelationProxy
+from .builder import ProjectedQuery, Query, Relation
+from .nodes import (
+    FieldProxy,
+    Predicate,
+    QueryNode,
+    QueryProxy,
+    RelationProxy,
+    RowSelector,
+)
+from .rows import Row, Rows
 
 __all__ = [
     "FieldProxy",
     "Predicate",
+    "ProjectedQuery",
     "Query",
     "QueryNode",
     "QueryProxy",
     "Relation",
     "RelationProxy",
+    "Row",
+    "RowSelector",
+    "Rows",
 ]

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -19,15 +19,22 @@ from .nodes import (
     QueryNode,
     QueryProxy,
     RelationProxy,
+    RowSelector,
     _serialize_query_value,
     validate_query_column,
 )
+from .rows import Row, Rows
 
 if TYPE_CHECKING:
     from .._core import RouteHandle
 
 T = TypeVar("T")
 E = TypeVar("E")
+
+# The concrete container type a projected query delivers (parameterized once
+# at import; `into=` record types would parameterize per call). Construction
+# always goes through Rows._wrap — never pydantic validation (ADR-0007).
+_ROWS_OF_ROW: type[Rows[Row]] = Rows[Row]
 
 
 def _query_ir_payload_to_json(query_payload: dict[str, Any]) -> str:
@@ -155,6 +162,76 @@ def _resolve_join_selector(
 def _path_edges(path: tuple[str, ...]) -> list[tuple[str, ...]]:
     """Every edge (prefix of length ≥ 1) of a relation ``path`` (#272)."""
     return [path[:i] for i in range(1, len(path) + 1)]
+
+
+def _resolve_projection_selector(
+    selector: "RowSelector[Any]", model_cls: type
+) -> tuple[str, ...]:
+    """Resolve a ``select()`` lambda selector into projected column names (#279).
+
+    ``selector`` receives a validating :class:`QueryProxy` and returns one
+    column (``lambda t: t.amount``) or a tuple/list of columns
+    (``lambda t: (t.id, t.amount)``). Column names validate at build time with
+    did-you-mean, exactly like ``where()``/``order_by()`` (the proxy raises
+    ``AttributeError`` on a misspelled name before any round-trip).
+
+    Returns:
+        The projected column names, in selection order.
+
+    Raises:
+        TypeError: If an element is a bare relation (``lambda t: t.account``),
+            a comparison (``lambda t: t.id == 1``), or any other non-column
+            value — a projection selects columns.
+        ValueError: If the selection is empty or names a column twice
+            (a duplicate would silently collapse in the record).
+        NotImplementedError: If a selected column traverses a relation
+            (``lambda t: t.account.name``) — traversed projection is designed
+            together with output aliases and aggregations (#282).
+    """
+    result = selector(QueryProxy(model_cls))
+    items = tuple(result) if isinstance(result, (tuple, list)) else (result,)
+    if not items:
+        raise ValueError(
+            "select() projection selected no columns; select at least one "
+            "(e.g. `lambda t: (t.id, t.amount)`), or call select() with no "
+            "arguments for the full query."
+        )
+    columns: list[str] = []
+    for item in items:
+        if isinstance(item, RelationProxy):
+            relation = item._path[-1]
+            raise TypeError(
+                f"select() cannot project the bare relation {relation!r}; "
+                f"select a column on it instead (traversed projection like "
+                f"t.{relation}.<column> is planned, see below) or select root "
+                "columns."
+            )
+        if isinstance(item, QueryNode):
+            raise TypeError(
+                "select() selector returned a comparison, not a column "
+                "(e.g. `lambda t: t.id == 1`); projections select columns "
+                "(`lambda t: t.id`) — put predicates in where()."
+            )
+        if not isinstance(item, FieldProxy):
+            raise TypeError(
+                "select() selector must return a column or a tuple of columns "
+                f"(e.g. `lambda t: (t.id, t.amount)`), got {type(item).__name__}"
+            )
+        if item.path:
+            dotted = ".".join((*item.path, item.column))
+            raise NotImplementedError(
+                f"select() cannot project the traversed column {dotted!r} yet: "
+                "traversed projection is designed together with output aliases "
+                "and aggregations (#282). Project root columns, or fetch the "
+                "related model through its own query."
+            )
+        if item.column in columns:
+            raise ValueError(
+                f"select() projects column {item.column!r} more than once; "
+                "each projected column must be unique."
+            )
+        columns.append(item.column)
+    return tuple(columns)
 
 
 def _target_pk_column(model_cls: type) -> str:
@@ -338,6 +415,69 @@ class Query(Generic[T]):
         new.where_clause.append(node)
         _register_join_paths(node, new._joins)
         return new
+
+    @overload
+    def select(self) -> Self: ...
+
+    @overload
+    def select(self, selector: "RowSelector[T]") -> "ProjectedQuery[T]": ...
+
+    def select(
+        self, *selectors: "RowSelector[T]"
+    ) -> "Self | ProjectedQuery[T]":
+        """Project the query to a column subset, or pass through unchanged.
+
+        Bare ``select()`` keeps meaning "full query": it returns an equivalent
+        query of complete model instances. With a lambda selector
+        (``select(lambda t: (t.id, t.amount))``, or the single-field form
+        ``select(lambda t: t.amount)``) the query becomes a projection: its
+        results are :class:`Row` records in the list-like :class:`Rows`
+        container, never model instances (the complete-instance invariant,
+        ADR-0007). Selected columns validate at build time with did-you-mean,
+        like ``where()`` and ``order_by()``.
+
+        A projected query composes like any other query: ``where()``
+        (relation traversal included), ``order_by()`` (by unselected columns
+        too), ``limit()``/``offset()``, ``first()``, ``count()``, and
+        ``exists()`` all work; ``update()``/``delete()`` and a second
+        ``select()`` raise at build time.
+
+        Args:
+            *selectors: Nothing (full query), or one lambda selector naming
+                root columns.
+
+        Returns:
+            A new query; ``self`` is unchanged. Projected when a selector is
+            given.
+
+        Raises:
+            TypeError: If the selector is not callable or selects non-columns
+                (a bare relation, a comparison).
+            ValueError: If the selection is empty or repeats a column.
+            NotImplementedError: If a selected column traverses a relation
+                (traversed projection lands with #282).
+
+        Examples:
+            >>> rows = await Transaction.select(lambda t: (t.id, t.amount)).all()  # doctest: +SKIP
+            >>> rows[0].amount  # doctest: +SKIP
+            Decimal('12.50')
+        """
+        if not selectors:
+            return self._clone()
+        if len(selectors) > 1:
+            raise TypeError(
+                "select() takes a single lambda selector naming the columns "
+                "(e.g. `select(lambda t: (t.id, t.amount))`), got "
+                f"{len(selectors)} arguments"
+            )
+        selector = selectors[0]
+        if not callable(selector):
+            raise TypeError(
+                "select() expected a selector callable "
+                f"(e.g. `lambda t: (t.id, t.amount)`), got {type(selector).__name__}"
+            )
+        columns = _resolve_projection_selector(selector, self.model_cls)
+        return ProjectedQuery(self, columns)
 
     def order_by(
         self,
@@ -636,6 +776,23 @@ class Query(Generic[T]):
             "materialization": {"kind": "root_instances"},
         }
 
+    def _fetch_query_def(self) -> dict[str, Any]:
+        """Build the QueryIR payload for a fetching operation (``all()``).
+
+        Carries the query's own materialization plan — ``root_instances``
+        here, a ``record`` plan on a :class:`ProjectedQuery` (ADR-0007).
+        """
+        return {
+            "model_name": _model_identity(self.model_cls),
+            "where": [node.to_ir_dict() for node in self.where_clause],
+            "order_by": self.order_by_clause,
+            "limit": self._limit,
+            "offset": self._offset,
+            "m2m": self._m2m_context,
+            "joins": self._serialize_joins(),
+            "materialization": self._materialization_ir(),
+        }
+
     async def all(self) -> list[T]:
         """Return all model instances that match the current query
 
@@ -647,16 +804,7 @@ class Query(Generic[T]):
             >>> isinstance(users, list)
             True
         """
-        query_def = {
-            "model_name": _model_identity(self.model_cls),
-            "where": [node.to_ir_dict() for node in self.where_clause],
-            "order_by": self.order_by_clause,
-            "limit": self._limit,
-            "offset": self._offset,
-            "m2m": self._m2m_context,
-            "joins": self._serialize_joins(),
-            "materialization": self._materialization_ir(),
-        }
+        query_def = self._fetch_query_def()
         route = await self._transaction_or_using()
         return await fetch_filtered(
             self.model_cls,
@@ -874,6 +1022,88 @@ class Query(Generic[T]):
     def __repr__(self):
         """Return a developer-friendly representation of the query"""
         return f"<Query model={self.model_cls.__name__} where={self.where_clause}>"
+
+
+class ProjectedQuery(Query[T]):
+    """A query projected to a column subset: results are records, not models.
+
+    Created by ``select()`` with a selector; carries a ``record``
+    materialization plan (ADR-0007), so ``all()`` delivers :class:`Row`
+    records in the list-like :class:`Rows` container and ``first()`` a
+    ``Row | None`` — never model instances (the complete-instance invariant).
+    Projected records bypass the identity map and carry no persistence
+    identity.
+
+    Filtering, ordering, and pagination compose exactly like on
+    :class:`Query`; ``count()``/``exists()`` are unaffected by the
+    projection.
+    """
+
+    def __init__(self, source: Query[T], columns: tuple[str, ...]) -> None:
+        """Project ``source`` to ``columns`` (selection order preserved).
+
+        Copies the source query's state through ``_clone()`` (fresh mutable
+        containers, FF-F F-1); ``source`` is unchanged.
+        """
+        self.__dict__.update(source._clone().__dict__)
+        # Immutable, so chained clones share it safely.
+        self._projection: tuple[str, ...] = columns
+
+    def _materialization_ir(self) -> dict[str, Any]:
+        """Serialize the ``record`` plan: one field per projected column.
+
+        ``name`` is declared separately from ``column`` and each field
+        carries a ``path`` so output aliases and traversed projection (#282)
+        extend this shape without reshaping it; this epic only ever emits
+        ``name == column`` with an empty path.
+        """
+        return {
+            "kind": "record",
+            "fields": [
+                {"name": column, "column": column, "path": []}
+                for column in self._projection
+            ],
+        }
+
+    async def all(self) -> Rows[Row]:  # type: ignore[override]  # ty: ignore[invalid-method-override]
+        """Return the projected records for every matching row.
+
+        Returns:
+            A :class:`Rows` of :class:`Row` records, fields in selection
+            order, wrapped without validation.
+
+        Examples:
+            >>> rows = await Transaction.select(lambda t: (t.id, t.amount)).all()  # doctest: +SKIP
+            >>> [r.amount for r in rows]  # doctest: +SKIP
+            [Decimal('12.50'), Decimal('7.00')]
+        """
+        query_def = self._fetch_query_def()
+        route = await self._transaction_or_using()
+        records = await fetch_filtered(
+            self.model_cls,
+            _query_ir_payload_to_json(query_def),
+            route,
+            record_cls=Row,
+        )
+        return _ROWS_OF_ROW._wrap(records)
+
+    async def first(self) -> Row | None:  # type: ignore[override]  # ty: ignore[invalid-method-override]
+        """Return the first matching projected record, or None.
+
+        Examples:
+            >>> row = await Transaction.select(lambda t: t.amount).order_by("id").first()  # doctest: +SKIP
+            >>> row is None or isinstance(row, Row)  # doctest: +SKIP
+            True
+        """
+        results = await self.limit(1).all()
+        return results[0] if results else None
+
+    def __repr__(self):
+        """Return a developer-friendly representation of the projection"""
+        return (
+            f"<ProjectedQuery model={self.model_cls.__name__} "
+            f"columns={list(self._projection)} where={self.where_clause}>"
+        )
 
 
 class Relation(Query[T]):

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -33,16 +33,17 @@ E = TypeVar("E")
 def _query_ir_payload_to_json(query_payload: dict[str, Any]) -> str:
     """Serialize a QueryIR payload into a versioned IR envelope JSON string.
 
-    Always emits ``ir_version: 2`` (#269 — unconditional bump; there is no v1
-    envelope left anywhere). Python and Rust ship in one wheel, so a single
-    supported version is the whole contract (#267 Implementation Decisions).
+    Always emits ``ir_version: 3`` (#278 — unconditional bump, exactly like v2
+    at #269; there is no v1 or v2 envelope left anywhere). Python and Rust ship
+    in one wheel, so a single supported version is the whole contract
+    (#267 Implementation Decisions).
     """
     import json
 
     return json.dumps(
         {
             "ir_kind": "query",
-            "ir_version": 2,
+            "ir_version": 3,
             "payload": _serialize_query_value(query_payload),
         }
     )
@@ -548,6 +549,14 @@ class Query(Generic[T]):
         new._offset = value
         return new
 
+    def _materialization_ir(self) -> dict[str, Any]:
+        """Serialize this query's materialization plan (ADR-0007, v3).
+
+        Every fetching query carries exactly one plan on the wire; a query
+        without a projection materializes complete root instances.
+        """
+        return {"kind": "root_instances"}
+
     def _serialize_joins(self) -> list[dict[str, Any]]:
         """Serialize collected relation paths into QueryIR ``joins`` entries.
 
@@ -622,6 +631,9 @@ class Query(Generic[T]):
             "order_by": [],
             "m2m": None,
             "joins": [],
+            # A mutation never materializes a projected result; projection on
+            # a mutating query is rejected before this payload is built.
+            "materialization": {"kind": "root_instances"},
         }
 
     async def all(self) -> list[T]:
@@ -643,6 +655,7 @@ class Query(Generic[T]):
             "offset": self._offset,
             "m2m": self._m2m_context,
             "joins": self._serialize_joins(),
+            "materialization": self._materialization_ir(),
         }
         route = await self._transaction_or_using()
         return await fetch_filtered(
@@ -670,6 +683,10 @@ class Query(Generic[T]):
             "offset": None,
             "m2m": self._m2m_context,
             "joins": self._serialize_joins(),
+            # count() is unaffected by projection (PRD #277 verb table): it
+            # materializes a scalar, so the plan is root_instances even on a
+            # projected query.
+            "materialization": {"kind": "root_instances"},
         }
         route = await self._transaction_or_using()
         return await count_filtered(

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -1,7 +1,19 @@
 """Build fluent query objects that serialize QueryIR payloads for the Rust core."""
 
 import copy
-from typing import TYPE_CHECKING, Any, Callable, Generic, Self, Type, TypeVar, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generic,
+    Never,
+    NoReturn,
+    Self,
+    Type,
+    TypeVar,
+    cast,
+    overload,
+)
 
 from .._bind_payload import update_bind_payload
 from .._core import (
@@ -196,6 +208,47 @@ def _resolve_projection_selector(
             "(e.g. `lambda t: (t.id, t.amount)`), or call select() with no "
             "arguments for the full query."
         )
+    return _collect_projection_columns(items)
+
+
+def _resolve_projection_strings(
+    names: tuple[str, ...], model_cls: type
+) -> tuple[str, ...]:
+    """Resolve ``select("id", "amount")`` string selectors (#280).
+
+    Exactly ``order_by``'s string contract: root columns only (declared fields
+    plus shadow ``{fk}_id`` columns), validated at build time with
+    did-you-mean. Strings never traverse — a dotted path is rejected
+    pointedly, permanently (PRD #277); traversed projection is lambda-only
+    when it lands (#282).
+
+    Raises:
+        ValueError: For a dotted path, or a column named twice.
+        AttributeError: For a name that is not a queryable column
+            (did-you-mean, from :func:`validate_query_column`).
+    """
+    columns: list[str] = []
+    for name in names:
+        if "." in name:
+            raise ValueError(
+                f"select() string selectors name root columns only and never "
+                f"traverse: {name!r} is not a column. String paths are "
+                "rejected permanently; traversed projection will be "
+                "lambda-only when it lands (#282). Select root columns "
+                '(e.g. select("id", "amount")).'
+            )
+        validate_query_column(model_cls, name)
+        if name in columns:
+            raise ValueError(
+                f"select() projects column {name!r} more than once; "
+                "each projected column must be unique."
+            )
+        columns.append(name)
+    return tuple(columns)
+
+
+def _collect_projection_columns(items: tuple[Any, ...]) -> tuple[str, ...]:
+    """Validate a lambda selector's resolved items into column names (#279)."""
     columns: list[str] = []
     for item in items:
         if isinstance(item, RelationProxy):
@@ -422,19 +475,25 @@ class Query(Generic[T]):
     @overload
     def select(self, selector: "RowSelector[T]") -> "ProjectedQuery[T]": ...
 
+    @overload
+    def select(self, *columns: str) -> "ProjectedQuery[T]": ...
+
     def select(
-        self, *selectors: "RowSelector[T]"
+        self, *selectors: "RowSelector[T] | str"
     ) -> "Self | ProjectedQuery[T]":
         """Project the query to a column subset, or pass through unchanged.
 
         Bare ``select()`` keeps meaning "full query": it returns an equivalent
         query of complete model instances. With a lambda selector
         (``select(lambda t: (t.id, t.amount))``, or the single-field form
-        ``select(lambda t: t.amount)``) the query becomes a projection: its
-        results are :class:`Row` records in the list-like :class:`Rows`
-        container, never model instances (the complete-instance invariant,
-        ADR-0007). Selected columns validate at build time with did-you-mean,
-        like ``where()`` and ``order_by()``.
+        ``select(lambda t: t.amount)``) — the documented style — the query
+        becomes a projection: its results are :class:`Row` records in the
+        list-like :class:`Rows` container, never model instances (the
+        complete-instance invariant, ADR-0007). Column-name strings
+        (``select("id", "amount")``) follow ``order_by``'s string contract
+        exactly: root columns only, never traversal, never mixed with a
+        lambda in one call. Both forms validate at build time with
+        did-you-mean.
 
         A projected query composes like any other query: ``where()``
         (relation traversal included), ``order_by()`` (by unselected columns
@@ -443,18 +502,20 @@ class Query(Generic[T]):
         ``select()`` raise at build time.
 
         Args:
-            *selectors: Nothing (full query), or one lambda selector naming
-                root columns.
+            *selectors: Nothing (full query), one lambda selector naming root
+                columns, or column-name strings.
 
         Returns:
             A new query; ``self`` is unchanged. Projected when a selector is
             given.
 
         Raises:
-            TypeError: If the selector is not callable or selects non-columns
-                (a bare relation, a comparison).
-            ValueError: If the selection is empty or repeats a column.
-            NotImplementedError: If a selected column traverses a relation
+            TypeError: If the selector is not callable/strings, selects
+                non-columns (a bare relation, a comparison), or mixes strings
+                with a lambda in one call.
+            ValueError: If the selection is empty, repeats a column, or a
+                string is a dotted path (strings never traverse).
+            NotImplementedError: If a lambda selects a traversed column
                 (traversed projection lands with #282).
 
         Examples:
@@ -464,6 +525,17 @@ class Query(Generic[T]):
         """
         if not selectors:
             return self._clone()
+        if any(isinstance(selector, str) for selector in selectors):
+            if not all(isinstance(selector, str) for selector in selectors):
+                raise TypeError(
+                    "select() cannot mix column-name strings and a lambda "
+                    "selector in one call; use one form "
+                    '(select("id", "amount") or '
+                    "select(lambda t: (t.id, t.amount)))."
+                )
+            names: tuple[str, ...] = selectors  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+            columns = _resolve_projection_strings(names, self.model_cls)
+            return ProjectedQuery(self, columns)
         if len(selectors) > 1:
             raise TypeError(
                 "select() takes a single lambda selector naming the columns "
@@ -473,10 +545,14 @@ class Query(Generic[T]):
         selector = selectors[0]
         if not callable(selector):
             raise TypeError(
-                "select() expected a selector callable "
+                "select() expected a selector callable or column-name strings "
                 f"(e.g. `lambda t: (t.id, t.amount)`), got {type(selector).__name__}"
             )
-        columns = _resolve_projection_selector(selector, self.model_cls)
+        # Strings were dispatched above, so the lone selector is the lambda
+        # form; the tuple element type is too wide for the checker to see it.
+        columns = _resolve_projection_selector(
+            cast("RowSelector[T]", selector), self.model_cls
+        )
         return ProjectedQuery(self, columns)
 
     def order_by(
@@ -1097,6 +1173,53 @@ class ProjectedQuery(Query[T]):
         """
         results = await self.limit(1).all()
         return results[0] if results else None
+
+    def select(self, *selectors: "RowSelector[T] | str") -> NoReturn:  # type: ignore[override]  # ty: ignore[invalid-method-override]
+        """Reject a second projection: it would change the result type
+        mid-chain (#280).
+
+        Raises:
+            ValueError: Always — build the projection in one ``select()``
+                call, or start a new query from the model.
+        """
+        raise ValueError(
+            "select() was already applied to this query; replacing a "
+            "projection changes the result type mid-chain. Name every "
+            "projected column in one select() call, or start a new query "
+            "from the model."
+        )
+
+    # `self: Never` makes mutating a projected query a STATIC error at the
+    # call site (pinned by tests/static_fixtures/bad_projections.py) while the
+    # runtime bodies raise at build time — synchronously, at the call, before
+    # any coroutine or SQL exists (#280). A projection is a read shape;
+    # silently ignoring it would make select(...) a no-op on mutations.
+
+    def update(self: Never, **fields: Any) -> NoReturn:  # type: ignore[override]
+        """Reject ``update()`` on a projected query (#280).
+
+        Raises:
+            ValueError: Always — mutate through an unprojected query
+                (``Model.where(...).update(...)``).
+        """
+        raise ValueError(
+            "update() is not supported on a projected query: a projection is "
+            "a read shape. Build the mutation from the model instead "
+            "(e.g. Model.where(...).update(...))."
+        )
+
+    def delete(self: Never) -> NoReturn:  # type: ignore[override]
+        """Reject ``delete()`` on a projected query (#280).
+
+        Raises:
+            ValueError: Always — mutate through an unprojected query
+                (``Model.where(...).delete()``).
+        """
+        raise ValueError(
+            "delete() is not supported on a projected query: a projection is "
+            "a read shape. Build the mutation from the model instead "
+            "(e.g. Model.where(...).delete())."
+        )
 
     def __repr__(self):
         """Return a developer-friendly representation of the projection"""

--- a/src/ferro/query/nodes.py
+++ b/src/ferro/query/nodes.py
@@ -561,3 +561,15 @@ class RelationProxy:
 
 Predicate: TypeAlias = Callable[[QueryProxy[TModel]], QueryNode]
 """Type alias for lambda predicates accepted by :meth:`Query.where`."""
+
+RowSelector: TypeAlias = Callable[
+    [QueryProxy[TModel]],
+    "FieldProxy[Any] | tuple[FieldProxy[Any], ...] | list[FieldProxy[Any]]",
+]
+"""Type alias for lambda selectors accepted by ``select()`` projections.
+
+A selector names root columns — one (``lambda t: t.amount``) or several
+(``lambda t: (t.id, t.amount)``). Returning a comparison (a
+:class:`QueryNode`) fails the static gate: a projection selects columns,
+a predicate belongs in ``where()``.
+"""

--- a/src/ferro/query/rows.py
+++ b/src/ferro/query/rows.py
@@ -1,0 +1,90 @@
+"""Projected-record containers: ``Row`` and the list-like ``Rows`` (ADR-0007).
+
+A projection (``Transaction.select(lambda t: (t.id, t.amount))``) returns
+projected records, never model instances — a model instance always carries a
+complete row (the complete-instance invariant). ``Row`` is one record;
+``Rows`` is the list-like container a projected query's ``all()`` delivers
+them in.
+
+Both are pydantic-shaped (``model_dump()``, FastAPI ``response_model``) but
+never pydantic-constructed: instances come off the same direct-to-dict
+hydration path as models (AGENTS.md I-2), and ``Rows`` wraps without
+re-validating. Pydantic is the interface, not the constructor.
+"""
+
+from collections.abc import Iterator
+from typing import TypeVar, overload
+
+from pydantic import BaseModel, ConfigDict, RootModel
+
+R = TypeVar("R")
+
+
+class Row(BaseModel):
+    """One projected record: named values from an explicit projection.
+
+    A ``Row`` is not a model instance. It carries no persistence identity —
+    no ``save()``, no refresh, no identity-map participation — and its field
+    set is whatever the projection selected, in selection order.
+
+    Fields live in pydantic's extra storage (``model_config`` is
+    ``extra="allow"``); the Rust hydration path populates them directly
+    (I-2), so construction never runs pydantic validation. Attribute access,
+    ``model_dump()``, ``model_dump_json()``, equality, and ``repr`` all work
+    as on any pydantic model:
+
+    Examples:
+        >>> rows = await Transaction.select(lambda t: (t.id, t.amount)).all()  # doctest: +SKIP
+        >>> rows[0].amount  # doctest: +SKIP
+        Decimal('12.50')
+        >>> rows[0].model_dump()  # doctest: +SKIP
+        {'id': 1, 'amount': Decimal('12.50')}
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+
+class Rows(RootModel[list[R]]):
+    """List-like pydantic container for projected records.
+
+    Delivered by a projected query's ``all()`` as ``Rows[Row]``. Indexing,
+    slicing, iteration, ``len()``, and truthiness work like a list; a slice
+    returns a ``Rows`` of the same record type. As a pydantic ``RootModel``
+    it drops straight into an API response: ``model_dump()`` yields
+    ``list[dict]`` and ``Rows[Row]`` works as a FastAPI ``response_model``.
+
+    Examples:
+        >>> len(rows), rows[0].id, [r.amount for r in rows]  # doctest: +SKIP
+        (3, 1, [Decimal('12.50'), Decimal('7.00'), Decimal('99.99')])
+        >>> rows[:2].model_dump()  # doctest: +SKIP
+        [{'id': 1, 'amount': Decimal('12.50')}, {'id': 2, 'amount': Decimal('7.00')}]
+    """
+
+    def __len__(self) -> int:
+        return len(self.root)
+
+    def __iter__(self) -> Iterator[R]:  # type: ignore[override]  # ty: ignore[invalid-method-override]
+        # BaseModel.__iter__ yields (field, value) pairs; a Rows iterates its
+        # records, like the list it stands in for.
+        return iter(self.root)
+
+    @overload
+    def __getitem__(self, index: int) -> R: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> "Rows[R]": ...
+
+    def __getitem__(self, index: int | slice) -> "R | Rows[R]":
+        if isinstance(index, slice):
+            return self.__class__.model_construct(root=self.root[index])
+        return self.root[index]
+
+    @classmethod
+    def _wrap(cls, records: list[R]) -> "Rows[R]":
+        """Wrap already-hydrated records WITHOUT validation (ADR-0007).
+
+        The records come off the Rust hydration path; re-validating them here
+        would put pydantic back on the hot path that direct-to-dict
+        construction exists to avoid (I-2).
+        """
+        return cls.model_construct(root=records)

--- a/src/hydration.rs
+++ b/src/hydration.rs
@@ -149,6 +149,74 @@ pub fn hydrate_model_instance<'py>(
     Ok(instance)
 }
 
+/// Hydrate a projected record (`Row`) from pre-decoded column values (#279).
+///
+/// The record flavor of [`hydrate_model_instance`]: same allocation via
+/// `cls.__new__(cls)`, same decoded-field write path
+/// ([`apply_decoded_fields`]), no `BaseModel.__init__`, no pydantic-core
+/// validation (I-2). Differences, per ADR-0007:
+///
+/// - Decoded fields land in `__pydantic_extra__`, not `__dict__`: a `Row`
+///   declares no static fields, and pydantic serializes/dumps extras (its
+///   `model_config` is `extra="allow"`), so `model_dump()` sees exactly the
+///   projected columns in selection order.
+/// - NO persistence identity: no `__ferro_connection_name`, no
+///   `__ferro_persisted` marker — a record can never masquerade as a row,
+///   and it never enters the identity map (callers must not insert it).
+///
+/// Slot initialization is driven by [`HANDLED_BASEMODEL_SLOTS`] like
+/// [`init_handled_slots`], so the record path fails as loudly as the model
+/// path if pydantic grows a slot this build does not handle.
+///
+/// # Errors
+/// Returns `PyErr` on allocation/slot failure, `RustValue` conversion
+/// failure, or an enum column value its enum class rejects.
+pub fn hydrate_record_instance<'py>(
+    py: Python<'py>,
+    record_cls: &Bound<'py, PyAny>,
+    fields: Vec<(String, RustValue)>,
+    py_col_names: &HashMap<String, pyo3::Py<pyo3::types::PyString>>,
+    enum_classes: &HashMap<String, Bound<'py, PyAny>>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let instance = record_cls.call_method1(pyo3::intern!(py, "__new__"), (record_cls,))?;
+    let extra = pyo3::types::PyDict::new(py);
+    let fields_set = pyo3::types::PySet::empty(py)?;
+
+    apply_decoded_fields(
+        py,
+        record_cls,
+        &extra,
+        &fields_set,
+        fields,
+        py_col_names,
+        enum_classes,
+    )?;
+
+    for slot in HANDLED_BASEMODEL_SLOTS {
+        match *slot {
+            // A Row's own __dict__ stays empty: projected values are pydantic
+            // extras, not declared fields.
+            "__dict__" => {}
+            "__pydantic_fields_set__" => {
+                instance.setattr(pyo3::intern!(py, "__pydantic_fields_set__"), &fields_set)?;
+            }
+            "__pydantic_extra__" => {
+                instance.setattr(pyo3::intern!(py, "__pydantic_extra__"), &extra)?;
+            }
+            "__pydantic_private__" => {
+                instance.setattr(pyo3::intern!(py, "__pydantic_private__"), py.None())?;
+            }
+            other => {
+                return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                    "HANDLED_BASEMODEL_SLOTS lists '{other}' but hydrate_record_instance has \
+                     no initializer for it — add a match arm"
+                )));
+            }
+        }
+    }
+    Ok(instance)
+}
+
 /// Write decoded column values into `dict` and record them in `fields_set`.
 ///
 /// The single materialization path for both fresh hydration and fetch-hit

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -424,6 +424,81 @@ fn reject_unsupported_materialization(plan: &QueryPlan, operation: &str) -> PyRe
     )))
 }
 
+/// Resolve the fetch walker's SELECT-list plan from the query's
+/// materialization (#279).
+///
+/// `root_instances` → `None` (render the root-table asterisk, full
+/// hydration). `record` → the ordered projected column names. The Python
+/// builder validates every field at build time; the per-field checks here are
+/// boundary defense (I-6) for the shapes the record plan already declares but
+/// this epic does not render: a relation `path`, an `expr`, or an output
+/// alias (`name != column`) — all #282, all rejected loudly, never silently
+/// projected wrong.
+///
+/// # Errors
+/// `PyValueError` for `instances` (reserved for joined-row hydration,
+/// #267 stage 2), an empty `record` field list, or a field shape from #282.
+fn projected_columns(plan: &QueryPlan) -> PyResult<Option<Vec<String>>> {
+    let fields = match &plan.materialization {
+        Materialization::RootInstances => return Ok(None),
+        Materialization::Instances => {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "materialization kind \"instances\" is reserved for joined-row \
+                 hydration (#267 stage 2) and is not yet implemented.",
+            ));
+        }
+        Materialization::Record { fields } => fields,
+    };
+    if fields.is_empty() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "record materialization plan carries no fields; a projection must \
+             select at least one column.",
+        ));
+    }
+    let mut columns = Vec::with_capacity(fields.len());
+    for field in fields {
+        if !field.path.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "record field {:?} carries relation path {:?}: traversed \
+                 projection is not yet implemented (#282).",
+                field.name, field.path
+            )));
+        }
+        if field.expr.is_some() {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "record field {:?} carries an expression: expression fields \
+                 (aggregations) are not yet implemented (#282).",
+                field.name
+            )));
+        }
+        if field.name != field.column {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "record field {:?} aliases column {:?}: output aliases are not \
+                 yet implemented (#282).",
+                field.name, field.column
+            )));
+        }
+        columns.push(field.column.clone());
+    }
+    Ok(Some(columns))
+}
+
+/// Apply a fetch SELECT list: the projected columns of a `record` plan (in
+/// selection order, root-table-qualified) or the root-table asterisk for full
+/// hydration (#279).
+fn apply_select_list(select: &mut SelectStatement, table_name: &str, projected: Option<&[String]>) {
+    match projected {
+        Some(columns) => {
+            for column in columns {
+                select.column((Alias::new(table_name), Alias::new(column.as_str())));
+            }
+        }
+        None => {
+            select.column((Alias::new(table_name), sea_query::Asterisk));
+        }
+    }
+}
+
 /// Reject `limit`/`offset` on mutating operations (FF-A A1, #171).
 ///
 /// Portable SQL has no `UPDATE/DELETE ... LIMIT`. The Python builder raises
@@ -1681,25 +1756,55 @@ pub fn save_bulk_records<'py>(
 
 /// Fetches records for a given model class based on a QueryIR-defined query.
 ///
+/// The query's materialization plan (ADR-0007) selects the result shape:
+/// `root_instances` hydrates complete model instances (identity-map aware);
+/// a `record` plan renders the projected SELECT list and hydrates
+/// `record_cls` records (#279) — no identity map, no persistence identity.
+///
 /// Args:
 ///     cls (PyAny): The Python model class.
 ///     query_ir_json (str): The serialized QueryIR envelope JSON.
+///     record_cls (PyAny | None): Record constructor for a `record` plan
+///         (`Row` today; the seam a future `into=` plugs into). Required for
+///         a record plan, forbidden otherwise.
 ///
 /// Returns:
-///     list[PyAny]: A list of hydrated model instances.
+///     list[PyAny]: Hydrated model instances, or projected records.
 #[pyfunction]
-#[pyo3(signature = (cls, query_ir_json, route))]
+#[pyo3(signature = (cls, query_ir_json, route, record_cls=None))]
 pub fn fetch_filtered<'py>(
     py: Python<'py>,
     cls: Bound<'py, PyAny>,
     query_ir_json: String,
     route: Py<crate::state::RouteHandle>,
+    record_cls: Option<Bound<'py, PyAny>>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let name = crate::state::model_identity(&cls)?;
     let cls_py = cls.unbind();
 
     let mut plan = query_plan_from_ir_json(&query_ir_json)?;
-    reject_unsupported_materialization(&plan, "fetch_filtered")?;
+    let projected = projected_columns(&plan)?;
+    // The record constructor travels with the call, paired to the plan kind:
+    // a record plan requires it, a root plan must not carry one. A mismatch
+    // is a caller bug — fail loud, never fall back (I-6).
+    let record_cls_py = match (&projected, record_cls) {
+        (Some(_), Some(record_cls)) => Some(record_cls.unbind()),
+        (None, None) => None,
+        (Some(_), None) => {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "fetch_filtered(): a record materialization plan requires a \
+                 record_cls constructor; the Python builder always passes one \
+                 for a projection.",
+            ));
+        }
+        (None, Some(_)) => {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "fetch_filtered(): record_cls was passed without a record \
+                 materialization plan; full hydration constructs model \
+                 instances.",
+            ));
+        }
+    };
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let r = route.get();
@@ -1726,7 +1831,7 @@ pub fn fetch_filtered<'py>(
             let pk = schema.meta.pk_col.clone();
 
             let mut select = Query::select();
-            select.column((Alias::new(&table_name), sea_query::Asterisk));
+            apply_select_list(&mut select, &table_name, projected.as_deref());
             select.from(Alias::new(&table_name));
 
             if let Some(m2m) = &plan.m2m {
@@ -1798,7 +1903,18 @@ pub fn fetch_filtered<'py>(
             .fetch_all(&sql, &engine_bind_values)
             .await
             .map_err(|e| crate::errors::map_db_error("Fetch failed", e))?;
-        let parsed_data = typed_rows_to_parsed_data(rows, &schema_for_decode, pk_col.as_deref());
+        // A record plan skips PK extraction entirely: projected records carry
+        // no persistence identity and never enter the identity map (ADR-0007)
+        // — the projection may not even include the PK column. Decode itself
+        // runs through the model's codec plan either way, so a projected
+        // datetime/uuid/enum/decimal column decodes identically to full
+        // hydration on both backends.
+        let pk_for_decode = if projected.is_some() {
+            None
+        } else {
+            pk_col.as_deref()
+        };
+        let parsed_data = typed_rows_to_parsed_data(rows, &schema_for_decode, pk_for_decode);
 
         Python::attach(|py| {
             let results = pyo3::types::PyList::empty(py);
@@ -1813,7 +1929,28 @@ pub fn fetch_filtered<'py>(
                     );
                 }
             }
+            // The MODEL's enum catalog, for both paths: a projected native-
+            // enum column hydrates the same enum member as the model field
+            // (decode parity, FF-C C4).
             let enum_classes = crate::hydration::enum_classes_for(py, cls);
+
+            if let Some(record_cls) = record_cls_py {
+                // Record path (#279): direct-to-dict record construction,
+                // deliberately bypassing the identity map — no lookup, no
+                // insert, no refresh of live instances.
+                let record_cls = record_cls.bind(py);
+                for (_, fields) in parsed_data {
+                    let record = crate::hydration::hydrate_record_instance(
+                        py,
+                        record_cls,
+                        fields,
+                        &py_col_names,
+                        &enum_classes,
+                    )?;
+                    results.append(record)?;
+                }
+                return Ok(results.into_any().unbind());
+            }
 
             for (row_pk_val, fields) in parsed_data {
                 if use_identity_map
@@ -3974,6 +4111,136 @@ mod materialization_walker_gate_tests {
                 "must name what the kind is reserved for: {msg}"
             );
         });
+    }
+}
+
+#[cfg(test)]
+mod record_select_list_tests {
+    //! Pin the record plan's SELECT-list resolution and rendering (#279):
+    //! projected columns render as an explicit root-qualified column list in
+    //! selection order on both dialects, and the field shapes deferred to
+    //! #282 (paths, aliases, expressions) are rejected loudly at the boundary.
+
+    use super::{apply_select_list, projected_columns, query_plan_from_ir_json};
+    use sea_query::{Alias, PostgresQueryBuilder, Query, SqliteQueryBuilder};
+
+    fn plan_with_materialization(materialization: serde_json::Value) -> crate::query::QueryPlan {
+        query_plan_from_ir_json(
+            &serde_json::json!({
+                "ir_kind": "query",
+                "ir_version": 3,
+                "payload": {
+                    "model_name": "Transaction",
+                    "where": [],
+                    "order_by": [],
+                    "limit": null,
+                    "offset": null,
+                    "m2m": null,
+                    "joins": [],
+                    "materialization": materialization
+                }
+            })
+            .to_string(),
+        )
+        .expect("envelope parses")
+    }
+
+    fn record_fields(fields: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({"kind": "record", "fields": fields})
+    }
+
+    #[test]
+    fn record_plan_renders_subset_select_in_selection_order_on_both_dialects() {
+        let plan = plan_with_materialization(record_fields(serde_json::json!([
+            {"name": "id", "column": "id", "path": []},
+            {"name": "amount", "column": "amount", "path": []}
+        ])));
+        let projected = projected_columns(&plan)
+            .expect("record plan resolves")
+            .expect("record plan projects columns");
+        assert_eq!(projected, vec!["id".to_string(), "amount".to_string()]);
+
+        let mut select = Query::select();
+        apply_select_list(&mut select, "transaction", Some(&projected));
+        select.from(Alias::new("transaction"));
+
+        let pg = select.to_string(PostgresQueryBuilder);
+        assert_eq!(
+            pg,
+            "SELECT \"transaction\".\"id\", \"transaction\".\"amount\" FROM \"transaction\""
+        );
+        let sqlite = select.to_string(SqliteQueryBuilder).to_lowercase();
+        assert!(
+            !sqlite.contains('*'),
+            "record plan must not render an asterisk: {sqlite}"
+        );
+        let id_pos = sqlite.find("\"id\"").expect("id rendered");
+        let amount_pos = sqlite.find("\"amount\"").expect("amount rendered");
+        assert!(id_pos < amount_pos, "selection order preserved: {sqlite}");
+    }
+
+    #[test]
+    fn root_instances_plan_renders_root_asterisk() {
+        let plan = plan_with_materialization(serde_json::json!({"kind": "root_instances"}));
+        let projected = projected_columns(&plan).expect("root plan resolves");
+        assert!(projected.is_none());
+
+        let mut select = Query::select();
+        apply_select_list(&mut select, "transaction", projected.as_deref());
+        select.from(Alias::new("transaction"));
+        let sql = select.to_string(PostgresQueryBuilder);
+        assert_eq!(sql, "SELECT \"transaction\".* FROM \"transaction\"");
+    }
+
+    #[test]
+    fn record_field_with_relation_path_is_rejected() {
+        let plan = plan_with_materialization(record_fields(serde_json::json!([
+            {"name": "label", "column": "label", "path": ["account"]}
+        ])));
+        let err = projected_columns(&plan).expect_err("path field must be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("label"), "must name the field: {msg}");
+        assert!(msg.contains("account"), "must name the path: {msg}");
+        assert!(msg.contains("#282"), "must name the deferred slice: {msg}");
+    }
+
+    #[test]
+    fn record_field_with_alias_is_rejected() {
+        let plan = plan_with_materialization(record_fields(serde_json::json!([
+            {"name": "total", "column": "amount", "path": []}
+        ])));
+        let err = projected_columns(&plan).expect_err("aliased field must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("total") && msg.contains("amount"),
+            "must name alias and column: {msg}"
+        );
+    }
+
+    #[test]
+    fn record_field_with_expr_is_rejected() {
+        let plan = plan_with_materialization(record_fields(serde_json::json!([
+            {"name": "n", "column": "n", "path": [], "expr": {"agg": "count"}}
+        ])));
+        let err = projected_columns(&plan).expect_err("expr field must be rejected");
+        assert!(err.to_string().contains("expression"), "got {err}");
+    }
+
+    #[test]
+    fn record_plan_with_no_fields_is_rejected() {
+        let plan = plan_with_materialization(record_fields(serde_json::json!([])));
+        let err = projected_columns(&plan).expect_err("empty projection must be rejected");
+        assert!(err.to_string().contains("at least one"), "got {err}");
+    }
+
+    #[test]
+    fn instances_plan_is_rejected() {
+        let plan = plan_with_materialization(serde_json::json!({"kind": "instances"}));
+        let err = projected_columns(&plan).expect_err("instances must be rejected");
+        assert!(
+            err.to_string().contains("joined-row hydration"),
+            "got {err}"
+        );
     }
 }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -13,7 +13,7 @@ use crate::state::{
     engine_for_connection, register_session, session_state, unregister_session,
 };
 use dashmap::DashMap;
-use ferro_schema_ir::QueryIrPayload;
+use ferro_schema_ir::{Materialization, QueryIrPayload};
 use pyo3::prelude::*;
 use sea_query::{
     Alias, Condition, Expr, Iden, InsertStatement, JoinType, OnConflict, Order,
@@ -243,18 +243,18 @@ fn tx_remove(session_id: Option<&str>, tx_id: &str) -> PyResult<Option<Transacti
     Ok(TRANSACTION_REGISTRY.remove(tx_id).map(|(_, handle)| handle))
 }
 
-/// The only QueryIR version this build accepts (#269, #267 Implementation Decisions).
+/// The only QueryIR version this build accepts (#269, #278).
 ///
 /// Python and Rust ship in one wheel, so there is exactly one supported version at any
 /// time — no negotiation, no fallback. A mismatch can only mean a mixed build (a stale
 /// `.so` next to a rebuilt Python package, or vice versa).
-const SUPPORTED_QUERY_IR_VERSION: u32 = 2;
+const SUPPORTED_QUERY_IR_VERSION: u32 = 3;
 
 /// Envelope shell used only to read `ir_kind`/`ir_version` before committing to a strict
-/// [`QueryIrPayload`] parse. `payload` is deliberately raw JSON: a real v1 payload (no
-/// `joins`/`path` fields) must fail on the version check below with an actionable
-/// message, not on a generic "missing field" serde error from parsing a payload shape
-/// this build no longer understands.
+/// [`QueryIrPayload`] parse. `payload` is deliberately raw JSON: a real v1/v2 payload
+/// (no `joins`/`path` fields, no `materialization` section) must fail on the version
+/// check below with an actionable message, not on a generic "missing field" serde error
+/// from parsing a payload shape this build no longer understands.
 #[derive(Debug, Clone, Deserialize)]
 struct QueryIrEnvelope {
     ir_kind: String,
@@ -397,6 +397,31 @@ fn reject_traversal_on_mutation(plan: &QueryPlan, operation: &str) -> PyResult<(
              primary keys first and {operation} by primary-key set."
         ))
     })
+}
+
+/// Reject a materialization plan this walker does not implement (#278).
+///
+/// Every query carries exactly one plan (ADR-0007). `root_instances` is the
+/// only kind the non-projecting walkers accept: `record` is the partial-select
+/// plan (built by the projecting fetch path, #279 — `count()`/`exists()` are
+/// unaffected by projection and mutations reject projection at build time, so
+/// the Python builder never emits `record` to any other walker); `instances`
+/// is reserved for joined-row hydration (#267 stage 2) and not yet
+/// implemented anywhere. A disallowed kind here is a loud error, never a
+/// silent fallback to full hydration (I-6).
+fn reject_unsupported_materialization(plan: &QueryPlan, operation: &str) -> PyResult<()> {
+    let kind = match &plan.materialization {
+        Materialization::RootInstances => return Ok(()),
+        Materialization::Record { .. } => "record",
+        Materialization::Instances => "instances",
+    };
+    Err(pyo3::exceptions::PyValueError::new_err(format!(
+        "{operation}() does not support materialization kind {kind:?}: this \
+         walker materializes complete root instances only (\"root_instances\"). \
+         \"record\" is the partial-select plan and applies to projecting \
+         fetches only; \"instances\" is reserved for joined-row hydration and \
+         is not yet implemented."
+    )))
 }
 
 /// Reject `limit`/`offset` on mutating operations (FF-A A1, #171).
@@ -1674,6 +1699,7 @@ pub fn fetch_filtered<'py>(
     let cls_py = cls.unbind();
 
     let mut plan = query_plan_from_ir_json(&query_ir_json)?;
+    reject_unsupported_materialization(&plan, "fetch_filtered")?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let r = route.get();
@@ -1859,6 +1885,9 @@ pub fn count_filtered(
     route: Py<crate::state::RouteHandle>,
 ) -> PyResult<Bound<'_, PyAny>> {
     let mut plan = query_plan_from_ir_json(&query_ir_json)?;
+    // count() is unaffected by projection (PRD #277 verb table): the Python
+    // builder always emits root_instances on count payloads, projected or not.
+    reject_unsupported_materialization(&plan, "count_filtered")?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let r = route.get();
@@ -2079,6 +2108,7 @@ pub fn delete_filtered(
     let mut plan = query_plan_from_ir_json(&query_ir_json)?;
     reject_pagination_on_mutation(&plan, "delete")?;
     reject_traversal_on_mutation(&plan, "delete")?;
+    reject_unsupported_materialization(&plan, "delete")?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let r = route.get();
@@ -2154,6 +2184,7 @@ pub fn update_filtered<'py>(
     let mut plan = query_plan_from_ir_json(&query_ir_json)?;
     reject_pagination_on_mutation(&plan, "update")?;
     reject_traversal_on_mutation(&plan, "update")?;
+    reject_unsupported_materialization(&plan, "update")?;
     let update_inputs = bind_inputs_from_py(&updates)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
@@ -3655,7 +3686,7 @@ mod mutation_pagination_guard_tests {
     fn envelope_without_pagination_keys() -> String {
         serde_json::json!({
             "ir_kind": "query",
-            "ir_version": 2,
+            "ir_version": 3,
             "payload": {
                 "model_name": "Widget",
                 "where": [{
@@ -3666,7 +3697,7 @@ mod mutation_pagination_guard_tests {
                     "path": []
                 }],
                 "order_by": [],
-                "m2m": null,
+                "m2m": null, "materialization": {"kind": "root_instances"},
                 "joins": []
             }
         })
@@ -3725,8 +3756,64 @@ mod mutation_pagination_guard_tests {
 mod query_ir_version_gate_tests {
     use super::query_plan_from_ir_json;
 
-    fn v2_envelope() -> serde_json::Value {
+    fn v3_envelope() -> serde_json::Value {
         serde_json::json!({
+            "ir_kind": "query",
+            "ir_version": 3,
+            "payload": {
+                "model_name": "Widget",
+                "where": [],
+                "order_by": [],
+                "limit": null,
+                "offset": null,
+                "m2m": null,
+                "joins": [],
+                "materialization": {"kind": "root_instances"}
+            }
+        })
+    }
+
+    /// Assert a rejected envelope's message names the received version, this
+    /// build's supported version (3), and the one-wheel fix — the actionable
+    /// shape pinned since the v1-at-v2 bump (#269), re-pinned at v3 (#278).
+    fn assert_actionable_version_rejection(err: pyo3::PyErr, received: char) {
+        pyo3::Python::attach(|py| {
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+        });
+        let msg = err.to_string();
+        assert!(
+            msg.contains(received),
+            "message should name the received version: {msg}"
+        );
+        assert!(
+            msg.contains('3'),
+            "message should name the supported version: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("one wheel"),
+            "message should explain Python/Rust ship in one wheel: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("reinstall") || msg.to_lowercase().contains("rebuild"),
+            "message should tell the caller how to fix a mismatch: {msg}"
+        );
+    }
+
+    #[test]
+    fn accepts_version_3() {
+        query_plan_from_ir_json(&v3_envelope().to_string())
+            .expect("a well-formed v3 envelope must be accepted");
+    }
+
+    /// Contract test (#278 acceptance criteria, mirroring the v1-at-v2
+    /// precedent): a v2 envelope — with a real v2 payload that predates the
+    /// `materialization` section entirely, as any real v2 emitter would
+    /// produce — must be rejected on the version check with an actionable
+    /// message, not on a serde "missing field" error from strict-parsing a
+    /// payload shape this build no longer understands.
+    #[test]
+    fn rejects_v2_envelope_with_actionable_message() {
+        let v2_envelope = serde_json::json!({
             "ir_kind": "query",
             "ir_version": 2,
             "payload": {
@@ -3738,20 +3825,15 @@ mod query_ir_version_gate_tests {
                 "m2m": null,
                 "joins": []
             }
-        })
+        });
+
+        let err = query_plan_from_ir_json(&v2_envelope.to_string())
+            .expect_err("a v2 envelope must be rejected");
+        assert_actionable_version_rejection(err, '2');
     }
 
-    #[test]
-    fn accepts_version_2() {
-        query_plan_from_ir_json(&v2_envelope().to_string())
-            .expect("a well-formed v2 envelope must be accepted");
-    }
-
-    /// Contract test (#269 acceptance criteria): a v1 envelope — including one
-    /// that predates the `joins`/`path` fields entirely, as any real v1 emitter
-    /// would produce — must be rejected with a message naming the version
-    /// actually received, this build's supported version, and that Python/Rust
-    /// ship in one wheel (so a mismatch means mixed builds).
+    /// A v1 envelope (no `joins`/`path`/`materialization`) stays rejected the
+    /// same way — the gate is "exactly one supported version", not a range.
     #[test]
     fn rejects_v1_envelope_with_actionable_message() {
         let v1_envelope = serde_json::json!({
@@ -3769,40 +3851,129 @@ mod query_ir_version_gate_tests {
 
         let err = query_plan_from_ir_json(&v1_envelope.to_string())
             .expect_err("a v1 envelope must be rejected");
-        pyo3::Python::attach(|py| {
-            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
-        });
-        let msg = err.to_string();
-        assert!(
-            msg.contains('1'),
-            "message should name the received version: {msg}"
-        );
-        assert!(
-            msg.contains('2'),
-            "message should name the supported version: {msg}"
-        );
-        assert!(
-            msg.to_lowercase().contains("one wheel"),
-            "message should explain Python/Rust ship in one wheel: {msg}"
-        );
-        assert!(
-            msg.to_lowercase().contains("reinstall") || msg.to_lowercase().contains("rebuild"),
-            "message should tell the caller how to fix a mismatch: {msg}"
-        );
+        assert_actionable_version_rejection(err, '1');
     }
 
     #[test]
     fn rejects_unsupported_future_version() {
-        let mut envelope = v2_envelope();
-        envelope["ir_version"] = serde_json::json!(3);
+        let mut envelope = v3_envelope();
+        envelope["ir_version"] = serde_json::json!(4);
 
         let err = query_plan_from_ir_json(&envelope.to_string())
             .expect_err("an unsupported future version must be rejected");
         let msg = err.to_string();
         assert!(
-            msg.contains('3'),
+            msg.contains('4'),
             "message should name the received version: {msg}"
         );
+    }
+
+    /// An unknown materialization kind fails the strict payload parse loudly,
+    /// naming the bad kind and the supported ones (#278).
+    #[test]
+    fn rejects_unknown_materialization_kind() {
+        let mut envelope = v3_envelope();
+        envelope["payload"]["materialization"] = serde_json::json!({"kind": "row_dicts"});
+
+        let err = query_plan_from_ir_json(&envelope.to_string())
+            .expect_err("an unknown materialization kind must be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("row_dicts"), "must name the bad kind: {msg}");
+        assert!(
+            msg.contains("root_instances"),
+            "must name the supported kinds: {msg}"
+        );
+    }
+
+    /// A v3 payload with NO materialization section fails the strict parse:
+    /// the plan travels with the query as data (ADR-0007), never defaulted.
+    #[test]
+    fn rejects_v3_payload_missing_materialization() {
+        let mut envelope = v3_envelope();
+        envelope["payload"]
+            .as_object_mut()
+            .unwrap()
+            .remove("materialization");
+
+        let err = query_plan_from_ir_json(&envelope.to_string())
+            .expect_err("a v3 payload without a materialization section must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("materialization"),
+            "must name the missing section: {msg}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod materialization_walker_gate_tests {
+    //! Pin the runtime rejection of declared-but-unimplemented materialization
+    //! kinds (#278): the types deserialize, the walkers refuse.
+
+    use super::{query_plan_from_ir_json, reject_unsupported_materialization};
+
+    fn plan_with_kind(kind: serde_json::Value) -> crate::query::QueryPlan {
+        query_plan_from_ir_json(
+            &serde_json::json!({
+                "ir_kind": "query",
+                "ir_version": 3,
+                "payload": {
+                    "model_name": "Widget",
+                    "where": [],
+                    "order_by": [],
+                    "limit": null,
+                    "offset": null,
+                    "m2m": null,
+                    "joins": [],
+                    "materialization": kind
+                }
+            })
+            .to_string(),
+        )
+        .expect("envelope parses")
+    }
+
+    #[test]
+    fn root_instances_passes_every_walker_gate() {
+        let plan = plan_with_kind(serde_json::json!({"kind": "root_instances"}));
+        for operation in ["fetch_filtered", "count_filtered", "update", "delete"] {
+            assert!(reject_unsupported_materialization(&plan, operation).is_ok());
+        }
+    }
+
+    #[test]
+    fn record_kind_is_rejected_loudly_by_non_projecting_walkers() {
+        let plan = plan_with_kind(serde_json::json!({
+            "kind": "record",
+            "fields": [{"name": "id", "column": "id", "path": []}]
+        }));
+        pyo3::Python::attach(|py| {
+            let err = reject_unsupported_materialization(&plan, "count_filtered")
+                .expect_err("record must be rejected");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+            let msg = err.to_string();
+            assert!(msg.contains("record"), "must name the kind: {msg}");
+            assert!(
+                msg.contains("count_filtered"),
+                "must name the operation: {msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn instances_kind_is_rejected_loudly() {
+        let plan = plan_with_kind(serde_json::json!({"kind": "instances"}));
+        pyo3::Python::attach(|py| {
+            let err = reject_unsupported_materialization(&plan, "fetch_filtered")
+                .expect_err("instances must be rejected");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+            let msg = err.to_string();
+            assert!(msg.contains("instances"), "must name the kind: {msg}");
+            assert!(
+                msg.contains("joined-row hydration"),
+                "must name what the kind is reserved for: {msg}"
+            );
+        });
     }
 }
 
@@ -3824,7 +3995,7 @@ mod mutation_qualification_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 2,
+                "ir_version": 3,
                 "payload": {
                     "model_name": "Widget",
                     "where": [{
@@ -3835,7 +4006,7 @@ mod mutation_qualification_tests {
                         "path": []
                     }],
                     "order_by": [],
-                    "m2m": null,
+                    "m2m": null, "materialization": {"kind": "root_instances"},
                     "joins": []
                 }
             })
@@ -3910,7 +4081,7 @@ mod select_join_render_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 2,
+                "ir_version": 3,
                 "payload": {
                     "model_name": "Transaction",
                     "where": [{
@@ -3921,7 +4092,7 @@ mod select_join_render_tests {
                         "path": ["account"]
                     }],
                     "order_by": [{"column": "name", "direction": "asc", "path": ["account"]}],
-                    "limit": null, "offset": null, "m2m": null,
+                    "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"},
                     "joins": [
                         {"join_type": "inner", "path": [
                             {"relation": "account", "from_column": "account_id",
@@ -4016,11 +4187,11 @@ mod select_join_render_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 2,
+                "ir_version": 3,
                 "payload": {
                     "model_name": model_name,
                     "where": [], "order_by": [],
-                    "limit": null, "offset": null, "m2m": null,
+                    "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"},
                     "joins": joins
                 }
             })
@@ -4038,7 +4209,7 @@ mod select_join_render_tests {
         let plan = query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 2,
+                "ir_version": 3,
                 "payload": {
                     "model_name": "Transaction",
                     "where": [{
@@ -4048,7 +4219,7 @@ mod select_join_render_tests {
                         "value": {"kind": "int", "value": 7},
                         "path": []
                     }],
-                    "order_by": [], "limit": null, "offset": null, "m2m": null,
+                    "order_by": [], "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"},
                     "joins": []
                 }
             })

--- a/src/query.rs
+++ b/src/query.rs
@@ -5,7 +5,7 @@
 //! null/UUID/enum binds via [`crate::codec`].
 
 use crate::state::Dialect;
-use ferro_schema_ir::{QueryIrPayload, QueryJoin, QueryNode, QueryOrderBy};
+use ferro_schema_ir::{Materialization, QueryIrPayload, QueryJoin, QueryNode, QueryOrderBy};
 use sea_query::{Alias, Condition, Expr, SimpleExpr};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -208,6 +208,9 @@ pub struct QueryPlan {
     pub joins: Vec<QueryJoin>,
     /// M2M join filter when loading through an association table.
     pub m2m: Option<M2mContext>,
+    /// The query's materialization plan (ADR-0007, required in v3): what its
+    /// result columns become. Each walker enforces the kinds it implements.
+    pub materialization: Materialization,
     /// Populated from `pg_catalog` before building filter SQL. Not part of the
     /// Python query IR payload.
     pub postgres_enum_udt: HashMap<String, String>,
@@ -266,6 +269,7 @@ impl QueryPlan {
             offset: payload.offset,
             joins: payload.joins,
             m2m,
+            materialization: payload.materialization,
             postgres_enum_udt: HashMap::new(),
             registration,
             hop_registrations: HashMap::new(),
@@ -651,6 +655,7 @@ mod tests {
             offset: None,
             joins: Vec::new(),
             m2m: None,
+            materialization: ferro_schema_ir::Materialization::RootInstances,
             postgres_enum_udt: HashMap::new(),
             registration,
             hop_registrations: HashMap::new(),
@@ -681,7 +686,7 @@ mod tests {
                            "value": {"kind": "string", "value": "a%"}, "path": []}}
             ],
             "order_by": [{"column": "age", "direction": "desc", "path": []}],
-            "limit": 10, "offset": 5, "m2m": null, "joins": []
+            "limit": 10, "offset": 5, "m2m": null, "materialization": {"kind": "root_instances"}, "joins": []
         }))
         .expect("payload deserializes");
         let plan = super::QueryPlan::from_ir_payload(payload).expect("plan builds");
@@ -711,7 +716,7 @@ mod tests {
                  "value": {"kind": "null", "value": null}, "path": []}
             ],
             "order_by": [],
-            "limit": null, "offset": null, "m2m": null, "joins": []
+            "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"}, "joins": []
         }))
         .expect("payload deserializes");
         let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
@@ -736,7 +741,7 @@ mod tests {
                  "value": {"kind": "int", "value": 18}, "path": []}
             ],
             "order_by": [],
-            "limit": null, "offset": null, "m2m": null, "joins": []
+            "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"}, "joins": []
         }))
         .expect("payload deserializes");
         let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
@@ -764,7 +769,7 @@ mod tests {
                  "value": {"kind": "int", "value": 18}, "path": []}
             ],
             "order_by": [],
-            "limit": null, "offset": null, "m2m": null, "joins": []
+            "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"}, "joins": []
         }))
         .expect("payload deserializes");
         let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
@@ -790,7 +795,7 @@ mod tests {
                  "value": {"kind": "int", "value": 18}, "path": []}
             ],
             "order_by": [],
-            "limit": null, "offset": null, "m2m": null, "joins": []
+            "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"}, "joins": []
         }))
         .expect("payload deserializes");
         let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
@@ -822,7 +827,7 @@ mod tests {
                            "value": {"kind": "int", "value": 100}, "path": []}}
             ],
             "order_by": [{"column": "id", "direction": "asc", "path": []}],
-            "limit": 50, "offset": 0, "m2m": null,
+            "limit": 50, "offset": 0, "m2m": null, "materialization": {"kind": "root_instances"},
             "joins": [
                 {"join_type": "inner", "path": [
                     {"relation": "account", "from_column": "account_id",
@@ -895,7 +900,7 @@ mod tests {
         // Transfer(from_account, to_account) -> two FKs into the same table.
         let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
             "model_name": "Transfer",
-            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"},
             "joins": [
                 {"join_type": "inner", "path": [
                     {"relation": "from_account", "from_column": "from_account_id",
@@ -925,7 +930,7 @@ mod tests {
         // table name gets `_x` appended until unique.
         let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
             "model_name": "Thing",
-            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"},
             "joins": [
                 {"join_type": "inner", "path": [
                     {"relation": "account", "from_column": "account_id",
@@ -945,7 +950,7 @@ mod tests {
     fn build_join_plan_rejects_unknown_join_type() {
         let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
             "model_name": "Thing",
-            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"},
             "joins": [
                 {"join_type": "cross", "path": [
                     {"relation": "account", "from_column": "account_id",
@@ -966,7 +971,7 @@ mod tests {
         // A lone `"left"` 1-hop entry renders its edge LEFT (#272).
         let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
             "model_name": "Note",
-            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"},
             "joins": [
                 {"join_type": "left", "path": [
                     {"relation": "account", "from_column": "account_id",
@@ -987,7 +992,7 @@ mod tests {
         // Whole-path rule: a `"left"` 2-hop entry marks BOTH edges LEFT (#272).
         let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
             "model_name": "Transaction",
-            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"},
             "joins": [
                 {"join_type": "left", "path": [
                     {"relation": "account", "from_column": "account_id",
@@ -1038,7 +1043,7 @@ mod tests {
         for joins in [left_first, inner_first] {
             let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
                 "model_name": "Transaction",
-                "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+                "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"},
                 "joins": joins
             }))
             .expect("payload deserializes");
@@ -1075,7 +1080,7 @@ mod tests {
                 {"node_kind": "leaf", "column": "email", "operator": "==",
                  "value": {"kind": "string", "value": "a"}, "path": ["account"]}
             ],
-            "order_by": [], "limit": null, "offset": null, "m2m": null, "joins": []
+            "order_by": [], "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"}, "joins": []
         }))
         .expect("payload deserializes");
         let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
@@ -1108,7 +1113,7 @@ mod tests {
                 {"node_kind": "leaf", "column": "email", "operator": "==",
                  "value": {"kind": "string", "value": "a"}, "path": ["account"]}
             ],
-            "order_by": [], "limit": null, "offset": null, "m2m": null, "joins": []
+            "order_by": [], "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"}, "joins": []
         }))
         .expect("payload deserializes");
         let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
@@ -1124,7 +1129,7 @@ mod tests {
         // entry now builds a plan like any other (the SELECT walkers render it).
         let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
             "model_name": "Pending",
-            "where": [], "limit": null, "offset": null, "m2m": null, "joins": [
+            "where": [], "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"}, "joins": [
                 {"join_type": "inner", "path": [
                     {"relation": "account", "from_column": "account_id",
                      "to_table": "account", "to_column": "id"}

--- a/tests/fixtures/ir_vectors/README.md
+++ b/tests/fixtures/ir_vectors/README.md
@@ -28,9 +28,9 @@ Rules:
 
 - `domain` and `ir.ir_kind` must match.
 - `ir.ir_version` must equal `1` for `schema` and `codec` vectors. `query`
-  vectors are on `ir_version: 2` (#269 — unconditional bump, path-qualified
-  column references, empty `joins: []` until #270 renders real JOINs); there
-  is no v1 `query` vector left.
+  vectors are on `ir_version: 3` (#278 — unconditional bump; the payload
+  carries a required `materialization` section, ADR-0007); there is no v1 or
+  v2 `query` vector left.
 - `expect_valid` currently supports only `true` fixtures (negative vectors can be added later).
 - Fixture file names use `<domain>_<scenario>_v<version>.json` (matching that
   domain's current `ir_version`).

--- a/tests/fixtures/ir_vectors/query_transaction_left_join_v3.json
+++ b/tests/fixtures/ir_vectors/query_transaction_left_join_v3.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_transaction_left_join_v2",
+  "vector_name": "query_transaction_left_join_v3",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 2,
+    "ir_version": 3,
     "payload": {
       "model_name": "Transaction",
       "where": [
@@ -16,7 +16,10 @@
             "kind": "string",
             "value": "owner@ferro.dev"
           },
-          "path": ["account", "owner"]
+          "path": [
+            "account",
+            "owner"
+          ]
         }
       ],
       "order_by": [],
@@ -52,7 +55,10 @@
             }
           ]
         }
-      ]
+      ],
+      "materialization": {
+        "kind": "root_instances"
+      }
     }
   }
 }

--- a/tests/fixtures/ir_vectors/query_transaction_record_v3.json
+++ b/tests/fixtures/ir_vectors/query_transaction_record_v3.json
@@ -1,0 +1,50 @@
+{
+  "vector_name": "query_transaction_record_v3",
+  "domain": "query",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "query",
+    "ir_version": 3,
+    "payload": {
+      "model_name": "Transaction",
+      "where": [
+        {
+          "node_kind": "leaf",
+          "column": "amount",
+          "operator": ">=",
+          "value": {
+            "kind": "int",
+            "value": 100
+          },
+          "path": []
+        }
+      ],
+      "order_by": [
+        {
+          "column": "amount",
+          "direction": "desc",
+          "path": []
+        }
+      ],
+      "limit": 25,
+      "offset": null,
+      "m2m": null,
+      "joins": [],
+      "materialization": {
+        "kind": "record",
+        "fields": [
+          {
+            "name": "id",
+            "column": "id",
+            "path": []
+          },
+          {
+            "name": "amount",
+            "column": "amount",
+            "path": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/ir_vectors/query_transaction_traversal_v3.json
+++ b/tests/fixtures/ir_vectors/query_transaction_traversal_v3.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_transaction_traversal_v2",
+  "vector_name": "query_transaction_traversal_v3",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 2,
+    "ir_version": 3,
     "payload": {
       "model_name": "Transaction",
       "where": [
@@ -19,7 +19,10 @@
               "kind": "string",
               "value": "owner@ferro.dev"
             },
-            "path": ["account", "owner"]
+            "path": [
+              "account",
+              "owner"
+            ]
           },
           "right": {
             "node_kind": "leaf",
@@ -37,7 +40,9 @@
         {
           "column": "name",
           "direction": "asc",
-          "path": ["account"]
+          "path": [
+            "account"
+          ]
         },
         {
           "column": "id",
@@ -77,7 +82,10 @@
             }
           ]
         }
-      ]
+      ],
+      "materialization": {
+        "kind": "root_instances"
+      }
     }
   }
 }

--- a/tests/fixtures/ir_vectors/query_user_compound_v3.json
+++ b/tests/fixtures/ir_vectors/query_user_compound_v3.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_user_compound_v2",
+  "vector_name": "query_user_compound_v3",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 2,
+    "ir_version": 3,
     "payload": {
       "model_name": "User",
       "where": [
@@ -40,7 +40,10 @@
               "operator": "IN",
               "value": {
                 "kind": "list",
-                "value": ["admin", "owner"]
+                "value": [
+                  "admin",
+                  "owner"
+                ]
               },
               "path": []
             }
@@ -57,7 +60,10 @@
       "limit": 100,
       "offset": 0,
       "m2m": null,
-      "joins": []
+      "joins": [],
+      "materialization": {
+        "kind": "root_instances"
+      }
     }
   }
 }

--- a/tests/static_fixtures/bad_projections.py
+++ b/tests/static_fixtures/bad_projections.py
@@ -29,3 +29,17 @@ async def _row_where_model_expected() -> None:
     one: BadPTxn | None = await BadPTxn.select(lambda t: t.id).first()
 
     del txns, one
+
+
+# Mutating a projected query fails statically (#280): ProjectedQuery's
+# update()/delete() take `self: Never`, so each call site reports
+# invalid-argument-type. One misuse per function — an earlier NoReturn await
+# would mark the rest of the body unreachable and suppress its diagnostic.
+
+
+async def _update_on_a_projection() -> None:
+    await BadPTxn.select(lambda t: (t.id,)).update(amount=1)
+
+
+async def _delete_on_a_projection() -> None:
+    await BadPTxn.select(lambda t: (t.id,)).delete()

--- a/tests/static_fixtures/bad_projections.py
+++ b/tests/static_fixtures/bad_projections.py
@@ -1,0 +1,31 @@
+"""Type-checked (never executed): projected-shape misuse must FAIL `ty check`.
+
+test_static_contracts.py asserts this file produces `invalid-assignment`
+diagnostics -- if it starts passing, the projected-shape gate has stopped
+biting (#279).
+"""
+
+from typing import Annotated
+
+from ferro import FerroField, ForeignKey, Model
+
+
+class BadPAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+
+
+class BadPTxn(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    amount: int = 0
+    account: Annotated[BadPAccount, ForeignKey(related_name="txns")]
+
+
+async def _row_where_model_expected() -> None:
+    # A projected query's results are Row records, never model instances —
+    # the complete-instance invariant extends through static typing
+    # (ADR-0007). Both assignments fail with invalid-assignment.
+    txns: list[BadPTxn] = await BadPTxn.select(lambda t: (t.id, t.amount)).all()
+
+    one: BadPTxn | None = await BadPTxn.select(lambda t: t.id).first()
+
+    del txns, one

--- a/tests/static_fixtures/good_predicates.py
+++ b/tests/static_fixtures/good_predicates.py
@@ -3,7 +3,16 @@
 from typing import Annotated, assert_type
 
 from ferro import FerroField, ForeignKey, Model
-from ferro.query import FieldProxy, Predicate, Query, QueryNode, QueryProxy
+from ferro.query import (
+    FieldProxy,
+    Predicate,
+    ProjectedQuery,
+    Query,
+    QueryNode,
+    QueryProxy,
+    Row,
+    Rows,
+)
 
 
 class GoodUser(Model):
@@ -57,3 +66,22 @@ join_query: Query[GoodTxn] = GoodTxn.select().join(lambda t: t.account)
 left_join_query: Query[GoodTxn] = GoodTxn.select().left_join(lambda t: t.account.owner)
 assert_type(join_query, Query[GoodTxn])
 assert_type(left_join_query, Query[GoodTxn])
+
+
+# Partial selects (#279): a projection flips the query's static shape —
+# `.all()` types as Rows[Row], `.first()` as Row | None; the bare form stays
+# a full query of model instances (shape, not names).
+proj_tuple: ProjectedQuery[GoodTxn] = GoodTxn.select(lambda t: (t.id, t.account_id))
+proj_single: ProjectedQuery[GoodTxn] = GoodTxn.select(lambda t: t.id)
+proj_with_traversal_pred: ProjectedQuery[GoodTxn] = GoodTxn.select(
+    lambda t: (t.id,)
+).where(lambda t: t.account.owner.email == "a@b.com")
+
+
+async def _projected_shapes() -> None:
+    rows = await GoodTxn.select(lambda t: (t.id,)).all()
+    assert_type(rows, Rows[Row])
+    row = await GoodTxn.select(lambda t: t.id).first()
+    assert_type(row, Row | None)
+    full = await GoodTxn.select().all()
+    assert_type(full, list[GoodTxn])

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -11,10 +11,11 @@ from ferro import BackRef, Field, ManyToMany, Model, Relation, clear_registry
 
 VECTORS_DIR = Path(__file__).parent / "fixtures" / "ir_vectors"
 SUPPORTED_DOMAINS = {"schema", "query", "codec"}
-# `query` is on ir_version 2 (#269 — unconditional bump, path-qualified column
-# references); `schema`/`codec` remain v1.
-SUPPORTED_IR_VERSIONS = {"schema": 1, "query": 2, "codec": 1}
+# `query` is on ir_version 3 (#278 — unconditional bump, required
+# `materialization` section, ADR-0007); `schema`/`codec` remain v1.
+SUPPORTED_IR_VERSIONS = {"schema": 1, "query": 3, "codec": 1}
 QUERY_OPERATORS = {"==", "!=", "<", "<=", ">", ">=", "IN", "LIKE", "AND", "OR"}
+MATERIALIZATION_KINDS = {"root_instances", "record", "instances"}
 
 
 class _DocFormat(StrEnum):
@@ -85,12 +86,46 @@ def _validate_schema_payload(payload: dict[str, Any], label: str) -> None:
         )
 
 
+def _validate_materialization(plan: dict[str, Any], label: str) -> None:
+    """Validate the v3 `materialization` section's required keys (#278)."""
+    _require_keys(plan, {"kind"}, label)
+    kind = plan["kind"]
+    assert kind in MATERIALIZATION_KINDS, f"{label}.kind invalid: {kind!r}"
+    if kind != "record":
+        return
+    _require_keys(plan, {"fields"}, label)
+    fields = plan["fields"]
+    assert isinstance(fields, list) and fields, f"{label}.fields must be non-empty list"
+    for i, field in enumerate(fields):
+        field_label = f"{label}.fields[{i}]"
+        assert isinstance(field, dict), f"{field_label} must be object"
+        _require_keys(field, {"name", "column", "path"}, field_label)
+        for key in ("name", "column"):
+            assert isinstance(field[key], str) and field[key], (
+                f"{field_label}.{key} must be non-empty string"
+            )
+        assert isinstance(field["path"], list), f"{field_label}.path must be a list"
+
+
 def _validate_query_payload(payload: dict[str, Any], label: str) -> None:
     _require_keys(
         payload,
-        {"model_name", "where", "order_by", "limit", "offset", "m2m", "joins"},
+        {
+            "model_name",
+            "where",
+            "order_by",
+            "limit",
+            "offset",
+            "m2m",
+            "joins",
+            "materialization",
+        },
         label,
     )
+    assert isinstance(payload["materialization"], dict), (
+        f"{label}.materialization must be object"
+    )
+    _validate_materialization(payload["materialization"], f"{label}.materialization")
     assert isinstance(payload["model_name"], str) and payload["model_name"], (
         f"{label}.model_name must be non-empty string"
     )

--- a/tests/test_partial_selects.py
+++ b/tests/test_partial_selects.py
@@ -241,6 +241,99 @@ class TestSelectorValidation:
 
 
 # ---------------------------------------------------------------------------
+# String selectors (#280): exactly order_by's string contract.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_string_selectors_behave_identically_to_the_lambda_form(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_transactions()
+
+        via_strings = await PSTransaction.select("amount", "id").order_by("id").all()
+        via_lambda = await (
+            PSTransaction.select(lambda t: (t.amount, t.id)).order_by("id").all()
+        )
+
+        assert via_strings.model_dump() == via_lambda.model_dump()
+        assert list(via_strings[0].model_dump()) == ["amount", "id"]
+
+
+@pytest.mark.asyncio
+async def test_string_selector_projects_shadow_fk_column(db_url):
+    """Shadow ``{fk}_id`` columns are queryable columns, so they project."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_transactions()
+
+        row = await PSTransaction.select("id", "account_id").order_by("id").first()
+
+        assert row is not None
+        assert row.account_id == 1
+
+
+class TestStringSelectorValidation:
+    def test_misspelled_string_raises_with_did_you_mean(self):
+        with pytest.raises(AttributeError, match="Did you mean 'amount'"):
+            PSTransaction.select("id", "amonut")
+
+    def test_dotted_string_path_raises_pointedly(self):
+        with pytest.raises(ValueError, match="never traverse.*lambda-only"):
+            PSTransaction.select("account.label")
+
+    def test_mixing_strings_and_lambda_raises(self):
+        with pytest.raises(TypeError, match="cannot mix column-name strings"):
+            PSTransaction.select("id", lambda t: t.amount)  # type: ignore[call-overload]  # ty: ignore[no-matching-overload]
+
+    def test_mixing_lambda_and_strings_raises(self):
+        with pytest.raises(TypeError, match="cannot mix column-name strings"):
+            PSTransaction.select(lambda t: t.amount, "id")  # type: ignore[call-overload]  # ty: ignore[no-matching-overload]
+
+    def test_duplicate_string_column_raises(self):
+        with pytest.raises(ValueError, match="'id' more than once"):
+            PSTransaction.select("id", "id")
+
+
+# ---------------------------------------------------------------------------
+# Mutation and double-select guardrails (#280): build-time, before any SQL.
+# ---------------------------------------------------------------------------
+
+
+class TestProjectedQueryGuardrails:
+    """These misuses raise synchronously at the call — no coroutine, no
+    connection, no DB round-trip (no ``ferro.connect`` in this class)."""
+
+    def test_update_on_projected_query_raises_before_any_round_trip(self):
+        projected = PSTransaction.select(lambda t: (t.id,))
+        with pytest.raises(
+            ValueError, match=r"update\(\) is not supported on a projected query"
+        ):
+            projected.update(note="x")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def test_delete_on_projected_query_raises_before_any_round_trip(self):
+        projected = PSTransaction.select(lambda t: (t.id,))
+        with pytest.raises(
+            ValueError, match=r"delete\(\) is not supported on a projected query"
+        ):
+            projected.delete()  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def test_double_select_raises_at_build_time(self):
+        projected = PSTransaction.select(lambda t: (t.id,))
+        with pytest.raises(
+            ValueError, match=r"select\(\) was already applied to this query"
+        ):
+            projected.select(lambda t: (t.amount,))
+
+    def test_double_select_with_strings_raises_too(self):
+        projected = PSTransaction.select("id")
+        with pytest.raises(
+            ValueError, match=r"select\(\) was already applied to this query"
+        ):
+            projected.select("amount")
+
+
+# ---------------------------------------------------------------------------
 # Verb composition (PRD #277 verb table).
 # ---------------------------------------------------------------------------
 

--- a/tests/test_partial_selects.py
+++ b/tests/test_partial_selects.py
@@ -1,0 +1,381 @@
+"""Backend-matrix integration tests for partial selects (#279).
+
+``select(lambda t: (t.id, t.amount))`` end to end: the record materialization
+plan renders a subset SELECT and decodes into ``Row`` records delivered in the
+list-like ``Rows`` container, on real SQLite and isolated-schema Postgres —
+no SQL-string snapshots at this layer (the rendered SELECT-list pins live in
+the Rust walker unit tests). Covers result values/order, container semantics,
+typed-column decode parity vs full hydration, build-time selector validation,
+verb composition per the PRD #277 verb table, identity-map bypass, and the
+validation-free construction pin (I-2).
+"""
+
+import json
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import StrEnum
+from typing import Annotated
+from uuid import UUID
+
+import pytest
+
+import ferro
+from ferro import FerroField, ForeignKey, Model, Relation, BackRef
+from ferro.query import ProjectedQuery, Query, Row, Rows
+
+pytestmark = pytest.mark.backend_matrix
+
+
+# ---------------------------------------------------------------------------
+# Schema: Transaction -> Account, plus a typed-column model for decode parity.
+# ---------------------------------------------------------------------------
+
+
+class PSAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    label: str = ""
+    transactions: Relation[list["PSTransaction"]] = BackRef()
+
+
+class PSTransaction(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    amount: int = 0
+    note: str = ""
+    account: Annotated[PSAccount, ForeignKey(related_name="transactions")]
+
+
+class PSTier(StrEnum):
+    FREE = "free"
+    PRO = "pro"
+
+
+class PSTyped(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    created_at: datetime
+    external_id: UUID
+    tier: PSTier = PSTier.FREE
+    balance: Decimal | None = None
+    name: str = ""
+
+
+_T1 = datetime(2026, 3, 1, 12, 30, 45, 123456, tzinfo=timezone.utc)
+_UID1 = UUID("11111111-1111-1111-1111-111111111111")
+
+
+async def _seed_transactions():
+    """One account with three transactions (amounts 10/20/30)."""
+    acct = PSAccount(id=1, label="a1")
+    await acct.save()
+    for i, amount in enumerate((10, 20, 30), start=1):
+        await PSTransaction(id=i, amount=amount, note=f"n{i}", account=acct).save()
+    return acct
+
+
+async def _seed_typed():
+    row = PSTyped(
+        id=1,
+        created_at=_T1,
+        external_id=_UID1,
+        tier=PSTier.PRO,
+        balance=Decimal("12.50"),
+        name="alice",
+    )
+    await row.save()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# The tracer bullet: values, order, container semantics.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_select_lambda_returns_rows_of_typed_records(db_url):
+    """The projected query returns correct values with field order equal to
+    selection order — amount deliberately selected before id."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_transactions()
+
+        rows = await PSTransaction.select(lambda t: (t.amount, t.id)).all()
+
+        assert isinstance(rows, Rows)
+        assert len(rows) == 3
+        assert all(isinstance(row, Row) for row in rows)
+        assert {(row.id, row.amount) for row in rows} == {(1, 10), (2, 20), (3, 30)}
+        # Field order = selection order (amount first), pinned via model_dump.
+        assert list(rows[0].model_dump()) == ["amount", "id"]
+
+
+@pytest.mark.asyncio
+async def test_select_single_field_form(db_url):
+    """``select(lambda t: t.amount)`` — one column, no tuple ceremony."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_transactions()
+
+        rows = await PSTransaction.select(lambda t: t.amount).order_by("amount").all()
+
+        assert [row.amount for row in rows] == [10, 20, 30]
+        assert list(rows[0].model_dump()) == ["amount"]
+
+
+@pytest.mark.asyncio
+async def test_rows_is_list_like_and_pydantic_shaped(db_url):
+    """Index, slice, iterate, len; model_dump() yields list[dict]; a slice is
+    itself a Rows."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_transactions()
+
+        rows = await PSTransaction.select(lambda t: (t.id, t.amount)).order_by("id").all()
+
+        assert len(rows) == 3
+        assert rows[0].id == 1
+        assert [row.id for row in rows] == [1, 2, 3]
+        head = rows[:2]
+        assert isinstance(head, Rows) and len(head) == 2
+        dumped = rows.model_dump()
+        assert dumped == [
+            {"id": 1, "amount": 10},
+            {"id": 2, "amount": 20},
+            {"id": 3, "amount": 30},
+        ]
+        # JSON serialization works end to end (FastAPI response_model shape).
+        assert json.loads(rows.model_dump_json()) == dumped
+
+
+@pytest.mark.asyncio
+async def test_row_is_a_record_not_a_model_instance(db_url):
+    """A Row is not a PSTransaction and exposes no persistence surface."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_transactions()
+
+        row = await PSTransaction.select(lambda t: (t.id, t.amount)).first()
+
+        assert row is not None
+        assert isinstance(row, Row)
+        assert not isinstance(row, Model)
+        assert not isinstance(row, PSTransaction)
+        assert not hasattr(row, "save")
+        assert not hasattr(row, "delete")
+
+
+# ---------------------------------------------------------------------------
+# Typed-column decode parity vs full hydration (both backends).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_projected_typed_columns_decode_identically_to_full_hydration(db_url):
+    """datetime / uuid / native enum / decimal round-trip through a projection
+    with the same types and values as full hydration — a projection is never a
+    different dialect of the data."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_typed()
+
+        full = await PSTyped.select().first()
+        row = await PSTyped.select(
+            lambda t: (t.created_at, t.external_id, t.tier, t.balance)
+        ).first()
+
+        assert full is not None and row is not None
+        for field in ("created_at", "external_id", "tier", "balance"):
+            hydrated = getattr(full, field)
+            projected = getattr(row, field)
+            assert type(projected) is type(hydrated), field
+            assert projected == hydrated, field
+        assert isinstance(row.created_at, datetime)
+        assert isinstance(row.external_id, UUID)
+        assert isinstance(row.tier, PSTier) and row.tier is PSTier.PRO
+        assert isinstance(row.balance, Decimal) and row.balance == Decimal("12.50")
+
+
+# ---------------------------------------------------------------------------
+# Build-time selector validation.
+# ---------------------------------------------------------------------------
+
+
+class TestSelectorValidation:
+    def test_misspelled_column_raises_with_did_you_mean(self):
+        with pytest.raises(AttributeError, match="Did you mean 'amount'"):
+            PSTransaction.select(lambda t: (t.id, t.amonut))
+
+    def test_traversed_column_raises_pointed_not_yet_error(self):
+        with pytest.raises(NotImplementedError, match="account.label.*#282"):
+            PSTransaction.select(lambda t: t.account.label)
+
+    def test_bare_relation_raises(self):
+        with pytest.raises(TypeError, match="bare relation 'account'"):
+            PSTransaction.select(lambda t: t.account)
+
+    def test_comparison_raises(self):
+        with pytest.raises(TypeError, match="comparison, not a column"):
+            PSTransaction.select(lambda t: t.id == 1)
+
+    def test_duplicate_column_raises(self):
+        with pytest.raises(ValueError, match="'id' more than once"):
+            PSTransaction.select(lambda t: (t.id, t.id))
+
+    def test_empty_selection_raises(self):
+        with pytest.raises(ValueError, match="selected no columns"):
+            PSTransaction.select(lambda t: ())
+
+    def test_non_callable_selector_raises(self):
+        with pytest.raises(TypeError, match="selector callable"):
+            PSTransaction.select().select(123)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def test_bare_select_stays_a_full_query(self):
+        q = PSTransaction.select()
+        assert isinstance(q, Query)
+        assert not isinstance(q, ProjectedQuery)
+
+    def test_projection_does_not_mutate_the_source_query(self):
+        base = PSTransaction.where(lambda t: t.amount >= 20)
+        projected = base.select(lambda t: (t.id,))
+        assert isinstance(projected, ProjectedQuery)
+        assert not isinstance(base, ProjectedQuery)
+        assert not hasattr(base, "_projection")
+
+
+# ---------------------------------------------------------------------------
+# Verb composition (PRD #277 verb table).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_projection_composes_with_where_order_limit_offset(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_transactions()
+
+        rows = await (
+            PSTransaction.select(lambda t: (t.id, t.amount))
+            .where(lambda t: t.amount >= 20)
+            .order_by(lambda t: t.amount, "desc")
+            .limit(1)
+            .offset(1)
+            .all()
+        )
+        assert [(row.id, row.amount) for row in rows] == [(2, 20)]
+
+
+@pytest.mark.asyncio
+async def test_projection_composes_with_relation_traversal_predicate(db_url):
+    """where() traversal (one JOIN) narrows a projected query like any other."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        acct = await _seed_transactions()
+        other = PSAccount(id=2, label="b1")
+        await other.save()
+        await PSTransaction(id=9, amount=99, note="other", account=other).save()
+
+        rows = await (
+            PSTransaction.select(lambda t: (t.id, t.amount))
+            .where(lambda t: t.account.label == "a1")
+            .order_by("id")
+            .all()
+        )
+        assert [row.id for row in rows] == [1, 2, 3]
+        assert acct.label == "a1"
+
+
+@pytest.mark.asyncio
+async def test_order_by_unselected_column(db_url):
+    """order_by may sort by a column the projection does not select."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_transactions()
+
+        rows = await PSTransaction.select(lambda t: t.id).order_by("amount", "desc").all()
+
+        assert [row.id for row in rows] == [3, 2, 1]
+        assert "amount" not in rows[0].model_dump()
+
+
+@pytest.mark.asyncio
+async def test_first_returns_row_or_none(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_transactions()
+
+        row = await (
+            PSTransaction.select(lambda t: (t.id,)).order_by("amount", "desc").first()
+        )
+        assert isinstance(row, Row) and row.id == 3
+
+        empty = await (
+            PSTransaction.select(lambda t: (t.id,))
+            .where(lambda t: t.amount > 1000)
+            .first()
+        )
+        assert empty is None
+
+
+@pytest.mark.asyncio
+async def test_count_and_exists_are_unaffected_by_projection(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_transactions()
+
+        projected = PSTransaction.select(lambda t: (t.id,)).where(
+            lambda t: t.amount >= 20
+        )
+        assert await projected.count() == 2
+        assert await projected.exists() is True
+        assert (
+            await PSTransaction.select(lambda t: (t.id,))
+            .where(lambda t: t.amount > 1000)
+            .exists()
+            is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# No persistence identity: identity-map bypass, no markers, no validation.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_projected_records_bypass_the_identity_map(db_url):
+    """A projection neither reads nor populates the session identity map, and
+    a Row carries no Ferro markers (`__dict__` stays empty — projected values
+    live in pydantic's extra storage)."""
+    from ferro._core import identity_map_len
+
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session() as s:
+        await _seed_transactions()
+        instances = await PSTransaction.select().all()
+        tracked_before = identity_map_len(s.session_id)
+        assert tracked_before >= len(instances)
+
+        rows = await PSTransaction.select(lambda t: (t.id, t.amount)).all()
+
+        assert identity_map_len(s.session_id) == tracked_before
+        assert rows[0].__dict__ == {}
+        assert "__ferro_persisted" not in rows[0].model_dump()
+
+
+@pytest.mark.asyncio
+async def test_row_construction_never_runs_pydantic_init(db_url, monkeypatch):
+    """Structural pin (I-2): the record hot path allocates via __new__ and
+    writes slots directly — pydantic __init__/validation would blow up here
+    if it were ever called."""
+
+    def _boom(self, *args, **kwargs):  # pragma: no cover - must never run
+        raise AssertionError("pydantic __init__ reached the record hot path")
+
+    monkeypatch.setattr(Row, "__init__", _boom)
+    monkeypatch.setattr(Rows, "__init__", _boom)
+
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_transactions()
+
+        rows = await PSTransaction.select(lambda t: (t.id, t.amount)).order_by("id").all()
+
+        assert len(rows) == 3
+        assert rows[0].amount == 10

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -65,6 +65,7 @@ def test_query_ir_payload_to_json_serializes_m2m_context_without_mutating_query_
         "offset": None,
         "m2m": query._m2m_context,
         "joins": [],
+        "materialization": {"kind": "root_instances"},
     }
 
     query_json = _query_ir_payload_to_json(query_def)
@@ -73,8 +74,14 @@ def test_query_ir_payload_to_json_serializes_m2m_context_without_mutating_query_
     assert query._m2m_context["source_id"] == source_id
     assert isinstance(query._m2m_context["source_id"], uuid.UUID)
     assert payload["ir_kind"] == "query"
-    assert payload["ir_version"] == 2
+    assert payload["ir_version"] == 3
     assert payload["payload"]["m2m"]["source_id"] == str(source_id)
+
+
+def test_query_carries_root_instances_materialization_by_default():
+    """Every query without a projection materializes complete root instances
+    (ADR-0007): the v3 plan is explicit data on the wire, never inferred."""
+    assert Query(Model)._materialization_ir() == {"kind": "root_instances"}
 
 
 def test_query_node_to_dict_serializes_uuid_values_inside_in_filters():

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -164,6 +164,14 @@ def test_junk_lambda_predicates_fail_the_type_checker():
     assert "invalid-assignment" in result.stdout
 
 
+def test_projected_shape_misuse_fails_the_type_checker():
+    """A `Row` where a model instance is expected must be rejected statically
+    (#279): projection flips the query shape to Rows[Row] / Row | None."""
+    result = _run_ty(FIXTURES / "bad_projections.py")
+    assert result.returncode != 0, "bad_projections.py must fail ty"
+    assert "invalid-assignment" in result.stdout
+
+
 def test_query_ir_is_the_only_query_shape_in_rust():
     """FF-F F-4 exit gate: no `struct QueryNode` outside the IR crate."""
     repo = Path(__file__).parent.parent

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -166,10 +166,14 @@ def test_junk_lambda_predicates_fail_the_type_checker():
 
 def test_projected_shape_misuse_fails_the_type_checker():
     """A `Row` where a model instance is expected must be rejected statically
-    (#279): projection flips the query shape to Rows[Row] / Row | None."""
+    (#279), and mutating a projected query is a static error at the call site
+    (#280, the `self: Never` pin)."""
     result = _run_ty(FIXTURES / "bad_projections.py")
     assert result.returncode != 0, "bad_projections.py must fail ty"
     assert "invalid-assignment" in result.stdout
+    assert result.stdout.count("invalid-argument-type") >= 2, (
+        "update() and delete() on a projected query must each be a static error"
+    )
 
 
 def test_query_ir_is_the_only_query_shape_in_rust():


### PR DESCRIPTION
Closes #277, closes #278, closes #279, closes #280, closes #281.

Partial materialization: the QueryIR v3 materialization plan and partial selects (`Rows`/`Row`), per the PRD (#277) and ADR-0007. One commit per slice, in dependency order.

## What a user gets

```python
rows = await Transaction.select(lambda t: (t.id, t.amount)).all()   # Rows[Row]

rows[0].amount            # attribute access
rows.model_dump()         # [{"id": 1, "amount": ...}, ...] — FastAPI-ready
```

- `select(lambda t: (t.id, t.amount))` (single-field form included) and `select("id", "amount")` (order_by's string contract) project a query; bare `select()` keeps meaning "full query".
- Results are **projected records** (`Row` in the list-like `Rows` container), never model instances — the complete-instance invariant (ADR-0007). No `save()`, no refresh, no identity-map participation.
- Typed columns (datetime/uuid/native enum/decimal) decode **identically to full hydration on both backends** — the record path reuses the model's codec plan and enum catalog, pinned by parity tests from day one.
- `Row`/`Rows` are pydantic-shaped but never pydantic-constructed: records ride a record flavor of the direct-to-dict hydration path (I-2, `hydrate_record_instance`), `Rows` wraps via `model_construct` — pinned structurally (no pydantic `__init__` on the hot path).
- Verb table: `.all()` → `Rows[Row]`, `.first()` → `Row | None`; `count()`/`exists()` unaffected; `order_by` may sort by unselected columns; `where` composes, relation traversal included.
- Loud misuse: misspelled columns fail at build time with did-you-mean; traversed selectors raise pointing at #282; dotted strings rejected permanently; mixed string/lambda calls raise; `update()`/`delete()` on a projection raise `ValueError` at the call (and are **static** errors via the `self: Never` pin); double-`select` raises.

## The contract underneath (#278)

Every query now emits `ir_version: 3` with a required `materialization` section — the plan travels as data, never inferred from a column list. `root_instances` is today's behavior and the default; `record` carries fields with `name` declared separately from source `column`, a relation `path`, and room for a future `expr` — so output aliases, traversed projection, and aggregations (#282) extend the section additively. `instances` is declared-but-rejected until joined-row hydration (#267 stage 2). v2/v1 envelopes are rejected with the actionable one-wheel message (same precedent as the v2 bump in #269). Golden vectors regenerated as v3 plus a new record-plan vector, with Rust round-trip pins.

## Verification

- Full backend matrix (`--db-backends=sqlite,postgres`, isolated-schema Postgres): **1365 passed, 11 skipped, 1 xfailed** (baseline on main: 1314/11/1 — 51 new tests, zero regressions; #278 alone was behavior-change-free at 1315).
- `cargo test --no-default-features --features testing`: 164 passed; `ferro-schema-ir`: 9 passed (round-trip pins incl. the new record vector; unit pins on the rendered subset SELECT list and the #282 boundary rejections).
- `just check` green; `bad_projections.py` static fixture fails ty as designed (`invalid-assignment` for Row-where-model-expected, `invalid-argument-type` ×2 for mutating a projection); `bad_predicates.py` still failing as before.
- Docs: `uv run zensical build` at baseline (exactly the 2 pre-existing architecture.md link issues, zero new); all docs example scripts run end to end, including the new `partial_selects.py` / `partial_selects_annotated.py` pair.

Out of scope, unchanged: aggregations / output aliases / traversed projection (#282), `instances` materialization (#267 stage 2), `into=` custom records, `Rows` for model queries (#7).
