### PR TITLE
feat: joined-row hydration — QueryIR v4 + populated relations via include()

### DIFF
--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -137,11 +137,13 @@ pub struct SchemaCheck {
 /// Query IR: filter, sort, pagination, joins, materialization plan, and
 /// optional M2M join context.
 ///
-/// `ir_version: 3` (unconditional, no v1/v2 emitted anywhere — #269, #278).
-/// `joins` is required and always present (`[]` when the query traverses no
-/// relation); every leaf and `order_by` entry carries a `path` (required,
-/// `[]` = root model); `materialization` is required — the plan travels with
-/// the query as data (ADR-0007), never inferred from a column list.
+/// `ir_version: 4` (unconditional, no earlier version emitted anywhere —
+/// #269, #278, #285). `joins` is required and always present (`[]` when the
+/// query traverses no relation); every leaf and `order_by` entry carries a
+/// `path` (required, `[]` = root model); `materialization` is required — the
+/// plan travels with the query as data (ADR-0007), never inferred from a
+/// column list. v4 gives the `instances` kind its field shape: `paths` of
+/// hop facts (#285).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueryIrPayload {
     /// Model class name the query targets.
@@ -165,13 +167,13 @@ pub struct QueryIrPayload {
 
 /// A query's materialization plan (ADR-0007): what its result columns become.
 ///
-/// Every v3 query carries exactly one plan. `root_instances` is complete
+/// Every v4 query carries exactly one plan. `root_instances` is complete
 /// root-model rows hydrated into model instances — the default and the only
 /// plan the non-projecting walkers accept. `record` is partial selects: a
-/// typed column subset decoded into projected records (#279). `instances`
-/// (populated instance graphs, joined-row hydration) is declared here so the
-/// hydration ABI grows once, but every walker rejects it loudly until
-/// #267 stage 2 builds it.
+/// typed column subset decoded into projected records (#279). `instances` is
+/// populated instance graphs (joined-row hydration, #284): the root rows plus
+/// every included relation path's complete hop rows, hydrated into a
+/// populated graph.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "kind")]
 pub enum Materialization {
@@ -184,10 +186,16 @@ pub enum Materialization {
         /// Projected fields in selection order.
         fields: Vec<RecordField>,
     },
-    /// Populated instance graphs (joined-row hydration, #267 stage 2).
-    /// Declared-but-rejected until that epic builds it.
+    /// Populated instance graphs (joined-row hydration, #284/#286).
     #[serde(rename = "instances")]
-    Instances,
+    Instances {
+        /// Included relation paths, each an ordered hop-fact list from the
+        /// root model (the same hop shape as the `joins` section). Nothing
+        /// else travels here: every hop of a populated graph is a complete
+        /// row, permanently (the complete-instance invariant, ADR-0008), so
+        /// there is no per-path configuration.
+        paths: Vec<Vec<QueryJoinHop>>,
+    },
 }
 
 /// One projected field in a [`Materialization::Record`] plan.
@@ -350,7 +358,7 @@ mod tests {
     #[test]
     fn query_fixture_roundtrip() {
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_user_compound_v3.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_user_compound_v4.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query fixture must parse");
         let ir = parsed
@@ -373,7 +381,7 @@ mod tests {
         // Multi-hop `joins` section + path-carrying leaves must survive a
         // deserialize/serialize round-trip without drift (#270 wire stability).
         let fixture = include_str!(
-            "../../../tests/fixtures/ir_vectors/query_transaction_traversal_v3.json"
+            "../../../tests/fixtures/ir_vectors/query_transaction_traversal_v4.json"
         );
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query traversal fixture must parse");
@@ -399,7 +407,7 @@ mod tests {
         // deserialize/serialize round-trip without drift, and the join_type
         // tokens must reach Rust exactly as written on the wire.
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_left_join_v3.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_left_join_v4.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query left_join fixture must parse");
         let ir = parsed
@@ -425,7 +433,7 @@ mod tests {
         // payload — predicate, order, limit, and a two-field record plan —
         // survives a deserialize/serialize round-trip without drift.
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_record_v3.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_record_v4.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query record fixture must parse");
         let ir = parsed
@@ -475,15 +483,93 @@ mod tests {
 
     #[test]
     fn instances_materialization_roundtrips() {
-        // `instances` is declared-but-rejected (#267 stage 2): it must
-        // deserialize so the hydration ABI grows once, and the runtime — not
-        // the type layer — is what rejects it.
-        let wire = serde_json::json!({"kind": "instances"});
+        // v4 (#285): the `instances` kind carries `paths` — ordered hop-fact
+        // lists in the same hop shape as the `joins` section — and nothing
+        // else. The types are the contract; the walkers reject the kind until
+        // the tracer bullet (#286) builds the fetch path.
+        let wire = serde_json::json!({
+            "kind": "instances",
+            "paths": [
+                [
+                    {"relation": "account", "from_column": "account_id",
+                     "to_table": "account", "to_column": "id"},
+                    {"relation": "owner", "from_column": "owner_id",
+                     "to_table": "owner", "to_column": "id"}
+                ]
+            ]
+        });
         let plan: Materialization =
             serde_json::from_value(wire.clone()).expect("instances kind must deserialize");
-        assert_eq!(plan, Materialization::Instances);
+        let Materialization::Instances { paths } = &plan else {
+            panic!("expected Instances, got {plan:?}");
+        };
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].len(), 2);
+        assert_eq!(paths[0][0].relation, "account");
+        assert_eq!(paths[0][0].from_column, "account_id");
+        assert_eq!(paths[0][1].to_table, "owner");
         let encoded = serde_json::to_value(&plan).expect("instances kind must serialize");
         assert_eq!(encoded, wire, "instances round-trip must not drift");
+    }
+
+    #[test]
+    fn instances_fixture_roundtrip() {
+        // The instances-plan golden vector (#285): an included query's full
+        // payload — root predicate, empty `joins`, and a one-path instances
+        // plan — survives a deserialize/serialize round-trip without drift.
+        let fixture =
+            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_include_v4.json");
+        let parsed: serde_json::Value =
+            serde_json::from_str(fixture).expect("query include fixture must parse");
+        let ir = parsed
+            .get("ir")
+            .cloned()
+            .expect("fixture must contain ir envelope");
+        let envelope: IrEnvelope<QueryIrPayload> =
+            serde_json::from_value(ir.clone()).expect("query include IR must deserialize");
+        let Materialization::Instances { paths } = &envelope.payload.materialization else {
+            panic!(
+                "expected an instances plan, got {:?}",
+                envelope.payload.materialization
+            );
+        };
+        // Include paths ride the materialization plan, never the `joins`
+        // section (ADR-0008): the fixture pins an include-only query with an
+        // EMPTY joins list and one single-hop path.
+        assert!(envelope.payload.joins.is_empty());
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].len(), 1);
+        assert_eq!(paths[0][0].relation, "account");
+        let encoded = serde_json::to_value(&envelope).expect("query include IR must serialize");
+        assert_eq!(encoded, ir, "query include round-trip must not drift");
+    }
+
+    #[test]
+    fn instances_without_paths_is_rejected() {
+        // v4 `instances` always carries `paths`; a bare `{"kind": "instances"}`
+        // (the v3 unit shape) must fail the strict parse loudly.
+        let err = serde_json::from_value::<Materialization>(
+            serde_json::json!({"kind": "instances"}),
+        )
+        .expect_err("instances without paths must fail to deserialize");
+        assert!(
+            err.to_string().contains("paths"),
+            "must name the missing field: {err}"
+        );
+    }
+
+    #[test]
+    fn instances_with_malformed_paths_is_rejected() {
+        // A hop missing its facts fails the strict parse loudly.
+        let err = serde_json::from_value::<Materialization>(serde_json::json!({
+            "kind": "instances",
+            "paths": [[{"relation": "account"}]]
+        }))
+        .expect_err("a malformed hop must fail to deserialize");
+        assert!(
+            err.to_string().contains("from_column"),
+            "must name the missing hop fact: {err}"
+        );
     }
 
     #[test]

--- a/docs/examples/populated_relations.py
+++ b/docs/examples/populated_relations.py
@@ -1,0 +1,201 @@
+"""Runnable companion to the "Populating Relations with include()" guide
+section (docs/pages/guide/queries.md) and the populated-relations parts of
+the relationships guide.
+
+Seeds a small ledger domain (Owner <- Account <- Transaction, both FKs
+nullable) and runs every include() query the guides show, asserting the exact
+populations that come back — the population contract, membership preservation,
+multi-hop paths, identity/accumulation, the refresh rule, and the loud limits.
+
+Two session blocks on purpose: populations accumulate across a session's
+queries, so the awaitable-contract and accumulation demos need instances no
+earlier include has touched.
+"""
+
+import asyncio
+import inspect
+from typing import Annotated
+
+from ferro import BackRef, Field, ForeignKey, Model, Relation, connect, engines, execute
+
+
+# --8<-- [start:schema]
+class Owner(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    accounts: Relation[list["Account"]] = BackRef()
+
+
+class Account(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    label: str
+    owner: Annotated[Owner | None, ForeignKey(related_name="accounts")] = None
+    transactions: Relation[list["Transaction"]] = BackRef()
+
+
+class Transaction(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    amount: int
+    account: Annotated[Account | None, ForeignKey(related_name="transactions")] = None
+
+
+# --8<-- [end:schema]
+
+
+async def _seed() -> None:
+    """Owner o1 <- accounts a1/a2; account b1 has no owner; txn 5 has no
+    account. Transactions: a1 has 10/20, a2 has 30, b1 has 40, orphan 50."""
+    o1 = Owner(id=1, name="o1")
+    await o1.save()
+    a1 = Account(id=1, label="a1", owner=o1)
+    a2 = Account(id=2, label="a2", owner=o1)
+    b1 = Account(id=3, label="b1", owner=None)
+    for row in (a1, a2, b1):
+        await row.save()
+    for txn in (
+        Transaction(id=1, amount=10, account=a1),
+        Transaction(id=2, amount=20, account=a1),
+        Transaction(id=3, amount=30, account=a2),
+        Transaction(id=4, amount=40, account=b1),
+        Transaction(id=5, amount=50, account=None),
+    ):
+        await txn.save()
+
+
+async def main() -> None:
+    await connect("sqlite::memory:", auto_migrate=True)
+
+    async with engines.session():
+        await _seed()
+
+        # --8<-- [start:awaitable]
+        # Without include(), a relation keeps the awaitable contract — access
+        # is a coroutine that runs its own query.
+        transaction = await Transaction.get(2)
+
+        account = await transaction.account
+        assert account.label == "a1"
+        # --8<-- [end:awaitable]
+
+        # --8<-- [start:basic]
+        # One SQL statement; every transaction's account arrives populated.
+        transactions = await Transaction.select().include(lambda t: t.account).all()
+
+        for transaction in transactions[:3]:
+            # Plain attribute access — no await, no query.
+            print(transaction.amount, transaction.account.label)
+        # --8<-- [end:basic]
+        assert [t.account.label for t in transactions[:3]] == ["a1", "a1", "a2"]
+
+        # --8<-- [start:membership]
+        # include() never changes which rows come back: the transaction whose
+        # account FK is NULL is still in the result, populated as None.
+        every = await Transaction.select().include(lambda t: t.account).all()
+
+        orphan = next(t for t in every if t.id == 5)
+        assert len(every) == 5
+        assert orphan.account is None
+        # --8<-- [end:membership]
+
+        # --8<-- [start:multi-hop]
+        # Including a path populates EVERY hop along it.
+        transactions = await (
+            Transaction.select().include(lambda t: t.account.owner).order_by("id").all()
+        )
+
+        first = transactions[0]
+        assert first.account.label == "a1"  # hop 1 populated
+        assert first.account.owner.name == "o1"  # hop 2 populated
+
+        # A NULL mid-chain ends the chain truthfully: b1 has no owner.
+        ownerless = transactions[3]
+        assert ownerless.account.label == "b1"
+        assert ownerless.account.owner is None
+        # --8<-- [end:multi-hop]
+
+        # --8<-- [start:identity]
+        # In a session, a populated instance IS the instance — the same object
+        # a direct fetch returns, deduped across result rows.
+        held = await Account.get(1)
+        transactions = await (
+            Transaction.select()
+            .include(lambda t: t.account)
+            .where(lambda t: t.amount <= 20)
+            .all()
+        )
+
+        assert transactions[0].account is held
+        assert transactions[0].account is transactions[1].account
+        # --8<-- [end:identity]
+
+    async with engines.session():
+        # --8<-- [start:accumulate]
+        # Populations accumulate across a session's queries: a later query's
+        # include attaches onto the instances the session already holds.
+        plain = await Transaction.get(3)  # no population yet
+        await Transaction.select().include(lambda t: t.account).all()
+
+        assert plain.account.label == "a2"  # now populated
+        # --8<-- [end:accumulate]
+
+        # --8<-- [start:count]
+        # count()/exists() measure the same rows with or without the include.
+        base = Transaction.where(lambda t: t.amount >= 20)
+        assert await base.include(lambda t: t.account).count() == await base.count()
+        # --8<-- [end:count]
+
+        # --8<-- [start:interplay]
+        # A predicate on the same path keeps its stage-1 INNER semantics —
+        # include attaches data, it never rewrites what a filter matches.
+        a1_rows = await (
+            Transaction.where(lambda t: t.account.label == "a1")
+            .include(lambda t: t.account)
+            .all()
+        )
+        assert [t.id for t in a1_rows] == [1, 2]
+        assert all(t.account.label == "a1" for t in a1_rows)
+        # --8<-- [end:interplay]
+
+        # --8<-- [start:refresh-rule]
+        # A refresh keeps a population only while it is still true. Change the
+        # row's FK underneath the ORM and re-fetch: the stale population is
+        # dropped, and access reverts to the awaitable.
+        transaction = await (
+            Transaction.select()
+            .include(lambda t: t.account)
+            .where(lambda t: t.id == 1)
+            .first()
+        )
+        assert transaction.account.label == "a1"
+
+        await execute('UPDATE "transaction" SET account_id = ? WHERE id = ?', 2, 1)
+        await Transaction.get(1)  # refreshes in place
+
+        pending = transaction.account  # awaitable again
+        assert inspect.iscoroutine(pending)
+        assert (await pending).label == "a2"
+        # --8<-- [end:refresh-rule]
+
+        # --8<-- [start:limits]
+        # The loud limits: reverse relations, projections, and mutations.
+        try:
+            Account.select().include(lambda a: a.transactions)
+        except TypeError as exc:
+            assert "reverse (BackRef) or many-to-many" in str(exc)
+
+        try:
+            Transaction.select().include(lambda t: t.account).select(lambda t: (t.id,))
+        except ValueError as exc:
+            assert "#282" in str(exc)
+
+        try:
+            await Transaction.select().include(lambda t: t.account).delete()
+        except ValueError as exc:
+            assert "does not support include()" in str(exc)
+        # --8<-- [end:limits]
+
+    print("populated_relations example ran successfully")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/examples/populated_relations_annotated.py
+++ b/docs/examples/populated_relations_annotated.py
@@ -1,0 +1,59 @@
+"""Annotated-style companion to populated_relations.py (AGENTS.md I-7).
+
+Field options move into ``Annotated[...]``. The relationship declarations are
+identical in both styles: forward FKs are always ``Annotated[Target,
+ForeignKey(...)]`` and ``BackRef()`` is always an assignment. The include()
+queries themselves declare no fields, so they live only in
+populated_relations.py.
+"""
+
+import asyncio
+from typing import Annotated
+
+from ferro import BackRef, Field, ForeignKey, Model, Relation, connect, engines
+
+
+# --8<-- [start:schema]
+class Owner(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    name: str
+    accounts: Relation[list["Account"]] = BackRef()
+
+
+class Account(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    label: str
+    owner: Annotated[Owner | None, ForeignKey(related_name="accounts")] = None
+    transactions: Relation[list["Transaction"]] = BackRef()
+
+
+class Transaction(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    amount: int
+    account: Annotated[Account | None, ForeignKey(related_name="transactions")] = None
+
+
+# --8<-- [end:schema]
+
+
+async def main() -> None:
+    await connect("sqlite::memory:", auto_migrate=True)
+
+    async with engines.session():
+        owner = Owner(id=1, name="o1")
+        await owner.save()
+        account = Account(id=1, label="a1", owner=owner)
+        await account.save()
+        await Transaction(id=1, amount=10, account=account).save()
+
+        transactions = (
+            await Transaction.select().include(lambda t: t.account.owner).all()
+        )
+        assert transactions[0].account.label == "a1"
+        assert transactions[0].account.owner.name == "o1"
+
+    print("populated_relations_annotated example ran successfully")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/pages/api/queries.md
+++ b/docs/pages/api/queries.md
@@ -4,6 +4,12 @@
 
 `where()` and `order_by()` lambdas may **traverse** a forward-FK relation (`lambda t: t.account.ledger_id == 1`): each hop renders one INNER join, deduplicated by relation path (ADR-0006). `join()` forces a join on a relation path (a bare `join()` is an existence filter on a nullable relation), and `left_join()` marks the whole path LEFT to keep relation-less rows. See the [Querying Across Relationships](../guide/queries.md#querying-across-relationships) guide for worked examples.
 
+## `include()` and populated relations
+
+`include(lambda t: t.account)` delivers each result with the relation **populated** (ADR-0008): access becomes a plain attribute holding the complete related instance — no await, no query — while unpopulated relations keep the awaitable contract. Include is the third orthogonal query axis (joins decide membership, projection decides shape, include decides attached data): it never changes which rows come back, `.all()` still returns `list[Model]`, and `count()`/`exists()` are unaffected. Paths populate whole (`include(lambda t: t.account.owner)` populates both hops); includes are cumulative, order-free, and idempotent; populated instances run the full session identity-map protocol, and a refresh keeps a population only while the row's FK still points at it.
+
+Loud limits, at build time: forward-FK lambda paths only (a `BackRef`/M2M selector, a string, or a column selector raises `TypeError`); combining include with a projection raises `ValueError` in either chain order (one materialization plan per query, #282); `update()`/`delete()` on an included query raise `ValueError`. See [Populating Relations with include()](../guide/queries.md#populating-relations-with-include) for worked examples.
+
 ## `select()` overloads
 
 `select()` has three forms, resolved at build time:

--- a/docs/pages/concepts/query-typing.md
+++ b/docs/pages/concepts/query-typing.md
@@ -74,6 +74,39 @@ The gate divides the work exactly like predicates do:
   did-you-mean when the query is built, before any round-trip — the same
   runtime validation as `where()` and `order_by()`.
 
+## Included Queries
+
+`include()` deliberately does **not** flip the query's type the way `select()`
+does. An included query stays `Query[Model]`-shaped: `.all()` checks as
+`list[Transaction]`, `.first()` as `Transaction | None`, and populated access
+(`txns[0].account.label`) type-checks through the field's ordinary declared
+annotation. There is no `Loaded[Transaction]`.
+
+That is a decision, not a gap, for two reasons:
+
+- **A per-query "loaded" type is unsound under the identity map.** In a
+  session, the instance an included query returns is the *same object* a
+  plain query returns — populations attach to shared instances and accumulate
+  across queries. A static brand that says "this object's `account` is
+  populated" asserts something the runtime cannot pin to a type: the next
+  refresh may drop the population (see the
+  [refresh rule](../guide/queries.md#refreshes-drop-populations-that-stopped-being-true)),
+  and a plain query can hand you the already-populated object. The honest
+  static type of every instance is the model itself.
+- **The declared annotation already claims the instance.** The field says
+  `account: Account`; a distinct loaded type would need to *transform*
+  per-field types on the unloaded side instead (`account: Awaitable[Account]`
+  → `Account`), which requires TypeScript-style mapped types —
+  [PEP 827](https://peps.python.org/pep-0827/) (draft, targeting
+  Python 3.16). Population is what makes the declared annotation *true* at
+  runtime, exactly where the user opted in.
+
+When PEP 827 lands, typing can sharpen with zero runtime change — precisely
+because the runtime type stayed single. Meanwhile the statically catchable
+misuses do fail the gate: `include()` on a projected query is an error at the
+call site (the `self: Never` pin), and a string selector fails the callable
+parameter type.
+
 ## What This Doesn't Change
 
 - Your model annotations. `archived: bool = False` stays exactly as it is.

--- a/docs/pages/guide/queries.md
+++ b/docs/pages/guide/queries.md
@@ -367,7 +367,7 @@ n = await author.posts.count()
 
 ### Results are plain root instances
 
-A traversed query is **shape-preserving**: filtering `Transaction` through `transaction.account.ledger_id` still returns `Transaction` instances, no matter how deep the predicate reaches. Traversal does *not* pre-load the related rows onto the results — `await transaction.account` still issues its own query, exactly as it does without any traversal. (Eager loading is separate future work; see [Not Yet Supported](#not-yet-supported).)
+A traversed query is **shape-preserving**: filtering `Transaction` through `transaction.account.ledger_id` still returns `Transaction` instances, no matter how deep the predicate reaches. Traversal does *not* pre-load the related rows onto the results — `await transaction.account` still issues its own query, exactly as it does without any traversal. Attaching related data is a separate, explicit request: [`include()`](#populating-relations-with-include).
 
 ### `update()` and `delete()` cannot traverse
 
@@ -390,6 +390,115 @@ Do the two-step: fetch the primary keys with the joined query, then mutate by th
 - Combining predicates with Python's `and`/`or` (instead of `&`/`|`) coerces a node to `bool` and raises `TypeError: QueryNode cannot be used in a boolean context; use & / |`. Always parenthesize and use the bitwise operators.
 
 See [Relationships](relationships.md) for the schema-declaration side of foreign keys and reverse relations.
+
+## Populating Relations with include()
+
+Every relation access is a query. A list view that renders 100 transactions with their account labels awaits `transaction.account` 100 times — 101 statements for one screen. `include()` cures that N+1: ask the query to bring the related rows along, and each result's relation arrives **populated**:
+
+```python
+--8<-- "docs/examples/populated_relations.py:basic"
+```
+
+One SQL statement. The query still returns the same `list[Transaction]` it always did — and `transaction.account` is now a plain attribute holding the complete `Account` instance, exactly as the field's annotation (`account: Account`) always claimed. No await, no query.
+
+The examples in this section use this schema (both foreign keys nullable, so you can see what happens when a relation is absent):
+
+=== "Assignment"
+
+    ```python
+    --8<-- "docs/examples/populated_relations.py:schema"
+    ```
+
+=== "Annotated"
+
+    ```python
+    --8<-- "docs/examples/populated_relations_annotated.py:schema"
+    ```
+
+### The population contract
+
+A relation is in exactly one of two states on any given instance:
+
+- **Populated** (the query included it): access is a **plain attribute** returning the complete related instance. A nullable FK with no target populates as `None` — truthful to the declared `Account | None`.
+- **Unpopulated** (everything else): access keeps today's **awaitable** contract, unchanged — a coroutine that runs its own query:
+
+```python
+--8<-- "docs/examples/populated_relations.py:awaitable"
+```
+
+!!! warning "Awaiting a populated relation is a hard break"
+    `await transaction.account` on a *populated* instance raises `TypeError: 'Account' object can't be awaited` — the attribute is the instance itself, not a coroutine. Code that must handle both states cheaply can check `inspect.isawaitable(...)`, but the better pattern is to decide at the query: if you are going to read the relation, include it.
+
+There is no separate "loaded" model type: `.all()` on an included query still returns `list[Transaction]`, and a populated instance is an ordinary instance of the target model. (Why no `Loaded[Transaction]`? See [Typed Query Predicates](../concepts/query-typing.md#included-queries).)
+
+### Include never changes membership
+
+Joins decide **membership**, projection decides **shape**, include decides **attached data** — three orthogonal axes. Adding `.include(...)` to any query returns exactly the rows that query returned without it:
+
+```python
+--8<-- "docs/examples/populated_relations.py:membership"
+```
+
+Under the hood, an edge only the include touches renders a LEFT join, and an edge any other clause references keeps that clause's join type. So a `where()` traversal on the same path keeps its INNER narrowing — include attaches data to the surviving rows, it never rewrites what a filter matches:
+
+```python
+--8<-- "docs/examples/populated_relations.py:interplay"
+```
+
+`count()` and `exists()` are likewise unaffected — they measure the same rows with or without the include:
+
+```python
+--8<-- "docs/examples/populated_relations.py:count"
+```
+
+### Multi-hop paths populate every hop
+
+`include(lambda t: t.account.owner)` populates the whole path — a populated graph is never missing its intermediate nodes. A `NULL` somewhere along the chain ends the chain as a populated `None`, with the root row retained:
+
+```python
+--8<-- "docs/examples/populated_relations.py:multi-hop"
+```
+
+Includes are cumulative, order-free, and idempotent: `.include(lambda t: t.account)` plus `.include(lambda t: t.account.owner)` — in either order — is the same query as `.include(lambda t: t.account.owner)` alone.
+
+### Populated instances are session instances
+
+In a session, population runs through the identity map like every other fetch: same row, same object. A populated `Account` **is** the `Account` a direct fetch returns — deduped across result rows, and attached onto instances the session already holds:
+
+```python
+--8<-- "docs/examples/populated_relations.py:identity"
+```
+
+Populations **accumulate** across a session's queries — an `account` include and a later `attachment` include both stick, so shared objects get richer, never forked:
+
+```python
+--8<-- "docs/examples/populated_relations.py:accumulate"
+```
+
+Outside a session there is no identity map, so an included query returns fresh instances per row — including a fresh related instance per row, with no query-local dedup. Sessionless Ferro keeps exactly one identity story: the session.
+
+### Refreshes drop populations that stopped being true
+
+Every fetch refreshes instances the session already holds. A refresh keeps each population **iff the row's foreign key still points at it**; if the FK changed (or went `NULL`) underneath you, the now-lying population is dropped and access reverts to the awaitable — a populated relation never points at the wrong row:
+
+```python
+--8<-- "docs/examples/populated_relations.py:refresh-rule"
+```
+
+### The loud limits
+
+Misuse raises at build time, before any SQL:
+
+- **Forward foreign keys only.** Including a `BackRef` or `ManyToMany` relation raises `TypeError`: reverse and M2M population will be a separate mechanism (a batched second query stitched onto the results), not `include()`. Until it lands, fetch collections through the relation itself (`await author.posts.all()`).
+- **Lambda selectors only.** `include("account")` raises pointing at the lambda form — strings never traverse. Selecting a *column* (`include(lambda t: t.account.label)`) raises too: every populated hop is a complete row, so there is nothing to select per column.
+- **No include × projection.** A query carries exactly one materialization plan — populated instances or projected records, not both. Either order raises `ValueError` naming [#282](https://github.com/syn54x/ferro-orm/issues/282), which designs record+relation results.
+- **No mutations.** `update()`/`delete()` on an included query raise — a mutation returns no instances to populate.
+
+```python
+--8<-- "docs/examples/populated_relations.py:limits"
+```
+
+Include composes with the M2M association context (`post.tags.include(lambda tag: tag.created_by)` populates each tag's forward FK) and with everything else a query does: `where()` (traversal included), `order_by()`, `limit()`/`offset()`, `first()`, and query branching.
 
 ## Selecting a Column Subset
 
@@ -484,7 +593,7 @@ Static typing follows the same shape promise as predicates: `select(...)` flips 
 
     - Aggregations beyond `count()` / `exists()` (`sum`, `avg`, `min`, `max`, `GROUP BY`)
     - Traversed projection and output aliases (`select(lambda t: t.account.name)`) — designed together with aggregations
-    - Eager loading (`prefetch_related` / `select_related`) — be mindful of N+1 patterns when looping over relations
+    - Reverse (`BackRef`) and many-to-many population — [`include()`](#populating-relations-with-include) covers forward FKs; collection population is a separate future mechanism
     - Case-insensitive `ilike()`
     - `not_in()` (negate with `!=` conditions combined with `&` in the meantime)
 

--- a/docs/pages/guide/relationships.md
+++ b/docs/pages/guide/relationships.md
@@ -6,7 +6,7 @@ Ferro connects models with foreign keys, zero-boilerplate reverse lookups, and a
 
 Relationships are **lazy** — nothing is fetched until you ask for it:
 
-- **Forward relations** (a `ForeignKey` field): `await post.author` performs one query and returns the related instance.
+- **Forward relations** (a `ForeignKey` field): `await post.author` performs one query and returns the related instance. A query can also deliver the relation already **populated** — `Post.select().include(lambda p: p.author)` makes `post.author` a plain attribute, no await, no extra query (see [Populated relations](#populated-relations)).
 - **Reverse relations** (a `BackRef` field): `author.posts` is a chainable query — filter, order, and slice it before awaiting a terminal.
 
 A forward `ForeignKey(related_name="x")` always pairs with a reverse field named `x` on the target model. The pairing is **required and checked at `connect()`** — a `ForeignKey` whose `related_name` has no matching `BackRef()` on the target raises at connect time.
@@ -36,6 +36,18 @@ The most common shape: a `ForeignKey` on the "child" model, declared as `Annotat
 For every `ForeignKey` field (e.g. `team`), Ferro creates a shadow scalar column and matching Pydantic field named `{field}_id` (e.g. `team_id`) holding the related row's primary key. Its Python type follows the target model's primary-key annotation. Read it or filter on it like any other column — `Player.where(lambda t: t.team_id == team.id)` — with no extra query.
 
 To filter or order by a column on the *related* model, a query lambda can traverse the relation itself (`Player.where(lambda player: player.team.name == "Rustaceans")`) — see [Querying Across Relationships](queries.md#querying-across-relationships).
+
+### Populated relations
+
+Awaiting a forward relation in a loop is the classic N+1 pattern — each access is a query. When a query knows it will read a relation, ask for it up front with `include()` and the relation arrives **populated**: a plain attribute holding the complete related instance, fetched in the same single statement as the roots:
+
+```python
+--8<-- "docs/examples/populated_relations.py:basic"
+```
+
+A relation is populated only on instances an including query delivered (or refreshed); everywhere else the awaitable form above keeps working, unchanged. Nullable FKs populate truthfully — `transaction.account` is `None` (not a coroutine) when the row has no account. The full semantics — membership preservation, multi-hop paths, identity-map behavior, and the refresh rule — live in [Populating Relations with include()](queries.md#populating-relations-with-include).
+
+`include()` covers **forward** foreign keys only. Populating a `BackRef` collection or an M2M set is a separate future mechanism; until it lands, reverse relations stay chainable queries (`await author.posts.all()`).
 
 ## One-to-One
 

--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -5,7 +5,7 @@ Ferro is pre-1.0 and under active development. The items below are known gaps we
 ## Query Features
 
 - **Aggregations beyond `count()`/`exists()`** — `sum`, `avg`, `min`, `max` on the query builder, plus output aliases and traversed projection (`select(lambda t: t.account.name)`), designed together on the [partial-select](guide/queries.md#selecting-a-column-subset) substrate. Today you either compute in Python after fetching or drop to raw SQL.
-- **Eager loading** — `prefetch_related`/`select_related`-style relationship loading to eliminate N+1 query patterns. Today each awaited relationship attribute is its own query.
+- **Reverse and many-to-many population** — [`include()`](guide/queries.md#populating-relations-with-include) populates forward-FK paths in one statement; populating `BackRef` collections and M2M sets is a separate future mechanism (a batched second query stitched onto the results). Today each awaited collection is its own query.
 - **`ilike()`** — case-insensitive pattern matching. Workaround: `like()` with normalized case.
 - **`not_in_()`** — NOT IN exclusion lists. Workaround: combine `!=` comparisons with `&`.
 - **Atomic update expressions** — database-side expressions in batch updates, e.g. `update(view_count=Post.view_count + 1)`, avoiding the read-modify-write race. Workaround today: load, mutate, `save()` (or raw SQL).

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -497,27 +497,39 @@ pub fn typed_rows_to_parsed_data(
     pk_col: Option<&str>,
 ) -> Vec<ParsedRow> {
     rows.into_iter()
-        .map(|row| {
-            let mut row_pk_val = None;
-            let mut fields = Vec::with_capacity(row.values.len());
-
-            for (col_name, value) in row.values {
-                if pk_col == Some(col_name.as_str()) {
-                    row_pk_val = match &value {
-                        EngineValue::I64(v) => Some(v.to_string()),
-                        EngineValue::String(v) => Some(v.clone()),
-                        // Native uuid PKs stringify to the same canonical
-                        // lowercase-hyphenated form SQLite stores as text, so
-                        // identity-map keys agree across backends.
-                        EngineValue::Uuid(v) => Some(v.hyphenated().to_string()),
-                        _ => None,
-                    };
-                }
-                let value = decode_engine_value(value, plan, &col_name);
-                fields.push((col_name, value));
-            }
-
-            (row_pk_val, fields)
-        })
+        .map(|row| typed_row_values_to_parsed(row.values, plan, pk_col))
         .collect()
+}
+
+/// Decode one row's `(column, value)` pairs into a [`ParsedRow`].
+///
+/// The single-row seam behind [`typed_rows_to_parsed_data`], exposed so the
+/// instances fetch walker (#286) can decode each hop's column slice against
+/// that hop model's OWN codec plan — never the root's (the stage-1
+/// root-vs-hop codec lesson, #270).
+pub fn typed_row_values_to_parsed(
+    values: Vec<(String, EngineValue)>,
+    plan: &ModelCodecPlan,
+    pk_col: Option<&str>,
+) -> ParsedRow {
+    let mut row_pk_val = None;
+    let mut fields = Vec::with_capacity(values.len());
+
+    for (col_name, value) in values {
+        if pk_col == Some(col_name.as_str()) {
+            row_pk_val = match &value {
+                EngineValue::I64(v) => Some(v.to_string()),
+                EngineValue::String(v) => Some(v.clone()),
+                // Native uuid PKs stringify to the same canonical
+                // lowercase-hyphenated form SQLite stores as text, so
+                // identity-map keys agree across backends.
+                EngineValue::Uuid(v) => Some(v.hyphenated().to_string()),
+                _ => None,
+            };
+        }
+        let value = decode_engine_value(value, plan, &col_name);
+        fields.push((col_name, value));
+    }
+
+    (row_pk_val, fields)
 }

--- a/src/ferro/_core.pyi
+++ b/src/ferro/_core.pyi
@@ -96,6 +96,7 @@ async def fetch_filtered(
     query_ir_json: str,
     route: RouteHandle,
     record_cls: type | None = None,
+    hop_classes: dict[str, type] | None = None,
 ) -> list[Any]: ...
 async def count_filtered(
     name: str,

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -177,6 +177,55 @@ def _path_edges(path: tuple[str, ...]) -> list[tuple[str, ...]]:
     return [path[:i] for i in range(1, len(path) + 1)]
 
 
+def _resolve_include_selector(
+    selector: "Callable[[QueryProxy[Any]], Any]", model_cls: type
+) -> tuple[str, ...]:
+    """Resolve an ``include()`` selector into a relation path (#286).
+
+    ``selector`` is a lambda receiving a validating :class:`QueryProxy` and
+    naming a forward-FK RELATION path (``lambda t: t.account``,
+    ``lambda t: t.account.owner``) — the same traversal syntax as ``join()``,
+    resolving to a :class:`RelationProxy`. Each hop is validated against the
+    relevant model at build time (the proxy raises ``AttributeError`` with a
+    did-you-mean for a bad hop, exactly like ``where()``).
+
+    Returns:
+        The relation ``path`` tuple the selector names (length ≥ 1).
+
+    Raises:
+        TypeError: If ``selector`` is a string or otherwise not callable
+            (strings never traverse, #280 — include is lambda-selector only),
+            resolves to a column (:class:`FieldProxy`) rather than a relation,
+            or returns any other non-relation value.
+    """
+    if isinstance(selector, str):
+        raise TypeError(
+            f"include() takes a lambda selector naming a relation path, not a "
+            f"string: include({selector!r}) is not supported (strings never "
+            f"traverse). Use include(lambda t: t.{selector})."
+        )
+    if not callable(selector):
+        raise TypeError(
+            "include() expected a selector callable "
+            f"(e.g. `lambda t: t.account`), got {type(selector).__name__}"
+        )
+    result = selector(QueryProxy(model_cls))
+    if isinstance(result, FieldProxy):
+        dotted = ".".join((*result.path, result.column))
+        raise TypeError(
+            f"include() selector resolved to the column {dotted!r}, not a "
+            "relation; include() populates whole related instances "
+            "(e.g. `lambda t: t.account`) — every populated hop is a complete "
+            "row, so there is nothing to select per column."
+        )
+    if not isinstance(result, RelationProxy):
+        raise TypeError(
+            "include() selector must return a relation path "
+            f"(e.g. `lambda t: t.account`), got {type(result).__name__}"
+        )
+    return result._path
+
+
 def _resolve_projection_selector(
     selector: "RowSelector[Any]", model_cls: type
 ) -> tuple[str, ...]:
@@ -388,6 +437,13 @@ class Query(Generic[T]):
         # for LEFT on the wire — implicit where()/order_by() traversal never
         # touches this, so explicit always beats implicit (#272).
         self._explicit_edges: dict[tuple[str, ...], str] = {}
+        # Relation paths to populate (#286, ADR-0008), insertion-ordered and
+        # deduped by path identity (dict-as-ordered-set). CRITICAL: include
+        # paths never enter ``_joins``/``_serialize_joins`` — they ride the
+        # ``instances`` materialization plan, so the ``joins`` wire section
+        # keeps its stage-1 semantics untouched and include contributes no
+        # join-type opinion on any edge another clause references.
+        self._includes: dict[tuple[str, ...], None] = {}
 
     async def _transaction_or_using(self) -> "RouteHandle":
         from .. import _ensure_rust_registration_synced_for_operation
@@ -411,6 +467,7 @@ class Query(Generic[T]):
         )
         new._joins = dict(self._joins)
         new._explicit_edges = dict(self._explicit_edges)
+        new._includes = dict(self._includes)
         return new
 
     def _m2m(
@@ -702,6 +759,54 @@ class Query(Generic[T]):
         """
         return self._add_explicit_join(selector, "left")
 
+    def include(self, selector: "Callable[[QueryProxy[T]], Any]") -> Self:
+        """Populate a relation path on every result and return a new query.
+
+        ``selector`` is a lambda naming a forward-FK RELATION path
+        (``lambda t: t.account``, ``lambda t: t.account.owner``) — the same
+        traversal syntax as :meth:`join`. Results are the same ``list[T]``
+        the query always returned, in one SQL statement, with each included
+        relation **populated**: access is a plain attribute
+        (``txn.account.label`` — no await, no query) returning the complete
+        related instance, exactly as the field's declared annotation claims
+        (ADR-0008). Unpopulated relations keep the awaitable contract
+        unchanged; a nullable FK with no target populates as ``None`` with
+        the root row retained.
+
+        Include decides attached data only — joins decide membership,
+        projection decides shape. Adding ``.include(...)`` to any query
+        returns exactly the rows that query returned without it: include
+        contributes no join-type opinion on any edge a predicate or explicit
+        chainer references, and renders LEFT only on edges nothing else
+        touches. ``count()``/``exists()`` are unaffected.
+
+        Cumulative, order-free, and idempotent: chained includes accumulate,
+        shared prefixes dedup by path identity, and including a path
+        populates every hop along it.
+
+        Args:
+            selector: A lambda receiving a :class:`QueryProxy` and returning
+                a relation path (a ``RelationProxy``).
+
+        Returns:
+            A new ``Query`` with the population registered; ``self`` is
+            unchanged.
+
+        Raises:
+            TypeError: If ``selector`` is a string or not callable, resolves
+                to a column rather than a relation, or names a BackRef/M2M
+                relation (reverse population is a separate future mechanism).
+
+        Examples:
+            >>> txns = await Transaction.select().include(lambda t: t.account).all()  # doctest: +SKIP
+            >>> txns[0].account.label  # doctest: +SKIP
+            'checking'
+        """
+        path = _resolve_include_selector(selector, self.model_cls)
+        new = self._clone()
+        new._includes.setdefault(path, None)
+        return new
+
     def _add_explicit_join(
         self, selector: "Callable[[QueryProxy[T]], Any]", join_type: str
     ) -> Self:
@@ -767,12 +872,50 @@ class Query(Generic[T]):
         return new
 
     def _materialization_ir(self) -> dict[str, Any]:
-        """Serialize this query's materialization plan (ADR-0007, v3).
+        """Serialize this query's materialization plan (ADR-0007, v4).
 
-        Every fetching query carries exactly one plan on the wire; a query
-        without a projection materializes complete root instances.
+        Every fetching query carries exactly one plan on the wire. A query
+        without a projection or includes materializes complete root
+        instances; an included query carries the ``instances`` plan — one
+        ordered hop-fact list per include path (#286), the same hop shape as
+        the ``joins`` section but deliberately separate from it (ADR-0008):
+        the fetch walker unions include-only edges in as LEFT, so include
+        can never change membership or a shared edge's join type.
         """
+        if self._includes:
+            return {
+                "kind": "instances",
+                "paths": [
+                    _resolve_join_hops(self.model_cls, path)
+                    for path in self._includes
+                ],
+            }
         return {"kind": "root_instances"}
+
+    def _include_hop_classes(self) -> dict[str, type]:
+        """Map each included hop's physical table to its model class (#286).
+
+        The Rust fetch walker hydrates every included hop through the full
+        model protocol (codec plan, enum classes, identity map), so it needs
+        the hop's Python class — resolved here, where the relation-spec chain
+        lives, and passed across the FFI keyed by ``to_table`` (one model per
+        table, enforced at registration).
+        """
+        hop_classes: dict[str, type] = {}
+        for path in self._includes:
+            current = self.model_cls
+            for relation in path:
+                specs = getattr(current, "__ferro_relation_specs__", None) or {}
+                spec = specs.get(relation)
+                if spec is None:
+                    raise ValueError(
+                        f"{current.__name__!r} has no relation {relation!r} "
+                        "for population."
+                    )
+                target = spec.target
+                hop_classes[target.__ferro_table__] = target
+                current = target
+        return hop_classes
 
     def _serialize_joins(self) -> list[dict[str, Any]]:
         """Serialize collected relation paths into QueryIR ``joins`` entries.
@@ -883,6 +1026,13 @@ class Query(Generic[T]):
         """
         query_def = self._fetch_query_def()
         route = await self._transaction_or_using()
+        if self._includes:
+            return await fetch_filtered(
+                self.model_cls,
+                _query_ir_payload_to_json(query_def),
+                route,
+                hop_classes=self._include_hop_classes(),
+            )
         return await fetch_filtered(
             self.model_cls,
             _query_ir_payload_to_json(query_def),

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -52,17 +52,18 @@ _ROWS_OF_ROW: type[Rows[Row]] = Rows[Row]
 def _query_ir_payload_to_json(query_payload: dict[str, Any]) -> str:
     """Serialize a QueryIR payload into a versioned IR envelope JSON string.
 
-    Always emits ``ir_version: 3`` (#278 — unconditional bump, exactly like v2
-    at #269; there is no v1 or v2 envelope left anywhere). Python and Rust ship
-    in one wheel, so a single supported version is the whole contract
-    (#267 Implementation Decisions).
+    Always emits ``ir_version: 4`` (#285 — unconditional bump, exactly like v3
+    at #278 and v2 at #269; there is no earlier envelope left anywhere). v4
+    gives the ``instances`` materialization kind its field shape (``paths`` of
+    hop facts). Python and Rust ship in one wheel, so a single supported
+    version is the whole contract (#267 Implementation Decisions).
     """
     import json
 
     return json.dumps(
         {
             "ir_kind": "query",
-            "ir_version": 3,
+            "ir_version": 4,
             "payload": _serialize_query_value(query_payload),
         }
     )

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -177,6 +177,35 @@ def _path_edges(path: tuple[str, ...]) -> list[tuple[str, ...]]:
     return [path[:i] for i in range(1, len(path) + 1)]
 
 
+def _reject_reverse_relation_include(exc: AttributeError) -> None:
+    """Raise pointedly when an include selector names a BackRef/M2M (#287).
+
+    The validating proxies raise ``AttributeError`` for any name that is not
+    a column or a forward relation; when the failing name (carried
+    structurally on the exception) is a declared reverse or many-to-many
+    relation of the hop's model, include() has a sharper story than
+    "no queryable column": reverse population is a separate future mechanism
+    — a batched second query stitched onto the results — deliberately not
+    ``include()``.
+    """
+    from ..relations.descriptors import RelationshipDescriptor
+
+    name = getattr(exc, "name", None)
+    model = getattr(exc, "obj", None)
+    if not name or model is None:
+        return
+    if isinstance(getattr(model, name, None), RelationshipDescriptor):
+        raise TypeError(
+            f"include() cannot populate {name!r}: it is a reverse (BackRef) "
+            "or many-to-many relation, and include() populates forward "
+            "foreign-key paths only (e.g. lambda t: t.account). Reverse and "
+            "M2M population will be a separate mechanism — a batched second "
+            "query stitched onto the results — not include(). Until it "
+            f"lands, fetch the collection through the relation itself "
+            f"(await instance.{name}.all())."
+        ) from None
+
+
 def _resolve_include_selector(
     selector: "Callable[[QueryProxy[Any]], Any]", model_cls: type
 ) -> tuple[str, ...]:
@@ -196,7 +225,8 @@ def _resolve_include_selector(
         TypeError: If ``selector`` is a string or otherwise not callable
             (strings never traverse, #280 — include is lambda-selector only),
             resolves to a column (:class:`FieldProxy`) rather than a relation,
-            or returns any other non-relation value.
+            names a BackRef/M2M relation (reverse population is a separate
+            future mechanism, #287), or returns any other non-relation value.
     """
     if isinstance(selector, str):
         raise TypeError(
@@ -209,7 +239,11 @@ def _resolve_include_selector(
             "include() expected a selector callable "
             f"(e.g. `lambda t: t.account`), got {type(selector).__name__}"
         )
-    result = selector(QueryProxy(model_cls))
+    try:
+        result = selector(QueryProxy(model_cls))
+    except AttributeError as exc:
+        _reject_reverse_relation_include(exc)
+        raise
     if isinstance(result, FieldProxy):
         dotted = ".".join((*result.path, result.column))
         raise TypeError(
@@ -571,8 +605,10 @@ class Query(Generic[T]):
             TypeError: If the selector is not callable/strings, selects
                 non-columns (a bare relation, a comparison), or mixes strings
                 with a lambda in one call.
-            ValueError: If the selection is empty, repeats a column, or a
-                string is a dotted path (strings never traverse).
+            ValueError: If the selection is empty, repeats a column, a
+                string is a dotted path (strings never traverse), or the
+                query already carries an ``include()`` (one materialization
+                plan per query — include × projection is #282).
             NotImplementedError: If a lambda selects a traversed column
                 (traversed projection lands with #282).
 
@@ -583,6 +619,15 @@ class Query(Generic[T]):
         """
         if not selectors:
             return self._clone()
+        if self._includes:
+            raise ValueError(
+                "select() with a projection cannot be combined with "
+                "include(): a query carries exactly one materialization plan "
+                "— projected records or populated instances, not both. The "
+                "flattened-vs-nested design for record+relation results is "
+                "#282; until it lands, drop the include() or project through "
+                "a separate query."
+            )
         if any(isinstance(selector, str) for selector in selectors):
             if not all(isinstance(selector, str) for selector in selectors):
                 raise TypeError(
@@ -985,6 +1030,13 @@ class Query(Generic[T]):
                 "(A join-free relation filter like `t.account == instance` is "
                 "allowed.)"
             )
+        if self._includes:
+            raise ValueError(
+                f"{operation}() does not support include(): a mutation is a "
+                "single-table write shape and returns no instances to "
+                "populate. Drop the .include(...) call, or fetch the "
+                "populated rows first and mutate by primary-key set."
+            )
         return {
             "model_name": _model_identity(self.model_cls),
             "where": [node.to_ir_dict() for node in self.where_clause],
@@ -1338,6 +1390,27 @@ class ProjectedQuery(Query[T]):
             "projection changes the result type mid-chain. Name every "
             "projected column in one select() call, or start a new query "
             "from the model."
+        )
+
+    def include(self: Never, selector: Any) -> NoReturn:  # type: ignore[override]
+        """Reject ``include()`` on a projected query (#287).
+
+        One materialization plan per query (ADR-0007/ADR-0008): projected
+        records and populated instances cannot ride one result shape until
+        #282 designs flattened-vs-nested record+relation results. The
+        ``self: Never`` pin makes this a STATIC error at the call site
+        (tests/static_fixtures/bad_includes.py), mirroring the mutation pins.
+
+        Raises:
+            ValueError: Always — include through an unprojected query, or
+                wait for #282.
+        """
+        raise ValueError(
+            "include() cannot be combined with a projection: a query carries "
+            "exactly one materialization plan — projected records or "
+            "populated instances, not both. The flattened-vs-nested design "
+            "for record+relation results is #282; until it lands, drop the "
+            "projection or populate through a separate query."
         )
 
     # `self: Never` makes mutating a projected query a STATIC error at the

--- a/src/ferro/query/nodes.py
+++ b/src/ferro/query/nodes.py
@@ -347,9 +347,15 @@ def validate_query_column(model_cls: type, name: str) -> str:
     relation_note = (
         f" Valid relations: {', '.join(sorted(relations))}." if relations else ""
     )
+    # `name`/`obj` carry the failing attribute and its model structurally
+    # (PEP 678-era AttributeError metadata), so callers with a sharper story
+    # for a specific name — include()'s BackRef/M2M guardrail (#287) — can
+    # re-raise pointedly without parsing this message.
     raise AttributeError(
         f"{model_cls.__name__} has no queryable column {name!r}.{hint} "
-        f"Valid columns: {', '.join(sorted(valid))}.{relation_note}"
+        f"Valid columns: {', '.join(sorted(valid))}.{relation_note}",
+        name=name,
+        obj=model_cls,
     )
 
 

--- a/src/hydration.rs
+++ b/src/hydration.rs
@@ -303,6 +303,30 @@ pub fn refresh_model_instance<'py>(
     Ok(())
 }
 
+/// Populate a forward-FK relation on a hydrated instance (#286, ADR-0008).
+///
+/// The population contract: the relation field name enters the instance's
+/// `__dict__`, shadowing the class-level non-data `ForwardDescriptor`, so
+/// access is a plain attribute returning the complete related instance —
+/// no await, no query. `value: None` is a *populated* `None` (a nullable FK
+/// with no target): the key is present, so access returns `None` instead of
+/// the awaitable. An instance with no entry under the relation name keeps
+/// today's awaitable contract untouched.
+pub fn set_populated_relation<'py>(
+    py: Python<'py>,
+    instance: &Bound<'py, PyAny>,
+    relation: &str,
+    value: Option<&Bound<'py, PyAny>>,
+) -> PyResult<()> {
+    let dict_attr = instance.getattr(pyo3::intern!(py, "__dict__"))?;
+    let dict = dict_attr.cast::<pyo3::types::PyDict>()?;
+    match value {
+        Some(obj) => dict.set_item(relation, obj)?,
+        None => dict.set_item(relation, py.None())?,
+    }
+    Ok(())
+}
+
 /// Diff a class's `__slots__` against [`HANDLED_BASEMODEL_SLOTS`].
 ///
 /// # Errors

--- a/src/hydration.rs
+++ b/src/hydration.rs
@@ -300,6 +300,67 @@ pub fn refresh_model_instance<'py>(
         enum_classes,
     )?;
     instance.setattr(pyo3::intern!(py, "__pydantic_fields_set__"), fields_set)?;
+    prune_stale_populations(py, cls, dict)?;
+    Ok(())
+}
+
+/// The refresh rule for populated relations (#287, ADR-0008): keep each
+/// population iff it is still true.
+///
+/// After a refresh overwrites the decoded columns, every populated relation
+/// (a `__dict__` entry under a relation field name) is checked against the
+/// freshly decoded shadow FK: the population survives iff the FK still
+/// equals the populated instance's primary key (a populated `None` survives
+/// iff the FK is still NULL) — so populations accumulate across a session's
+/// queries. An FK that changed or went NULL drops the entry: access reverts
+/// to the awaitable — never silently wrong, and never "repaired" from
+/// whatever the identity map happens to hold.
+fn prune_stale_populations<'py>(
+    py: Python<'py>,
+    cls: &Bound<'py, PyAny>,
+    dict: &Bound<'py, pyo3::types::PyDict>,
+) -> PyResult<()> {
+    let Ok(specs) = cls.getattr(pyo3::intern!(py, "__ferro_relation_specs__")) else {
+        return Ok(());
+    };
+    let Ok(specs) = specs.cast::<pyo3::types::PyDict>() else {
+        return Ok(());
+    };
+    for (relation, spec) in specs.iter() {
+        let Some(population) = dict.get_item(&relation)? else {
+            continue; // unpopulated: nothing to check
+        };
+        let shadow_column = spec.getattr(pyo3::intern!(py, "shadow_column"))?;
+        let new_fk = dict.get_item(&shadow_column)?;
+        let keep = match (&new_fk, population.is_none()) {
+            // Populated `None` stays truthful while the FK stays NULL.
+            (Some(fk), true) => fk.is_none(),
+            // A live population survives iff the fresh FK equals its PK.
+            (Some(fk), false) if !fk.is_none() => {
+                let target = spec.getattr(pyo3::intern!(py, "target"))?;
+                let identity = crate::state::model_identity(&target)?;
+                let pk_col = crate::state::registered_model(&identity)?
+                    .meta
+                    .pk_col
+                    .clone()
+                    .ok_or_else(|| {
+                        pyo3::exceptions::PyRuntimeError::new_err(format!(
+                            "populated relation target '{identity}' has no \
+                             primary key; cannot evaluate the refresh rule"
+                        ))
+                    })?;
+                let pk_val = population.getattr(pk_col.as_str())?;
+                fk.eq(pk_val)?
+            }
+            // FK went NULL under a live population, or the shadow column is
+            // missing from the refreshed row (cannot happen on a full-row
+            // decode — the refresh precondition): drop, never guess.
+            _ => false,
+        };
+        if !keep {
+            dict.del_item(&relation)?;
+        }
+    }
     Ok(())
 }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -243,18 +243,19 @@ fn tx_remove(session_id: Option<&str>, tx_id: &str) -> PyResult<Option<Transacti
     Ok(TRANSACTION_REGISTRY.remove(tx_id).map(|(_, handle)| handle))
 }
 
-/// The only QueryIR version this build accepts (#269, #278).
+/// The only QueryIR version this build accepts (#269, #278, #285).
 ///
 /// Python and Rust ship in one wheel, so there is exactly one supported version at any
 /// time — no negotiation, no fallback. A mismatch can only mean a mixed build (a stale
 /// `.so` next to a rebuilt Python package, or vice versa).
-const SUPPORTED_QUERY_IR_VERSION: u32 = 3;
+const SUPPORTED_QUERY_IR_VERSION: u32 = 4;
 
 /// Envelope shell used only to read `ir_kind`/`ir_version` before committing to a strict
-/// [`QueryIrPayload`] parse. `payload` is deliberately raw JSON: a real v1/v2 payload
-/// (no `joins`/`path` fields, no `materialization` section) must fail on the version
-/// check below with an actionable message, not on a generic "missing field" serde error
-/// from parsing a payload shape this build no longer understands.
+/// [`QueryIrPayload`] parse. `payload` is deliberately raw JSON: a real earlier-version
+/// payload (a v3 unit `instances` kind, or a v1/v2 payload with no `joins`/`path`/
+/// `materialization` at all) must fail on the version check below with an actionable
+/// message, not on a generic "missing field" serde error from parsing a payload shape
+/// this build no longer understands.
 #[derive(Debug, Clone, Deserialize)]
 struct QueryIrEnvelope {
     ir_kind: String,
@@ -413,7 +414,7 @@ fn reject_unsupported_materialization(plan: &QueryPlan, operation: &str) -> PyRe
     let kind = match &plan.materialization {
         Materialization::RootInstances => return Ok(()),
         Materialization::Record { .. } => "record",
-        Materialization::Instances => "instances",
+        Materialization::Instances { .. } => "instances",
     };
     Err(pyo3::exceptions::PyValueError::new_err(format!(
         "{operation}() does not support materialization kind {kind:?}: this \
@@ -441,7 +442,7 @@ fn reject_unsupported_materialization(plan: &QueryPlan, operation: &str) -> PyRe
 fn projected_columns(plan: &QueryPlan) -> PyResult<Option<Vec<String>>> {
     let fields = match &plan.materialization {
         Materialization::RootInstances => return Ok(None),
-        Materialization::Instances => {
+        Materialization::Instances { .. } => {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "materialization kind \"instances\" is reserved for joined-row \
                  hydration (#267 stage 2) and is not yet implemented.",
@@ -3823,7 +3824,7 @@ mod mutation_pagination_guard_tests {
     fn envelope_without_pagination_keys() -> String {
         serde_json::json!({
             "ir_kind": "query",
-            "ir_version": 3,
+            "ir_version": 4,
             "payload": {
                 "model_name": "Widget",
                 "where": [{
@@ -3893,10 +3894,10 @@ mod mutation_pagination_guard_tests {
 mod query_ir_version_gate_tests {
     use super::query_plan_from_ir_json;
 
-    fn v3_envelope() -> serde_json::Value {
+    fn v4_envelope() -> serde_json::Value {
         serde_json::json!({
             "ir_kind": "query",
-            "ir_version": 3,
+            "ir_version": 4,
             "payload": {
                 "model_name": "Widget",
                 "where": [],
@@ -3911,8 +3912,9 @@ mod query_ir_version_gate_tests {
     }
 
     /// Assert a rejected envelope's message names the received version, this
-    /// build's supported version (3), and the one-wheel fix — the actionable
-    /// shape pinned since the v1-at-v2 bump (#269), re-pinned at v3 (#278).
+    /// build's supported version (4), and the one-wheel fix — the actionable
+    /// shape pinned since the v1-at-v2 bump (#269), re-pinned at v3 (#278)
+    /// and at v4 (#285).
     fn assert_actionable_version_rejection(err: pyo3::PyErr, received: char) {
         pyo3::Python::attach(|py| {
             assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
@@ -3923,7 +3925,7 @@ mod query_ir_version_gate_tests {
             "message should name the received version: {msg}"
         );
         assert!(
-            msg.contains('3'),
+            msg.contains('4'),
             "message should name the supported version: {msg}"
         );
         assert!(
@@ -3937,9 +3939,37 @@ mod query_ir_version_gate_tests {
     }
 
     #[test]
-    fn accepts_version_3() {
-        query_plan_from_ir_json(&v3_envelope().to_string())
-            .expect("a well-formed v3 envelope must be accepted");
+    fn accepts_version_4() {
+        query_plan_from_ir_json(&v4_envelope().to_string())
+            .expect("a well-formed v4 envelope must be accepted");
+    }
+
+    /// Contract test (#285 acceptance criteria, mirroring the v2-at-v3
+    /// precedent): a v3 envelope — with a real v3 payload whose `instances`
+    /// kind is the unit shape this build's strict parse no longer accepts —
+    /// must be rejected on the version check with the actionable one-wheel
+    /// message, not on a serde "missing field `paths`" error. The version
+    /// check fires before strict payload parsing.
+    #[test]
+    fn rejects_v3_envelope_with_actionable_message() {
+        let v3_envelope = serde_json::json!({
+            "ir_kind": "query",
+            "ir_version": 3,
+            "payload": {
+                "model_name": "Widget",
+                "where": [],
+                "order_by": [],
+                "limit": null,
+                "offset": null,
+                "m2m": null,
+                "joins": [],
+                "materialization": {"kind": "instances"}
+            }
+        });
+
+        let err = query_plan_from_ir_json(&v3_envelope.to_string())
+            .expect_err("a v3 envelope must be rejected");
+        assert_actionable_version_rejection(err, '3');
     }
 
     /// Contract test (#278 acceptance criteria, mirroring the v1-at-v2
@@ -3993,14 +4023,14 @@ mod query_ir_version_gate_tests {
 
     #[test]
     fn rejects_unsupported_future_version() {
-        let mut envelope = v3_envelope();
-        envelope["ir_version"] = serde_json::json!(4);
+        let mut envelope = v4_envelope();
+        envelope["ir_version"] = serde_json::json!(5);
 
         let err = query_plan_from_ir_json(&envelope.to_string())
             .expect_err("an unsupported future version must be rejected");
         let msg = err.to_string();
         assert!(
-            msg.contains('4'),
+            msg.contains('5'),
             "message should name the received version: {msg}"
         );
     }
@@ -4009,7 +4039,7 @@ mod query_ir_version_gate_tests {
     /// naming the bad kind and the supported ones (#278).
     #[test]
     fn rejects_unknown_materialization_kind() {
-        let mut envelope = v3_envelope();
+        let mut envelope = v4_envelope();
         envelope["payload"]["materialization"] = serde_json::json!({"kind": "row_dicts"});
 
         let err = query_plan_from_ir_json(&envelope.to_string())
@@ -4022,18 +4052,18 @@ mod query_ir_version_gate_tests {
         );
     }
 
-    /// A v3 payload with NO materialization section fails the strict parse:
+    /// A v4 payload with NO materialization section fails the strict parse:
     /// the plan travels with the query as data (ADR-0007), never defaulted.
     #[test]
-    fn rejects_v3_payload_missing_materialization() {
-        let mut envelope = v3_envelope();
+    fn rejects_v4_payload_missing_materialization() {
+        let mut envelope = v4_envelope();
         envelope["payload"]
             .as_object_mut()
             .unwrap()
             .remove("materialization");
 
         let err = query_plan_from_ir_json(&envelope.to_string())
-            .expect_err("a v3 payload without a materialization section must be rejected");
+            .expect_err("a v4 payload without a materialization section must be rejected");
         let msg = err.to_string();
         assert!(
             msg.contains("materialization"),
@@ -4053,7 +4083,7 @@ mod materialization_walker_gate_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 3,
+                "ir_version": 4,
                 "payload": {
                     "model_name": "Widget",
                     "where": [],
@@ -4099,7 +4129,13 @@ mod materialization_walker_gate_tests {
 
     #[test]
     fn instances_kind_is_rejected_loudly() {
-        let plan = plan_with_kind(serde_json::json!({"kind": "instances"}));
+        let plan = plan_with_kind(serde_json::json!({
+            "kind": "instances",
+            "paths": [[
+                {"relation": "account", "from_column": "account_id",
+                 "to_table": "account", "to_column": "id"}
+            ]]
+        }));
         pyo3::Python::attach(|py| {
             let err = reject_unsupported_materialization(&plan, "fetch_filtered")
                 .expect_err("instances must be rejected");
@@ -4128,7 +4164,7 @@ mod record_select_list_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 3,
+                "ir_version": 4,
                 "payload": {
                     "model_name": "Transaction",
                     "where": [],
@@ -4235,7 +4271,13 @@ mod record_select_list_tests {
 
     #[test]
     fn instances_plan_is_rejected() {
-        let plan = plan_with_materialization(serde_json::json!({"kind": "instances"}));
+        let plan = plan_with_materialization(serde_json::json!({
+            "kind": "instances",
+            "paths": [[
+                {"relation": "account", "from_column": "account_id",
+                 "to_table": "account", "to_column": "id"}
+            ]]
+        }));
         let err = projected_columns(&plan).expect_err("instances must be rejected");
         assert!(
             err.to_string().contains("joined-row hydration"),
@@ -4262,7 +4304,7 @@ mod mutation_qualification_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 3,
+                "ir_version": 4,
                 "payload": {
                     "model_name": "Widget",
                     "where": [{
@@ -4348,7 +4390,7 @@ mod select_join_render_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 3,
+                "ir_version": 4,
                 "payload": {
                     "model_name": "Transaction",
                     "where": [{
@@ -4454,7 +4496,7 @@ mod select_join_render_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 3,
+                "ir_version": 4,
                 "payload": {
                     "model_name": model_name,
                     "where": [], "order_by": [],
@@ -4476,7 +4518,7 @@ mod select_join_render_tests {
         let plan = query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 3,
+                "ir_version": 4,
                 "payload": {
                     "model_name": "Transaction",
                     "where": [{

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -13,7 +13,7 @@ use crate::state::{
     engine_for_connection, register_session, session_state, unregister_session,
 };
 use dashmap::DashMap;
-use ferro_schema_ir::{Materialization, QueryIrPayload};
+use ferro_schema_ir::{Materialization, QueryIrPayload, QueryJoinHop};
 use pyo3::prelude::*;
 use sea_query::{
     Alias, Condition, Expr, Iden, InsertStatement, JoinType, OnConflict, Order,
@@ -404,12 +404,13 @@ fn reject_traversal_on_mutation(plan: &QueryPlan, operation: &str) -> PyResult<(
 ///
 /// Every query carries exactly one plan (ADR-0007). `root_instances` is the
 /// only kind the non-projecting walkers accept: `record` is the partial-select
-/// plan (built by the projecting fetch path, #279 — `count()`/`exists()` are
-/// unaffected by projection and mutations reject projection at build time, so
-/// the Python builder never emits `record` to any other walker); `instances`
-/// is reserved for joined-row hydration (#267 stage 2) and not yet
-/// implemented anywhere. A disallowed kind here is a loud error, never a
-/// silent fallback to full hydration (I-6).
+/// plan (built by the projecting fetch path, #279) and `instances` is the
+/// joined-row hydration plan (built by the instance-graph fetch path, #286) —
+/// `count()`/`exists()` are unaffected by projection AND include (their
+/// payloads emit `root_instances`), and mutations reject both at build time,
+/// so the Python builder never emits either kind to any other walker. A
+/// disallowed kind here is a loud error, never a silent fallback to full
+/// hydration (I-6).
 fn reject_unsupported_materialization(plan: &QueryPlan, operation: &str) -> PyResult<()> {
     let kind = match &plan.materialization {
         Materialization::RootInstances => return Ok(()),
@@ -420,8 +421,8 @@ fn reject_unsupported_materialization(plan: &QueryPlan, operation: &str) -> PyRe
         "{operation}() does not support materialization kind {kind:?}: this \
          walker materializes complete root instances only (\"root_instances\"). \
          \"record\" is the partial-select plan and applies to projecting \
-         fetches only; \"instances\" is reserved for joined-row hydration and \
-         is not yet implemented."
+         fetches only; \"instances\" is the joined-row hydration plan and \
+         applies to instance-graph fetches only."
     )))
 }
 
@@ -437,15 +438,18 @@ fn reject_unsupported_materialization(plan: &QueryPlan, operation: &str) -> PyRe
 /// projected wrong.
 ///
 /// # Errors
-/// `PyValueError` for `instances` (reserved for joined-row hydration,
-/// #267 stage 2), an empty `record` field list, or a field shape from #282.
+/// `PyValueError` for `instances` (the joined-row hydration plan resolves no
+/// projected SELECT list — the instances fetch path widens the SELECT itself,
+/// #286, and dispatches before calling this), an empty `record` field list,
+/// or a field shape from #282.
 fn projected_columns(plan: &QueryPlan) -> PyResult<Option<Vec<String>>> {
     let fields = match &plan.materialization {
         Materialization::RootInstances => return Ok(None),
         Materialization::Instances { .. } => {
             return Err(pyo3::exceptions::PyValueError::new_err(
-                "materialization kind \"instances\" is reserved for joined-row \
-                 hydration (#267 stage 2) and is not yet implemented.",
+                "materialization kind \"instances\" resolves no projected \
+                 SELECT list; the joined-row hydration fetch path widens the \
+                 SELECT itself and must dispatch before the record resolver.",
             ));
         }
         Materialization::Record { fields } => fields,
@@ -498,6 +502,235 @@ fn apply_select_list(select: &mut SelectStatement, table_name: &str, projected: 
             select.column((Alias::new(table_name), sea_query::Asterisk));
         }
     }
+}
+
+/// One included hop of an `instances` plan, resolved against the query's
+/// [`JoinPlan`] and the hop table's registration (#286).
+///
+/// Hops are ordered parent-before-child (each path's prefixes are walked in
+/// order and deduped across paths), so the graph hydrator can attach every
+/// hop to an already-materialized parent in one forward pass.
+struct IncludeHop {
+    /// Full relation path from the root model to this hop.
+    path: Vec<String>,
+    /// The relation field name populated on the parent (the path's last hop).
+    relation: String,
+    /// The parent's relation path (`[]` = the root instance).
+    parent_path: Vec<String>,
+    /// The hop's JOIN alias; its SELECT columns are aliased `{alias}__{col}`.
+    alias: String,
+    /// The hop's physical table.
+    table: String,
+    /// The hop model's registration: codec plan (per-hop decode uses the hop
+    /// model's own plan, never the root's), ordered column list, PK metadata.
+    registration: Arc<crate::state::RegisteredModel>,
+}
+
+/// The aliased output-column name of one hop column in the widened SELECT.
+///
+/// `__` cannot collide with the root's unaliased columns in practice (join
+/// aliases are internal `j{i}_{relation}` names); the decode side partitions
+/// result columns by these exact strings, so render and decode cannot drift.
+fn include_column_alias(hop_alias: &str, column: &str) -> String {
+    format!("{hop_alias}__{column}")
+}
+
+/// Resolve an `instances` plan's paths into ordered [`IncludeHop`]s (#286).
+///
+/// # Errors
+/// `PyValueError` when a path's prefix has no join-plan entry (cannot happen
+/// with a [`QueryPlan::build_join_plan`]-built plan — defense in depth), no
+/// registration (the walker populates every rendered join's table first), or
+/// the hop model has no primary key (population runs the identity protocol
+/// per hop, which needs one; Python validates this at build time too).
+fn resolve_include_hops(
+    paths: &[Vec<QueryJoinHop>],
+    join_plan: &JoinPlan,
+    plan: &QueryPlan,
+) -> PyResult<Vec<IncludeHop>> {
+    let mut hops: Vec<IncludeHop> = Vec::new();
+    let mut seen: HashSet<Vec<String>> = HashSet::new();
+    for path in paths {
+        let mut prefix: Vec<String> = Vec::new();
+        for hop in path {
+            let parent_path = prefix.clone();
+            prefix.push(hop.relation.clone());
+            if !seen.insert(prefix.clone()) {
+                continue;
+            }
+            let alias = join_plan.prefix_alias.get(&prefix).ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "include path {prefix:?} has no join-plan entry; the \
+                     instances edge union must render every included edge"
+                ))
+            })?;
+            let table = join_plan.prefix_table.get(&prefix).ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "include path {prefix:?} has no join-plan table; the \
+                     instances edge union must render every included edge"
+                ))
+            })?;
+            let registration = plan.hop_registrations.get(table).cloned().ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "included table {table:?} (path {prefix:?}) has no \
+                     registration; resolve every hop's bind context before \
+                     hydrating the graph"
+                ))
+            })?;
+            if registration.meta.pk_col.is_none() {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "included table {table:?} (path {prefix:?}) has no primary \
+                     key; population runs the identity protocol per hop and \
+                     requires one"
+                )));
+            }
+            hops.push(IncludeHop {
+                path: prefix.clone(),
+                relation: hop.relation.clone(),
+                parent_path,
+                alias: alias.clone(),
+                table: table.clone(),
+                registration,
+            });
+        }
+    }
+    Ok(hops)
+}
+
+/// Widen an instances SELECT with every included hop's complete, aliased
+/// column list (#286): `<alias>.<col> AS "<alias>__<col>"` per column, in the
+/// hop's declaration order. Aliasing is what keeps a hop column from
+/// colliding with a same-named root (or sibling-hop) column in the result
+/// set — the reason `SELECT root.*, hop.*` cannot work here.
+fn apply_include_select_list(select: &mut SelectStatement, hops: &[IncludeHop]) {
+    for hop in hops {
+        for column in &hop.registration.column_names {
+            select.expr_as(
+                Expr::col((Alias::new(&hop.alias), Alias::new(column.as_str()))),
+                Alias::new(include_column_alias(&hop.alias, column)),
+            );
+        }
+    }
+}
+
+/// Decode instances-plan rows: each [`EngineRow`] is partitioned into the
+/// root's columns (unaliased) and one column slice per included hop (by the
+/// exact `{alias}__{col}` names the widened SELECT rendered), then every
+/// slice is decoded against its OWN model's codec plan — root via the root
+/// plan, each hop via the hop registration's plan (#286).
+///
+/// Returns one `(root, hop_rows)` pair per input row; `hop_rows` aligns with
+/// `hops` by index. A hop whose row the LEFT join did not match decodes to a
+/// `(None, all-NULL fields)` parsed row — the graph hydrator turns that into
+/// a populated `None` (the hop PK is NULL exactly when the FK is NULL).
+fn instances_rows_to_parsed_data(
+    rows: Vec<EngineRow>,
+    root: &crate::state::RegisteredModel,
+    root_pk: Option<&str>,
+    hops: &[IncludeHop],
+) -> Vec<(ParsedRow, Vec<ParsedRow>)> {
+    let mut aliased: HashMap<String, (usize, String)> = HashMap::new();
+    for (i, hop) in hops.iter().enumerate() {
+        for column in &hop.registration.column_names {
+            aliased.insert(include_column_alias(&hop.alias, column), (i, column.clone()));
+        }
+    }
+    rows.into_iter()
+        .map(|row| {
+            let mut root_values: Vec<(String, EngineValue)> = Vec::new();
+            let mut hop_values: Vec<Vec<(String, EngineValue)>> =
+                (0..hops.len()).map(|_| Vec::new()).collect();
+            for (name, value) in row.values {
+                match aliased.get(&name) {
+                    Some((i, column)) => hop_values[*i].push((column.clone(), value)),
+                    None => root_values.push((name, value)),
+                }
+            }
+            let root_parsed =
+                crate::codec::typed_row_values_to_parsed(root_values, &root.codec_plan, root_pk);
+            let hop_parsed = hops
+                .iter()
+                .zip(hop_values)
+                .map(|(hop, values)| {
+                    crate::codec::typed_row_values_to_parsed(
+                        values,
+                        &hop.registration.codec_plan,
+                        hop.registration.meta.pk_col.as_deref(),
+                    )
+                })
+                .collect();
+            (root_parsed, hop_parsed)
+        })
+        .collect()
+}
+
+/// Materialize one model row through the full identity-map protocol (FF-D):
+/// map hit → refresh in place + reuse; miss → hydrate + insert. Sessionless
+/// (or identity map disabled) always hydrates a fresh instance — no
+/// query-local dedup (ADR-0008). The factored seam behind both the root
+/// result loop and the per-hop graph hydration (#286); `fields` must be a
+/// FULL row decode (the `refresh_model_instance` precondition — every caller
+/// here selects complete rows).
+#[allow(clippy::too_many_arguments)]
+fn materialize_model_row<'py>(
+    py: Python<'py>,
+    cls: &Bound<'py, PyAny>,
+    connection_name: &str,
+    model_identity: &str,
+    session_id: Option<&str>,
+    use_identity_map: bool,
+    row_pk_val: Option<String>,
+    fields: Vec<(String, crate::state::RustValue)>,
+    py_col_names: &HashMap<String, Py<pyo3::types::PyString>>,
+    enum_classes: &HashMap<String, Bound<'py, PyAny>>,
+) -> PyResult<Bound<'py, PyAny>> {
+    if use_identity_map
+        && let Some(ref pk_val) = row_pk_val
+        && let Some(existing_obj) = identity_map_get(
+            py,
+            session_id,
+            &(
+                connection_name.to_string(),
+                model_identity.to_string(),
+                pk_val.clone(),
+            ),
+        )?
+    {
+        let existing = existing_obj.bind(py).clone();
+        crate::hydration::refresh_model_instance(
+            py,
+            cls,
+            &existing,
+            fields,
+            py_col_names,
+            enum_classes,
+        )?;
+        return Ok(existing);
+    }
+
+    let instance = crate::hydration::hydrate_model_instance(
+        py,
+        cls,
+        connection_name,
+        fields,
+        py_col_names,
+        enum_classes,
+    )?;
+
+    if use_identity_map && let Some(pk_val) = row_pk_val {
+        identity_map_insert(
+            py,
+            session_id,
+            (
+                connection_name.to_string(),
+                model_identity.to_string(),
+                pk_val,
+            ),
+            &instance,
+        )?;
+    }
+
+    Ok(instance)
 }
 
 /// Reject `limit`/`offset` on mutating operations (FF-A A1, #171).
@@ -1760,7 +1993,9 @@ pub fn save_bulk_records<'py>(
 /// The query's materialization plan (ADR-0007) selects the result shape:
 /// `root_instances` hydrates complete model instances (identity-map aware);
 /// a `record` plan renders the projected SELECT list and hydrates
-/// `record_cls` records (#279) — no identity map, no persistence identity.
+/// `record_cls` records (#279) — no identity map, no persistence identity;
+/// an `instances` plan widens the SELECT with every included hop's complete
+/// aliased row and hydrates a populated instance graph (#286, ADR-0008).
 ///
 /// Args:
 ///     cls (PyAny): The Python model class.
@@ -1768,23 +2003,36 @@ pub fn save_bulk_records<'py>(
 ///     record_cls (PyAny | None): Record constructor for a `record` plan
 ///         (`Row` today; the seam a future `into=` plugs into). Required for
 ///         a record plan, forbidden otherwise.
+///     hop_classes (dict[str, type] | None): Included hop model classes keyed
+///         by physical table name, for an `instances` plan. Required for an
+///         instances plan, forbidden otherwise.
 ///
 /// Returns:
-///     list[PyAny]: Hydrated model instances, or projected records.
+///     list[PyAny]: Hydrated model instances (populated when included), or
+///     projected records.
 #[pyfunction]
-#[pyo3(signature = (cls, query_ir_json, route, record_cls=None))]
+#[pyo3(signature = (cls, query_ir_json, route, record_cls=None, hop_classes=None))]
 pub fn fetch_filtered<'py>(
     py: Python<'py>,
     cls: Bound<'py, PyAny>,
     query_ir_json: String,
     route: Py<crate::state::RouteHandle>,
     record_cls: Option<Bound<'py, PyAny>>,
+    hop_classes: Option<Bound<'py, pyo3::types::PyDict>>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let name = crate::state::model_identity(&cls)?;
     let cls_py = cls.unbind();
 
     let mut plan = query_plan_from_ir_json(&query_ir_json)?;
-    let projected = projected_columns(&plan)?;
+    let include_paths: Option<Vec<Vec<QueryJoinHop>>> = match &plan.materialization {
+        Materialization::Instances { paths } => Some(paths.clone()),
+        _ => None,
+    };
+    let projected = if include_paths.is_some() {
+        None
+    } else {
+        projected_columns(&plan)?
+    };
     // The record constructor travels with the call, paired to the plan kind:
     // a record plan requires it, a root plan must not carry one. A mismatch
     // is a caller bug — fail loud, never fall back (I-6).
@@ -1803,6 +2051,26 @@ pub fn fetch_filtered<'py>(
                 "fetch_filtered(): record_cls was passed without a record \
                  materialization plan; full hydration constructs model \
                  instances.",
+            ));
+        }
+    };
+    // The hop-class map travels the same way, paired to the instances plan
+    // (#286): population hydrates every hop through the full model protocol,
+    // so each included table's Python class must arrive with the call.
+    let hop_classes_py = match (&include_paths, hop_classes) {
+        (Some(_), Some(hop_classes)) => Some(hop_classes.unbind()),
+        (None, None) => None,
+        (Some(_), None) => {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "fetch_filtered(): an instances materialization plan requires \
+                 hop_classes; the Python builder always passes the included \
+                 hop model classes.",
+            ));
+        }
+        (None, Some(_)) => {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "fetch_filtered(): hop_classes was passed without an \
+                 instances materialization plan.",
             ));
         }
     };
@@ -1827,12 +2095,19 @@ pub fn fetch_filtered<'py>(
         let reserved: Vec<&str> = m2m_join_table.as_deref().into_iter().collect();
         let join_plan = query_join_plan(&plan, &table_name, &reserved)?;
         populate_hop_bind_context(&mut plan, &join_plan, &engine, exec, backend).await?;
+        // Included hops (#286): resolved after the bind context, so every
+        // include-edge table's registration is already in place.
+        let include_hops = match &include_paths {
+            Some(paths) => resolve_include_hops(paths, &join_plan, &plan)?,
+            None => Vec::new(),
+        };
         // ...
         let (sql, bind_values, pk_col, schema_for_decode) = {
             let pk = schema.meta.pk_col.clone();
 
             let mut select = Query::select();
             apply_select_list(&mut select, &table_name, projected.as_deref());
+            apply_include_select_list(&mut select, &include_hops);
             select.from(Alias::new(&table_name));
 
             if let Some(m2m) = &plan.m2m {
@@ -1915,6 +2190,142 @@ pub fn fetch_filtered<'py>(
         } else {
             pk_col.as_deref()
         };
+
+        if include_paths.is_some() {
+            // Instances path (#286): decode root + hops (each against its own
+            // model's codec plan), then hydrate the populated graph — every
+            // node through the full identity-map protocol.
+            let parsed_data =
+                instances_rows_to_parsed_data(rows, &schema_for_decode, pk_for_decode, &include_hops);
+            let hop_classes_py = hop_classes_py
+                .expect("validated above: an instances plan carries hop_classes");
+
+            return Python::attach(|py| {
+                let results = pyo3::types::PyList::empty(py);
+                let cls = cls_py.bind(py);
+                let hop_classes = hop_classes_py.bind(py);
+
+                // Per-hop Python context, resolved once per fetch (not per
+                // row): class, registry identity, enum catalog, interned
+                // column names.
+                struct HopPyCtx<'py> {
+                    cls: Bound<'py, PyAny>,
+                    identity: String,
+                    enum_classes: HashMap<String, Bound<'py, PyAny>>,
+                    py_col_names: HashMap<String, Py<pyo3::types::PyString>>,
+                }
+                let mut hop_ctx: Vec<HopPyCtx<'_>> = Vec::with_capacity(include_hops.len());
+                for (i, hop) in include_hops.iter().enumerate() {
+                    let hop_cls =
+                        hop_classes.get_item(hop.table.as_str())?.ok_or_else(|| {
+                            pyo3::exceptions::PyValueError::new_err(format!(
+                                "fetch_filtered(): hop_classes has no model class \
+                                 for included table {:?}.",
+                                hop.table
+                            ))
+                        })?;
+                    let identity = crate::state::model_identity(&hop_cls)?;
+                    let enum_classes = crate::hydration::enum_classes_for(py, &hop_cls);
+                    let mut py_col_names = HashMap::new();
+                    if let Some((_, first_hops)) = parsed_data.first() {
+                        for (col_name, _) in &first_hops[i].1 {
+                            py_col_names.insert(
+                                col_name.clone(),
+                                pyo3::types::PyString::new(py, col_name).unbind(),
+                            );
+                        }
+                    }
+                    hop_ctx.push(HopPyCtx {
+                        cls: hop_cls,
+                        identity,
+                        enum_classes,
+                        py_col_names,
+                    });
+                }
+
+                let mut py_col_names = HashMap::new();
+                if let Some((first_root, _)) = parsed_data.first() {
+                    for (col_name, _) in &first_root.1 {
+                        py_col_names.insert(
+                            col_name.clone(),
+                            pyo3::types::PyString::new(py, col_name).unbind(),
+                        );
+                    }
+                }
+                let enum_classes = crate::hydration::enum_classes_for(py, cls);
+
+                for ((root_pk, root_fields), hop_rows) in parsed_data {
+                    let root_obj = materialize_model_row(
+                        py,
+                        cls,
+                        &connection_name,
+                        &name,
+                        session_id.as_deref(),
+                        use_identity_map,
+                        root_pk,
+                        root_fields,
+                        &py_col_names,
+                        &enum_classes,
+                    )?;
+
+                    // Walk the hops parent-before-child, tracking this row's
+                    // materialized node per path. A populated-`None` (or a
+                    // parent skipped under one) ends its chain: deeper hops
+                    // have nothing to attach to.
+                    let mut populated: HashMap<&[String], Option<Bound<'_, PyAny>>> =
+                        HashMap::new();
+                    for ((hop, ctx), (hop_pk, hop_fields)) in
+                        include_hops.iter().zip(&hop_ctx).zip(hop_rows)
+                    {
+                        let parent = if hop.parent_path.is_empty() {
+                            Some(root_obj.clone())
+                        } else {
+                            match populated.get(hop.parent_path.as_slice()) {
+                                Some(Some(obj)) => Some(obj.clone()),
+                                _ => None,
+                            }
+                        };
+                        let Some(parent) = parent else { continue };
+                        if hop_pk.is_none() {
+                            // The LEFT join matched no row ⟺ the FK is NULL:
+                            // populate `None` (truthful to the declared
+                            // `| None` type), root row retained.
+                            crate::hydration::set_populated_relation(
+                                py,
+                                &parent,
+                                &hop.relation,
+                                None,
+                            )?;
+                            populated.insert(hop.path.as_slice(), None);
+                            continue;
+                        }
+                        let instance = materialize_model_row(
+                            py,
+                            &ctx.cls,
+                            &connection_name,
+                            &ctx.identity,
+                            session_id.as_deref(),
+                            use_identity_map,
+                            hop_pk,
+                            hop_fields,
+                            &ctx.py_col_names,
+                            &ctx.enum_classes,
+                        )?;
+                        crate::hydration::set_populated_relation(
+                            py,
+                            &parent,
+                            &hop.relation,
+                            Some(&instance),
+                        )?;
+                        populated.insert(hop.path.as_slice(), Some(instance));
+                    }
+
+                    results.append(root_obj)?;
+                }
+                Ok(results.into_any().unbind())
+            });
+        }
+
         let parsed_data = typed_rows_to_parsed_data(rows, &schema_for_decode, pk_for_decode);
 
         Python::attach(|py| {
@@ -1954,45 +2365,18 @@ pub fn fetch_filtered<'py>(
             }
 
             for (row_pk_val, fields) in parsed_data {
-                if use_identity_map
-                    && let Some(ref pk_val) = row_pk_val
-                    && let Some(existing_obj) = identity_map_get(
-                        py,
-                        session_id.as_deref(),
-                        &(connection_name.clone(), name.clone(), pk_val.clone()),
-                    )?
-                {
-                    let existing = existing_obj.bind(py);
-                    crate::hydration::refresh_model_instance(
-                        py,
-                        cls,
-                        existing,
-                        fields,
-                        &py_col_names,
-                        &enum_classes,
-                    )?;
-                    results.append(existing)?;
-                    continue;
-                }
-
-                let instance = crate::hydration::hydrate_model_instance(
+                let instance = materialize_model_row(
                     py,
                     cls,
                     &connection_name,
+                    &name,
+                    session_id.as_deref(),
+                    use_identity_map,
+                    row_pk_val,
                     fields,
                     &py_col_names,
                     &enum_classes,
                 )?;
-
-                if use_identity_map && let Some(pk_val) = row_pk_val {
-                    identity_map_insert(
-                        py,
-                        session_id.as_deref(),
-                        (connection_name.clone(), name.clone(), pk_val),
-                        &instance,
-                    )?;
-                }
-
                 results.append(instance)?;
             }
             Ok(results.into_any().unbind())
@@ -4283,6 +4667,171 @@ mod record_select_list_tests {
             err.to_string().contains("joined-row hydration"),
             "got {err}"
         );
+    }
+}
+
+#[cfg(test)]
+mod instances_select_list_tests {
+    //! Pin the instances plan's widened SELECT (#286): the root asterisk plus
+    //! every included hop's complete column list, aliased `{alias}__{col}` so
+    //! a hop column can never collide with a same-named root column in the
+    //! result set — and the include edge rendered LEFT via the edge union.
+
+    use super::{
+        apply_include_select_list, apply_relation_joins, apply_select_list,
+        instances_rows_to_parsed_data, query_join_plan, query_plan_from_ir_json,
+        resolve_include_hops,
+    };
+    use crate::backend::{EngineRow, EngineValue};
+    use sea_query::{Alias, PostgresQueryBuilder, Query};
+
+    /// `Transaction.select().include(lambda t: t.account)` as it arrives on
+    /// the wire: empty `joins`, a one-path instances plan.
+    fn include_plan() -> crate::query::QueryPlan {
+        let mut plan = query_plan_from_ir_json(
+            &serde_json::json!({
+                "ir_kind": "query",
+                "ir_version": 4,
+                "payload": {
+                    "model_name": "Transaction",
+                    "where": [], "order_by": [], "limit": null, "offset": null,
+                    "m2m": null,
+                    "joins": [],
+                    "materialization": {"kind": "instances", "paths": [[
+                        {"relation": "account", "from_column": "account_id",
+                         "to_table": "account", "to_column": "id"}
+                    ]]}
+                }
+            })
+            .to_string(),
+        )
+        .expect("envelope parses");
+        // The walkers resolve each included table's registration before
+        // hydrating; mirror that (columns sort alphabetically here: id, label).
+        plan.hop_registrations.insert(
+            "account".to_string(),
+            crate::state::RegisteredModel::new_for_test(
+                serde_json::json!({
+                    "properties": {
+                        "id": {"type": "integer", "primary_key": true},
+                        "label": {"type": "string"}
+                    }
+                }),
+                "account".to_string(),
+            ),
+        );
+        plan
+    }
+
+    #[test]
+    fn rendered_select_widens_with_aliased_hop_columns_and_left_join() {
+        let plan = include_plan();
+        let join_plan = query_join_plan(&plan, "transaction", &[]).expect("join plan");
+        let ferro_schema_ir::Materialization::Instances { paths } = &plan.materialization
+        else {
+            panic!("include plan expected");
+        };
+        let hops = resolve_include_hops(paths, &join_plan, &plan).expect("hops resolve");
+        assert_eq!(hops.len(), 1);
+        assert_eq!(hops[0].relation, "account");
+        assert_eq!(hops[0].alias, "j1_account");
+        assert!(hops[0].parent_path.is_empty());
+
+        let mut select = Query::select();
+        apply_select_list(&mut select, "transaction", None);
+        apply_include_select_list(&mut select, &hops);
+        select.from(Alias::new("transaction"));
+        apply_relation_joins(&mut select, &join_plan).expect("joins render");
+
+        let sql = select.to_string(PostgresQueryBuilder);
+        assert_eq!(
+            sql,
+            "SELECT \"transaction\".*, \
+             \"j1_account\".\"id\" AS \"j1_account__id\", \
+             \"j1_account\".\"label\" AS \"j1_account__label\" \
+             FROM \"transaction\" \
+             LEFT JOIN \"account\" AS \"j1_account\" ON \
+             \"transaction\".\"account_id\" = \"j1_account\".\"id\""
+        );
+    }
+
+    #[test]
+    fn instances_rows_partition_and_decode_root_and_hop_independently() {
+        // One fetched row splits into the root's unaliased columns (decoded by
+        // the root plan) and the hop's aliased columns (decoded by the HOP
+        // model's own codec plan), with the hop PK extracted for the identity
+        // protocol.
+        let plan = include_plan();
+        let join_plan = query_join_plan(&plan, "transaction", &[]).expect("join plan");
+        let ferro_schema_ir::Materialization::Instances { paths } = &plan.materialization
+        else {
+            panic!("include plan expected");
+        };
+        let hops = resolve_include_hops(paths, &join_plan, &plan).expect("hops resolve");
+        let root = crate::state::RegisteredModel::new_for_test(
+            serde_json::json!({
+                "properties": {
+                    "amount": {"type": "integer"},
+                    "id": {"type": "integer", "primary_key": true}
+                }
+            }),
+            "transaction".to_string(),
+        );
+
+        let rows = vec![EngineRow {
+            values: vec![
+                ("id".to_string(), EngineValue::I64(7)),
+                ("amount".to_string(), EngineValue::I64(120)),
+                ("account_id".to_string(), EngineValue::I64(3)),
+                ("j1_account__id".to_string(), EngineValue::I64(3)),
+                (
+                    "j1_account__label".to_string(),
+                    EngineValue::String("a1".to_string()),
+                ),
+            ],
+        }];
+        let parsed = instances_rows_to_parsed_data(rows, &root, Some("id"), &hops);
+        assert_eq!(parsed.len(), 1);
+        let (root_row, hop_rows) = &parsed[0];
+        assert_eq!(root_row.0.as_deref(), Some("7"));
+        assert_eq!(root_row.1.len(), 3, "root keeps its unaliased columns");
+        assert_eq!(hop_rows.len(), 1);
+        assert_eq!(hop_rows[0].0.as_deref(), Some("3"), "hop PK extracted");
+        // Hop columns arrive under their BARE names (alias prefix stripped).
+        let hop_cols: Vec<&str> = hop_rows[0].1.iter().map(|(c, _)| c.as_str()).collect();
+        assert_eq!(hop_cols, vec!["id", "label"]);
+    }
+
+    #[test]
+    fn left_missed_hop_row_decodes_to_pk_none() {
+        // A LEFT join that matched no row (NULL FK) yields a hop slice whose
+        // PK is None — the graph hydrator's populated-`None` signal.
+        let plan = include_plan();
+        let join_plan = query_join_plan(&plan, "transaction", &[]).expect("join plan");
+        let ferro_schema_ir::Materialization::Instances { paths } = &plan.materialization
+        else {
+            panic!("include plan expected");
+        };
+        let hops = resolve_include_hops(paths, &join_plan, &plan).expect("hops resolve");
+        let root = crate::state::RegisteredModel::new_for_test(
+            serde_json::json!({
+                "properties": {"id": {"type": "integer", "primary_key": true}}
+            }),
+            "transaction".to_string(),
+        );
+
+        let rows = vec![EngineRow {
+            values: vec![
+                ("id".to_string(), EngineValue::I64(9)),
+                ("account_id".to_string(), EngineValue::Null),
+                ("j1_account__id".to_string(), EngineValue::Null),
+                ("j1_account__label".to_string(), EngineValue::Null),
+            ],
+        }];
+        let parsed = instances_rows_to_parsed_data(rows, &root, Some("id"), &hops);
+        let (root_row, hop_rows) = &parsed[0];
+        assert_eq!(root_row.0.as_deref(), Some("9"), "root row retained");
+        assert!(hop_rows[0].0.is_none(), "missed hop has no PK");
     }
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -113,6 +113,101 @@ pub struct JoinPlan {
     pub prefix_table: HashMap<Vec<String>, String>,
 }
 
+/// How a [`JoinPlanBuilder`] types an edge it materializes for the first time.
+enum EdgeType<'a> {
+    /// A `joins`-section edge: `"left"` iff some `"left"` entry covers it
+    /// (the whole-path rule, #272), else `"inner"`.
+    Resolved(&'a HashSet<Vec<String>>),
+    /// An include-path edge no `joins` entry covers (#286): always `"left"`,
+    /// so attaching data can never narrow membership (ADR-0008).
+    IncludeOnly,
+}
+
+/// Incremental [`JoinPlan`] assembly shared by the `joins` walk and the
+/// include-path union (#286): first-unseen prefixes materialize one edge each
+/// with a deterministic `j{i}_{relation}` alias; seen prefixes just advance
+/// the previous-alias chain.
+struct JoinPlanBuilder {
+    prefix_alias: HashMap<Vec<String>, String>,
+    prefix_table: HashMap<Vec<String>, String>,
+    used: HashSet<String>,
+    renders: Vec<JoinRender>,
+    next_index: usize,
+}
+
+impl JoinPlanBuilder {
+    fn new(root_table: &str, reserved: &[&str]) -> Self {
+        let mut used: HashSet<String> = HashSet::new();
+        used.insert(root_table.to_string());
+        for name in reserved {
+            used.insert((*name).to_string());
+        }
+        JoinPlanBuilder {
+            prefix_alias: HashMap::new(),
+            prefix_table: HashMap::new(),
+            used,
+            renders: Vec::new(),
+            next_index: 1,
+        }
+    }
+
+    /// Walk one relation path, materializing every first-unseen prefix as an
+    /// edge typed by `edge_type`. Prefixes an earlier walk already
+    /// materialized keep their existing alias AND join type — this is what
+    /// makes the include union unable to touch a `joins` edge (#286).
+    fn walk_path(
+        &mut self,
+        root_table: &str,
+        path: &[ferro_schema_ir::QueryJoinHop],
+        edge_type: EdgeType<'_>,
+    ) {
+        let mut prefix: Vec<String> = Vec::new();
+        let mut prev_alias = root_table.to_string();
+        for hop in path {
+            prefix.push(hop.relation.clone());
+            if let Some(existing) = self.prefix_alias.get(&prefix) {
+                prev_alias = existing.clone();
+                continue;
+            }
+            let edge_join_type = match &edge_type {
+                EdgeType::Resolved(left_edges) => {
+                    if left_edges.contains(&prefix) {
+                        "left"
+                    } else {
+                        "inner"
+                    }
+                }
+                EdgeType::IncludeOnly => "left",
+            };
+            let mut alias = format!("j{}_{}", self.next_index, hop.relation);
+            self.next_index += 1;
+            while self.used.contains(&alias) {
+                alias.push_str("_x");
+            }
+            self.used.insert(alias.clone());
+            self.prefix_alias.insert(prefix.clone(), alias.clone());
+            self.prefix_table.insert(prefix.clone(), hop.to_table.clone());
+            self.renders.push(JoinRender {
+                join_type: edge_join_type.to_string(),
+                to_table: hop.to_table.clone(),
+                alias: alias.clone(),
+                prev_alias: prev_alias.clone(),
+                from_column: hop.from_column.clone(),
+                to_column: hop.to_column.clone(),
+            });
+            prev_alias = alias;
+        }
+    }
+
+    fn finish(self) -> JoinPlan {
+        JoinPlan {
+            renders: self.renders,
+            prefix_alias: self.prefix_alias,
+            prefix_table: self.prefix_table,
+        }
+    }
+}
+
 /// Validate a join_type token from the IR (`"inner"`/`"left"`), erroring loudly
 /// on anything else so an unknown type can never silently mis-render.
 fn validate_join_type(join_type: &str) -> Result<&'static str, String> {
@@ -294,7 +389,7 @@ impl QueryPlan {
     }
 
     /// Assign deterministic aliases and build the ordered JOIN render plan (#270,
-    /// with per-edge LEFT/INNER resolution #272).
+    /// with per-edge LEFT/INNER resolution #272 and the include edge union #286).
     ///
     /// Walks each `joins` entry's hops in order, keeping a `prefix -> alias` map so
     /// the first-unseen prefix emits exactly one edge and shared prefixes across
@@ -312,6 +407,13 @@ impl QueryPlan {
     /// materializes a shared prefix; e.g. a `"left"` `[account]` entry and an
     /// `"inner"` `[account, owner]` entry render the `account` edge LEFT and the
     /// `owner` edge INNER regardless of their order on the wire (#272).
+    ///
+    /// An `instances` materialization plan's include paths union in AFTER every
+    /// `joins` entry (#286, ADR-0008): an edge some `joins` entry already covers
+    /// keeps its stage-1 type untouched — include contributes no join-type
+    /// opinion there — and an include-only edge renders LEFT, so include is
+    /// membership-preserving by construction. Because the `joins` section is
+    /// walked first, the union is independent of entry/path order on the wire.
     ///
     /// # Errors
     /// Returns `Err(String)` for an unknown `join_type` (see [`validate_join_type`]).
@@ -335,53 +437,18 @@ impl QueryPlan {
             }
         }
 
-        let mut prefix_alias: HashMap<Vec<String>, String> = HashMap::new();
-        let mut prefix_table: HashMap<Vec<String>, String> = HashMap::new();
-        let mut used: HashSet<String> = HashSet::new();
-        used.insert(root_table.to_string());
-        for name in reserved {
-            used.insert((*name).to_string());
-        }
-        let mut renders: Vec<JoinRender> = Vec::new();
-        let mut next_index = 1usize;
+        let mut builder = JoinPlanBuilder::new(root_table, reserved);
         for join in &self.joins {
-            let mut prefix: Vec<String> = Vec::new();
-            let mut prev_alias = root_table.to_string();
-            for hop in &join.path {
-                prefix.push(hop.relation.clone());
-                if let Some(existing) = prefix_alias.get(&prefix) {
-                    prev_alias = existing.clone();
-                    continue;
-                }
-                let edge_join_type = if left_edges.contains(&prefix) {
-                    "left"
-                } else {
-                    "inner"
-                };
-                let mut alias = format!("j{}_{}", next_index, hop.relation);
-                next_index += 1;
-                while used.contains(&alias) {
-                    alias.push_str("_x");
-                }
-                used.insert(alias.clone());
-                prefix_alias.insert(prefix.clone(), alias.clone());
-                prefix_table.insert(prefix.clone(), hop.to_table.clone());
-                renders.push(JoinRender {
-                    join_type: edge_join_type.to_string(),
-                    to_table: hop.to_table.clone(),
-                    alias: alias.clone(),
-                    prev_alias: prev_alias.clone(),
-                    from_column: hop.from_column.clone(),
-                    to_column: hop.to_column.clone(),
-                });
-                prev_alias = alias;
+            builder.walk_path(root_table, &join.path, EdgeType::Resolved(&left_edges));
+        }
+        // Include edge union (#286): only edges no `joins` entry materialized
+        // above are new here, and those render LEFT (never narrowing).
+        if let Materialization::Instances { paths } = &self.materialization {
+            for path in paths {
+                builder.walk_path(root_table, path, EdgeType::IncludeOnly);
             }
         }
-        Ok(JoinPlan {
-            renders,
-            prefix_alias,
-            prefix_table,
-        })
+        Ok(builder.finish())
     }
 
     /// Combine all root predicates into one SeaQuery `Condition` (AND of nodes).
@@ -1068,6 +1135,67 @@ mod tests {
             assert_eq!(account.join_type, "left", "account edge is LEFT");
             assert_eq!(owner.join_type, "inner", "owner edge is INNER");
         }
+    }
+
+    /// Include edge union (#286, ADR-0008): a payload with `joins` entries
+    /// and/or `instances` paths.
+    fn union_plan(joins: serde_json::Value, paths: serde_json::Value) -> QueryPlan {
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Transaction",
+            "where": [], "order_by": [], "limit": null, "offset": null, "m2m": null,
+            "joins": joins,
+            "materialization": {"kind": "instances", "paths": paths}
+        }))
+        .expect("payload deserializes");
+        QueryPlan::from_ir_payload(payload).expect("plan builds")
+    }
+
+    fn account_hop() -> serde_json::Value {
+        json!({"relation": "account", "from_column": "account_id",
+               "to_table": "account", "to_column": "id"})
+    }
+
+    #[test]
+    fn build_join_plan_include_only_edge_renders_left() {
+        // An edge only include references renders LEFT (never narrowing);
+        // include paths ride the materialization plan, `joins` stays empty.
+        let plan = union_plan(json!([]), json!([[account_hop()]]));
+        let join_plan = plan.build_join_plan("transaction", &[]).expect("join plan");
+        assert_eq!(join_plan.renders.len(), 1);
+        assert_eq!(join_plan.renders[0].join_type, "left");
+        assert_eq!(join_plan.renders[0].alias, "j1_account");
+        assert_eq!(join_plan.renders[0].prev_alias, "transaction");
+        assert_eq!(
+            join_plan.prefix_alias.get(&vec!["account".to_string()]),
+            Some(&"j1_account".to_string())
+        );
+    }
+
+    #[test]
+    fn build_join_plan_include_shared_edge_keeps_stage1_inner() {
+        // Include contributes NO join-type opinion on an edge a `joins` entry
+        // covers: a where()-traversed (implicit INNER) edge stays INNER when
+        // the same path is also included — one edge total, predicate
+        // semantics untouched.
+        let plan = union_plan(
+            json!([{"join_type": "inner", "path": [account_hop()]}]),
+            json!([[account_hop()]]),
+        );
+        let join_plan = plan.build_join_plan("transaction", &[]).expect("join plan");
+        assert_eq!(join_plan.renders.len(), 1, "shared edge dedups to one JOIN");
+        assert_eq!(join_plan.renders[0].join_type, "inner");
+    }
+
+    #[test]
+    fn build_join_plan_include_shared_edge_keeps_stage1_left() {
+        // An explicit `.left_join` edge stays LEFT when also included.
+        let plan = union_plan(
+            json!([{"join_type": "left", "path": [account_hop()]}]),
+            json!([[account_hop()]]),
+        );
+        let join_plan = plan.build_join_plan("transaction", &[]).expect("join plan");
+        assert_eq!(join_plan.renders.len(), 1);
+        assert_eq!(join_plan.renders[0].join_type, "left");
     }
 
     #[test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -1186,6 +1186,45 @@ mod tests {
         assert_eq!(join_plan.renders[0].join_type, "inner");
     }
 
+    fn owner_hop() -> serde_json::Value {
+        json!({"relation": "owner", "from_column": "owner_id",
+               "to_table": "owner", "to_column": "id"})
+    }
+
+    #[test]
+    fn build_join_plan_include_paths_dedup_shared_prefixes() {
+        // `.include(account)` + `.include(account.owner)` renders the same
+        // two joins as `.include(account.owner)` alone (#287): shared
+        // prefixes dedup by path identity, every include-only edge LEFT.
+        let expanded = union_plan(json!([]), json!([[account_hop()], [account_hop(), owner_hop()]]));
+        let collapsed = union_plan(json!([]), json!([[account_hop(), owner_hop()]]));
+        let reversed = union_plan(json!([]), json!([[account_hop(), owner_hop()], [account_hop()]]));
+        for plan in [expanded, collapsed, reversed] {
+            let join_plan = plan.build_join_plan("transaction", &[]).expect("join plan");
+            assert_eq!(join_plan.renders.len(), 2, "shared prefix dedups");
+            assert_eq!(join_plan.renders[0].alias, "j1_account");
+            assert_eq!(join_plan.renders[0].join_type, "left");
+            assert_eq!(join_plan.renders[1].alias, "j2_owner");
+            assert_eq!(join_plan.renders[1].join_type, "left");
+            assert_eq!(join_plan.renders[1].prev_alias, "j1_account");
+        }
+    }
+
+    #[test]
+    fn build_join_plan_include_deeper_hop_is_left_beyond_a_joins_prefix() {
+        // A predicate traverses [account] (INNER); the include continues to
+        // [account, owner]. The shared prefix keeps its stage-1 INNER; only
+        // the include-only deeper edge renders LEFT.
+        let plan = union_plan(
+            json!([{"join_type": "inner", "path": [account_hop()]}]),
+            json!([[account_hop(), owner_hop()]]),
+        );
+        let join_plan = plan.build_join_plan("transaction", &[]).expect("join plan");
+        assert_eq!(join_plan.renders.len(), 2);
+        assert_eq!(join_plan.renders[0].join_type, "inner", "shared prefix untouched");
+        assert_eq!(join_plan.renders[1].join_type, "left", "include-only edge LEFT");
+    }
+
     #[test]
     fn build_join_plan_include_shared_edge_keeps_stage1_left() {
         // An explicit `.left_join` edge stays LEFT when also included.

--- a/src/state.rs
+++ b/src/state.rs
@@ -58,6 +58,11 @@ pub struct RegisteredModel {
     pub codec_plan: crate::codec_plan::ModelCodecPlan,
     /// Primary-key metadata, scanned once at registration (FF-G G2).
     pub meta: ModelMeta,
+    /// Column names in SchemaIR declaration order (#286): the instances
+    /// fetch walker enumerates each included hop's complete column list to
+    /// widen the SELECT deterministically (every populated hop is a complete
+    /// row — the complete-instance invariant, ADR-0008).
+    pub column_names: Vec<String>,
 }
 
 impl RegisteredModel {
@@ -65,10 +70,12 @@ impl RegisteredModel {
     pub fn new(columns: Vec<SchemaColumn>, table_name: String) -> Result<Arc<Self>, String> {
         let codec_plan = crate::codec_plan::ModelCodecPlan::compile_from_columns(&columns)?;
         let meta = ModelMeta::from_columns(&columns);
+        let column_names = columns.iter().map(|col| col.name.clone()).collect();
         Ok(Arc::new(RegisteredModel {
             table_name,
             codec_plan,
             meta,
+            column_names,
         }))
     }
 }

--- a/tests/fixtures/ir_vectors/README.md
+++ b/tests/fixtures/ir_vectors/README.md
@@ -28,9 +28,10 @@ Rules:
 
 - `domain` and `ir.ir_kind` must match.
 - `ir.ir_version` must equal `1` for `schema` and `codec` vectors. `query`
-  vectors are on `ir_version: 3` (#278 — unconditional bump; the payload
-  carries a required `materialization` section, ADR-0007); there is no v1 or
-  v2 `query` vector left.
+  vectors are on `ir_version: 4` (#285 — unconditional bump; the payload
+  carries a required `materialization` section (ADR-0007), and the
+  `instances` kind carries `paths` of hop facts (ADR-0008)); there is no
+  earlier `query` vector left.
 - `expect_valid` currently supports only `true` fixtures (negative vectors can be added later).
 - Fixture file names use `<domain>_<scenario>_v<version>.json` (matching that
   domain's current `ir_version`).

--- a/tests/fixtures/ir_vectors/query_transaction_include_v4.json
+++ b/tests/fixtures/ir_vectors/query_transaction_include_v4.json
@@ -1,0 +1,48 @@
+{
+  "vector_name": "query_transaction_include_v4",
+  "domain": "query",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "query",
+    "ir_version": 4,
+    "payload": {
+      "model_name": "Transaction",
+      "where": [
+        {
+          "node_kind": "leaf",
+          "column": "amount",
+          "operator": ">=",
+          "value": {
+            "kind": "int",
+            "value": 100
+          },
+          "path": []
+        }
+      ],
+      "order_by": [
+        {
+          "column": "id",
+          "direction": "asc",
+          "path": []
+        }
+      ],
+      "limit": null,
+      "offset": null,
+      "m2m": null,
+      "joins": [],
+      "materialization": {
+        "kind": "instances",
+        "paths": [
+          [
+            {
+              "relation": "account",
+              "from_column": "account_id",
+              "to_table": "account",
+              "to_column": "id"
+            }
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/ir_vectors/query_transaction_left_join_v4.json
+++ b/tests/fixtures/ir_vectors/query_transaction_left_join_v4.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_transaction_left_join_v3",
+  "vector_name": "query_transaction_left_join_v4",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 3,
+    "ir_version": 4,
     "payload": {
       "model_name": "Transaction",
       "where": [

--- a/tests/fixtures/ir_vectors/query_transaction_record_v4.json
+++ b/tests/fixtures/ir_vectors/query_transaction_record_v4.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_transaction_record_v3",
+  "vector_name": "query_transaction_record_v4",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 3,
+    "ir_version": 4,
     "payload": {
       "model_name": "Transaction",
       "where": [

--- a/tests/fixtures/ir_vectors/query_transaction_traversal_v4.json
+++ b/tests/fixtures/ir_vectors/query_transaction_traversal_v4.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_transaction_traversal_v3",
+  "vector_name": "query_transaction_traversal_v4",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 3,
+    "ir_version": 4,
     "payload": {
       "model_name": "Transaction",
       "where": [

--- a/tests/fixtures/ir_vectors/query_user_compound_v4.json
+++ b/tests/fixtures/ir_vectors/query_user_compound_v4.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_user_compound_v3",
+  "vector_name": "query_user_compound_v4",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 3,
+    "ir_version": 4,
     "payload": {
       "model_name": "User",
       "where": [

--- a/tests/static_fixtures/bad_includes.py
+++ b/tests/static_fixtures/bad_includes.py
@@ -1,0 +1,36 @@
+"""Type-checked (never executed): include misuse must FAIL `ty check` (#287).
+
+test_static_contracts.py asserts this file produces `invalid-argument-type`
+diagnostics — include on a projected query (the `self: Never` pin, one
+materialization plan per query / #282) and a string selector (strings never
+traverse, #280) are static errors at the call site. One misuse per function —
+an earlier NoReturn await would mark the rest of the body unreachable and
+suppress its diagnostic.
+"""
+
+from typing import Annotated
+
+from ferro import FerroField, ForeignKey, Model
+
+
+class BadIAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    label: str = ""
+
+
+class BadITxn(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    amount: int = 0
+    account: Annotated[BadIAccount, ForeignKey(related_name="txns")]
+
+
+async def _include_on_a_projection() -> None:
+    # select(columns…) then include(): the projected query's include() takes
+    # `self: Never`, so the call site reports invalid-argument-type.
+    await BadITxn.select(lambda t: (t.id,)).include(lambda t: t.account).all()
+
+
+async def _string_include_selector() -> None:
+    # include("account"): strings never traverse (#280) — the selector
+    # parameter is a callable, so a str argument is invalid-argument-type.
+    await BadITxn.select().include("account").all()

--- a/tests/static_fixtures/good_includes.py
+++ b/tests/static_fixtures/good_includes.py
@@ -1,0 +1,44 @@
+"""Type-checked (never executed): include chains must PASS `ty check` (#286).
+
+test_static_contracts.py asserts this file produces no diagnostics — an
+included query stays ``Query[T]``-shaped (``.all()`` still ``list[T]``, no
+distinct loaded type, ADR-0008), and populated access types as the field's
+declared annotation.
+"""
+
+from typing import Annotated
+
+from ferro import FerroField, ForeignKey, Model
+
+
+class GIAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    label: str = ""
+
+
+class GITxn(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    amount: int = 0
+    account: Annotated[GIAccount, ForeignKey(related_name="txns")]
+
+
+async def _include_chain_stays_query_shaped() -> None:
+    # include() composes like any chainer and .all() stays list[GITxn] — the
+    # shape-not-names promise extends through include.
+    txns: list[GITxn] = await (
+        GITxn.select()
+        .include(lambda t: t.account)
+        .where(lambda t: t.amount >= 0)
+        .order_by(lambda t: t.amount, "desc")
+        .limit(10)
+        .all()
+    )
+
+    one: GITxn | None = await GITxn.select().include(lambda t: t.account).first()
+
+    # Populated access is a plain attribute matching the declared annotation.
+    label: str = txns[0].account.label
+
+    n: int = await GITxn.select().include(lambda t: t.account).count()
+
+    del one, label, n

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -23,7 +23,15 @@ from uuid import UUID
 import pytest
 
 import ferro
-from ferro import BackRef, FerroField, ForeignKey, Model, Relation, execute
+from ferro import (
+    BackRef,
+    FerroField,
+    ForeignKey,
+    ManyToMany,
+    Model,
+    Relation,
+    execute,
+)
 from ferro.query import builder as builder_module
 
 pytestmark = pytest.mark.backend_matrix
@@ -31,8 +39,10 @@ pytestmark = pytest.mark.backend_matrix
 
 # ---------------------------------------------------------------------------
 # Schema: Transaction -> Account -> Owner (both FKs nullable, so populated-
-# `None` and mid-chain NULL are observable), plus a typed-column pair with a
-# root/hop name collision for decode-parity pins.
+# `None` and mid-chain NULL are observable), a second Transaction FK
+# (Category) so accumulation across includes is observable, a typed-column
+# pair with a root/hop name collision for decode-parity pins, and an M2M trio
+# whose target model carries a forward FK.
 # ---------------------------------------------------------------------------
 
 
@@ -49,11 +59,39 @@ class INAccount(Model):
     transactions: Relation[list["INTransaction"]] = BackRef()
 
 
+class INCategory(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str = ""
+    transactions: Relation[list["INTransaction"]] = BackRef()
+
+
 class INTransaction(Model):
     id: Annotated[int | None, FerroField(primary_key=True)] = None
     amount: int = 0
     note: str = ""
     account: Annotated[INAccount | None, ForeignKey(related_name="transactions")] = None
+    category: Annotated[INCategory | None, ForeignKey(related_name="transactions")] = (
+        None
+    )
+
+
+class INMAuthor(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    role: str = ""
+    tags: Relation[list["INMTag"]] = BackRef()
+
+
+class INMTag(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str = ""
+    created_by: Annotated[INMAuthor, ForeignKey(related_name="tags")]
+    posts: Relation[list["INMPost"]] = BackRef()
+
+
+class INMPost(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    title: str = ""
+    tags: Relation[list["INMTag"]] = ManyToMany(related_name="posts")
 
 
 class INTier(StrEnum):
@@ -85,23 +123,25 @@ _TY_UID1 = UUID("11111111-1111-1111-1111-111111111111")
 
 async def _seed_core():
     """Owner o1 <- accounts a1 (2 txns) and a2 (1 txn); account b1 with no
-    owner (1 txn); and one transaction with no account at all (NULL FK)."""
+    owner (1 txn); one transaction with no account at all (NULL FK); txn 1
+    additionally categorized (the second FK, for accumulation pins)."""
     o1 = INOwner(id=1, name="o1")
     await o1.save()
     a1 = INAccount(id=1, label="a1", owner=o1)
     a2 = INAccount(id=2, label="a2", owner=o1)
     b1 = INAccount(id=3, label="b1", owner=None)
-    for row in (a1, a2, b1):
+    c1 = INCategory(id=1, name="groceries")
+    for row in (a1, a2, b1, c1):
         await row.save()
     for txn in (
-        INTransaction(id=1, amount=10, note="n1", account=a1),
+        INTransaction(id=1, amount=10, note="n1", account=a1, category=c1),
         INTransaction(id=2, amount=20, note="n2", account=a1),
         INTransaction(id=3, amount=30, note="n3", account=a2),
         INTransaction(id=4, amount=40, note="n4", account=b1),
         INTransaction(id=5, amount=50, note="n5", account=None),
     ):
         await txn.save()
-    return {"o1": o1, "a1": a1, "a2": a2, "b1": b1}
+    return {"o1": o1, "a1": a1, "a2": a2, "b1": b1, "c1": c1}
 
 
 async def _seed_typed():
@@ -495,3 +535,288 @@ def test_include_selector_validation():
         INTransaction.select().include(lambda t: 42)
     with pytest.raises(TypeError, match="selector callable"):
         INTransaction.select().include(42)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+# ---------------------------------------------------------------------------
+# Multi-hop (#287): whole-path population, prefix dedup, order freedom, NULL
+# mid-chain.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multi_hop_include_populates_every_hop(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        txn = await (
+            INTransaction.select()
+            .include(lambda t: t.account.owner)
+            .where(lambda t: t.id == 1)
+            .first()
+        )
+
+        assert txn is not None
+        # Whole-path population: a populated graph is never missing its
+        # intermediate nodes.
+        assert isinstance(txn.account, INAccount) and txn.account.label == "a1"
+        assert isinstance(txn.account.owner, INOwner) and txn.account.owner.name == "o1"
+
+
+@pytest.mark.asyncio
+async def test_shared_prefix_includes_dedup_and_are_order_free(db_url):
+    """`.include(account)` + `.include(account.owner)` — in either chain
+    order — populates exactly what `.include(account.owner)` alone does."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        base = INTransaction.select().where(lambda t: t.id == 1)
+        variants = (
+            base.include(lambda t: t.account).include(lambda t: t.account.owner),
+            base.include(lambda t: t.account.owner).include(lambda t: t.account),
+            base.include(lambda t: t.account.owner),
+        )
+        for q in variants:
+            txn = await q.first()
+            assert txn is not None
+            assert txn.account.label == "a1"
+            assert txn.account.owner.name == "o1"
+
+
+@pytest.mark.asyncio
+async def test_null_mid_chain_ends_the_chain_as_populated_none(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        txns = await (
+            INTransaction.select()
+            .include(lambda t: t.account.owner)
+            .order_by("id")
+            .all()
+        )
+
+        assert [t.id for t in txns] == [1, 2, 3, 4, 5], "roots retained"
+        # b1 has no owner: hop 1 populated, hop 2 populated-None.
+        ownerless = txns[3]
+        assert ownerless.account.label == "b1"
+        assert ownerless.account.owner is None
+        # No account at all: hop 1 populated-None, the chain ends there.
+        orphan = txns[4]
+        assert orphan.account is None
+
+
+# ---------------------------------------------------------------------------
+# The refresh rule (#287, ADR-0008): keep iff the FK still matches; drop on
+# change; accumulate across a session's queries.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_population_survives_a_refresh_with_unchanged_fk(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        txn = await (
+            INTransaction.select()
+            .include(lambda t: t.account)
+            .where(lambda t: t.id == 1)
+            .first()
+        )
+        assert txn is not None and txn.account.label == "a1"
+
+        again = await INTransaction.get(1)
+
+        assert again is txn, "refresh hit the same identity-mapped object"
+        assert isinstance(txn.account, INAccount), "population survived"
+        assert txn.account.label == "a1"
+
+
+@pytest.mark.asyncio
+async def test_populations_accumulate_across_a_sessions_queries(db_url):
+    """An account include and a later category include both stick: queries
+    compose instead of clobbering each other."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        first = await (
+            INTransaction.select()
+            .include(lambda t: t.account)
+            .where(lambda t: t.id == 1)
+            .first()
+        )
+        second = await (
+            INTransaction.select()
+            .include(lambda t: t.category)
+            .where(lambda t: t.id == 1)
+            .first()
+        )
+
+        assert second is first
+        assert isinstance(first.account, INAccount), "earlier population kept"
+        assert isinstance(first.category, INCategory), "later population added"
+        assert first.category.name == "groceries"
+
+
+@pytest.mark.asyncio
+async def test_refresh_drops_population_when_the_fk_changed(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        txn = await (
+            INTransaction.select()
+            .include(lambda t: t.account)
+            .where(lambda t: t.id == 1)
+            .first()
+        )
+        assert txn is not None and txn.account.id == 1
+
+        # External write: the row now points at a different account.
+        await execute(
+            f"UPDATE intransaction SET account_id = {_ph(db_url, 1)} "
+            f"WHERE id = {_ph(db_url, 2)}",
+            2,
+            1,
+        )
+        again = await INTransaction.get(1)
+        assert again is txn
+
+        # The population would lie now — it was dropped, so access reverts
+        # to the awaitable and resolves to the CURRENT row.
+        pending = txn.account
+        assert inspect.iscoroutine(pending)
+        fresh = await pending
+        assert fresh.id == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_drops_population_when_the_fk_went_null(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        txn = await (
+            INTransaction.select()
+            .include(lambda t: t.account)
+            .where(lambda t: t.id == 1)
+            .first()
+        )
+        assert txn is not None and isinstance(txn.account, INAccount)
+
+        await execute(
+            f"UPDATE intransaction SET account_id = NULL WHERE id = {_ph(db_url, 1)}",
+            1,
+        )
+        again = await INTransaction.get(1)
+        assert again is txn
+
+        pending = txn.account
+        assert inspect.iscoroutine(pending), "population dropped on NULLed FK"
+        assert await pending is None
+
+
+@pytest.mark.asyncio
+async def test_populated_none_survives_while_the_fk_stays_null(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        txn = await (
+            INTransaction.select()
+            .include(lambda t: t.account)
+            .where(lambda t: t.id == 5)
+            .first()
+        )
+        assert txn is not None and txn.account is None
+
+        again = await INTransaction.get(5)
+        assert again is txn
+        assert txn.account is None, "populated-None kept: the FK is still NULL"
+
+
+# ---------------------------------------------------------------------------
+# M2M association context (#287): include composes with `post.tags`.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_m2m_association_query_composes_with_include(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        author = INMAuthor(id=1, role="editor")
+        await author.save()
+        t1 = INMTag(id=1, name="rust", created_by=author)
+        t2 = INMTag(id=2, name="python", created_by=author)
+        for tag in (t1, t2):
+            await tag.save()
+        post = INMPost(id=1, title="ferro")
+        await post.save()
+        await post.tags.add(t1, t2)
+
+        tags = await post.tags.include(lambda tag: tag.created_by).order_by("id").all()
+
+        assert [t.name for t in tags] == ["rust", "python"]
+        assert all(isinstance(t.created_by, INMAuthor) for t in tags)
+        assert tags[0].created_by is tags[1].created_by, "identity-mapped"
+        assert tags[0].created_by.role == "editor"
+
+
+# ---------------------------------------------------------------------------
+# Guardrails (#287): loud, pointed, before any round-trip.
+# ---------------------------------------------------------------------------
+
+
+def test_string_include_selector_names_the_lambda_form():
+    with pytest.raises(
+        TypeError,
+        match=r"not a string.*include\(lambda t: t\.account\)",
+    ):
+        INTransaction.select().include("account")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+@pytest.mark.asyncio
+async def test_backref_include_selector_names_the_future_mechanism(db_url):
+    # connect() resolves relationships, injecting the reverse descriptors the
+    # guardrail identifies.
+    await ferro.connect(db_url, auto_migrate=True)
+    with pytest.raises(
+        TypeError,
+        match=r"reverse \(BackRef\) or many-to-many.*batched second query",
+    ):
+        INAccount.select().include(lambda a: a.transactions)
+
+
+@pytest.mark.asyncio
+async def test_m2m_include_selector_names_the_future_mechanism(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    with pytest.raises(
+        TypeError,
+        match=r"reverse \(BackRef\) or many-to-many.*batched second query",
+    ):
+        INMPost.select().include(lambda p: p.tags)
+
+
+def test_include_and_projection_raise_in_both_chain_orders():
+    with pytest.raises(ValueError, match=r"exactly one materialization plan.*#282"):
+        INTransaction.select().include(lambda t: t.account).select(
+            lambda t: (t.id, t.amount)
+        )
+    with pytest.raises(ValueError, match=r"exactly one materialization plan.*#282"):
+        INTransaction.select(lambda t: (t.id, t.amount)).include(  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+            lambda t: t.account
+        )
+
+
+@pytest.mark.asyncio
+async def test_mutations_on_an_included_query_raise_before_any_round_trip():
+    """No ferro.connect in scope: the build-time guard fires before any
+    route or SQL exists."""
+    included = INTransaction.select().include(lambda t: t.account)
+    with pytest.raises(ValueError, match=r"update\(\) does not support include\(\)"):
+        await included.update(note="x")
+    with pytest.raises(ValueError, match=r"delete\(\) does not support include\(\)"):
+        await included.delete()

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -1,0 +1,497 @@
+"""Backend-matrix integration tests for populated relations (#286, ADR-0008).
+
+``select().include(lambda t: t.account)`` end to end: the ``instances``
+materialization plan renders the include-only LEFT join and the widened,
+aliased SELECT, decodes every hop against the hop model's own codec plan, and
+populates the relation per the population contract — plain attribute access
+returning the complete instance, no await, no query — while unpopulated
+relations keep the awaitable contract unchanged. No SQL-string snapshots at
+this layer (the rendered SELECT/edge-union pins live in the Rust walker unit
+tests). Covers membership preservation, the population contract, identity-map
+semantics (dedup, refresh-attach), sessionless freshness, typed-column parity
+vs a direct query, verb composition, and the include-vs-joins wire split.
+"""
+
+import inspect
+import json
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import StrEnum
+from typing import Annotated
+from uuid import UUID
+
+import pytest
+
+import ferro
+from ferro import BackRef, FerroField, ForeignKey, Model, Relation, execute
+from ferro.query import builder as builder_module
+
+pytestmark = pytest.mark.backend_matrix
+
+
+# ---------------------------------------------------------------------------
+# Schema: Transaction -> Account -> Owner (both FKs nullable, so populated-
+# `None` and mid-chain NULL are observable), plus a typed-column pair with a
+# root/hop name collision for decode-parity pins.
+# ---------------------------------------------------------------------------
+
+
+class INOwner(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str = ""
+    accounts: Relation[list["INAccount"]] = BackRef()
+
+
+class INAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    label: str = ""
+    owner: Annotated[INOwner | None, ForeignKey(related_name="accounts")] = None
+    transactions: Relation[list["INTransaction"]] = BackRef()
+
+
+class INTransaction(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    amount: int = 0
+    note: str = ""
+    account: Annotated[INAccount | None, ForeignKey(related_name="transactions")] = None
+
+
+class INTier(StrEnum):
+    FREE = "free"
+    PRO = "pro"
+
+
+class INTyProfile(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    created_at: datetime
+    external_id: UUID
+    balance: Decimal | None = None
+    tier: INTier = INTier.FREE
+    # Plain-text column; collides by name with INTyUser.tag (a native enum) —
+    # the per-hop codec pin (the stage-1 root-vs-hop lesson).
+    tag: str = ""
+    users: Relation[list["INTyUser"]] = BackRef()
+
+
+class INTyUser(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    tag: INTier = INTier.FREE
+    profile: Annotated[INTyProfile, ForeignKey(related_name="users")]
+
+
+_TY_T1 = datetime(2026, 3, 1, 12, 30, 45, 123456, tzinfo=timezone.utc)
+_TY_UID1 = UUID("11111111-1111-1111-1111-111111111111")
+
+
+async def _seed_core():
+    """Owner o1 <- accounts a1 (2 txns) and a2 (1 txn); account b1 with no
+    owner (1 txn); and one transaction with no account at all (NULL FK)."""
+    o1 = INOwner(id=1, name="o1")
+    await o1.save()
+    a1 = INAccount(id=1, label="a1", owner=o1)
+    a2 = INAccount(id=2, label="a2", owner=o1)
+    b1 = INAccount(id=3, label="b1", owner=None)
+    for row in (a1, a2, b1):
+        await row.save()
+    for txn in (
+        INTransaction(id=1, amount=10, note="n1", account=a1),
+        INTransaction(id=2, amount=20, note="n2", account=a1),
+        INTransaction(id=3, amount=30, note="n3", account=a2),
+        INTransaction(id=4, amount=40, note="n4", account=b1),
+        INTransaction(id=5, amount=50, note="n5", account=None),
+    ):
+        await txn.save()
+    return {"o1": o1, "a1": a1, "a2": a2, "b1": b1}
+
+
+async def _seed_typed():
+    profile = INTyProfile(
+        id=1,
+        created_at=_TY_T1,
+        external_id=_TY_UID1,
+        balance=Decimal("12.50"),
+        tier=INTier.PRO,
+        tag="vip",
+    )
+    await profile.save()
+    await INTyUser(id=1, tag=INTier.PRO, profile=profile).save()
+
+
+def _ph(db_url: str, n: int = 1) -> str:
+    """Return the Nth positional placeholder for the active backend."""
+    return f"${n}" if "postgres" in db_url else "?"
+
+
+# ---------------------------------------------------------------------------
+# The tracer bullet: populated plain-attribute access, one statement.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_include_populates_relation_as_plain_attribute(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        txns = await (
+            INTransaction.select().include(lambda t: t.account).order_by("id").all()
+        )
+
+        assert isinstance(txns, list)
+        assert all(isinstance(t, INTransaction) for t in txns)
+        # Plain attribute — a complete instance, not a coroutine.
+        assert isinstance(txns[0].account, INAccount)
+        assert txns[0].account.label == "a1"
+        assert txns[2].account.label == "a2"
+        assert txns[3].account.label == "b1"
+
+
+@pytest.mark.asyncio
+async def test_include_preserves_membership_and_populates_null_fk_as_none(db_url):
+    """Adding .include(...) returns exactly the rows the query returned
+    without it; a NULL nullable FK populates as None with the root retained."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        plain = await INTransaction.select().order_by("id").all()
+        included = await (
+            INTransaction.select().include(lambda t: t.account).order_by("id").all()
+        )
+
+        assert [t.id for t in included] == [t.id for t in plain] == [1, 2, 3, 4, 5]
+        orphan = included[4]
+        # Populated-`None`: a plain attribute, truthful to the declared
+        # `| None` type — not an awaitable.
+        assert orphan.account is None
+
+
+@pytest.mark.asyncio
+async def test_unpopulated_relations_keep_the_awaitable_contract(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        txn = await INTransaction.select().where(lambda t: t.id == 1).first()
+        assert txn is not None
+
+        pending = txn.account
+        assert inspect.iscoroutine(pending), "unpopulated access stays awaitable"
+        account = await pending
+        assert isinstance(account, INAccount) and account.label == "a1"
+
+
+# ---------------------------------------------------------------------------
+# Identity map: same object as a direct fetch, deduped across rows,
+# refresh-attached onto instances the session already holds.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_populated_instances_are_identity_mapped_and_deduped(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        direct = await INAccount.get(1)
+        txns = await (
+            INTransaction.select()
+            .include(lambda t: t.account)
+            .where(lambda t: t.amount <= 20)
+            .order_by("id")
+            .all()
+        )
+
+        assert len(txns) == 2
+        # Same row, same object: across result rows AND with the instance the
+        # session already held.
+        assert txns[0].account is txns[1].account
+        assert txns[0].account is direct
+
+
+@pytest.mark.asyncio
+async def test_include_refresh_attaches_onto_a_live_instance(db_url):
+    """A later include query refreshes the session's existing instance in
+    place (full hop.* row) and attaches it — shared objects get richer,
+    never forked."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        held = await INAccount.get(1)
+        # External write the ORM cache knows nothing about.
+        await execute(
+            f"UPDATE inaccount SET label = {_ph(db_url, 1)} "
+            f"WHERE id = {_ph(db_url, 2)}",
+            "a1-renamed",
+            1,
+        )
+
+        txn = await (
+            INTransaction.select()
+            .include(lambda t: t.account)
+            .where(lambda t: t.id == 1)
+            .first()
+        )
+
+        assert txn is not None
+        assert txn.account is held, "population reuses the held instance"
+        assert held.label == "a1-renamed", "the hit refreshed the held instance"
+
+
+@pytest.mark.asyncio
+async def test_sessionless_include_returns_fresh_instances_per_row(db_url):
+    """Sessionless Ferro keeps exactly one identity story: no session, no
+    identity map, no query-local dedup — fresh instances per row."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+    txns = await (
+        INTransaction.using("default")
+        .select()
+        .include(lambda t: t.account)
+        .where(lambda t: t.amount <= 20)
+        .order_by("id")
+        .all()
+    )
+
+    assert len(txns) == 2
+    assert isinstance(txns[0].account, INAccount)
+    assert txns[0].account is not txns[1].account
+    assert txns[0].account.id == txns[1].account.id == 1
+
+
+# ---------------------------------------------------------------------------
+# Typed-column decode parity: per-hop decode uses the hop model's codec plan.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_populated_typed_columns_equal_a_direct_query(db_url):
+    """datetime / uuid / native enum / decimal on a populated instance match a
+    direct query's instance in type and value on both backends — even with a
+    root/hop column-name collision (INTyUser.tag enum vs INTyProfile.tag
+    text), so the hop can only have decoded through its OWN codec plan."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_typed()
+
+    # Sessionless on purpose: distinct objects, so equality is decode parity,
+    # not identity.
+    user = await (
+        INTyUser.using("default").select().include(lambda u: u.profile).first()
+    )
+    direct = await INTyProfile.using("default").select().first()
+
+    assert user is not None and direct is not None
+    populated = user.profile
+    assert isinstance(populated, INTyProfile)
+    assert populated is not direct
+    for field in ("id", "created_at", "external_id", "balance", "tier", "tag"):
+        hydrated = getattr(direct, field)
+        via_include = getattr(populated, field)
+        assert type(via_include) is type(hydrated), field
+        assert via_include == hydrated, field
+    assert isinstance(populated.created_at, datetime)
+    assert isinstance(populated.external_id, UUID)
+    assert isinstance(populated.tier, INTier) and populated.tier is INTier.PRO
+    assert isinstance(populated.balance, Decimal) and populated.balance == Decimal(
+        "12.50"
+    )
+    # The root's same-named enum column still decodes as the root's enum.
+    assert user.tag is INTier.PRO
+    assert isinstance(populated.tag, str) and populated.tag == "vip"
+
+
+# ---------------------------------------------------------------------------
+# Interplay with stage-1 joins: include never changes membership or a shared
+# edge's semantics.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_include_keeps_traversal_predicate_semantics(db_url):
+    """A where() traversal on the same path keeps its INNER semantics — the
+    row set is identical with and without the include — and the surviving
+    rows come back populated."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        plain = await (
+            INTransaction.select()
+            .where(lambda t: t.account.label == "a1")
+            .order_by("id")
+            .all()
+        )
+        included = await (
+            INTransaction.select()
+            .where(lambda t: t.account.label == "a1")
+            .include(lambda t: t.account)
+            .order_by("id")
+            .all()
+        )
+
+        assert [t.id for t in included] == [t.id for t in plain] == [1, 2]
+        assert all(t.account.label == "a1" for t in included)
+
+
+@pytest.mark.asyncio
+async def test_include_keeps_order_by_traversal_semantics(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        plain = await (
+            INTransaction.select()
+            .order_by(lambda t: t.account.label, "desc")
+            .order_by("id")
+            .all()
+        )
+        included = await (
+            INTransaction.select()
+            .order_by(lambda t: t.account.label, "desc")
+            .order_by("id")
+            .include(lambda t: t.account)
+            .all()
+        )
+
+        assert [t.id for t in included] == [t.id for t in plain]
+        assert included[0].account.label == "b1"
+
+
+@pytest.mark.asyncio
+async def test_include_composes_with_explicit_left_join_on_the_same_path(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        txns = await (
+            INTransaction.select()
+            .left_join(lambda t: t.account)
+            .include(lambda t: t.account)
+            .order_by("id")
+            .all()
+        )
+
+        assert [t.id for t in txns] == [1, 2, 3, 4, 5], "LEFT keeps orphans"
+        assert txns[0].account.label == "a1"
+        assert txns[4].account is None
+
+
+# ---------------------------------------------------------------------------
+# Verb composition: first(), count(), exists(), pagination, immutability.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_returns_a_populated_instance_or_none(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        q = INTransaction.select().include(lambda t: t.account)
+        first = await q.order_by("amount", "desc").where(lambda t: t.id <= 4).first()
+        assert first is not None and first.account.label == "b1"
+
+        empty = await q.where(lambda t: t.amount > 1000).first()
+        assert empty is None
+
+
+@pytest.mark.asyncio
+async def test_count_and_exists_are_unaffected_by_include(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        plain = INTransaction.select().where(lambda t: t.amount >= 20)
+        included = plain.include(lambda t: t.account)
+        assert await included.count() == await plain.count() == 4
+        assert await included.exists() is True
+
+
+@pytest.mark.asyncio
+async def test_count_payload_stays_root_instances_under_include(db_url, monkeypatch):
+    """count() measures rows, not attached data: its payload emits
+    root_instances and no include joins — pinned on the wire."""
+    captured = {}
+
+    async def _capture(name, query_ir_json, route):
+        captured["envelope"] = json.loads(query_ir_json)
+        return 0
+
+    monkeypatch.setattr(builder_module, "count_filtered", _capture)
+    await ferro.connect(db_url, auto_migrate=True)
+
+    await INTransaction.using("default").select().include(lambda t: t.account).count()
+
+    payload = captured["envelope"]["payload"]
+    assert payload["materialization"] == {"kind": "root_instances"}
+    assert payload["joins"] == []
+
+
+@pytest.mark.asyncio
+async def test_include_composes_with_limit_offset(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed_core()
+
+        txns = await (
+            INTransaction.select()
+            .include(lambda t: t.account)
+            .order_by("id")
+            .limit(2)
+            .offset(1)
+            .all()
+        )
+        assert [t.id for t in txns] == [2, 3]
+        assert txns[1].account.label == "a2"
+
+
+def test_include_is_immutable_and_idempotent():
+    base = INTransaction.select()
+    included = base.include(lambda t: t.account)
+    again = included.include(lambda t: t.account)
+
+    assert base._includes == {}
+    assert list(included._includes) == [("account",)]
+    assert list(again._includes) == [("account",)], "same path dedups"
+    assert included is not base and again is not included
+
+
+# ---------------------------------------------------------------------------
+# The wire split (ADR-0008): include paths ride the instances plan, never the
+# joins section.
+# ---------------------------------------------------------------------------
+
+
+def test_include_paths_never_enter_the_joins_wire_section():
+    q = INTransaction.select().include(lambda t: t.account)
+
+    assert q._joins == {}
+    assert q._serialize_joins() == []
+    assert q._materialization_ir() == {
+        "kind": "instances",
+        "paths": [
+            [
+                {
+                    "relation": "account",
+                    "from_column": "account_id",
+                    "to_table": "inaccount",
+                    "to_column": "id",
+                }
+            ]
+        ],
+    }
+
+
+def test_include_selector_validation():
+    with pytest.raises(AttributeError, match="Did you mean 'account'"):
+        INTransaction.select().include(lambda t: t.acount)
+    with pytest.raises(TypeError, match="column 'account.label', not a relation"):
+        INTransaction.select().include(lambda t: t.account.label)
+    with pytest.raises(TypeError, match="must return a relation path"):
+        INTransaction.select().include(lambda t: 42)
+    with pytest.raises(TypeError, match="selector callable"):
+        INTransaction.select().include(42)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -70,9 +70,9 @@ class INTransaction(Model):
     amount: int = 0
     note: str = ""
     account: Annotated[INAccount | None, ForeignKey(related_name="transactions")] = None
-    category: Annotated[INCategory | None, ForeignKey(related_name="transactions")] = (
-        None
-    )
+    category: Annotated[
+        INCategory | None, ForeignKey(related_name="transactions")
+    ] = None
 
 
 class INMAuthor(Model):
@@ -319,9 +319,7 @@ async def test_populated_typed_columns_equal_a_direct_query(db_url):
 
     # Sessionless on purpose: distinct objects, so equality is decode parity,
     # not identity.
-    user = await (
-        INTyUser.using("default").select().include(lambda u: u.profile).first()
-    )
+    user = await INTyUser.using("default").select().include(lambda u: u.profile).first()
     direct = await INTyProfile.using("default").select().first()
 
     assert user is not None and direct is not None

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -11,9 +11,10 @@ from ferro import BackRef, Field, ManyToMany, Model, Relation, clear_registry
 
 VECTORS_DIR = Path(__file__).parent / "fixtures" / "ir_vectors"
 SUPPORTED_DOMAINS = {"schema", "query", "codec"}
-# `query` is on ir_version 3 (#278 — unconditional bump, required
-# `materialization` section, ADR-0007); `schema`/`codec` remain v1.
-SUPPORTED_IR_VERSIONS = {"schema": 1, "query": 3, "codec": 1}
+# `query` is on ir_version 4 (#285 — unconditional bump; the `instances`
+# materialization kind carries `paths` of hop facts, ADR-0008 on the
+# ADR-0007 plan substrate); `schema`/`codec` remain v1.
+SUPPORTED_IR_VERSIONS = {"schema": 1, "query": 4, "codec": 1}
 QUERY_OPERATORS = {"==", "!=", "<", "<=", ">", ">=", "IN", "LIKE", "AND", "OR"}
 MATERIALIZATION_KINDS = {"root_instances", "record", "instances"}
 
@@ -86,11 +87,39 @@ def _validate_schema_payload(payload: dict[str, Any], label: str) -> None:
         )
 
 
+def _validate_hop(hop: dict[str, Any], label: str) -> None:
+    """Validate one relation-hop fact (the shared `joins`/`instances` shape)."""
+    assert isinstance(hop, dict), f"{label} must be object"
+    _require_keys(
+        hop,
+        {"relation", "from_column", "to_table", "to_column"},
+        label,
+    )
+    for key in ("relation", "from_column", "to_table", "to_column"):
+        assert isinstance(hop[key], str), f"{label}.{key} must be a str"
+
+
 def _validate_materialization(plan: dict[str, Any], label: str) -> None:
-    """Validate the v3 `materialization` section's required keys (#278)."""
+    """Validate the `materialization` section's required keys (#278, #285)."""
     _require_keys(plan, {"kind"}, label)
     kind = plan["kind"]
     assert kind in MATERIALIZATION_KINDS, f"{label}.kind invalid: {kind!r}"
+    if kind == "instances":
+        # v4 (#285): the instances plan carries `paths` — ordered hop-fact
+        # lists in the same hop shape as the `joins` section.
+        _require_keys(plan, {"paths"}, label)
+        paths = plan["paths"]
+        assert isinstance(paths, list) and paths, (
+            f"{label}.paths must be non-empty list"
+        )
+        for i, path in enumerate(paths):
+            path_label = f"{label}.paths[{i}]"
+            assert isinstance(path, list) and path, (
+                f"{path_label} must be a non-empty list of hops"
+            )
+            for h, hop in enumerate(path):
+                _validate_hop(hop, f"{path_label}[{h}]")
+        return
     if kind != "record":
         return
     _require_keys(plan, {"fields"}, label)
@@ -162,15 +191,7 @@ def _validate_query_payload(payload: dict[str, Any], label: str) -> None:
         )
         assert isinstance(join["path"], list), f"{join_label}.path must be a list"
         for h, hop in enumerate(join["path"]):
-            hop_label = f"{join_label}.path[{h}]"
-            assert isinstance(hop, dict), f"{hop_label} must be object"
-            _require_keys(
-                hop,
-                {"relation", "from_column", "to_table", "to_column"},
-                hop_label,
-            )
-            for key in ("relation", "from_column", "to_table", "to_column"):
-                assert isinstance(hop[key], str), f"{hop_label}.{key} must be a str"
+            _validate_hop(hop, f"{join_label}.path[{h}]")
 
 
 def _validate_codec_payload(payload: dict[str, Any], label: str) -> None:

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -74,7 +74,7 @@ def test_query_ir_payload_to_json_serializes_m2m_context_without_mutating_query_
     assert query._m2m_context["source_id"] == source_id
     assert isinstance(query._m2m_context["source_id"], uuid.UUID)
     assert payload["ir_kind"] == "query"
-    assert payload["ir_version"] == 3
+    assert payload["ir_version"] == 4
     assert payload["payload"]["m2m"]["source_id"] == str(source_id)
 
 

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -186,6 +186,16 @@ def test_projected_shape_misuse_fails_the_type_checker():
     )
 
 
+def test_include_misuse_fails_the_type_checker():
+    """include() on a projected query (the `self: Never` pin, #287) and a
+    string include selector are static errors at the call site."""
+    result = _run_ty(FIXTURES / "bad_includes.py")
+    assert result.returncode != 0, "bad_includes.py must fail ty"
+    assert result.stdout.count("invalid-argument-type") >= 2, (
+        "projected include() and a string selector must each be a static error"
+    )
+
+
 def test_query_ir_is_the_only_query_shape_in_rust():
     """FF-F F-4 exit gate: no `struct QueryNode` outside the IR crate."""
     repo = Path(__file__).parent.parent

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -164,6 +164,16 @@ def test_junk_lambda_predicates_fail_the_type_checker():
     assert "invalid-assignment" in result.stdout
 
 
+def test_include_chains_pass_the_type_checker():
+    """An included query stays Query[T]-shaped: .all() is list[T], .first()
+    is T | None, and populated access types as the declared annotation
+    (#286, ADR-0008 — no distinct loaded type)."""
+    result = _run_ty(FIXTURES / "good_includes.py")
+    assert result.returncode == 0, (
+        f"include chains must type-check cleanly:\n{result.stdout}\n{result.stderr}"
+    )
+
+
 def test_projected_shape_misuse_fails_the_type_checker():
     """A `Row` where a model instance is expected must be rejected statically
     (#279), and mutating a projected query is a static error at the call site


### PR DESCRIPTION
Joined-row hydration end to end (#267 stage 2, executed per the PRD in #284 on the ADR-0007/ADR-0006 substrate; semantics fixed by ADR-0008). One commit per slice, in dependency order.

Closes #285. Closes #286. Closes #287. Closes #288. Closes #284.

## What landed

**QueryIR v4 — the instances plan shape (#285).** Every query emits a v4 envelope; v3 is rejected with the actionable one-wheel message, and the version check fires before strict payload parsing (the v2-at-v3 precedent). `Materialization::Instances` gains its field shape: `paths` — ordered hop-fact lists (`relation`, `from_column`, `to_table`, `to_column`, the same hop shape as the `joins` section) and nothing else. Golden query vectors regenerated as v4 plus a new `instances` vector with IR-crate round-trip pins; the vector contract validator covers the instances paths' hop keys. Zero behavior change.

**The tracer bullet (#286).** `Transaction.select().include(lambda t: t.account).all()` returns the same `list[Transaction]` it always did, in one SQL statement, with each `account` **populated**: a plain attribute in the instance's `__dict__` (shadowing the non-data `ForwardDescriptor`) holding the complete related instance — no await, no query — exactly as the declared annotation claims. Unpopulated relations keep the awaitable contract untouched; a NULL nullable FK populates as `None` with the root row retained.

- Include paths ride the materialization plan, never the `joins` wire section: the fetch walker unions them in edge-by-edge — an edge any other clause references keeps its stage-1 join type, an include-only edge renders LEFT — so include is membership-preserving by construction and can never rewrite a predicate's meaning (pinned by order-independent `build_join_plan` unit tests and integration).
- The widened SELECT carries every hop's complete column list under `{alias}__{col}` aliases (root/hop name collisions are structurally impossible), and each hop decodes against its **own** model's codec plan — typed parity (datetime/uuid/native enum/decimal) with a direct query pinned on both backends, including a root/hop column-name collision.
- Every populated node runs the full session identity-map protocol: hit → refresh in place + reuse (attaching onto instances the session already holds), miss → hydrate + insert. Sessionless queries return fresh instances per row, no query-local dedup.
- `count()`/`exists()` payloads stay `root_instances` (pinned on the wire); `first()` returns a populated instance or `None`; include chains stay `Query[T]`-shaped under the static gate (`.all()` is `list[T]` — no distinct loaded type).

**Multi-hop, refresh rule, guardrails (#287).** `include(lambda t: t.account.owner)` populates every hop along the path; shared prefixes dedup by path identity (cumulative, order-free, idempotent); a NULL mid-chain ends its chain as populated-`None` with the root retained. The refresh rule: a refresh keeps each population iff the freshly decoded shadow FK still equals the populated instance's pk (populated-`None` survives while the FK stays NULL) — so populations **accumulate** across a session's queries — and drops it when the FK changed or went NULL: access reverts to the awaitable, never repaired from identity-map contents. Include composes with the M2M association context (`post.tags.include(lambda tag: tag.created_by)`). Misuse is loud at build time with pinned messages: string selectors name the lambda form; BackRef/M2M selectors name the future reverse-population mechanism; include × projection raises in both chain orders naming #282 (with a `self: Never` static pin on the projected side); `update()`/`delete()` on an included query raise before any round-trip.

**Docs (#288).** The queries guide gains "Populating Relations with include()" (example-first: the population contract, membership preservation, identity/refresh/accumulation, the loud limits), the relationships guide teaches populated access alongside the awaitable form, the API reference covers `include()`, and the query-typing page explains why there is no `Loaded[T]` (identity-map soundness; PEP 827 sharpens typing later with zero runtime change). Every snippet is backed by the runnable `populated_relations.py` / `populated_relations_annotated.py` pair executed in CI. Stale eager-loading roadmap entries pruned in favor of the shipped `include()` and the future reverse/M2M mechanism.

## Out of scope (per the PRD)

BackRef/M2M population (future separate mechanism — selectors raise pointing at it), include × projection (#282), partial hop columns (never — the complete-instance invariant), eager-by-default configuration.

## Gates (all green per slice and at tip)

- Full backend matrix `pytest --db-backends=sqlite,postgres`: **1425 passed, 11 skipped, 1 xfailed** (baseline 1365/11/1 + the new suites)
- `cargo test --no-default-features --features testing`: **173 passed** (baseline 164)
- `cargo test -p ferro-schema-ir`: **12 passed** (baseline 9)
- `just check` (ty static gate): clean; new good/bad include fixtures active, existing bad fixtures still failing
- Docs build (`zensical build`): at baseline — exactly the 2 pre-existing out-of-tree link warnings in `concepts/architecture.md`, zero new
