### PR TITLE
feat: aggregations, output aliases, and traversed projection (#282)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,6 +80,18 @@ _Avoid_: Eager-loaded field, select_related, prefetched attribute, joined attrib
 A query's declaration of what its result columns become: complete root instances (every query today), a projected record of named fields, or — in the future — a populated instance graph. Every query carries exactly one plan; the plan travels with the query rather than being inferred from its column list.
 _Avoid_: Select list, projection spec, hydration mode flag
 
+**Aggregate projection**:
+A projection containing at least one aggregate field. Each group collapses to exactly one projected record: every non-aggregate field is a group key, so grouping is derived from the projection and never declared separately. With no non-aggregate fields, the whole result collapses to a single record. Grouping collapses rows — bucketing complete instances by a key ("partitioning") is a different, client-side operation and is not grouping.
+_Avoid_: Group-by query, summary query, rollup, partition
+
+**Traversed projection**:
+A projected record field whose source column lives across a forward-FK relation path (`select(lambda t: t.account.name)`). Projection traversal narrows exactly like predicate traversal (ADR-0006). Unaliased, the field takes the bare leaf column name; two selected fields sharing an output name is a build-time error, resolved with an output alias.
+_Avoid_: Nested select, join column, related-field pull
+
+**Output alias**:
+A user-chosen name for one field of a projected record, given as the key in a dict-returning selector (`select(lambda t: {"account_name": t.account.name})`). Aliases name output fields only — never joins or tables; the relation path remains the sole join identity.
+_Avoid_: Column alias, AS label, join alias
+
 **Provisional registration**:
 The per-model state installed when a class body finishes executing — enough for runtime codec and PK metadata, but relationships may still be pending and the modelset is not yet authoritative for DDL.
 _Avoid_: Import-time registration, partial registry

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -705,6 +705,43 @@ mod tests {
     }
 
     #[test]
+    fn query_traversed_record_fixture_roundtrip() {
+        // The traversed-projection golden vector (#293): an aliased root
+        // field, a 1-hop field under a LEFT-marked path, and a 2-hop field
+        // sharing that path's prefix — the full dict-selector wire shape,
+        // joins section included — survives a deserialize/serialize
+        // round-trip without drift.
+        let fixture = include_str!(
+            "../../../tests/fixtures/ir_vectors/query_transaction_traversed_record_v5.json"
+        );
+        let parsed: serde_json::Value =
+            serde_json::from_str(fixture).expect("query traversed record fixture must parse");
+        let ir = parsed
+            .get("ir")
+            .cloned()
+            .expect("fixture must contain ir envelope");
+        let envelope: IrEnvelope<QueryIrPayload> = serde_json::from_value(ir.clone())
+            .expect("query traversed record IR must deserialize");
+        let Materialization::Record { fields } = &envelope.payload.materialization else {
+            panic!(
+                "expected a record plan, got {:?}",
+                envelope.payload.materialization
+            );
+        };
+        assert_eq!(fields.len(), 3);
+        // The root field is aliased: name and column differ.
+        assert_eq!(fields[0].name, "txn_id");
+        assert_eq!(fields[0].column.as_deref(), Some("id"));
+        // Traversed fields carry relation-name paths keying into `joins`.
+        assert_eq!(fields[1].path, vec!["account".to_string()]);
+        assert_eq!(fields[2].path.len(), 2);
+        assert_eq!(envelope.payload.joins[0].join_type, "left");
+        let encoded =
+            serde_json::to_value(&envelope).expect("query traversed record IR must serialize");
+        assert_eq!(encoded, ir, "query traversed record round-trip must not drift");
+    }
+
+    #[test]
     fn query_aggregate_fixture_roundtrip() {
         // The aggregate-projection golden vector (#292): a grouped query's
         // full payload — a traversed group key sharing its path with the

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -705,6 +705,44 @@ mod tests {
     }
 
     #[test]
+    fn query_global_aggregate_fixture_roundtrip() {
+        // The global-aggregate golden vector (#294): an aggregate-only record
+        // plan — count, root sum, and a traversed avg carrying hop facts on
+        // the expression, plus a `joins` entry sharing the avg's path (join
+        // identity) — survives a deserialize/serialize round-trip without
+        // drift. No group keys: the whole result collapses to one record.
+        let fixture = include_str!(
+            "../../../tests/fixtures/ir_vectors/query_transaction_global_aggregate_v5.json"
+        );
+        let parsed: serde_json::Value =
+            serde_json::from_str(fixture).expect("global aggregate fixture must parse");
+        let ir = parsed
+            .get("ir")
+            .cloned()
+            .expect("fixture must contain ir envelope");
+        let envelope: IrEnvelope<QueryIrPayload> = serde_json::from_value(ir.clone())
+            .expect("global aggregate IR must deserialize");
+        let Materialization::Record { fields } = &envelope.payload.materialization else {
+            panic!(
+                "expected a record plan, got {:?}",
+                envelope.payload.materialization
+            );
+        };
+        assert_eq!(fields.len(), 3);
+        assert!(
+            fields.iter().all(|f| f.expr.is_some()),
+            "a global aggregate plan is aggregate-only"
+        );
+        assert_eq!(
+            fields[0].expr.as_ref().map(|e| e.r#fn),
+            Some(AggregateFn::Count)
+        );
+        let encoded =
+            serde_json::to_value(&envelope).expect("global aggregate IR must serialize");
+        assert_eq!(encoded, ir, "global aggregate round-trip must not drift");
+    }
+
+    #[test]
     fn query_traversed_record_fixture_roundtrip() {
         // The traversed-projection golden vector (#293): an aliased root
         // field, a 1-hop field under a LEFT-marked path, and a 2-hop field

--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -137,13 +137,13 @@ pub struct SchemaCheck {
 /// Query IR: filter, sort, pagination, joins, materialization plan, and
 /// optional M2M join context.
 ///
-/// `ir_version: 4` (unconditional, no earlier version emitted anywhere —
-/// #269, #278, #285). `joins` is required and always present (`[]` when the
-/// query traverses no relation); every leaf and `order_by` entry carries a
+/// `ir_version: 5` (unconditional, no earlier version emitted anywhere —
+/// #269, #278, #285, #292). `joins` is required and always present (`[]` when
+/// the query traverses no relation); every leaf and `order_by` entry carries a
 /// `path` (required, `[]` = root model); `materialization` is required — the
 /// plan travels with the query as data (ADR-0007), never inferred from a
-/// column list. v4 gives the `instances` kind its field shape: `paths` of
-/// hop facts (#285).
+/// column list. v5 gives `record` fields expression sources: a field carries
+/// either a `column` + `path` or an `expr` (#292, ADR-0009).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueryIrPayload {
     /// Model class name the query targets.
@@ -200,23 +200,103 @@ pub enum Materialization {
 
 /// One projected field in a [`Materialization::Record`] plan.
 ///
-/// `name` is declared separately from the source `column`, the field carries a
-/// relation `path`, and may later carry an `expr` instead of a column — so
-/// output aliases, traversed projection, and aggregations (#282) extend this
-/// shape additively without reshaping the v3 contract.
+/// `name` is declared separately from the source, so output aliases are free
+/// (`name` is the alias). A field reads from exactly one source (v5, #292,
+/// ADR-0009): a `column` + relation `path` (plain and traversed projection),
+/// or an `expr` (aggregations) — never both, never neither, enforced at
+/// deserialization via [`RecordFieldWire`]. GROUP BY never travels on the
+/// wire: the renderer derives group keys from the plan — every non-`expr`
+/// field is a key (ADR-0009).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(try_from = "RecordFieldWire")]
 pub struct RecordField {
     /// Output field name on the projected record.
     pub name: String,
-    /// Source column the value reads from (`name == column` until output
-    /// aliases land with #282).
-    pub column: String,
+    /// Source column the value reads from. `Some` iff `expr` is `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<String>,
     /// Relation path from the root model to `column`'s table (`[]` = root
-    /// model; non-empty paths are traversed projection, #282).
+    /// model; non-empty paths are traversed projection, #293). Belongs to the
+    /// `column` arm: an `expr` field carries its traversal on the expression
+    /// itself, so its outer `path` is always `[]`.
     pub path: Vec<String>,
-    /// Reserved: expression source instead of a column (aggregations, #282).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expr: Option<Value>,
+    /// Expression source instead of a column (aggregations, #294/#295).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expr: Option<RecordExpr>,
+}
+
+/// The expression source of an aggregate record field (v5, #292, ADR-0009).
+///
+/// Self-contained on the wire: `fn` travels as data (the closed aggregate
+/// set), and `path` carries the source column's traversal as ordered hop
+/// facts — the same hop shape as the `joins` section — rather than keying
+/// into it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RecordExpr {
+    /// Aggregate function applied to `column`.
+    pub r#fn: AggregateFn,
+    /// Source column the aggregate reads from.
+    pub column: String,
+    /// Relation hops from the root model to `column`'s table (`[]` = root
+    /// model), in the `joins`-section hop-fact shape.
+    pub path: Vec<QueryJoinHop>,
+}
+
+/// The closed set of aggregate functions a [`RecordExpr`] may apply
+/// (ADR-0009). Carried as data on the wire; an unknown token fails the strict
+/// parse naming the supported set.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AggregateFn {
+    Count,
+    Sum,
+    Avg,
+    Min,
+    Max,
+}
+
+/// Field-wise wire shape backing [`RecordField`] deserialization, so the
+/// exactly-one-source invariant is a parse-time rejection, not a downstream
+/// walker check.
+#[derive(Debug, Deserialize)]
+struct RecordFieldWire {
+    name: String,
+    #[serde(default)]
+    column: Option<String>,
+    path: Vec<String>,
+    #[serde(default)]
+    expr: Option<RecordExpr>,
+}
+
+impl TryFrom<RecordFieldWire> for RecordField {
+    type Error = String;
+
+    fn try_from(wire: RecordFieldWire) -> Result<Self, Self::Error> {
+        match (&wire.column, &wire.expr) {
+            (Some(_), Some(_)) => Err(format!(
+                "record field {:?} carries both `column` and `expr`; \
+                 a field reads from exactly one source",
+                wire.name
+            )),
+            (None, None) => Err(format!(
+                "record field {:?} carries neither `column` nor `expr`; \
+                 a field reads from exactly one source",
+                wire.name
+            )),
+            (None, Some(_)) if !wire.path.is_empty() => Err(format!(
+                "record field {:?} carries an `expr` and a non-empty field \
+                 `path` {:?}; an expression field's traversal travels on \
+                 `expr.path` (hop facts), so its field `path` must be empty",
+                wire.name, wire.path
+            )),
+            _ => Ok(RecordField {
+                name: wire.name,
+                column: wire.column,
+                path: wire.path,
+                expr: wire.expr,
+            }),
+        }
+    }
 }
 
 /// One relation JOIN collected from query-time traversal (#270 lands rendering).
@@ -358,7 +438,7 @@ mod tests {
     #[test]
     fn query_fixture_roundtrip() {
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_user_compound_v4.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_user_compound_v5.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query fixture must parse");
         let ir = parsed
@@ -381,7 +461,7 @@ mod tests {
         // Multi-hop `joins` section + path-carrying leaves must survive a
         // deserialize/serialize round-trip without drift (#270 wire stability).
         let fixture = include_str!(
-            "../../../tests/fixtures/ir_vectors/query_transaction_traversal_v4.json"
+            "../../../tests/fixtures/ir_vectors/query_transaction_traversal_v5.json"
         );
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query traversal fixture must parse");
@@ -407,7 +487,7 @@ mod tests {
         // deserialize/serialize round-trip without drift, and the join_type
         // tokens must reach Rust exactly as written on the wire.
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_left_join_v4.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_left_join_v5.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query left_join fixture must parse");
         let ir = parsed
@@ -433,7 +513,7 @@ mod tests {
         // payload — predicate, order, limit, and a two-field record plan —
         // survives a deserialize/serialize round-trip without drift.
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_record_v4.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_record_v5.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query record fixture must parse");
         let ir = parsed
@@ -474,11 +554,194 @@ mod tests {
         };
         assert_eq!(fields.len(), 2);
         assert_eq!(fields[0].name, "id");
-        assert_eq!(fields[0].column, "id");
+        assert_eq!(fields[0].column.as_deref(), Some("id"));
         assert!(fields[0].path.is_empty());
-        assert!(fields[0].expr.is_none(), "expr is reserved and absent");
+        assert!(fields[0].expr.is_none(), "a column field carries no expr");
         let encoded = serde_json::to_value(&plan).expect("record kind must serialize");
         assert_eq!(encoded, wire, "record round-trip must not drift");
+    }
+
+    #[test]
+    fn traversed_record_field_roundtrips() {
+        // v5 (#292): a plain traversed record field — non-empty relation
+        // `path`, a `column`, no `expr` — is the shape the tracer-bullet
+        // slice (#293) consumes. The path stays relation names (it keys into
+        // the `joins` section, like `order_by.path`), not hop facts.
+        let wire = serde_json::json!({
+            "kind": "record",
+            "fields": [
+                {"name": "account_name", "column": "name", "path": ["account"]},
+                {"name": "owner_email", "column": "email",
+                 "path": ["account", "owner"]}
+            ]
+        });
+        let plan: Materialization =
+            serde_json::from_value(wire.clone()).expect("traversed fields must deserialize");
+        let Materialization::Record { fields } = &plan else {
+            panic!("expected Record, got {plan:?}");
+        };
+        assert_eq!(fields[0].path, vec!["account".to_string()]);
+        assert_eq!(fields[1].path.len(), 2);
+        let encoded = serde_json::to_value(&plan).expect("traversed fields must serialize");
+        assert_eq!(encoded, wire, "traversed record round-trip must not drift");
+    }
+
+    #[test]
+    fn record_expr_fields_roundtrip() {
+        // v5 (#292): expression fields — root and traversed sources. `fn`
+        // travels as data; `expr.path` carries hop facts (the `joins`-section
+        // shape), self-contained rather than keying into the joins list.
+        let wire = serde_json::json!({
+            "kind": "record",
+            "fields": [
+                {"name": "acct", "column": "account_id", "path": []},
+                {"name": "total", "path": [],
+                 "expr": {"fn": "sum", "column": "amount", "path": []}},
+                {"name": "avg_balance", "path": [],
+                 "expr": {"fn": "avg", "column": "balance", "path": [
+                     {"relation": "account", "from_column": "account_id",
+                      "to_table": "account", "to_column": "id"}
+                 ]}}
+            ]
+        });
+        let plan: Materialization =
+            serde_json::from_value(wire.clone()).expect("expr fields must deserialize");
+        let Materialization::Record { fields } = &plan else {
+            panic!("expected Record, got {plan:?}");
+        };
+        assert_eq!(fields.len(), 3);
+        // The group-key field is a plain column source.
+        assert_eq!(fields[0].column.as_deref(), Some("account_id"));
+        assert!(fields[0].expr.is_none());
+        // The root aggregate: fn as data, no column, empty hop path.
+        let total = fields[1].expr.as_ref().expect("total must carry an expr");
+        assert!(fields[1].column.is_none());
+        assert_eq!(total.r#fn, AggregateFn::Sum);
+        assert_eq!(total.column, "amount");
+        assert!(total.path.is_empty());
+        // The traversed aggregate: hop facts on the expression itself.
+        let avg = fields[2].expr.as_ref().expect("avg must carry an expr");
+        assert_eq!(avg.r#fn, AggregateFn::Avg);
+        assert_eq!(avg.path.len(), 1);
+        assert_eq!(avg.path[0].relation, "account");
+        assert_eq!(avg.path[0].from_column, "account_id");
+        let encoded = serde_json::to_value(&plan).expect("expr fields must serialize");
+        assert_eq!(encoded, wire, "expr record round-trip must not drift");
+    }
+
+    #[test]
+    fn record_field_with_both_column_and_expr_is_rejected() {
+        // Exactly-one-of is a deserialization invariant (#292): both sources
+        // present fails the strict parse naming the field.
+        let err = serde_json::from_value::<Materialization>(serde_json::json!({
+            "kind": "record",
+            "fields": [{
+                "name": "total", "column": "amount", "path": [],
+                "expr": {"fn": "sum", "column": "amount", "path": []}
+            }]
+        }))
+        .expect_err("both column and expr must fail to deserialize");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("total") && msg.contains("both"),
+            "must name the field and the violation: {msg}"
+        );
+    }
+
+    #[test]
+    fn record_field_with_neither_column_nor_expr_is_rejected() {
+        let err = serde_json::from_value::<Materialization>(serde_json::json!({
+            "kind": "record",
+            "fields": [{"name": "total", "path": []}]
+        }))
+        .expect_err("neither column nor expr must fail to deserialize");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("total") && msg.contains("neither"),
+            "must name the field and the violation: {msg}"
+        );
+    }
+
+    #[test]
+    fn record_expr_with_unknown_fn_is_rejected() {
+        // `fn` is the closed aggregate set (ADR-0009); an unknown token fails
+        // the strict parse naming the bad token and the supported set.
+        let err = serde_json::from_value::<Materialization>(serde_json::json!({
+            "kind": "record",
+            "fields": [{
+                "name": "mid", "path": [],
+                "expr": {"fn": "median", "column": "amount", "path": []}
+            }]
+        }))
+        .expect_err("an unknown aggregate fn must fail to deserialize");
+        let msg = err.to_string();
+        assert!(msg.contains("median"), "must name the bad fn: {msg}");
+        for supported in ["count", "sum", "avg", "min", "max"] {
+            assert!(
+                msg.contains(supported),
+                "must name supported fn {supported:?}: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn record_expr_field_with_outer_path_is_rejected() {
+        // An expression field's traversal travels on `expr.path`; a non-empty
+        // field-level `path` next to an `expr` is two contradictory traversal
+        // claims and fails the strict parse.
+        let err = serde_json::from_value::<Materialization>(serde_json::json!({
+            "kind": "record",
+            "fields": [{
+                "name": "avg_balance", "path": ["account"],
+                "expr": {"fn": "avg", "column": "balance", "path": []}
+            }]
+        }))
+        .expect_err("an expr field with a field-level path must fail to deserialize");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("avg_balance") && msg.contains("expr.path"),
+            "must name the field and point at expr.path: {msg}"
+        );
+    }
+
+    #[test]
+    fn query_aggregate_fixture_roundtrip() {
+        // The aggregate-projection golden vector (#292): a grouped query's
+        // full payload — a traversed group key sharing its path with the
+        // `joins` section, a root aggregate, a traversed aggregate carrying
+        // hop facts on the expression, and an output-name ORDER BY — survives
+        // a deserialize/serialize round-trip without drift. GROUP BY does not
+        // travel: the renderer derives it from the non-expr fields (ADR-0009).
+        let fixture = include_str!(
+            "../../../tests/fixtures/ir_vectors/query_transaction_aggregate_v5.json"
+        );
+        let parsed: serde_json::Value =
+            serde_json::from_str(fixture).expect("query aggregate fixture must parse");
+        let ir = parsed
+            .get("ir")
+            .cloned()
+            .expect("fixture must contain ir envelope");
+        let envelope: IrEnvelope<QueryIrPayload> =
+            serde_json::from_value(ir.clone()).expect("query aggregate IR must deserialize");
+        let Materialization::Record { fields } = &envelope.payload.materialization else {
+            panic!(
+                "expected a record plan, got {:?}",
+                envelope.payload.materialization
+            );
+        };
+        assert_eq!(fields.len(), 3);
+        assert_eq!(fields[0].path, vec!["account".to_string()]);
+        assert_eq!(
+            fields[1].expr.as_ref().map(|e| e.r#fn),
+            Some(AggregateFn::Sum)
+        );
+        assert_eq!(
+            fields[2].expr.as_ref().map(|e| e.path.len()),
+            Some(1),
+            "the traversed aggregate carries its hop facts"
+        );
+        let encoded = serde_json::to_value(&envelope).expect("query aggregate IR must serialize");
+        assert_eq!(encoded, ir, "query aggregate round-trip must not drift");
     }
 
     #[test]
@@ -518,7 +781,7 @@ mod tests {
         // payload — root predicate, empty `joins`, and a one-path instances
         // plan — survives a deserialize/serialize round-trip without drift.
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_include_v4.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_include_v5.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query include fixture must parse");
         let ir = parsed

--- a/docs/adr/0009-aggregate-projections-derived-grouping.md
+++ b/docs/adr/0009-aggregate-projections-derived-grouping.md
@@ -1,0 +1,70 @@
+# Aggregate projections: grouping derived from the projection, pinned decode contract, flat record+relation results
+
+Aggregation rides the `record` materialization plan (ADR-0007): aggregate
+fields (`t.amount.sum()` — methods on scalar field proxies; the closed set
+`count/sum/avg/min/max`) land in projected records, and a projection
+containing any aggregate is an **aggregate projection** (`CONTEXT.md`) in
+which every non-aggregate field is a group key — GROUP BY is **derived from
+the projection, never declared**; there is no `group_by()` chainer. Aggregate
+result types are a **pinned cross-backend contract** derived from the source
+column's Python type (`count → int`; `min`/`max` → source type and codec;
+`sum` → source numeric type; `avg` → float for int/float, Decimal for
+Decimal); source families with no portable cross-backend meaning (enum, uuid,
+json, bool) are rejected at build time. Record results that reach across a
+relation are **flat** — traversed projection with output aliases — and
+`include()` × `select()` is rejected permanently (flattened-as-final),
+closing the question ADR-0008 parked with #282.
+
+Decision by owner (2026-07-12), grilling #282 on the partial-materialization
+substrate (#277/#279).
+
+Rejected alternatives:
+
+- **An explicit `group_by()` chainer**: SQL's own rule already forces every
+  bare selected column to be a group key, so a chainer is pure redundancy
+  plus a new error class ("bare column not in group_by") that Postgres
+  rejects at runtime and SQLite answers with an *arbitrary row's value*.
+  Derivation makes the invalid query unwritable and keeps the dict literal
+  the whole story: the record shape determines the grouping. The only
+  expressiveness lost — grouping by an unselected column — can arrive later
+  additively; the reverse (retiring a shipped chainer) could not.
+- **Backend-native result types** (driver passthrough): Postgres `SUM(int8)`
+  and `AVG(int)` are `numeric`; SQLite `sum(int)` is int and `avg` is float —
+  the same query would return different Python types per backend.
+- **Aggregating any column family, letting the DB decide**: `min`/`max` over
+  uuid does not exist on Postgres, and over a native enum silently diverges
+  (definition order vs. SQLite's lexical text order). Where no portable
+  meaning exists, build time is the only honest place to fail.
+- **Nested record+relation results** (`Row(amount=…, account=<Account>)`): a
+  third result shape — part record, part instance — needing its own decode,
+  typing, and identity story, while every concrete need is served flatter and
+  clearer by a traversed, aliased field. Records carry values; instances
+  carry rows.
+- **Coalescing empty aggregates to zero**: "sum of no rows" and "sum of rows
+  totaling zero" are different facts, and zero is the wrong identity for
+  `min`/`max` anyway. SQL's NULL passes through as `None` uniformly
+  (`count → 0`), with no hidden COALESCE.
+
+## Consequences
+
+- The canonical grouped query is one lambda —
+  `select(lambda t: {"acct": t.account_id, "total": t.amount.sum()})` renders
+  `GROUP BY account_id`. Aggregate-only projections collapse to one record
+  (read with `first()`); a grouped query over zero rows returns zero records.
+- GROUP BY never travels on the wire: the renderer derives the keys from the
+  v5 `record` plan (every non-`expr` field), pinned by golden vectors —
+  renderer work, like joins rendering from paths.
+- Aggregate record fields are `T | None` (`count` excepted) — empty-input
+  NULL passes through.
+- `order_by` strings resolve output field names before root columns on a
+  projected query (SQL's own ORDER BY scoping); on an aggregate projection
+  every sort key must be a group key or an aggregate — build-time error, the
+  SQLite arbitrary-row trap made unwritable. `limit()`/`offset()` act on
+  groups.
+- `count()`/`exists()` raise on an aggregate projection with guidance (rows:
+  unprojected query; groups: `len(await q.all())`) — #279's "unaffected by
+  projection" contract is the *plain*-projection rule.
+- `where()` never accepts an aggregate predicate; post-aggregation filtering
+  is `having()` (#291).
+- A left-joined traversed group key yields a `None`-keyed group — "has no
+  relation" is a visible bucket, not a dropped row.

--- a/docs/examples/aggregations.py
+++ b/docs/examples/aggregations.py
@@ -1,0 +1,259 @@
+"""Runnable companion to the "Aggregations & Grouped Queries" guide
+(docs/pages/guide/aggregations.md).
+
+Seeds a small transactions table, then runs every aggregate query the guide
+shows and asserts the exact records that come back.
+"""
+
+import asyncio
+from decimal import Decimal
+from typing import Annotated
+
+from ferro import BackRef, Field, ForeignKey, Model, Relation, connect, engines
+
+
+# --8<-- [start:schema]
+class Account(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    label: str
+    transactions: Relation[list["Transaction"]] = BackRef()
+
+
+class Transaction(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    amount: int
+    price: Decimal | None = Field(default=None)
+    memo: str
+    account: Annotated[
+        Account | None, ForeignKey(related_name="transactions")
+    ] = None
+# --8<-- [end:schema]
+
+
+async def main() -> None:
+    await connect("sqlite::memory:", auto_migrate=True)
+
+    async with engines.session():
+        a1 = await Account.create(id=1, label="a1")
+        b1 = await Account.create(id=2, label="b1")
+        await Transaction.create(
+            id=1, amount=10, price=Decimal("1.25"), memo="coffee", account=a1
+        )
+        await Transaction.create(
+            id=2, amount=20, price=Decimal("2.75"), memo="lunch", account=a1
+        )
+        await Transaction.create(
+            id=3, amount=30, price=Decimal("6.00"), memo="dinner", account=b1
+        )
+        await Transaction.create(id=4, amount=40, memo="orphan")  # no account
+
+        # --8<-- [start:global]
+        # An aggregate-only projection collapses to exactly one record:
+        # the global aggregate, read idiomatically with first().
+        row = await Transaction.select(
+            lambda t: {
+                "n": t.id.count(),
+                "total": t.amount.sum(),
+                "average": t.amount.avg(),
+                "smallest": t.amount.min(),
+                "largest": t.amount.max(),
+            }
+        ).first()
+
+        assert row is not None
+        assert row.model_dump() == {
+            "n": 4,
+            "total": 100,
+            "average": 25.0,
+            "smallest": 10,
+            "largest": 40,
+        }
+        # --8<-- [end:global]
+
+        # --8<-- [start:global-where]
+        # Aggregates measure whatever where() leaves in — traversal included.
+        row = await (
+            Transaction.select(lambda t: {"total": t.amount.sum()})
+            .where(lambda t: t.account.label == "a1")
+            .first()
+        )
+        assert row is not None and row.total == 30
+        # --8<-- [end:global-where]
+
+        # --8<-- [start:empty]
+        # Over zero matching rows, SQL's own empty-input semantics pass
+        # through verbatim: one record, None for sum/avg/min/max, 0 for
+        # count. No hidden COALESCE — "sum of no rows" and "sum of rows
+        # totaling zero" stay distinguishable.
+        row = await (
+            Transaction.select(
+                lambda t: {"n": t.id.count(), "total": t.amount.sum()}
+            )
+            .where(lambda t: t.amount > 10_000)
+            .first()
+        )
+        assert row is not None
+        assert row.n == 0
+        assert row.total is None
+        # --8<-- [end:empty]
+
+        # --8<-- [start:count-nulls]
+        # COUNT(column) counts non-NULL values of that column — SQL
+        # semantics, verbatim. Only one of four transactions has a price...
+        row = await Transaction.select(
+            lambda t: {"rows": t.id.count(), "priced": t.price.count()}
+        ).first()
+        assert row is not None
+        assert row.rows == 4
+        assert row.priced == 3
+        # --8<-- [end:count-nulls]
+
+        # --8<-- [start:grouped]
+        # Mix a plain field in and the query becomes GROUPED: every
+        # non-aggregate field is a group key. There is no group_by() —
+        # the record shape IS the grouping.
+        rows = await (
+            Transaction.select(
+                lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+            )
+            .where(lambda t: t.account_id != None)  # noqa: E711
+            .order_by("acct")
+            .all()
+        )
+        assert rows.model_dump() == [
+            {"acct": 1, "total": 30},
+            {"acct": 2, "total": 30},
+        ]
+        # --8<-- [end:grouped]
+
+        # --8<-- [start:grouped-traversed]
+        # Group keys may traverse. Traversal narrows (the account-less
+        # transaction drops out) exactly like a where() predicate would.
+        rows = await (
+            Transaction.select(
+                lambda t: {"account_label": t.account.label, "total": t.amount.sum()}
+            )
+            .order_by("account_label")
+            .all()
+        )
+        assert rows.model_dump() == [
+            {"account_label": "a1", "total": 30},
+            {"account_label": "b1", "total": 30},
+        ]
+        # --8<-- [end:grouped-traversed]
+
+        # --8<-- [start:none-bucket]
+        # left_join() keeps relation-less rows, so "has no account" becomes
+        # a visible None-keyed group instead of a dropped row.
+        rows = await (
+            Transaction.select(
+                lambda t: {"account_label": t.account.label, "total": t.amount.sum()}
+            )
+            .left_join(lambda t: t.account)
+            .all()
+        )
+        buckets = {row.account_label: row.total for row in rows}
+        assert buckets == {"a1": 30, "b1": 30, None: 40}
+        # --8<-- [end:none-bucket]
+
+        # --8<-- [start:top-n]
+        # The top-N idiom: keys + aggregates, order by the aggregate's
+        # output name, limit the groups.
+        top = await (
+            Transaction.select(
+                lambda t: {"account_label": t.account.label, "total": t.amount.sum()}
+            )
+            .order_by("total", "desc")
+            .limit(1)
+            .all()
+        )
+        assert len(top) == 1
+        # --8<-- [end:top-n]
+
+        # --8<-- [start:order-by-lambda]
+        # order_by's lambda form spells the source expression — including
+        # the aggregate itself.
+        rows = await (
+            Transaction.select(
+                lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+            )
+            .where(lambda t: t.account_id != None)  # noqa: E711
+            .order_by(lambda t: t.amount.sum(), "desc")
+            .order_by("acct")
+            .all()
+        )
+        assert [row.acct for row in rows] == [1, 2]
+        # --8<-- [end:order-by-lambda]
+
+        # --8<-- [start:zero-groups]
+        # A grouped query over zero rows returns zero records — unlike a
+        # global aggregate, there is no group to report on.
+        rows = await (
+            Transaction.select(
+                lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+            )
+            .where(lambda t: t.amount > 10_000)
+            .all()
+        )
+        assert len(rows) == 0
+        # --8<-- [end:zero-groups]
+
+        # --8<-- [start:decimal-contract]
+        # Result types are a pinned cross-backend contract derived from the
+        # source column: avg over a Decimal column stays Decimal (never a
+        # silently lossy float), on SQLite and Postgres alike.
+        row = await (
+            Transaction.select(lambda t: {"avg_price": t.price.avg()})
+            .where(lambda t: t.price != None)  # noqa: E711
+            .first()
+        )
+        assert row is not None
+        assert isinstance(row.avg_price, Decimal)
+        # --8<-- [end:decimal-contract]
+
+        # --8<-- [start:errors]
+        # The loud limits, all at build time — before any SQL:
+
+        # Aggregates over families with no portable cross-backend meaning.
+        try:
+            Transaction.select(lambda t: {"x": t.memo.sum()})
+        except TypeError as exc:
+            assert "string-typed" in str(exc)
+
+        # Aggregates inside where() — filtering after aggregation is
+        # having(), which is not built yet.
+        try:
+            Transaction.where(lambda t: t.amount.sum() > 100)
+        except TypeError as exc:
+            assert "having()" in str(exc)
+
+        # The builtin-sum trap: aggregation is a method on the column.
+        try:
+            Transaction.select(lambda t: {"x": sum(t.amount)})  # type: ignore[arg-type]
+        except TypeError as exc:
+            assert "did you mean t.amount.sum()?" in str(exc)
+
+        # Sorting a grouped query by a column that is not a group key would
+        # let each group answer with an arbitrary row's value.
+        try:
+            Transaction.select(
+                lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+            ).order_by("memo")
+        except ValueError as exc:
+            assert "group key or an aggregate" in str(exc)
+
+        # count()/exists() on an aggregate projection are ambiguous between
+        # rows and groups; both spellings are in the error.
+        try:
+            Transaction.select(
+                lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+            ).count()
+        except ValueError as exc:
+            assert "len(await q.all())" in str(exc)
+        # --8<-- [end:errors]
+
+    print("aggregations example ran successfully")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/examples/aggregations_annotated.py
+++ b/docs/examples/aggregations_annotated.py
@@ -1,33 +1,28 @@
-"""Annotated-style companion to partial_selects.py (AGENTS.md I-7).
+"""Annotated-style companion to aggregations.py (AGENTS.md I-7).
 
-Field options move into ``Annotated[...]``. Projection is independent of the
+Field options move into ``Annotated[...]``. Aggregation is independent of the
 declaration style — the queries are identical in both — so only the schema and
 one round-trip live here.
 """
 
 import asyncio
+from decimal import Decimal
 from typing import Annotated
 
 from ferro import BackRef, Field, ForeignKey, Model, Relation, connect, engines
 
 
 # --8<-- [start:schema]
-class Owner(Model):
-    id: Annotated[int | None, Field(default=None, primary_key=True)]
-    email: str
-    accounts: Relation[list["Account"]] = BackRef()
-
-
 class Account(Model):
     id: Annotated[int | None, Field(default=None, primary_key=True)]
     label: str
-    owner: Annotated[Owner | None, ForeignKey(related_name="accounts")] = None
     transactions: Relation[list["Transaction"]] = BackRef()
 
 
 class Transaction(Model):
     id: Annotated[int | None, Field(default=None, primary_key=True)]
     amount: int
+    price: Annotated[Decimal | None, Field(default=None)]
     memo: str
     account: Annotated[
         Account | None, ForeignKey(related_name="transactions")
@@ -40,12 +35,17 @@ async def main() -> None:
 
     async with engines.session():
         a1 = await Account.create(id=1, label="a1")
-        await Transaction.create(id=1, amount=10, memo="coffee", account=a1)
+        await Transaction.create(
+            id=1, amount=10, price=Decimal("1.25"), memo="coffee", account=a1
+        )
+        await Transaction.create(id=2, amount=20, memo="lunch", account=a1)
 
-        rows = await Transaction.select(lambda t: (t.id, t.amount)).all()
-        assert rows.model_dump() == [{"id": 1, "amount": 10}]
+        rows = await Transaction.select(
+            lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+        ).all()
+        assert rows.model_dump() == [{"acct": 1, "total": 30}]
 
-    print("partial_selects_annotated example ran successfully")
+    print("aggregations_annotated example ran successfully")
 
 
 if __name__ == "__main__":

--- a/docs/examples/partial_selects.py
+++ b/docs/examples/partial_selects.py
@@ -12,9 +12,16 @@ from ferro import BackRef, Field, ForeignKey, Model, Relation, Rows, connect, en
 
 
 # --8<-- [start:schema]
+class Owner(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    email: str
+    accounts: Relation[list["Account"]] = BackRef()
+
+
 class Account(Model):
     id: int | None = Field(default=None, primary_key=True)
     label: str
+    owner: Annotated[Owner | None, ForeignKey(related_name="accounts")] = None
     transactions: Relation[list["Transaction"]] = BackRef()
 
 
@@ -22,7 +29,9 @@ class Transaction(Model):
     id: int | None = Field(default=None, primary_key=True)
     amount: int
     memo: str
-    account: Annotated[Account, ForeignKey(related_name="transactions")]
+    account: Annotated[
+        Account | None, ForeignKey(related_name="transactions")
+    ] = None
 # --8<-- [end:schema]
 
 
@@ -30,7 +39,8 @@ async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
 
     async with engines.session():
-        a1 = await Account.create(id=1, label="a1")
+        alice = await Owner.create(id=1, email="alice@example.com")
+        a1 = await Account.create(id=1, label="a1", owner=alice)
         b1 = await Account.create(id=2, label="b1")
         await Transaction.create(id=1, amount=10, memo="coffee", account=a1)
         await Transaction.create(id=2, amount=20, memo="lunch", account=a1)
@@ -75,6 +85,69 @@ async def main() -> None:
         rows = await Transaction.select("id", "amount").order_by("id").all()
         assert rows[0].model_dump() == {"id": 1, "amount": 10}
         # --8<-- [end:strings]
+
+        # --8<-- [start:traversed]
+        # A selected field may reach across a relation, at any depth.
+        # Unaliased, the field takes the bare leaf column name.
+        rows = await (
+            Transaction.select(lambda t: (t.memo, t.account.label))
+            .order_by("id")
+            .all()
+        )
+        assert rows[0].model_dump() == {"memo": "coffee", "label": "a1"}
+        # --8<-- [end:traversed]
+
+        # --8<-- [start:aliases]
+        # A dict-returning selector names the output fields — keys are the
+        # record's field names, values may traverse.
+        rows = await (
+            Transaction.select(
+                lambda t: {
+                    "memo": t.memo,
+                    "account_label": t.account.label,
+                    "owner_email": t.account.owner.email,
+                }
+            )
+            .order_by("id")
+            .all()
+        )
+        assert rows[0].model_dump() == {
+            "memo": "coffee",
+            "account_label": "a1",
+            "owner_email": "alice@example.com",
+        }
+        # --8<-- [end:aliases]
+
+        # --8<-- [start:traversal-narrows]
+        # Traversal narrows exactly like a where() predicate on the same
+        # path: rows without the relation drop out (b1 has no owner)...
+        rows = await Transaction.select(
+            lambda t: {"memo": t.memo, "owner_email": t.account.owner.email}
+        ).all()
+        assert {r.memo for r in rows} == {"coffee", "lunch"}
+
+        # ... and left_join() is the opt-out: rows are kept, and their
+        # traversed fields decode to None — even from a non-nullable column.
+        rows = await (
+            Transaction.select(
+                lambda t: {"memo": t.memo, "owner_email": t.account.owner.email}
+            )
+            .left_join(lambda t: t.account.owner)
+            .order_by("id")
+            .all()
+        )
+        assert rows.model_dump()[2] == {"memo": "dinner", "owner_email": None}
+        # --8<-- [end:traversal-narrows]
+
+        # --8<-- [start:collision]
+        # Two selected fields resolving to the same output name is a
+        # build-time error naming the fix: the dict form.
+        try:
+            Transaction.select(lambda t: (t.id, t.account.id))
+        except ValueError as exc:
+            assert "two fields named 'id'" in str(exc)
+            assert "dict selector form" in str(exc)
+        # --8<-- [end:collision]
 
         # --8<-- [start:compose]
         # Projection composes with everything a read query can do: traversal

--- a/docs/examples/populated_relations.py
+++ b/docs/examples/populated_relations.py
@@ -186,7 +186,7 @@ async def main() -> None:
         try:
             Transaction.select().include(lambda t: t.account).select(lambda t: (t.id,))
         except ValueError as exc:
-            assert "#282" in str(exc)
+            assert "traversed projection" in str(exc)
 
         try:
             await Transaction.select().include(lambda t: t.account).delete()

--- a/docs/pages/api/queries.md
+++ b/docs/pages/api/queries.md
@@ -8,19 +8,26 @@
 
 `include(lambda t: t.account)` delivers each result with the relation **populated** (ADR-0008): access becomes a plain attribute holding the complete related instance — no await, no query — while unpopulated relations keep the awaitable contract. Include is the third orthogonal query axis (joins decide membership, projection decides shape, include decides attached data): it never changes which rows come back, `.all()` still returns `list[Model]`, and `count()`/`exists()` are unaffected. Paths populate whole (`include(lambda t: t.account.owner)` populates both hops); includes are cumulative, order-free, and idempotent; populated instances run the full session identity-map protocol, and a refresh keeps a population only while the row's FK still points at it.
 
-Loud limits, at build time: forward-FK lambda paths only (a `BackRef`/M2M selector, a string, or a column selector raises `TypeError`); combining include with a projection raises `ValueError` in either chain order (one materialization plan per query, #282); `update()`/`delete()` on an included query raise `ValueError`. See [Populating Relations with include()](../guide/queries.md#populating-relations-with-include) for worked examples.
+Loud limits, at build time: forward-FK lambda paths only (a `BackRef`/M2M selector, a string, or a column selector raises `TypeError`); combining include with a projection raises `ValueError` in either chain order (one materialization plan per query; record results are flat — reach across a relation with traversed projection instead); `update()`/`delete()` on an included query raise `ValueError`. See [Populating Relations with include()](../guide/queries.md#populating-relations-with-include) for worked examples.
 
 ## `select()` overloads
 
-`select()` has three forms, resolved at build time:
+`select()` has four forms, resolved at build time:
 
 | Call | Returns | Result of `.all()` |
 | :--- | :--- | :--- |
 | `Model.select()` | `Query[Model]` | `list[Model]` — the full query, unchanged. |
-| `Model.select(lambda t: (t.id, t.amount))` | `ProjectedQuery[Model]` | `Rows[Row]` — projected records (single-field form: `select(lambda t: t.amount)`). |
-| `Model.select("id", "amount")` | `ProjectedQuery[Model]` | `Rows[Row]` — `order_by()`'s string contract: root columns only, never mixed with a lambda. |
+| `Model.select(lambda t: (t.id, t.account.name))` | `ProjectedQuery[Model]` | `Rows[Row]` — projected records; fields may traverse forward-FK paths at any depth and take the bare leaf column name (single-field form: `select(lambda t: t.amount)`). |
+| `Model.select(lambda t: {"owner_email": t.account.owner.email})` | `ProjectedQuery[Model]` | `Rows[Row]` — dict keys name the output fields (output aliases); values are field references or aggregate expressions. |
+| `Model.select("id", "amount")` | `ProjectedQuery[Model]` | `Rows[Row]` — `order_by()`'s string contract: root columns only, never traversal, never mixed with a lambda. |
 
-A `ProjectedQuery` composes like any `Query` (`where()` with traversal, `order_by()` by unselected columns, `limit()`/`offset()`, `first()`, `count()`, `exists()`); `update()`/`delete()` and a second `select()` raise at build time. See [Selecting a Column Subset](../guide/queries.md#selecting-a-column-subset) for worked examples and the complete-instance invariant behind the `Row` result shape.
+A `ProjectedQuery` composes like any `Query` (`where()` with traversal, `order_by()` by unselected columns, `limit()`/`offset()`, `first()`, `count()`, `exists()`); `update()`/`delete()`, a second `select()`, output-name collisions, and nested selector shapes raise at build time. Projection traversal narrows per ADR-0006 (INNER, one join per path, shared with `where()`/`order_by()`); `left_join()` keeps relation-less rows with their traversed fields decoded to `None`. See [Selecting a Column Subset](../guide/queries.md#selecting-a-column-subset) for worked examples and the complete-instance invariant behind the `Row` result shape.
+
+## Aggregates and grouped queries
+
+Five methods on column references build aggregate fields for the dict selector: `t.amount.count()` / `.sum()` / `.avg()` / `.min()` / `.max()` (traversal included: `t.account.balance.avg()`). Source families validate at build time — `sum`/`avg` take numeric columns, `min`/`max` orderable ones (numeric, text, date/time), `count` any column; enum/uuid/json/bool are rejected. Result types are a pinned cross-backend contract derived from the source column (`count → int`, `min`/`max` → source type, `sum` → source numeric type, `avg` → `float` for int/float and `Decimal` for Decimal); empty input passes SQL through verbatim (`None`, `count → 0`).
+
+An aggregate-only projection collapses to one record (read with `first()`). Mixing plain fields in makes the query **grouped**: every plain field is a group key — `GROUP BY` is derived from the projection, never declared. On a projected query `order_by()` strings resolve output field names first, then root columns; the lambda form spells source expressions including aggregates (`order_by(lambda t: t.amount.sum(), "desc")`); on an aggregate projection every sort key must be a group key or an aggregate — anything else raises at build time, as do `count()`/`exists()` (ambiguous between rows and groups) and aggregate predicates in `where()` (post-aggregation filtering is `having()`, #291). See [Aggregations & Grouped Queries](../guide/aggregations.md) for worked examples.
 
 ::: ferro.query.builder.Query
 
@@ -35,3 +42,5 @@ A `ProjectedQuery` composes like any `Query` (`where()` with traversal, `order_b
 ::: ferro.query.Predicate
 
 ::: ferro.query.RowSelector
+
+::: ferro.query.AggregateExpr

--- a/docs/pages/concepts/query-typing.md
+++ b/docs/pages/concepts/query-typing.md
@@ -62,6 +62,23 @@ row = await Transaction.select(lambda t: t.amount).first()  # Row | None
 full = await Transaction.select().all()  # list[Transaction] — bare form unchanged
 ```
 
+Every selector form keeps that shape: the tuple, the single field, traversal
+at any depth (`t.account.owner.email` chains as `FieldProxy[Any]`), and the
+dict form, whose values may also be **aggregate expressions**:
+
+```python
+row = await Transaction.select(
+    lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+).first()  # Row | None
+```
+
+An aggregate expression types **opaquely**: `t.amount.sum()` is an
+`AggregateExpr` — deliberately not a value, not a `QueryNode`, not a column.
+That is what makes the misuse gates work: an aggregate compared inside
+`where()` raises at build time (post-aggregation filtering is `having()`),
+and an `AggregateExpr` is only ever valid as a dict-selector value or an
+`order_by()` lambda result.
+
 The gate divides the work exactly like predicates do:
 
 - **Shape is checked statically.** Passing a `Row` where a model instance is
@@ -73,6 +90,14 @@ The gate divides the work exactly like predicates do:
   to the checker; a misspelled column raises `AttributeError` with a
   did-you-mean when the query is built, before any round-trip — the same
   runtime validation as `where()` and `order_by()`.
+
+The promise is **shape, not names**: the checker knows a projected query
+yields `Rows[Row]`, but not that this particular `Row` has a `.total` of type
+`int | None` — record fields type as `Any` on access. Inferring per-field
+record types from the selector (so `row.total` checks as what the aggregate
+contract says it is) is the record-field inference lane, tracked in
+[#290](https://github.com/syn54x/ferro-orm/issues/290) — another place
+typing can sharpen later with zero runtime change.
 
 ## Included Queries
 
@@ -118,7 +143,8 @@ parameter type.
 - `ferro.query.QueryProxy` — validating attribute proxy passed to lambda predicates.
 - `ferro.query.Predicate` — `Callable[[QueryProxy[TModel]], QueryNode]`, the type of any lambda predicate.
 - `ferro.query.FieldProxy` — generic over the column's Python type (`FieldProxy[T]`); the mechanism a `QueryProxy` attribute access returns.
-- `ferro.query.RowSelector` — the type of a `select()` lambda selector: a callable returning one column or a tuple of columns.
+- `ferro.query.RowSelector` — the type of a `select()` lambda selector: a callable returning one field, a tuple of fields, or a dict of output names to fields/aggregates.
+- `ferro.query.AggregateExpr` — the opaque type of `t.amount.sum()` and friends; valid only as a dict-selector value or an `order_by()` lambda result.
 - `ferro.query.Row` / `ferro.query.Rows` — projected records and their list-like container, the result shape of a projected query.
 
 ## See Also

--- a/docs/pages/guide/aggregations.md
+++ b/docs/pages/guide/aggregations.md
@@ -1,0 +1,162 @@
+# Aggregations & Grouped Queries
+
+Ferro aggregates with five methods on the columns themselves — `count()`, `sum()`, `avg()`, `min()`, `max()` — inside the same `select()` lambda that projects columns. There is no `group_by()` chainer anywhere in the API, and you will not miss it: **the record shape is the grouping**. Bare fields are the keys; aggregate fields are the measures.
+
+The examples on this page use this schema:
+
+=== "Assignment"
+
+    ```python
+    --8<-- "docs/examples/aggregations.py:schema"
+    ```
+
+=== "Annotated"
+
+    ```python
+    --8<-- "docs/examples/aggregations_annotated.py:schema"
+    ```
+
+## Global Aggregates
+
+An aggregate is a method on a column reference: `t.amount.sum()`. Aggregate fields are **user-named** — they live in the dict selector form, where the key names the output field. A projection containing *only* aggregates collapses the whole result to exactly one record, read idiomatically with `first()`:
+
+```python
+--8<-- "docs/examples/aggregations.py:global"
+```
+
+Aggregates measure whatever `where()` leaves in — relation traversal included:
+
+```python
+--8<-- "docs/examples/aggregations.py:global-where"
+```
+
+The source column may itself traverse (`t.account.balance.avg()`): the traversal narrows to rows where the relation exists, exactly like a `where()` predicate on the same path, and shares that path's join with any other clause that references it.
+
+### What each aggregate returns
+
+Result types are a **pinned cross-backend contract**, derived from the source column's Python type — the same query returns the same Python types on SQLite and Postgres, even where the databases themselves disagree (Postgres widens `SUM(bigint)` to `numeric`; SQLite averages everything as a float):
+
+| Aggregate | Source column | Result type |
+| :--- | :--- | :--- |
+| `count()` | any column | `int` — never `None` |
+| `sum()` | `int` / `float` / `Decimal` | the source numeric type |
+| `avg()` | `int` / `float` | `float` |
+| `avg()` | `Decimal` | `Decimal` — never a silently lossy `float` |
+| `min()` / `max()` | numeric, `str`, `datetime` / `date` / `time` | the source type, via the source codec |
+
+```python
+--8<-- "docs/examples/aggregations.py:decimal-contract"
+```
+
+Every aggregate result except `count` is `T | None`, because of what comes next.
+
+### Empty input: `None` and `0`, no COALESCE
+
+SQL answers an aggregate over zero rows with `NULL` (`COUNT` with `0`), and Ferro passes that through verbatim — "sum of no rows" and "sum of rows totaling zero" are different facts, and zero would be the wrong identity for `min`/`max` anyway:
+
+```python
+--8<-- "docs/examples/aggregations.py:empty"
+```
+
+### `count()` counts non-NULL values
+
+`t.price.count()` is SQL's `COUNT(price)`: it counts rows where *that column* is non-NULL. Count rows regardless of any column with the primary key (`t.id.count()`):
+
+```python
+--8<-- "docs/examples/aggregations.py:count-nulls"
+```
+
+## Grouped Queries: Bare Fields Are the Keys
+
+Mix a plain field into an aggregate projection and the query becomes **grouped** — every non-aggregate field is a group key, and each group collapses to exactly one record:
+
+```python
+--8<-- "docs/examples/aggregations.py:grouped"
+```
+
+This is SQL's own rule, made unwritable to violate: SQL already requires every bare selected column to be a group key, so declaring the grouping separately could only ever restate the projection or contradict it (Postgres rejects the contradiction at runtime; SQLite silently answers with an arbitrary row's value). Deriving `GROUP BY` from the record shape deletes that entire error class — the dict literal is the whole story.
+
+Group keys may traverse, and traversal narrows exactly like a predicate:
+
+```python
+--8<-- "docs/examples/aggregations.py:grouped-traversed"
+```
+
+### "Has no relation" is a visible bucket
+
+Add `left_join()` and relation-less rows stay in — grouped under a `None` key instead of silently dropped:
+
+```python
+--8<-- "docs/examples/aggregations.py:none-bucket"
+```
+
+### Zero rows, zero groups
+
+A grouped query over zero matching rows returns zero records — unlike a global aggregate, there is no group to report on:
+
+```python
+--8<-- "docs/examples/aggregations.py:zero-groups"
+```
+
+### Grouping is not partitioning
+
+Grouping **collapses** rows: each group becomes one projected record of keys and measures, and the individual rows are gone. If you want complete model instances *bucketed* by a key — every transaction, arranged per account — that is a different, client-side operation over a full query:
+
+```python
+from collections import defaultdict
+
+by_account: dict[int | None, list[Transaction]] = defaultdict(list)
+for txn in await Transaction.select().all():
+    by_account[txn.account_id].append(txn)
+```
+
+Reach for aggregation when you want *facts about groups*; partition in Python when you want *the rows themselves, organized*.
+
+## Ordering Grouped Results
+
+`order_by` on a projected query follows SQL's own ORDER BY scoping, pinned as three rules.
+
+**Strings resolve output field names first, then root columns.** `order_by("total")` sorts by the aggregate you named `total`, even if the model happens to have a column with the same name:
+
+```python
+--8<-- "docs/examples/aggregations.py:top-n"
+```
+
+That is the **top-N idiom** — keys plus aggregates, ordered by the measure's output name, `limit()` applied to the *groups*. `limit()`/`offset()` always act on groups in a grouped query, so pagination pages through the summary, not the underlying rows.
+
+**The lambda form spells source expressions — aggregates included.** Where strings name outputs, lambdas write the expression itself:
+
+```python
+--8<-- "docs/examples/aggregations.py:order-by-lambda"
+```
+
+An aggregate sort key must match a projected aggregate field (same function, same column, same path); an expression you did not project is a build-time error telling you to name it in the projection.
+
+**On an aggregate projection, every sort key must be a group key or an aggregate.** Sorting groups by a column that is neither is the arbitrary-row trap again — SQLite would happily pick *some* row's value per group — so Ferro rejects it when you build the query, whether the key is a string, a lambda, or was chained before the `select()`:
+
+```text
+>>> Transaction.select(lambda t: {"acct": t.account_id, "total": t.amount.sum()}).order_by("memo")
+ValueError: order_by('memo') on an aggregate projection must name a group key or an aggregate: ...
+```
+
+On a plain (non-aggregate) projection nothing changes: unselected root columns still sort, as they always have.
+
+## The Loud Limits
+
+Everything below fails **when you build the query** — before any SQL, with an error that names the fix:
+
+- **Source families with no portable meaning.** `sum()`/`avg()` take numeric columns (`int`, `float`, `Decimal`); `min()`/`max()` take orderable ones (numeric, text, date/time); `count()` takes anything. Enum, UUID, JSON, and bool columns are rejected — `min()` over a UUID does not exist on Postgres, and `max()` over a native enum silently diverges between backends (definition order vs. lexical order). Where no portable meaning exists, build time is the only honest place to fail.
+- **No aggregates in `where()`.** `WHERE` filters rows *before* aggregation, so `where(lambda t: t.amount.sum() > 100)` raises pointing at `having()` — the post-aggregation filter, tracked in [#291](https://github.com/syn54x/ferro-orm/issues/291). Until it lands, filter rows with `where()` and compare aggregated results in Python.
+- **The builtin-`sum` trap.** `sum(t.amount)` (Python's builtin over a column reference) raises `did you mean t.amount.sum()?` instead of failing obscurely.
+- **Aggregates are user-named.** An aggregate outside the dict form (`select(lambda t: t.amount.sum())`) raises: give it an output name.
+- **`count()`/`exists()` on an aggregate projection.** "Count" is ambiguous between rows and groups, so both raise with both spellings: count matching rows with an unprojected query (`Transaction.where(...).count()`), count groups with `len(await q.all())`.
+
+```python
+--8<-- "docs/examples/aggregations.py:errors"
+```
+
+## See Also
+
+- [Selecting a Column Subset](queries.md#selecting-a-column-subset) — projections, traversed fields, and output aliases, which aggregations build on
+- [Querying Across Relationships](queries.md#querying-across-relationships) — traversal and join semantics (ADR-0006)
+- [Typed Query Predicates](../concepts/query-typing.md#projected-queries) — how aggregate expressions type

--- a/docs/pages/guide/queries.md
+++ b/docs/pages/guide/queries.md
@@ -146,7 +146,7 @@ Queries are lazy — nothing hits the database until you await a terminal:
 
 `Model.all()` is shorthand for `Model.select().all()`.
 
-On a **projected** query (`select(lambda t: (t.id, t.amount))`), `.all()` returns `Rows[Row]` and `.first()` returns `Row | None` — records, not model instances; `count()` and `exists()` are unchanged. See [Selecting a Column Subset](#selecting-a-column-subset).
+On a **projected** query (`select(lambda t: (t.id, t.amount))`), `.all()` returns `Rows[Row]` and `.first()` returns `Row | None` — records, not model instances; `count()` and `exists()` are unchanged on a plain projection (on an aggregate projection they raise with guidance). See [Selecting a Column Subset](#selecting-a-column-subset) and [Aggregations & Grouped Queries](aggregations.md).
 
 ## Querying Across Relationships
 
@@ -491,7 +491,7 @@ Misuse raises at build time, before any SQL:
 
 - **Forward foreign keys only.** Including a `BackRef` or `ManyToMany` relation raises `TypeError`: reverse and M2M population will be a separate mechanism (a batched second query stitched onto the results), not `include()`. Until it lands, fetch collections through the relation itself (`await author.posts.all()`).
 - **Lambda selectors only.** `include("account")` raises pointing at the lambda form — strings never traverse. Selecting a *column* (`include(lambda t: t.account.label)`) raises too: every populated hop is a complete row, so there is nothing to select per column.
-- **No include × projection.** A query carries exactly one materialization plan — populated instances or projected records, not both. Either order raises `ValueError` naming [#282](https://github.com/syn54x/ferro-orm/issues/282), which designs record+relation results.
+- **No include × projection.** A query carries exactly one materialization plan — populated instances or projected records, never both — and record results are flat, permanently. Either order raises `ValueError` pointing at [traversed projection](#reaching-across-a-relation), the record-shaped way across a relation.
 - **No mutations.** `update()`/`delete()` on an included query raise — a mutation returns no instances to populate.
 
 ```python
@@ -556,9 +556,41 @@ Quick scripts can pass column names as strings — the same string contract as `
 --8<-- "docs/examples/partial_selects.py:strings"
 ```
 
+### Reaching across a relation
+
+A selected field may traverse a forward-FK relation, at any depth — the same attribute chaining as a `where()` predicate. Unaliased, a traversed field takes the **bare leaf column name**:
+
+```python
+--8<-- "docs/examples/partial_selects.py:traversed"
+```
+
+Strings never traverse (`select("account.label")` is rejected permanently) — traversed projection is lambda-only.
+
+### Naming output fields
+
+Return a **dict** from the selector and the keys name the record's fields — an *output alias*. Aliases name output fields only, never joins or tables, and the dict's insertion order is the record's field order:
+
+```python
+--8<-- "docs/examples/partial_selects.py:aliases"
+```
+
+The dict form is also how you resolve a name collision: `t.id` and `t.account.id` both want to be called `id`, so selecting them unaliased is a build-time error naming this fix:
+
+```python
+--8<-- "docs/examples/partial_selects.py:collision"
+```
+
+### Traversal narrows; `left_join()` opts out
+
+Projection traversal is ordinary traversal (ADR-0006): it renders an INNER join per relation path — **shared** with any `where()`/`order_by()` traversal of the same path — so rows without the relation drop out. `left_join()` keeps them, and their traversed fields decode to `None`, *even when the source column is non-nullable* — a projected record describes the row you got, not the related model:
+
+```python
+--8<-- "docs/examples/partial_selects.py:traversal-narrows"
+```
+
 ### Projections compose like any other query
 
-`where()` (relation traversal included), `order_by()` (even by columns the projection does not select), `limit()`/`offset()`, and `first()` all work unchanged; `count()` and `exists()` are unaffected by projection — they measure the same matching rows a full query would:
+`where()` (relation traversal included), `order_by()` (even by columns the projection does not select), `limit()`/`offset()`, and `first()` all work unchanged; on a plain projection `count()` and `exists()` are unaffected — they measure the same matching rows a full query would. (On an *aggregate* projection they raise with guidance instead — see [Aggregations & Grouped Queries](aggregations.md#the-loud-limits).)
 
 ```python
 --8<-- "docs/examples/partial_selects.py:compose"
@@ -570,7 +602,7 @@ Quick scripts can pass column names as strings — the same string contract as `
 
 ### Build-time validation and the loud limits
 
-A misspelled column fails when you build the query, with a did-you-mean — exactly like `where()` and `order_by()`:
+A misspelled column fails when you build the query, with a did-you-mean — exactly like `where()` and `order_by()`, and a traversed field validates every hop against that hop's model:
 
 ```text
 >>> Transaction.select(lambda t: (t.id, t.amonut))
@@ -579,26 +611,30 @@ AttributeError: Transaction has no queryable column 'amonut'. Did you mean 'amou
 
 Misuse is loud, never silently ignored:
 
-- **No traversed projection yet.** `select(lambda t: t.account.label)` raises `NotImplementedError` — projecting related columns is designed together with output aliases and aggregations. Dotted strings (`select("account.label")`) are rejected permanently; traversal will be lambda-only when it lands.
+- **No output-name collisions.** Two selected fields resolving to the same name raise `ValueError` naming the dict form (see above).
+- **One selector, one shape.** A dict nested in a tuple, a tuple (or dict) as a dict value, and non-string dict keys all raise `TypeError` — a projected record is flat.
 - **No mutations through a projection.** `update()` / `delete()` on a projected query raise `ValueError` at the call, before any SQL — a projection is a read shape, and silently ignoring it would make `select(...)` a no-op on mutations. Mutate through an unprojected query instead.
-- **No double `select()`.** Replacing a projection mid-chain would change the result type; name every column in one call, or start a new query from the model.
+- **No double `select()`.** Replacing a projection mid-chain would change the result type; name every field in one call, or start a new query from the model.
 - **No mixing forms.** Strings and a lambda in one `select()` call raise `TypeError`.
+- **No `include()` with a projection**, in either chain order: a query carries exactly one materialization plan, and record results are flat — permanently. Reach across the relation with traversed projection, or populate instances on an unprojected query.
 
 Static typing follows the same shape promise as predicates: `select(...)` flips the query's type so `.all()` checks as `Rows[Row]` and `.first()` as `Row | None` — passing a `Row` where a model instance is expected fails the type checker. See [Typed Query Predicates](../concepts/query-typing.md#projected-queries).
+
+Aggregation builds directly on this machinery — `select(lambda t: {"total": t.amount.sum()})` — and mixing aggregate and plain fields turns the projection into a **grouped query**. That is its own chapter: [Aggregations & Grouped Queries](aggregations.md).
 
 ## Not Yet Supported
 
 !!! note "On the roadmap"
     The following query features are **not yet implemented** — see the [Roadmap](../roadmap.md):
 
-    - Aggregations beyond `count()` / `exists()` (`sum`, `avg`, `min`, `max`, `GROUP BY`)
-    - Traversed projection and output aliases (`select(lambda t: t.account.name)`) — designed together with aggregations
+    - `having()` — post-aggregation filtering; `where()` rejects aggregate predicates pointing at it ([#291](https://github.com/syn54x/ferro-orm/issues/291))
     - Reverse (`BackRef`) and many-to-many population — [`include()`](#populating-relations-with-include) covers forward FKs; collection population is a separate future mechanism
     - Case-insensitive `ilike()`
     - `not_in()` (negate with `!=` conditions combined with `&` in the meantime)
 
 ## See Also
 
+- [Aggregations & Grouped Queries](aggregations.md) — `count`/`sum`/`avg`/`min`/`max` and derived grouping
 - [Mutations](mutations.md) — creating, updating, and deleting records
 - [Relationships](relationships.md) — forward and reverse relations
 - [Typed Query Predicates](../concepts/query-typing.md) — why three predicate styles exist

--- a/docs/pages/guide/raw-sql.md
+++ b/docs/pages/guide/raw-sql.md
@@ -4,7 +4,7 @@ Ferro exposes a raw SQL escape hatch — `execute`, `fetch_all`, `fetch_one` —
 
 ## When to Reach for Raw SQL
 
-Reach for raw SQL when the ORM can't express what you need: aggregations and reports, Postgres GUCs (`set_config`, `SET LOCAL`), advisory locks, `LISTEN/NOTIFY`, database-side functions, or one-off maintenance statements. For everyday CRUD, prefer the ORM — it returns typed, validated instances; raw SQL returns plain dicts of primitives.
+Reach for raw SQL when the ORM can't express what you need: complex reports (window functions, CTEs, `HAVING`), Postgres GUCs (`set_config`, `SET LOCAL`), advisory locks, `LISTEN/NOTIFY`, database-side functions, or one-off maintenance statements. For everyday CRUD — and for plain [aggregations and grouped queries](aggregations.md), which are ORM territory now — prefer the ORM: it returns typed, validated instances; raw SQL returns plain dicts of primitives.
 
 !!! warning "Raw SQL is an escape hatch"
     Bind values cross the FFI as wire-close primitives, and rows come back as `dict[str, str | int | float | bool | bytes | None]`. UUID, datetime, and JSON columns are returned as **strings**. If you want typed rows, use the ORM.

--- a/docs/pages/howto/migrate-from-sqlalchemy.md
+++ b/docs/pages/howto/migrate-from-sqlalchemy.md
@@ -254,11 +254,11 @@ Install the extra with `pip install "ferro-orm[alembic]"`. For development, `con
 
 ## What Has No Ferro Equivalent Yet
 
-Some SQLAlchemy features have no Ferro counterpart today:
+Some SQLAlchemy features map differently, or have no Ferro counterpart today:
 
-- **Eager loading** (`selectinload` / `joinedload`) — relations load lazily per access; there is no prefetch API yet.
-- **Partial column selects** — queries always hydrate full model instances; there is no `select(User.id, User.name)` equivalent.
-- **Aggregations beyond `count()` / `exists()`** — no `func.sum`/`avg`/`min`/`max` or `GROUP BY` builder; use [raw SQL](../guide/raw-sql.md) for those.
+- **Eager loading** (`selectinload` / `joinedload`) — forward-FK paths populate with [`include()`](../guide/queries.md#populating-relations-with-include) in one statement; `BackRef`/M2M collections still load lazily per access (reverse population is a future mechanism).
+- **Partial column selects** (`select(User.id, User.name)`) — [`select(lambda u: (u.id, u.name))`](../guide/queries.md#selecting-a-column-subset) returns projected records; traversal and output aliases use the dict form.
+- **`func.sum` / `avg` / `min` / `max` and `group_by()`** — aggregate methods on columns (`t.amount.sum()`), with [grouping derived from the projection](../guide/aggregations.md) — there is deliberately no `group_by()` chainer. `having()` is not built yet ([#291](https://github.com/syn54x/ferro-orm/issues/291)); filter groups in Python or use [raw SQL](../guide/raw-sql.md).
 - **Atomic update expressions** — no `update().values(count=Model.count + 1)`; batch `update()` sets literal values.
 
 For what's planned, see the [Roadmap](../roadmap.md). Where you hit a gap, `execute()` / `fetch_all()` give you full SQL with bound parameters.

--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -4,7 +4,8 @@ Ferro is pre-1.0 and under active development. The items below are known gaps we
 
 ## Query Features
 
-- **Aggregations beyond `count()`/`exists()`** — `sum`, `avg`, `min`, `max` on the query builder, plus output aliases and traversed projection (`select(lambda t: t.account.name)`), designed together on the [partial-select](guide/queries.md#selecting-a-column-subset) substrate. Today you either compute in Python after fetching or drop to raw SQL.
+- **`having()`** — post-aggregation filtering for [grouped queries](guide/aggregations.md); `where()` rejects aggregate predicates pointing at it ([#291](https://github.com/syn54x/ferro-orm/issues/291)). Workaround: filter groups in Python after `all()`.
+- **Typed record fields** — a projected `Row`'s fields type as `Any` on access today; inferring per-field types from the selector (so `row.total` checks as `int | None`) is [#290](https://github.com/syn54x/ferro-orm/issues/290).
 - **Reverse and many-to-many population** — [`include()`](guide/queries.md#populating-relations-with-include) populates forward-FK paths in one statement; populating `BackRef` collections and M2M sets is a separate future mechanism (a batched second query stitched onto the results). Today each awaited collection is its own query.
 - **`ilike()`** — case-insensitive pattern matching. Workaround: `like()` with normalized case.
 - **`not_in_()`** — NOT IN exclusion lists. Workaround: combine `!=` comparisons with `&`.

--- a/docs/pages/why-ferro.md
+++ b/docs/pages/why-ferro.md
@@ -49,7 +49,7 @@ Ferro is not the right choice for every project. Be honest with yourself about t
 
 - **Python 3.13+ only.** Ferro targets modern Python and does not support older interpreters.
 - **Async-only API.** There is no synchronous interface. If your application is sync (e.g., classic Flask or scripts without an event loop), Ferro is a poor fit.
-- **Young feature set.** Ferro covers models, queries, mutations, relationships, transactions, and Alembic-based migrations — but some features common in mature ORMs are not implemented yet, including eager loading (`prefetch`/`select_related`), aggregations beyond `count()` and `exists()`, and partial column selects. See the [Roadmap](roadmap.md) for what's planned.
+- **Young feature set.** Ferro covers models, queries, mutations, relationships (including forward-FK population via `include()`), partial selects, aggregations with grouped queries, transactions, and Alembic-based migrations — but some features common in mature ORMs are not implemented yet, including `having()`, reverse/M2M collection population, and atomic update expressions. See the [Roadmap](roadmap.md) for what's planned.
 - **Smaller ecosystem.** Fewer third-party integrations, plugins, and Stack Overflow answers than SQLAlchemy or Django.
 - **Rust at the bottom.** You never need Rust to *use* Ferro, but contributing to or extending the engine requires it, and building from source needs a Rust toolchain.
 

--- a/src/ferro/query/__init__.py
+++ b/src/ferro/query/__init__.py
@@ -2,6 +2,7 @@
 
 from .builder import ProjectedQuery, Query, Relation
 from .nodes import (
+    AggregateExpr,
     FieldProxy,
     Predicate,
     QueryNode,
@@ -12,6 +13,7 @@ from .nodes import (
 from .rows import Row, Rows
 
 __all__ = [
+    "AggregateExpr",
     "FieldProxy",
     "Predicate",
     "ProjectedQuery",

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -28,6 +28,7 @@ from .._core import (
     update_filtered,
 )
 from .nodes import (
+    AggregateExpr,
     FieldProxy,
     Predicate,
     QueryNode,
@@ -91,6 +92,14 @@ def _resolve_where_node(predicate: "Predicate[Any]", model_cls: type) -> QueryNo
             f"where() predicate returned the bare relation {relation!r}; compare "
             f"a column (e.g. t.{relation}.<column> == ...) or use == None / "
             "== an instance to filter by the relation."
+        )
+    if isinstance(result, AggregateExpr):
+        # Comparing an aggregate already raises inside the lambda (#294); a
+        # BARE aggregate returned from where() gets the same having() story.
+        raise TypeError(
+            f"where() cannot filter on the aggregate {result._dotted()}: "
+            "WHERE filters rows before aggregation. Post-aggregation "
+            "filtering is having() (#291)."
         )
     if not isinstance(result, QueryNode):
         raise TypeError(
@@ -264,23 +273,28 @@ def _resolve_include_selector(
 
 
 class _ProjectedField(NamedTuple):
-    """One projected record field, resolved at build time (#279/#293).
+    """One projected record field, resolved at build time (#279/#293/#294).
 
     ``name`` is the output field name on the record — the dict key when the
     selector is dict-returning (an output alias, CONTEXT.md), the bare leaf
     column name otherwise. ``column`` is the source column and ``path`` the
     relation path to its table (``()`` = root model; non-empty is traversed
-    projection).
+    projection). ``agg`` is the aggregate function applied to the source
+    (``None`` = a plain column field); an aggregate field serializes as a v5
+    ``expr`` — its traversal rides ``expr.path`` as hop facts, never the
+    field-level ``path``.
     """
 
     name: str
     column: str
     path: tuple[str, ...]
+    agg: str | None = None
 
     @property
     def dotted(self) -> str:
         """The selector expression this field came from (error messages)."""
-        return "t." + ".".join((*self.path, self.column))
+        base = "t." + ".".join((*self.path, self.column))
+        return f"{base}.{self.agg}()" if self.agg else base
 
 
 def _resolve_projection_selector(
@@ -331,6 +345,20 @@ def _resolve_projection_selector(
                 f'"<other name>": {field.dotted}}})).'
             )
         seen[field.name] = field
+    # Mixing aggregate and plain fields makes the projection a GROUPED query
+    # — every plain field becomes a group key (ADR-0009). Derived grouping
+    # lands with #295; until then the mix is rejected loudly, never rendered
+    # as the SQL both backends would misanswer (Postgres errors at runtime,
+    # SQLite answers with an arbitrary row's value).
+    if any(field.agg for field in fields) and any(not field.agg for field in fields):
+        plain = next(field for field in fields if not field.agg)
+        raise NotImplementedError(
+            f"select() cannot mix aggregate and plain fields yet: "
+            f"{plain.dotted} next to an aggregate makes this a grouped query "
+            "(every plain field is a group key, ADR-0009), which lands with "
+            "#295. Project the aggregates alone, or wait for grouped "
+            "aggregates."
+        )
     return fields
 
 
@@ -384,6 +412,12 @@ def _projection_item_field(item: Any, *, context: str) -> _ProjectedField:
             "output fields, return one dict for the whole selection "
             '(e.g. `lambda t: {"id": t.id, "account_name": t.account.name}`).'
         )
+    if isinstance(item, AggregateExpr):
+        raise TypeError(
+            f"aggregate fields are user-named (#294): give {item._dotted()} "
+            "an output name with the dict selector form "
+            f'(e.g. select(lambda t: {{"total": {item._dotted()}}})).'
+        )
     if isinstance(item, RelationProxy):
         relation = item._path[-1]
         raise TypeError(
@@ -417,9 +451,10 @@ def _collect_dict_projection(result: dict[Any, Any]) -> tuple[_ProjectedField, .
     """Validate a dict selector into aliased fields (#293).
 
     Keys are output field names (CONTEXT.md: Output alias) and must be
-    strings; values are field references and may traverse. Nesting a tuple,
-    list, or dict as a value is rejected — flat records only (ADR-0009:
-    record results are flat).
+    strings; values are field references (which may traverse) or aggregate
+    expressions (``t.amount.sum()`` — #294, dict-only: aggregate fields are
+    user-named). Nesting a tuple, list, or dict as a value is rejected —
+    flat records only (ADR-0009: record results are flat).
     """
     fields: list[_ProjectedField] = []
     for key, value in result.items():
@@ -428,6 +463,13 @@ def _collect_dict_projection(result: dict[Any, Any]) -> tuple[_ProjectedField, .
                 f"select() dict selector keys are output field names and must "
                 f"be strings, got {key!r} ({type(key).__name__})."
             )
+        if isinstance(value, AggregateExpr):
+            fields.append(
+                _ProjectedField(
+                    name=key, column=value.column, path=value.path, agg=value.fn
+                )
+            )
+            continue
         if isinstance(value, (dict, tuple, list)):
             raise TypeError(
                 f"select() dict selector value for {key!r} is a "
@@ -1450,25 +1492,47 @@ class ProjectedQuery(Query[T]):
         """Serialize the ``record`` plan: one field per projected field.
 
         ``name`` is declared separately from ``column`` (output aliases) and
-        each field carries its relation ``path`` (traversed projection,
-        #293); an aggregate field will carry an ``expr`` instead (#294).
+        each plain field carries its relation ``path`` (traversed projection,
+        #293). An aggregate field carries an ``expr`` instead (#294): ``fn``
+        as data and the source's traversal as hop facts on ``expr.path`` —
+        self-contained on the wire — with the field-level ``path`` empty.
         """
-        return {
-            "kind": "record",
-            "fields": [
-                {"name": field.name, "column": field.column, "path": list(field.path)}
-                for field in self._projection
-            ],
-        }
+        fields: list[dict[str, Any]] = []
+        for field in self._projection:
+            if field.agg is not None:
+                fields.append(
+                    {
+                        "name": field.name,
+                        "path": [],
+                        "expr": {
+                            "fn": field.agg,
+                            "column": field.column,
+                            "path": _resolve_join_hops(self.model_cls, field.path),
+                        },
+                    }
+                )
+            else:
+                fields.append(
+                    {
+                        "name": field.name,
+                        "column": field.column,
+                        "path": list(field.path),
+                    }
+                )
+        return {"kind": "record", "fields": fields}
 
     def _traversed_hop_classes(self) -> dict[str, type] | None:
-        """Hop classes for traversed projection paths, or None if all-root.
+        """Hop classes for traversed PLAIN projection paths, or None.
 
         The record decode path resolves each traversed leaf's enum catalog
         through its owning model's class (#293) — the same per-table map the
-        instances plan travels with (#286).
+        instances plan travels with (#286). Aggregate fields never need one:
+        enum sources are rejected at build time and ``count`` decodes to a
+        plain int, so no aggregate output is enum-typed.
         """
-        paths = {field.path for field in self._projection if field.path}
+        paths = {
+            field.path for field in self._projection if field.path and not field.agg
+        }
         if not paths:
             return None
         return self._hop_classes_for_paths(paths)

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -345,20 +345,6 @@ def _resolve_projection_selector(
                 f'"<other name>": {field.dotted}}})).'
             )
         seen[field.name] = field
-    # Mixing aggregate and plain fields makes the projection a GROUPED query
-    # — every plain field becomes a group key (ADR-0009). Derived grouping
-    # lands with #295; until then the mix is rejected loudly, never rendered
-    # as the SQL both backends would misanswer (Postgres errors at runtime,
-    # SQLite answers with an arbitrary row's value).
-    if any(field.agg for field in fields) and any(not field.agg for field in fields):
-        plain = next(field for field in fields if not field.agg)
-        raise NotImplementedError(
-            f"select() cannot mix aggregate and plain fields yet: "
-            f"{plain.dotted} next to an aggregate makes this a grouped query "
-            "(every plain field is a group key, ADR-0009), which lands with "
-            "#295. Project the aggregates alone, or wait for grouped "
-            "aggregates."
-        )
     return fields
 
 
@@ -1487,6 +1473,26 @@ class ProjectedQuery(Query[T]):
         for field in fields:
             if field.path:
                 self._joins.setdefault(field.path, "inner")
+        # Rule 3 (#295) covers sort keys added BEFORE the projection too:
+        # an order_by() chained ahead of an aggregate select() must already
+        # name a group key (or coincide with an output field) — checked here
+        # so the error stays at build time, not at the render boundary.
+        if self._has_aggregate():
+            output_names = {field.name for field in fields}
+            for order in self.order_by_clause:
+                column, path = order["column"], tuple(order["path"])
+                if not path and column in output_names:
+                    continue
+                if self._is_group_key_source(column, path):
+                    continue
+                dotted = "t." + ".".join((*path, column))
+                raise ValueError(
+                    f"order_by() key {dotted} (added before this select()) "
+                    "is not a group key of the aggregate projection: each "
+                    "group would answer with an arbitrary row's value. "
+                    "Project it as a group key, or sort by an output field "
+                    "after the select()."
+                )
 
     def _materialization_ir(self) -> dict[str, Any]:
         """Serialize the ``record`` plan: one field per projected field.
@@ -1520,6 +1526,186 @@ class ProjectedQuery(Query[T]):
                     }
                 )
         return {"kind": "record", "fields": fields}
+
+    def _has_aggregate(self) -> bool:
+        """True when this is an AGGREGATE PROJECTION (CONTEXT.md): at least
+        one aggregate field, so every plain field is a group key (#295)."""
+        return any(field.agg for field in self._projection)
+
+    def _append_order_by(
+        self, column: str, direction: str, path: tuple[str, ...]
+    ) -> Self:
+        """Clone with one resolved ORDER BY entry appended (#295)."""
+        new = self._clone()
+        new.order_by_clause.append(
+            {"column": column, "direction": direction.lower(), "path": list(path)}
+        )
+        if path:
+            new._joins.setdefault(path, "inner")
+        return new
+
+    def order_by(
+        self,
+        field: "str | Callable[[QueryProxy[T]], Any]",
+        direction: str = "asc",
+    ) -> Self:
+        """Add an ordering clause to a projected query (#295's three rules).
+
+        Strings resolve OUTPUT field names first, then root columns — SQL's
+        own ORDER BY scoping (``order_by("total")`` sorts by the projected
+        aggregate, even if a root column shares the name). The lambda form
+        spells SOURCE expressions: a column (traversal included), or an
+        aggregate (``order_by(lambda t: t.amount.sum(), "desc")``) which must
+        match a projected aggregate field and sorts by its output name.
+
+        On an AGGREGATE projection every sort key must be a group key or an
+        aggregate — anything else raises at build time (each group would
+        answer with an arbitrary row's value; SQLite would even permit it).
+        On a plain projection unselected root columns stay sortable,
+        unchanged.
+
+        Args:
+            field: Output field name or root column-name string, or a lambda
+                naming a source column / aggregate expression.
+            direction: ``"asc"`` (default) or ``"desc"``.
+
+        Returns:
+            A new query with the ordering added; ``self`` is unchanged.
+
+        Raises:
+            ValueError: If ``direction`` is invalid, or the sort key is not a
+                group key or aggregate on an aggregate projection (including
+                an aggregate expression matching no projected field).
+            AttributeError: If a string names neither an output field nor a
+                queryable root column.
+            TypeError: If a lambda resolves to a bare relation or any other
+                non-sortable value.
+        """
+        if direction.lower() not in ("asc", "desc"):
+            raise ValueError("direction must be 'asc' or 'desc'")
+        has_aggregate = self._has_aggregate()
+        output_names = {f.name for f in self._projection}
+
+        if isinstance(field, str):
+            # Rule 1: output field names first (group keys and aggregates
+            # both sort by name), then root columns.
+            if field in output_names:
+                return self._append_order_by(field, direction, ())
+            try:
+                validate_query_column(self.model_cls, field)
+            except AttributeError as exc:
+                raise AttributeError(
+                    f"{exc.args[0]} On this projected query, output field "
+                    f"names also sort: {', '.join(sorted(output_names))}.",
+                    name=getattr(exc, "name", None),
+                    obj=getattr(exc, "obj", None),
+                ) from None
+            if has_aggregate and not self._is_group_key_source(field, ()):
+                raise ValueError(
+                    f"order_by({field!r}) on an aggregate projection must "
+                    "name a group key or an aggregate: it is neither an "
+                    "output field nor a group key's source column, so each "
+                    "group would answer with an arbitrary row's value. Sort "
+                    "by an output field name, or project the column as a "
+                    "group key."
+                )
+            return self._append_order_by(field, direction, ())
+
+        if not callable(field):
+            raise TypeError(
+                "order_by() expected a column-name string or a lambda "
+                f"selector, got {type(field).__name__}"
+            )
+        selected = field(QueryProxy(self.model_cls))
+        # Rule 2: the lambda form spells source expressions — aggregates
+        # resolve to the projected field carrying the same expression and
+        # sort by its output name.
+        if isinstance(selected, AggregateExpr):
+            for proj in self._projection:
+                if (
+                    proj.agg == selected.fn
+                    and proj.column == selected.column
+                    and proj.path == selected.path
+                ):
+                    return self._append_order_by(proj.name, direction, ())
+            raise ValueError(
+                f"order_by() aggregate {selected._dotted()} matches no "
+                "projected field; project it to sort by it (e.g. "
+                f'select(lambda t: {{..., "key": {selected._dotted()}}}) '
+                'with order_by("key")).'
+            )
+        if isinstance(selected, RelationProxy):
+            relation = selected._path[-1]
+            raise TypeError(
+                f"order_by() selector returned the bare relation {relation!r}, "
+                "not a column; order by a column on it instead "
+                f"(e.g. t.{relation}.<column>)."
+            )
+        if not isinstance(selected, FieldProxy):
+            raise TypeError(
+                "order_by() selector must return a FieldProxy "
+                f"(e.g. `lambda u: u.created_at`), got {type(selected).__name__}"
+            )
+        # Rule 3: on an aggregate projection a source column must be a group
+        # key; on a plain projection unselected columns stay sortable.
+        if has_aggregate and not self._is_group_key_source(
+            selected.column, selected.path
+        ):
+            dotted = "t." + ".".join((*selected.path, selected.column))
+            raise ValueError(
+                f"order_by() key {dotted} on an aggregate projection must be "
+                "a group key or an aggregate: it is not a group key's source "
+                "column, so each group would answer with an arbitrary row's "
+                "value. Project it as a group key, or sort by an aggregate."
+            )
+        return self._append_order_by(selected.column, direction, selected.path)
+
+    def _is_group_key_source(self, column: str, path: tuple[str, ...]) -> bool:
+        """True when ``(column, path)`` is some plain field's source (#295)."""
+        return any(
+            field.agg is None and field.column == column and field.path == path
+            for field in self._projection
+        )
+
+    def count(self):  # type: ignore[override]
+        """Count matching rows — or raise on an aggregate projection (#295).
+
+        On a plain projection ``count()`` stays projection-blind (#279's
+        verb contract). On an AGGREGATE projection "count" is ambiguous
+        between rows and groups, so it raises synchronously at the call,
+        before any coroutine or SQL exists, with both spellings.
+
+        Raises:
+            ValueError: On an aggregate projection — count rows with an
+                unprojected query, count groups with ``len(await q.all())``.
+        """
+        if self._has_aggregate():
+            raise ValueError(
+                "count() on an aggregate projection is ambiguous: count the "
+                "matching rows with an unprojected query "
+                "(Model.where(...).count()), or count the groups with "
+                "len(await q.all())."
+            )
+        return super().count()
+
+    def exists(self):  # type: ignore[override]
+        """Existence check — or raise on an aggregate projection (#295).
+
+        Raises:
+            ValueError: On an aggregate projection — a global aggregate
+                always yields one record, and "a group exists" is
+                ``len(await q.all()) > 0``; test the unprojected query
+                instead (``Model.where(...).exists()``).
+        """
+        if self._has_aggregate():
+            raise ValueError(
+                "exists() on an aggregate projection is ambiguous: an "
+                "aggregate-only projection always yields exactly one record. "
+                "Test row existence with an unprojected query "
+                "(Model.where(...).exists()), or group existence with "
+                "len(await q.all()) > 0."
+            )
+        return super().exists()
 
     def _traversed_hop_classes(self) -> dict[str, type] | None:
         """Hop classes for traversed PLAIN projection paths, or None.

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -52,18 +52,19 @@ _ROWS_OF_ROW: type[Rows[Row]] = Rows[Row]
 def _query_ir_payload_to_json(query_payload: dict[str, Any]) -> str:
     """Serialize a QueryIR payload into a versioned IR envelope JSON string.
 
-    Always emits ``ir_version: 4`` (#285 — unconditional bump, exactly like v3
-    at #278 and v2 at #269; there is no earlier envelope left anywhere). v4
-    gives the ``instances`` materialization kind its field shape (``paths`` of
-    hop facts). Python and Rust ship in one wheel, so a single supported
-    version is the whole contract (#267 Implementation Decisions).
+    Always emits ``ir_version: 5`` (#292 — unconditional bump, exactly like v4
+    at #285, v3 at #278, and v2 at #269; there is no earlier envelope left
+    anywhere). v5 gives ``record`` fields expression sources (ADR-0009): a
+    field carries either a ``column`` + ``path`` or an aggregate ``expr``.
+    Python and Rust ship in one wheel, so a single supported version is the
+    whole contract (#267 Implementation Decisions).
     """
     import json
 
     return json.dumps(
         {
             "ir_kind": "query",
-            "ir_version": 4,
+            "ir_version": 5,
             "payload": _serialize_query_value(query_payload),
         }
     )

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -6,6 +6,8 @@ from typing import (
     Any,
     Callable,
     Generic,
+    Iterable,
+    NamedTuple,
     Never,
     NoReturn,
     Self,
@@ -261,39 +263,75 @@ def _resolve_include_selector(
     return result._path
 
 
+class _ProjectedField(NamedTuple):
+    """One projected record field, resolved at build time (#279/#293).
+
+    ``name`` is the output field name on the record — the dict key when the
+    selector is dict-returning (an output alias, CONTEXT.md), the bare leaf
+    column name otherwise. ``column`` is the source column and ``path`` the
+    relation path to its table (``()`` = root model; non-empty is traversed
+    projection).
+    """
+
+    name: str
+    column: str
+    path: tuple[str, ...]
+
+    @property
+    def dotted(self) -> str:
+        """The selector expression this field came from (error messages)."""
+        return "t." + ".".join((*self.path, self.column))
+
+
 def _resolve_projection_selector(
     selector: "RowSelector[Any]", model_cls: type
-) -> tuple[str, ...]:
-    """Resolve a ``select()`` lambda selector into projected column names (#279).
+) -> tuple[_ProjectedField, ...]:
+    """Resolve a ``select()`` lambda selector into projected fields (#279/#293).
 
     ``selector`` receives a validating :class:`QueryProxy` and returns one
-    column (``lambda t: t.amount``) or a tuple/list of columns
-    (``lambda t: (t.id, t.amount)``). Column names validate at build time with
-    did-you-mean, exactly like ``where()``/``order_by()`` (the proxy raises
-    ``AttributeError`` on a misspelled name before any round-trip).
+    field (``lambda t: t.amount``), a tuple/list of fields
+    (``lambda t: (t.id, t.account.name)``), or a dict whose keys name the
+    output fields (``lambda t: {"account_name": t.account.name}`` — output
+    aliases, CONTEXT.md). Fields may traverse declared forward-FK relations
+    at any depth; every hop validates at build time with did-you-mean,
+    exactly like ``where()``/``order_by()``. Mixed nesting — a dict inside a
+    tuple, a tuple inside a dict — is rejected: one selector, one shape.
 
     Returns:
-        The projected column names, in selection order.
+        The projected fields, in selection/insertion order.
 
     Raises:
         TypeError: If an element is a bare relation (``lambda t: t.account``),
-            a comparison (``lambda t: t.id == 1``), or any other non-column
-            value — a projection selects columns.
-        ValueError: If the selection is empty or names a column twice
-            (a duplicate would silently collapse in the record).
-        NotImplementedError: If a selected column traverses a relation
-            (``lambda t: t.account.name``) — traversed projection is designed
-            together with output aliases and aggregations (#282).
+            a comparison (``lambda t: t.id == 1``), a nested dict/tuple, a
+            non-string dict key, or any other non-field value.
+        ValueError: If the selection is empty, or two fields resolve to the
+            same output name (the collision error names the dict form).
     """
     result = selector(QueryProxy(model_cls))
-    items = tuple(result) if isinstance(result, (tuple, list)) else (result,)
-    if not items:
+    if isinstance(result, dict):
+        fields = _collect_dict_projection(result)
+    else:
+        items = tuple(result) if isinstance(result, (tuple, list)) else (result,)
+        fields = _collect_tuple_projection(items)
+    if not fields:
         raise ValueError(
             "select() projection selected no columns; select at least one "
             "(e.g. `lambda t: (t.id, t.amount)`), or call select() with no "
             "arguments for the full query."
         )
-    return _collect_projection_columns(items)
+    seen: dict[str, _ProjectedField] = {}
+    for field in fields:
+        first = seen.get(field.name)
+        if first is not None:
+            raise ValueError(
+                f"select() projects two fields named {field.name!r} "
+                f"({first.dotted} and {field.dotted}); output names must be "
+                "unique. Name them explicitly with the dict selector form "
+                f'(e.g. select(lambda t: {{"{first.name}": {first.dotted}, '
+                f'"<other name>": {field.dotted}}})).'
+            )
+        seen[field.name] = field
+    return fields
 
 
 def _resolve_projection_strings(
@@ -305,7 +343,7 @@ def _resolve_projection_strings(
     plus shadow ``{fk}_id`` columns), validated at build time with
     did-you-mean. Strings never traverse — a dotted path is rejected
     pointedly, permanently (PRD #277); traversed projection is lambda-only
-    when it lands (#282).
+    (#293).
 
     Raises:
         ValueError: For a dotted path, or a column named twice.
@@ -318,8 +356,8 @@ def _resolve_projection_strings(
             raise ValueError(
                 f"select() string selectors name root columns only and never "
                 f"traverse: {name!r} is not a column. String paths are "
-                "rejected permanently; traversed projection will be "
-                "lambda-only when it lands (#282). Select root columns "
+                "rejected permanently; traversed projection is lambda-only "
+                f"(select(lambda t: t.{name})). Select root columns "
                 '(e.g. select("id", "amount")).'
             )
         validate_query_column(model_cls, name)
@@ -332,44 +370,91 @@ def _resolve_projection_strings(
     return tuple(columns)
 
 
-def _collect_projection_columns(items: tuple[Any, ...]) -> tuple[str, ...]:
-    """Validate a lambda selector's resolved items into column names (#279)."""
-    columns: list[str] = []
-    for item in items:
-        if isinstance(item, RelationProxy):
-            relation = item._path[-1]
+def _projection_item_field(item: Any, *, context: str) -> _ProjectedField:
+    """Validate one selector item into an unaliased field (#279/#293).
+
+    Shared by the single-field and tuple forms; ``context`` names the
+    selector shape in error messages. The output name defaults to the bare
+    leaf column name (CONTEXT.md: Traversed projection).
+    """
+    if isinstance(item, dict):
+        raise TypeError(
+            "select() selector cannot nest a dict inside a tuple; a selector "
+            "returns one shape — a dict, a tuple, or a single field. To name "
+            "output fields, return one dict for the whole selection "
+            '(e.g. `lambda t: {"id": t.id, "account_name": t.account.name}`).'
+        )
+    if isinstance(item, RelationProxy):
+        relation = item._path[-1]
+        raise TypeError(
+            f"select() cannot project the bare relation {relation!r}; "
+            f"select a column on it instead (e.g. t.{relation}.<column>) "
+            "or select root columns."
+        )
+    if isinstance(item, QueryNode):
+        raise TypeError(
+            "select() selector returned a comparison, not a column "
+            "(e.g. `lambda t: t.id == 1`); projections select columns "
+            "(`lambda t: t.id`) — put predicates in where()."
+        )
+    if not isinstance(item, FieldProxy):
+        raise TypeError(
+            f"select() selector must return {context} "
+            f"(e.g. `lambda t: (t.id, t.amount)`), got {type(item).__name__}"
+        )
+    return _ProjectedField(name=item.column, column=item.column, path=item.path)
+
+
+def _collect_tuple_projection(items: tuple[Any, ...]) -> tuple[_ProjectedField, ...]:
+    """Validate a single-field or tuple selector's items into fields (#293)."""
+    return tuple(
+        _projection_item_field(item, context="a column or a tuple of columns")
+        for item in items
+    )
+
+
+def _collect_dict_projection(result: dict[Any, Any]) -> tuple[_ProjectedField, ...]:
+    """Validate a dict selector into aliased fields (#293).
+
+    Keys are output field names (CONTEXT.md: Output alias) and must be
+    strings; values are field references and may traverse. Nesting a tuple,
+    list, or dict as a value is rejected — flat records only (ADR-0009:
+    record results are flat).
+    """
+    fields: list[_ProjectedField] = []
+    for key, value in result.items():
+        if not isinstance(key, str):
             raise TypeError(
-                f"select() cannot project the bare relation {relation!r}; "
-                f"select a column on it instead (traversed projection like "
-                f"t.{relation}.<column> is planned, see below) or select root "
-                "columns."
+                f"select() dict selector keys are output field names and must "
+                f"be strings, got {key!r} ({type(key).__name__})."
             )
-        if isinstance(item, QueryNode):
+        if isinstance(value, (dict, tuple, list)):
             raise TypeError(
-                "select() selector returned a comparison, not a column "
-                "(e.g. `lambda t: t.id == 1`); projections select columns "
-                "(`lambda t: t.id`) — put predicates in where()."
+                f"select() dict selector value for {key!r} is a "
+                f"{type(value).__name__}; a projected record is flat — each "
+                "dict value names one field (e.g. "
+                '`lambda t: {"account_name": t.account.name}`).'
             )
-        if not isinstance(item, FieldProxy):
+        if isinstance(value, RelationProxy):
+            relation = value._path[-1]
             raise TypeError(
-                "select() selector must return a column or a tuple of columns "
-                f"(e.g. `lambda t: (t.id, t.amount)`), got {type(item).__name__}"
+                f"select() cannot project the bare relation {relation!r} "
+                f"(dict key {key!r}); select a column on it instead "
+                f"(e.g. {{{key!r}: t.{relation}.<column>}})."
             )
-        if item.path:
-            dotted = ".".join((*item.path, item.column))
-            raise NotImplementedError(
-                f"select() cannot project the traversed column {dotted!r} yet: "
-                "traversed projection is designed together with output aliases "
-                "and aggregations (#282). Project root columns, or fetch the "
-                "related model through its own query."
+        if isinstance(value, QueryNode):
+            raise TypeError(
+                f"select() dict selector value for {key!r} is a comparison, "
+                "not a column; projections select columns — put predicates "
+                "in where()."
             )
-        if item.column in columns:
-            raise ValueError(
-                f"select() projects column {item.column!r} more than once; "
-                "each projected column must be unique."
+        if not isinstance(value, FieldProxy):
+            raise TypeError(
+                f"select() dict selector value for {key!r} must be a column "
+                f"reference, got {type(value).__name__}."
             )
-        columns.append(item.column)
-    return tuple(columns)
+        fields.append(_ProjectedField(name=key, column=value.column, path=value.path))
+    return tuple(fields)
 
 
 def _target_pk_column(model_cls: type) -> str:
@@ -577,16 +662,24 @@ class Query(Generic[T]):
         """Project the query to a column subset, or pass through unchanged.
 
         Bare ``select()`` keeps meaning "full query": it returns an equivalent
-        query of complete model instances. With a lambda selector
-        (``select(lambda t: (t.id, t.amount))``, or the single-field form
-        ``select(lambda t: t.amount)``) — the documented style — the query
-        becomes a projection: its results are :class:`Row` records in the
-        list-like :class:`Rows` container, never model instances (the
-        complete-instance invariant, ADR-0007). Column-name strings
-        (``select("id", "amount")``) follow ``order_by``'s string contract
-        exactly: root columns only, never traversal, never mixed with a
-        lambda in one call. Both forms validate at build time with
-        did-you-mean.
+        query of complete model instances. With a lambda selector — the
+        documented style — the query becomes a projection: its results are
+        :class:`Row` records in the list-like :class:`Rows` container, never
+        model instances (the complete-instance invariant, ADR-0007). The
+        selector returns one field (``select(lambda t: t.amount)``), a tuple
+        (``select(lambda t: (t.id, t.amount))``), or a dict whose keys name
+        the output fields (``select(lambda t: {"account_name":
+        t.account.name})`` — output aliases). Fields may traverse declared
+        forward-FK relations at any depth (``t.account.name`` — traversed
+        projection); traversal narrows exactly like a ``where()`` predicate
+        on the same path (INNER, one join per path, ADR-0006) and
+        ``left_join()`` is the opt-out — kept rows decode the traversed
+        fields as ``None``. Unaliased traversed fields take the bare leaf
+        column name; two fields resolving to the same output name raise at
+        build time. Column-name strings (``select("id", "amount")``) follow
+        ``order_by``'s string contract exactly: root columns only, never
+        traversal, never mixed with a lambda in one call. All forms validate
+        at build time with did-you-mean.
 
         A projected query composes like any other query: ``where()``
         (relation traversal included), ``order_by()`` (by unselected columns
@@ -595,8 +688,8 @@ class Query(Generic[T]):
         ``select()`` raise at build time.
 
         Args:
-            *selectors: Nothing (full query), one lambda selector naming root
-                columns, or column-name strings.
+            *selectors: Nothing (full query), one lambda selector, or
+                column-name strings.
 
         Returns:
             A new query; ``self`` is unchanged. Projected when a selector is
@@ -604,19 +697,23 @@ class Query(Generic[T]):
 
         Raises:
             TypeError: If the selector is not callable/strings, selects
-                non-columns (a bare relation, a comparison), or mixes strings
-                with a lambda in one call.
-            ValueError: If the selection is empty, repeats a column, a
-                string is a dotted path (strings never traverse), or the
-                query already carries an ``include()`` (one materialization
-                plan per query — include × projection is #282).
-            NotImplementedError: If a lambda selects a traversed column
-                (traversed projection lands with #282).
+                non-fields (a bare relation, a comparison), nests shapes
+                (a dict inside a tuple, a tuple inside a dict), uses a
+                non-string dict key, or mixes strings with a lambda in one
+                call.
+            ValueError: If the selection is empty, two fields resolve to the
+                same output name, a string is a dotted path (strings never
+                traverse), or the query already carries an ``include()``
+                (one materialization plan per query — record results are
+                flat, permanently).
 
         Examples:
             >>> rows = await Transaction.select(lambda t: (t.id, t.amount)).all()  # doctest: +SKIP
             >>> rows[0].amount  # doctest: +SKIP
             Decimal('12.50')
+            >>> named = await Transaction.select(  # doctest: +SKIP
+            ...     lambda t: {"id": t.id, "account_name": t.account.name}
+            ... ).all()
         """
         if not selectors:
             return self._clone()
@@ -624,10 +721,11 @@ class Query(Generic[T]):
             raise ValueError(
                 "select() with a projection cannot be combined with "
                 "include(): a query carries exactly one materialization plan "
-                "— projected records or populated instances, not both. The "
-                "flattened-vs-nested design for record+relation results is "
-                "#282; until it lands, drop the include() or project through "
-                "a separate query."
+                "— projected records or populated instances, never both, and "
+                "record results are flat (ADR-0009). Reach across the "
+                "relation with traversed projection instead (e.g. "
+                'select(lambda t: {"account_name": t.account.name})), or '
+                "populate instances with include() on an unprojected query."
             )
         if any(isinstance(selector, str) for selector in selectors):
             if not all(isinstance(selector, str) for selector in selectors):
@@ -639,7 +737,11 @@ class Query(Generic[T]):
                 )
             names: tuple[str, ...] = selectors  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
             columns = _resolve_projection_strings(names, self.model_cls)
-            return ProjectedQuery(self, columns)
+            fields = tuple(
+                _ProjectedField(name=column, column=column, path=())
+                for column in columns
+            )
+            return ProjectedQuery(self, fields)
         if len(selectors) > 1:
             raise TypeError(
                 "select() takes a single lambda selector naming the columns "
@@ -654,10 +756,10 @@ class Query(Generic[T]):
             )
         # Strings were dispatched above, so the lone selector is the lambda
         # form; the tuple element type is too wide for the checker to see it.
-        columns = _resolve_projection_selector(
+        fields = _resolve_projection_selector(
             cast("RowSelector[T]", selector), self.model_cls
         )
-        return ProjectedQuery(self, columns)
+        return ProjectedQuery(self, fields)
 
     def order_by(
         self,
@@ -939,16 +1041,23 @@ class Query(Generic[T]):
         return {"kind": "root_instances"}
 
     def _include_hop_classes(self) -> dict[str, type]:
-        """Map each included hop's physical table to its model class (#286).
+        """Map each included hop's physical table to its model class (#286)."""
+        return self._hop_classes_for_paths(self._includes)
 
-        The Rust fetch walker hydrates every included hop through the full
-        model protocol (codec plan, enum classes, identity map), so it needs
-        the hop's Python class — resolved here, where the relation-spec chain
-        lives, and passed across the FFI keyed by ``to_table`` (one model per
-        table, enforced at registration).
+    def _hop_classes_for_paths(
+        self, paths: "Iterable[tuple[str, ...]]"
+    ) -> dict[str, type]:
+        """Map each hop table along ``paths`` to its model class (#286/#293).
+
+        The Rust fetch walker needs a hop's Python class whenever it decodes
+        or hydrates through that model's protocol — every included hop (codec
+        plan, enum classes, identity map, #286) and every traversed
+        projection leaf (enum decode, #293). Resolved here, where the
+        relation-spec chain lives, and passed across the FFI keyed by
+        ``to_table`` (one model per table, enforced at registration).
         """
         hop_classes: dict[str, type] = {}
-        for path in self._includes:
+        for path in paths:
             current = self.model_cls
             for relation in path:
                 specs = getattr(current, "__ferro_relation_specs__", None) or {}
@@ -1319,31 +1428,50 @@ class ProjectedQuery(Query[T]):
     projection.
     """
 
-    def __init__(self, source: Query[T], columns: tuple[str, ...]) -> None:
-        """Project ``source`` to ``columns`` (selection order preserved).
+    def __init__(self, source: Query[T], fields: tuple[_ProjectedField, ...]) -> None:
+        """Project ``source`` to ``fields`` (selection order preserved).
 
         Copies the source query's state through ``_clone()`` (fresh mutable
-        containers, FF-F F-1); ``source`` is unchanged.
+        containers, FF-F F-1); ``source`` is unchanged. Every traversed
+        field's relation path registers a join (#293): projection traversal
+        narrows exactly like ``where()``/``order_by()`` traversal, sharing
+        join identity per relation path (ADR-0006) — ``setdefault`` keeps an
+        already-registered path's entry, and an explicit ``left_join()``
+        still wins at serialization via the edge marks.
         """
         self.__dict__.update(source._clone().__dict__)
         # Immutable, so chained clones share it safely.
-        self._projection: tuple[str, ...] = columns
+        self._projection: tuple[_ProjectedField, ...] = fields
+        for field in fields:
+            if field.path:
+                self._joins.setdefault(field.path, "inner")
 
     def _materialization_ir(self) -> dict[str, Any]:
-        """Serialize the ``record`` plan: one field per projected column.
+        """Serialize the ``record`` plan: one field per projected field.
 
-        ``name`` is declared separately from ``column`` and each field
-        carries a ``path`` so output aliases and traversed projection (#282)
-        extend this shape without reshaping it; this epic only ever emits
-        ``name == column`` with an empty path.
+        ``name`` is declared separately from ``column`` (output aliases) and
+        each field carries its relation ``path`` (traversed projection,
+        #293); an aggregate field will carry an ``expr`` instead (#294).
         """
         return {
             "kind": "record",
             "fields": [
-                {"name": column, "column": column, "path": []}
-                for column in self._projection
+                {"name": field.name, "column": field.column, "path": list(field.path)}
+                for field in self._projection
             ],
         }
+
+    def _traversed_hop_classes(self) -> dict[str, type] | None:
+        """Hop classes for traversed projection paths, or None if all-root.
+
+        The record decode path resolves each traversed leaf's enum catalog
+        through its owning model's class (#293) — the same per-table map the
+        instances plan travels with (#286).
+        """
+        paths = {field.path for field in self._projection if field.path}
+        if not paths:
+            return None
+        return self._hop_classes_for_paths(paths)
 
     async def all(self) -> Rows[Row]:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         """Return the projected records for every matching row.
@@ -1359,12 +1487,22 @@ class ProjectedQuery(Query[T]):
         """
         query_def = self._fetch_query_def()
         route = await self._transaction_or_using()
-        records = await fetch_filtered(
-            self.model_cls,
-            _query_ir_payload_to_json(query_def),
-            route,
-            record_cls=Row,
-        )
+        hop_classes = self._traversed_hop_classes()
+        if hop_classes is not None:
+            records = await fetch_filtered(
+                self.model_cls,
+                _query_ir_payload_to_json(query_def),
+                route,
+                record_cls=Row,
+                hop_classes=hop_classes,
+            )
+        else:
+            records = await fetch_filtered(
+                self.model_cls,
+                _query_ir_payload_to_json(query_def),
+                route,
+                record_cls=Row,
+            )
         return _ROWS_OF_ROW._wrap(records)
 
     async def first(self) -> Row | None:  # type: ignore[override]  # ty: ignore[invalid-method-override]
@@ -1394,24 +1532,28 @@ class ProjectedQuery(Query[T]):
         )
 
     def include(self: Never, selector: Any) -> NoReturn:  # type: ignore[override]
-        """Reject ``include()`` on a projected query (#287).
+        """Reject ``include()`` on a projected query (#287, final at #293).
 
-        One materialization plan per query (ADR-0007/ADR-0008): projected
-        records and populated instances cannot ride one result shape until
-        #282 designs flattened-vs-nested record+relation results. The
-        ``self: Never`` pin makes this a STATIC error at the call site
-        (tests/static_fixtures/bad_includes.py), mirroring the mutation pins.
+        One materialization plan per query (ADR-0007/ADR-0008), and record
+        results are flat, permanently (ADR-0009: flattened-as-final) — a
+        record reaches across a relation with traversed projection, never by
+        nesting an instance. The ``self: Never`` pin makes this a STATIC
+        error at the call site (tests/static_fixtures/bad_includes.py),
+        mirroring the mutation pins.
 
         Raises:
-            ValueError: Always — include through an unprojected query, or
-                wait for #282.
+            ValueError: Always — reach across the relation with traversed
+                projection, or populate instances through an unprojected
+                query.
         """
         raise ValueError(
             "include() cannot be combined with a projection: a query carries "
             "exactly one materialization plan — projected records or "
-            "populated instances, not both. The flattened-vs-nested design "
-            "for record+relation results is #282; until it lands, drop the "
-            "projection or populate through a separate query."
+            "populated instances, never both, and record results are flat "
+            "(ADR-0009). Reach across the relation with traversed projection "
+            'instead (e.g. select(lambda t: {"account_name": '
+            "t.account.name})), or populate instances with include() on an "
+            "unprojected query."
         )
 
     # `self: Never` makes mutating a projected query a STATIC error at the
@@ -1450,7 +1592,8 @@ class ProjectedQuery(Query[T]):
         """Return a developer-friendly representation of the projection"""
         return (
             f"<ProjectedQuery model={self.model_cls.__name__} "
-            f"columns={list(self._projection)} where={self.where_clause}>"
+            f"fields={[field.name for field in self._projection]} "
+            f"where={self.where_clause}>"
         )
 
 

--- a/src/ferro/query/nodes.py
+++ b/src/ferro/query/nodes.py
@@ -4,10 +4,43 @@ import difflib
 import uuid
 from collections.abc import Callable
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, NoReturn, TypeAlias, TypeVar
 
 TField = TypeVar("TField")
 TModel = TypeVar("TModel")
+
+# Aggregate source families (#294, ADR-0009): which column families each
+# aggregate accepts, validated at build time. `None` = any column. Families
+# with no portable cross-backend meaning — enum (definition order vs lexical
+# text order diverges), uuid (no Postgres min/max), json, bool — are outside
+# every non-count set; build time is the only honest place to fail them.
+_AGG_NUMERIC = frozenset({"integer", "number", "decimal"})
+_AGG_ORDERED = _AGG_NUMERIC | {"string", "datetime", "date", "time"}
+_AGGREGATE_FAMILIES: dict[str, frozenset[str] | None] = {
+    "count": None,
+    "sum": _AGG_NUMERIC,
+    "avg": _AGG_NUMERIC,
+    "min": _AGG_ORDERED,
+    "max": _AGG_ORDERED,
+}
+_AGGREGATE_FAMILY_HINT = {
+    "sum": "a numeric column (int, float, or Decimal)",
+    "avg": "a numeric column (int, float, or Decimal)",
+    "min": "an orderable column (numeric, text, or date/time)",
+    "max": "an orderable column (numeric, text, or date/time)",
+}
+
+
+def _aggregate_source_family(spec: Any) -> str:
+    """Classify a column spec into an aggregate source family (#294).
+
+    Enum-typed columns classify as ``enum`` regardless of their storage
+    family (a text enum's logical type is ``string``, an IntEnum's is
+    ``integer`` — both aggregate-hostile for the same portability reason).
+    """
+    if spec.enum_values is not None or spec.enum_class is not None:
+        return "enum"
+    return spec.logical_type
 
 
 class QueryNode:
@@ -195,7 +228,12 @@ class FieldProxy(Generic[TField]):
         True
     """
 
-    def __init__(self, column: str, path: tuple[str, ...] = ()):
+    def __init__(
+        self,
+        column: str,
+        path: tuple[str, ...] = (),
+        owner: type | None = None,
+    ):
         """Initialize a field proxy for a specific column
 
         Args:
@@ -204,9 +242,81 @@ class FieldProxy(Generic[TField]):
                 table; empty (default) means the root model. Plumbed through
                 so relation traversal (#270) can populate it — this slice
                 never produces a non-empty path.
+            owner: The model class this column belongs to (the root model, or
+                a traversal's target model), when known. Query proxies always
+                pass it; aggregate methods (#294) read the column spec off it
+                to validate source families at build time. A hand-built proxy
+                without an owner skips that validation.
         """
         self.column = column
         self.path = path
+        # Underscored so the attribute can never statically shadow traversal
+        # to a relation FIELD named "owner" (`t.account.owner.email`) through
+        # the TYPE_CHECKING `__getattr__` chain.
+        self._owner = owner
+
+    def _dotted(self) -> str:
+        """The selector expression this proxy came from (error messages)."""
+        return "t." + ".".join((*self.path, self.column))
+
+    def _aggregate(self, fn: str) -> "AggregateExpr":
+        """Build an aggregate expression over this column (#294, ADR-0009).
+
+        Validates the source family at build time when the owning model is
+        known: ``sum``/``avg`` need a numeric column, ``min``/``max`` an
+        orderable one (numeric, text, date/time), ``count`` takes any column.
+        Families with no portable cross-backend meaning (enum, uuid, json,
+        bool) are rejected pointedly — build time is the only honest place
+        to fail.
+        """
+        if self._owner is not None:
+            spec = getattr(self._owner, "__ferro_columns__", {}).get(self.column)
+            if spec is not None:
+                family = _aggregate_source_family(spec)
+                allowed = _AGGREGATE_FAMILIES[fn]
+                if allowed is not None and family not in allowed:
+                    model = self._owner.__name__
+                    raise TypeError(
+                        f"{self._dotted()}.{fn}() is not supported: "
+                        f"{model}.{self.column} is {family}-typed, and {fn}() "
+                        f"takes {_AGGREGATE_FAMILY_HINT[fn]}. No portable "
+                        "cross-backend meaning exists for this aggregate over "
+                        f"a {family} column."
+                    )
+        return AggregateExpr(fn, self.column, self.path)
+
+    def count(self) -> "AggregateExpr":
+        """``COUNT(column)`` — counts rows where this column is non-NULL."""
+        return self._aggregate("count")
+
+    def sum(self) -> "AggregateExpr":
+        """``SUM(column)`` — numeric columns only; ``None`` over no rows."""
+        return self._aggregate("sum")
+
+    def avg(self) -> "AggregateExpr":
+        """``AVG(column)`` — numeric columns only; ``None`` over no rows."""
+        return self._aggregate("avg")
+
+    def min(self) -> "AggregateExpr":
+        """``MIN(column)`` — numeric, text, or date/time columns."""
+        return self._aggregate("min")
+
+    def max(self) -> "AggregateExpr":
+        """``MAX(column)`` — numeric, text, or date/time columns."""
+        return self._aggregate("max")
+
+    def __iter__(self) -> "NoReturn":
+        """Reject iteration — the builtin-``sum`` trap (#294).
+
+        ``sum(t.amount)`` calls ``iter(t.amount)`` and would otherwise fail
+        with an opaque message (or hang on an infinite proxy). Aggregation is
+        a method on the proxy, not a Python builtin over it.
+        """
+        raise TypeError(
+            f"{self._dotted()} is a column reference and cannot be iterated; "
+            f"did you mean {self._dotted()}.sum()? Aggregates are methods on "
+            "the column (.count()/.sum()/.avg()/.min()/.max())."
+        )
 
     if TYPE_CHECKING:
 
@@ -319,6 +429,71 @@ class FieldProxy(Generic[TField]):
         return f"FieldProxy(column={self.column!r})"
 
 
+class AggregateExpr:
+    """A build-time aggregate expression over one column (#294, ADR-0009).
+
+    Built by the five aggregate methods on :class:`FieldProxy`
+    (``t.amount.sum()``, traversal included: ``t.account.balance.avg()``).
+    Carries the aggregate ``fn`` (the closed ``count/sum/avg/min/max`` set),
+    the source ``column``, and the source's relation ``path`` — the data the
+    ``select()`` resolver turns into a v5 ``expr`` record field.
+
+    Deliberately opaque: an aggregate expression is a projection source, not
+    a value — comparing one raises pointedly at build time (post-aggregation
+    filtering is ``having()``, #291), and it is not a predicate, a column, or
+    an iterable.
+    """
+
+    __slots__ = ("fn", "column", "path")
+
+    def __init__(self, fn: str, column: str, path: tuple[str, ...]) -> None:
+        self.fn = fn
+        self.column = column
+        self.path = path
+
+    def _dotted(self) -> str:
+        """The selector expression this aggregate came from (errors)."""
+        return "t." + ".".join((*self.path, self.column)) + f".{self.fn}()"
+
+    def _reject_comparison(self, symbol: str) -> NoReturn:
+        """Reject a comparison on an aggregate (#294 → having(), #291)."""
+        raise TypeError(
+            f"{self._dotted()} {symbol} ... is not a where() predicate: "
+            "WHERE filters rows before aggregation, so an aggregate cannot "
+            "appear in it. Post-aggregation filtering is having() (#291); "
+            "until it lands, filter rows with where() and compare the "
+            "aggregated result in Python."
+        )
+
+    def __eq__(self, other: object) -> NoReturn:  # type: ignore[override]
+        self._reject_comparison("==")
+
+    def __ne__(self, other: object) -> NoReturn:  # type: ignore[override]
+        self._reject_comparison("!=")
+
+    def __lt__(self, other: object) -> NoReturn:
+        self._reject_comparison("<")
+
+    def __le__(self, other: object) -> NoReturn:
+        self._reject_comparison("<=")
+
+    def __gt__(self, other: object) -> NoReturn:
+        self._reject_comparison(">")
+
+    def __ge__(self, other: object) -> NoReturn:
+        self._reject_comparison(">=")
+
+    def __bool__(self) -> NoReturn:
+        raise TypeError(
+            f"{self._dotted()} has no truth value; an aggregate expression "
+            "is a projection source (select(lambda t: {\"total\": "
+            f"{self._dotted()}}})), not a predicate."
+        )
+
+    def __repr__(self) -> str:
+        return f"AggregateExpr(fn={self.fn!r}, column={self.column!r}, path={self.path!r})"
+
+
 def validate_query_column(model_cls: type, name: str) -> str:
     """Validate a queryable column name at build time (FF-F F-2).
 
@@ -403,7 +578,7 @@ class QueryProxy(Generic[TModel]):
                 self._model_cls, (name,), spec.target
             )
         validate_query_column(self._model_cls, name)
-        return FieldProxy(name)
+        return FieldProxy(name, owner=self._model_cls)
 
 
 class RelationProxy:
@@ -455,7 +630,7 @@ class RelationProxy:
         if spec is not None:
             return RelationProxy(self._root_model, self._path + (name,), spec.target)
         validate_query_column(self._target, name)
-        return FieldProxy(name, path=self._path)
+        return FieldProxy(name, path=self._path, owner=self._target)
 
     def _relation_name(self) -> str:
         """The last-hop relation field name (the one being compared)."""
@@ -573,14 +748,16 @@ RowSelector: TypeAlias = Callable[
     FieldProxy[Any]
     | tuple[FieldProxy[Any], ...]
     | list[FieldProxy[Any]]
-    | dict[str, FieldProxy[Any]],
+    | dict[str, "FieldProxy[Any] | AggregateExpr"],
 ]
 """Type alias for lambda selectors accepted by ``select()`` projections.
 
 A selector names fields — one (``lambda t: t.amount``), several
 (``lambda t: (t.id, t.amount)``), or a dict whose string keys name the
 output fields (``lambda t: {"account_name": t.account.name}`` — output
-aliases, #293). Fields may traverse forward-FK relations at any depth.
+aliases, #293). Fields may traverse forward-FK relations at any depth, and
+dict values may be aggregate expressions (``{"total": t.amount.sum()}`` —
+#294; aggregates are user-named, so the dict form is their only home).
 Returning a comparison (a :class:`QueryNode`), nesting shapes, or using a
 non-string dict key fails the static gate: a projection selects fields,
 a predicate belongs in ``where()``.

--- a/src/ferro/query/nodes.py
+++ b/src/ferro/query/nodes.py
@@ -570,12 +570,18 @@ Predicate: TypeAlias = Callable[[QueryProxy[TModel]], QueryNode]
 
 RowSelector: TypeAlias = Callable[
     [QueryProxy[TModel]],
-    "FieldProxy[Any] | tuple[FieldProxy[Any], ...] | list[FieldProxy[Any]]",
+    FieldProxy[Any]
+    | tuple[FieldProxy[Any], ...]
+    | list[FieldProxy[Any]]
+    | dict[str, FieldProxy[Any]],
 ]
 """Type alias for lambda selectors accepted by ``select()`` projections.
 
-A selector names root columns — one (``lambda t: t.amount``) or several
-(``lambda t: (t.id, t.amount)``). Returning a comparison (a
-:class:`QueryNode`) fails the static gate: a projection selects columns,
+A selector names fields — one (``lambda t: t.amount``), several
+(``lambda t: (t.id, t.amount)``), or a dict whose string keys name the
+output fields (``lambda t: {"account_name": t.account.name}`` — output
+aliases, #293). Fields may traverse forward-FK relations at any depth.
+Returning a comparison (a :class:`QueryNode`), nesting shapes, or using a
+non-string dict key fails the static gate: a projection selects fields,
 a predicate belongs in ``where()``.
 """

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -452,21 +452,21 @@ struct ProjectedField {
 }
 
 /// Resolve the fetch walker's record plan from the query's materialization
-/// (#279/#293/#294).
+/// (#279/#293/#294/#295).
 ///
 /// `root_instances` → `None` (render the root-table asterisk, full
 /// hydration). `record` → the ordered projected fields: plain, aliased
 /// (`name != column`), traversed (non-empty `path`), and aggregate (`expr`)
-/// fields all render. Mixing aggregate and plain fields makes the plan a
-/// GROUPED query — derived GROUP BY lands with #295 — so the mix is boundary
-/// defense (I-6) until then: rejected loudly, never rendered as SQL SQLite
-/// would answer with an arbitrary row's value.
+/// fields all render. A plan mixing aggregate and plain fields is a GROUPED
+/// query (#295, ADR-0009): every plain field is a group key, and the
+/// renderer derives GROUP BY from this resolution — grouping never travels
+/// on the wire.
 ///
 /// # Errors
 /// `PyValueError` for `instances` (the joined-row hydration plan resolves no
 /// projected SELECT list — the instances fetch path widens the SELECT itself,
 /// #286, and dispatches before calling this), an empty `record` field list,
-/// a duplicate output name, or a mixed aggregate/plain plan (#295).
+/// or a duplicate output name.
 fn projected_record_fields(plan: &QueryPlan) -> PyResult<Option<Vec<ProjectedField>>> {
     let fields = match &plan.materialization {
         Materialization::RootInstances => return Ok(None),
@@ -524,20 +524,16 @@ fn projected_record_fields(plan: &QueryPlan) -> PyResult<Option<Vec<ProjectedFie
             source,
         });
     }
-    let has_aggregate = resolved
-        .iter()
-        .any(|f| matches!(f.source, ProjectedSource::Aggregate { .. }));
-    let has_plain = resolved
-        .iter()
-        .any(|f| matches!(f.source, ProjectedSource::Column { .. }));
-    if has_aggregate && has_plain {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "record plan mixes aggregate and plain fields: a mixed projection \
-             is a grouped query (every plain field is a group key, ADR-0009), \
-             which is not yet implemented (#295).",
-        ));
-    }
     Ok(Some(resolved))
+}
+
+/// True when a record plan contains at least one aggregate field — the plan
+/// is then an AGGREGATE PROJECTION (CONTEXT.md): every plain field is a
+/// group key and the renderer derives GROUP BY from the plan (#295).
+fn record_plan_has_aggregate(fields: &[ProjectedField]) -> bool {
+    fields
+        .iter()
+        .any(|f| matches!(f.source, ProjectedSource::Aggregate { .. }))
 }
 
 /// Resolve a record field's SELECT qualifier: the root table for an empty
@@ -580,6 +576,13 @@ fn record_field_qualifier<'a>(
 /// traversed source reads through the same join its path renders for
 /// `where()`/`order_by()` (shared join identity, ADR-0006).
 ///
+/// An AGGREGATE PROJECTION derives its GROUP BY here (#295, ADR-0009): when
+/// any field is an aggregate, every plain field's qualified source column
+/// becomes a group key, in selection order. Grouping never travels on the
+/// wire — the record plan determines it, exactly as joins render from paths.
+/// With no plain fields there is no GROUP BY: the whole result collapses to
+/// one record (the global aggregate, #294).
+///
 /// # Errors
 /// `PyValueError` when a field's path has no join-plan entry
 /// ([`record_field_qualifier`]).
@@ -593,15 +596,17 @@ fn apply_select_list(
         select.column((Alias::new(table_name), sea_query::Asterisk));
         return Ok(());
     };
+    let derive_group_by = record_plan_has_aggregate(fields);
     for field in fields {
         match &field.source {
             ProjectedSource::Column { column, path } => {
                 let qualifier =
                     record_field_qualifier(table_name, join_plan, &field.name, path)?;
-                select.expr_as(
-                    Expr::col((Alias::new(qualifier), Alias::new(column.as_str()))),
-                    Alias::new(field.name.as_str()),
-                );
+                let source = Expr::col((Alias::new(qualifier), Alias::new(column.as_str())));
+                if derive_group_by {
+                    select.add_group_by([source.clone().into()]);
+                }
+                select.expr_as(source, Alias::new(field.name.as_str()));
             }
             ProjectedSource::Aggregate { func, column, path } => {
                 let qualifier =
@@ -619,6 +624,44 @@ fn apply_select_list(
         }
     }
     Ok(())
+}
+
+/// Resolve one `ORDER BY` term against a record plan (#295): SQL's own
+/// ORDER BY scoping, made deterministic in the renderer.
+///
+/// An empty-path term whose column matches an OUTPUT field name renders as
+/// the bare result-column alias (output names resolve first — group keys and
+/// aggregates both sort this way); anything else falls back to a qualified
+/// source column. On an aggregate projection the fallback must be a group
+/// key's source `(column, path)` — an ungrouped bare column is rejected
+/// loudly (the SQLite arbitrary-row trap made unwritable; the Python builder
+/// rejects it at build time, so this is boundary defense, I-6).
+fn record_order_by_expr(
+    order: &ferro_schema_ir::QueryOrderBy,
+    fields: &[ProjectedField],
+    table_name: &str,
+    join_plan: &JoinPlan,
+) -> PyResult<Expr> {
+    if order.path.is_empty() && fields.iter().any(|f| f.name == order.column) {
+        return Ok(Expr::col(Alias::new(order.column.as_str())));
+    }
+    if record_plan_has_aggregate(fields) {
+        let is_group_key_source = fields.iter().any(|f| {
+            matches!(&f.source, ProjectedSource::Column { column, path }
+                if *column == order.column && *path == order.path)
+        });
+        if !is_group_key_source {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "ORDER BY {:?} on an aggregate projection must name a group \
+                 key or an aggregate: it is neither an output field nor a \
+                 group key's source column, so each group would answer with \
+                 an arbitrary row's value.",
+                order.column
+            )));
+        }
+    }
+    crate::query::qualify_column_with_joins(table_name, join_plan, &order.column, &order.path)
+        .map_err(pyo3::exceptions::PyValueError::new_err)
 }
 
 /// How one record result column decodes (#293/#294): through its source
@@ -2518,15 +2561,22 @@ pub fn fetch_filtered<'py>(
             // path qualifies by the root table, a relation path by its JOIN alias
             // (#271). A path with no matching join entry is a loud error — the
             // Python builder always registers the join for an order_by path, so
-            // this is defense-in-depth, never reachable in normal use.
+            // this is defense-in-depth, never reachable in normal use. On a
+            // record plan the term resolves output field names FIRST (#295):
+            // a matching name renders as the bare result-column alias.
             for order in &plan.order_by {
-                let col = crate::query::qualify_column_with_joins(
-                    &table_name,
-                    &join_plan,
-                    &order.column,
-                    &order.path,
-                )
-                .map_err(pyo3::exceptions::PyValueError::new_err)?;
+                let col = match projected.as_deref() {
+                    Some(fields) => {
+                        record_order_by_expr(order, fields, &table_name, &join_plan)?
+                    }
+                    None => crate::query::qualify_column_with_joins(
+                        &table_name,
+                        &join_plan,
+                        &order.column,
+                        &order.path,
+                    )
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?,
+                };
                 let dir = if order.direction.to_lowercase() == "desc" {
                     Order::Desc
                 } else {
@@ -4956,16 +5006,17 @@ mod materialization_walker_gate_tests {
 
 #[cfg(test)]
 mod record_select_list_tests {
-    //! Pin the record plan's SELECT-list resolution and rendering (#279/#293):
-    //! every field renders `<qualifier>.<column> AS "<name>"` in selection
-    //! order — root-qualified for plain fields, join-alias-qualified for
-    //! traversed ones (sharing the path's join with `where()`, ADR-0006) —
-    //! and the expression shape this walker does not render yet (#294) is
-    //! rejected loudly at the boundary.
+    //! Pin the record plan's SELECT-list resolution and rendering
+    //! (#279/#293/#294/#295): every field renders under its output name in
+    //! selection order — root-qualified for plain fields,
+    //! join-alias-qualified for traversed ones (sharing the path's join with
+    //! `where()`, ADR-0006), aggregate functions over their sources — with
+    //! GROUP BY derived from the plain fields of an aggregate plan and the
+    //! #295 ORDER BY scoping rules.
 
     use super::{
-        apply_relation_joins, apply_select_list, projected_record_fields, query_join_plan,
-        query_plan_from_ir_json,
+        apply_relation_joins, apply_select_list, projected_record_fields,
+        query_join_plan, query_plan_from_ir_json, record_order_by_expr,
     };
     use crate::query::JoinPlan;
     use sea_query::{Alias, PostgresQueryBuilder, Query, SqliteQueryBuilder};
@@ -5254,19 +5305,153 @@ mod record_select_list_tests {
     }
 
     #[test]
-    fn mixed_aggregate_and_plain_plan_is_rejected() {
-        // A mixed projection is a grouped query (every plain field is a group
-        // key, ADR-0009) — boundary defense until #295 derives GROUP BY.
+    fn mixed_plan_derives_group_by_from_the_plain_fields() {
+        // The grouped query (#295, ADR-0009): GROUP BY never travels on the
+        // wire — the renderer derives it from the plan, one key per plain
+        // field in selection order, qualified like the SELECT list. Pins the
+        // rendered SQL for the wire shape golden-vectored in
+        // query_transaction_aggregate_v5.json.
+        let plan = plan_from_payload_parts(
+            account_joins(),
+            serde_json::json!([]),
+            record_fields(serde_json::json!([
+                {"name": "account_name", "column": "name", "path": ["account"]},
+                {"name": "acct", "column": "account_id", "path": []},
+                {"name": "total", "path": [],
+                 "expr": {"fn": "sum", "column": "amount", "path": []}}
+            ])),
+        );
+        let projected = projected_record_fields(&plan)
+            .expect("record plan resolves")
+            .expect("record plan projects fields");
+        let join_plan = query_join_plan(&plan, "transaction", &[]).expect("join plan");
+
+        let mut select = Query::select();
+        apply_select_list(&mut select, "transaction", Some(&projected), &join_plan)
+            .expect("grouped plan renders");
+        apply_relation_joins(&mut select, &join_plan).expect("joins render");
+        select.from(Alias::new("transaction"));
+
+        let sql = select.to_string(PostgresQueryBuilder);
+        assert!(
+            sql.contains(
+                "GROUP BY \"j1_account\".\"name\", \"transaction\".\"account_id\""
+            ),
+            "every plain field is a group key, in selection order: {sql}"
+        );
+        assert!(
+            sql.contains("SUM(\"transaction\".\"amount\") AS \"total\""),
+            "the aggregate renders alongside the keys: {sql}"
+        );
+    }
+
+    #[test]
+    fn plain_plan_renders_no_group_by() {
+        // Grouping is derived only when an aggregate is present: a plain
+        // projection never grows a GROUP BY.
+        let plan = plan_with_materialization(record_fields(serde_json::json!([
+            {"name": "id", "column": "id", "path": []},
+            {"name": "amount", "column": "amount", "path": []}
+        ])));
+        let projected = projected_record_fields(&plan)
+            .expect("record plan resolves")
+            .expect("record plan projects fields");
+
+        let mut select = Query::select();
+        apply_select_list(&mut select, "transaction", Some(&projected), &JoinPlan::default())
+            .expect("plain plan renders");
+        select.from(Alias::new("transaction"));
+        let sql = select.to_string(PostgresQueryBuilder);
+        assert!(!sql.contains("GROUP BY"), "no aggregate, no grouping: {sql}");
+    }
+
+    #[test]
+    fn order_by_output_field_name_renders_the_bare_alias() {
+        // #295 rule 1 in the renderer: an empty-path ORDER BY term matching
+        // an output field name renders unqualified — SQL's own output-column
+        // scoping resolves it, aggregates included.
         let plan = plan_with_materialization(record_fields(serde_json::json!([
             {"name": "acct", "column": "account_id", "path": []},
             {"name": "total", "path": [],
              "expr": {"fn": "sum", "column": "amount", "path": []}}
         ])));
-        let err = projected_record_fields(&plan).expect_err("mixed plan must be rejected");
+        let projected = projected_record_fields(&plan)
+            .expect("record plan resolves")
+            .expect("record plan projects fields");
+
+        let order = ferro_schema_ir::QueryOrderBy {
+            column: "total".to_string(),
+            direction: "desc".to_string(),
+            path: vec![],
+        };
+        let expr = record_order_by_expr(&order, &projected, "transaction", &JoinPlan::default())
+            .expect("output-name term resolves");
+        let mut select = Query::select();
+        select.expr(expr);
+        select.from(Alias::new("transaction"));
+        let sql = select.to_string(PostgresQueryBuilder);
+        assert!(
+            sql.starts_with("SELECT \"total\" "),
+            "output-name term must render bare: {sql}"
+        );
+    }
+
+    #[test]
+    fn order_by_group_key_source_column_qualifies_as_usual() {
+        // A term that is no output name falls back to the qualified source —
+        // allowed on an aggregate plan when it is a group key's source.
+        let plan = plan_with_materialization(record_fields(serde_json::json!([
+            {"name": "acct", "column": "account_id", "path": []},
+            {"name": "total", "path": [],
+             "expr": {"fn": "sum", "column": "amount", "path": []}}
+        ])));
+        let projected = projected_record_fields(&plan)
+            .expect("record plan resolves")
+            .expect("record plan projects fields");
+
+        let order = ferro_schema_ir::QueryOrderBy {
+            column: "account_id".to_string(),
+            direction: "asc".to_string(),
+            path: vec![],
+        };
+        let expr = record_order_by_expr(&order, &projected, "transaction", &JoinPlan::default())
+            .expect("group-key source term resolves");
+        let mut select = Query::select();
+        select.expr(expr);
+        select.from(Alias::new("transaction"));
+        let sql = select.to_string(PostgresQueryBuilder);
+        assert!(
+            sql.contains("\"transaction\".\"account_id\""),
+            "source term must stay qualified: {sql}"
+        );
+    }
+
+    #[test]
+    fn order_by_ungrouped_column_on_aggregate_plan_errors_loudly() {
+        // Boundary defense for #295 rule 3 (the Python builder rejects this
+        // at build time): an ORDER BY term that is neither an output field
+        // nor a group key's source would make SQLite answer with an
+        // arbitrary row's value.
+        let plan = plan_with_materialization(record_fields(serde_json::json!([
+            {"name": "acct", "column": "account_id", "path": []},
+            {"name": "total", "path": [],
+             "expr": {"fn": "sum", "column": "amount", "path": []}}
+        ])));
+        let projected = projected_record_fields(&plan)
+            .expect("record plan resolves")
+            .expect("record plan projects fields");
+
+        let order = ferro_schema_ir::QueryOrderBy {
+            column: "note".to_string(),
+            direction: "asc".to_string(),
+            path: vec![],
+        };
+        let err = record_order_by_expr(&order, &projected, "transaction", &JoinPlan::default())
+            .expect_err("an ungrouped bare term must be rejected");
         let msg = err.to_string();
         assert!(
-            msg.contains("grouped") && msg.contains("#295"),
-            "must point at grouped aggregates: {msg}"
+            msg.contains("note") && msg.contains("group key"),
+            "must name the term and the rule: {msg}"
         );
     }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -426,30 +426,47 @@ fn reject_unsupported_materialization(plan: &QueryPlan, operation: &str) -> PyRe
     )))
 }
 
-/// One projected record field resolved for rendering and decode (#279/#293):
-/// the output `name`, the source `column`, and the relation `path` to the
-/// source column's table (`[]` = root model).
+/// The source one projected record field reads from (#279/#293/#294).
+#[derive(Debug, Clone)]
+enum ProjectedSource {
+    /// A plain column: source `column` on the table `path` reaches
+    /// (`[]` = root model).
+    Column { column: String, path: Vec<String> },
+    /// An aggregate over a column (#294): `func` applied to `column` on the
+    /// table `path` reaches. `path` holds relation NAMES (derived from the
+    /// wire expression's hop facts) so it keys into the join plan exactly
+    /// like a plain field's path.
+    Aggregate {
+        func: ferro_schema_ir::AggregateFn,
+        column: String,
+        path: Vec<String>,
+    },
+}
+
+/// One projected record field resolved for rendering and decode: the output
+/// `name` plus its [`ProjectedSource`].
 #[derive(Debug, Clone)]
 struct ProjectedField {
     name: String,
-    column: String,
-    path: Vec<String>,
+    source: ProjectedSource,
 }
 
 /// Resolve the fetch walker's record plan from the query's materialization
-/// (#279/#293).
+/// (#279/#293/#294).
 ///
 /// `root_instances` → `None` (render the root-table asterisk, full
 /// hydration). `record` → the ordered projected fields: plain, aliased
-/// (`name != column`), and traversed (non-empty `path`) fields all render
-/// (#293); an `expr` field is boundary defense (I-6) until aggregations land
-/// (#294) — rejected loudly, never silently projected wrong.
+/// (`name != column`), traversed (non-empty `path`), and aggregate (`expr`)
+/// fields all render. Mixing aggregate and plain fields makes the plan a
+/// GROUPED query — derived GROUP BY lands with #295 — so the mix is boundary
+/// defense (I-6) until then: rejected loudly, never rendered as SQL SQLite
+/// would answer with an arbitrary row's value.
 ///
 /// # Errors
 /// `PyValueError` for `instances` (the joined-row hydration plan resolves no
 /// projected SELECT list — the instances fetch path widens the SELECT itself,
 /// #286, and dispatches before calling this), an empty `record` field list,
-/// or an `expr` field (#294).
+/// a duplicate output name, or a mixed aggregate/plain plan (#295).
 fn projected_record_fields(plan: &QueryPlan) -> PyResult<Option<Vec<ProjectedField>>> {
     let fields = match &plan.materialization {
         Materialization::RootInstances => return Ok(None),
@@ -481,86 +498,228 @@ fn projected_record_fields(plan: &QueryPlan) -> PyResult<Option<Vec<ProjectedFie
                 field.name
             )));
         }
-        if field.expr.is_some() {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "record field {:?} carries an expression: expression fields \
-                 (aggregations) are not yet implemented (#294).",
-                field.name
-            )));
-        }
-        // Deserialization enforces exactly-one-of, so a field without an
-        // `expr` always carries a column; `None` here is a mixed-build shape
-        // that cannot reach this walker.
-        let Some(column) = field.column.as_deref() else {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "record field {:?} carries neither a column nor an expression.",
-                field.name
-            )));
+        let source = if let Some(expr) = &field.expr {
+            ProjectedSource::Aggregate {
+                func: expr.r#fn,
+                column: expr.column.clone(),
+                path: expr.path.iter().map(|hop| hop.relation.clone()).collect(),
+            }
+        } else {
+            // Deserialization enforces exactly-one-of, so a field without an
+            // `expr` always carries a column; `None` here is a mixed-build
+            // shape that cannot reach this walker.
+            let Some(column) = field.column.as_deref() else {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "record field {:?} carries neither a column nor an expression.",
+                    field.name
+                )));
+            };
+            ProjectedSource::Column {
+                column: column.to_string(),
+                path: field.path.clone(),
+            }
         };
         resolved.push(ProjectedField {
             name: field.name.clone(),
-            column: column.to_string(),
-            path: field.path.clone(),
+            source,
         });
     }
+    let has_aggregate = resolved
+        .iter()
+        .any(|f| matches!(f.source, ProjectedSource::Aggregate { .. }));
+    let has_plain = resolved
+        .iter()
+        .any(|f| matches!(f.source, ProjectedSource::Column { .. }));
+    if has_aggregate && has_plain {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "record plan mixes aggregate and plain fields: a mixed projection \
+             is a grouped query (every plain field is a group key, ADR-0009), \
+             which is not yet implemented (#295).",
+        ));
+    }
     Ok(Some(resolved))
+}
+
+/// Resolve a record field's SELECT qualifier: the root table for an empty
+/// `path`, the path's JOIN alias otherwise (#293).
+///
+/// # Errors
+/// `Err` when the path has no join-plan entry — the Python builder always
+/// registers a projection path's join and [`QueryPlan::build_join_plan`]
+/// unions aggregate-source paths, so this is defense-in-depth, never a
+/// silently unqualified column.
+fn record_field_qualifier<'a>(
+    table_name: &'a str,
+    join_plan: &'a JoinPlan,
+    name: &str,
+    path: &[String],
+) -> PyResult<&'a str> {
+    if path.is_empty() {
+        return Ok(table_name);
+    }
+    join_plan
+        .prefix_alias
+        .get(path)
+        .map(String::as_str)
+        .ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "record field {name:?} traverses relation path {path:?} but \
+                 the query renders no join for that path; the Python builder \
+                 always registers projection joins.",
+            ))
+        })
 }
 
 /// Apply a fetch SELECT list: the projected fields of a `record` plan (in
 /// selection order) or the root-table asterisk for full hydration (#279).
 ///
-/// Every record field renders `<qualifier>.<column> AS "<name>"` (#293): the
-/// qualifier is the root table for an empty `path` and the path's JOIN alias
-/// otherwise, so a traversed field reads through the same join its path
-/// renders for `where()`/`order_by()` (shared join identity, ADR-0006) and
-/// the result column arrives under the output name, aliases included.
+/// Every record field renders under its output name (#293): a plain field as
+/// `<qualifier>.<column> AS "<name>"`, an aggregate as
+/// `<FN>(<qualifier>.<column>) AS "<name>"` (#294) — the qualifier is the
+/// root table for an empty path and the path's JOIN alias otherwise, so a
+/// traversed source reads through the same join its path renders for
+/// `where()`/`order_by()` (shared join identity, ADR-0006).
 ///
 /// # Errors
-/// `PyValueError` when a field's path has no join-plan entry — the Python
-/// builder always registers the join for a traversed projection, so this is
-/// defense-in-depth, never a silently unqualified column.
+/// `PyValueError` when a field's path has no join-plan entry
+/// ([`record_field_qualifier`]).
 fn apply_select_list(
     select: &mut SelectStatement,
     table_name: &str,
     projected: Option<&[ProjectedField]>,
     join_plan: &JoinPlan,
 ) -> PyResult<()> {
-    match projected {
-        Some(fields) => {
-            for field in fields {
-                let qualifier = if field.path.is_empty() {
-                    table_name
-                } else {
-                    join_plan.prefix_alias.get(&field.path).ok_or_else(|| {
-                        pyo3::exceptions::PyValueError::new_err(format!(
-                            "record field {:?} traverses relation path {:?} \
-                             but the query renders no join for that path; \
-                             the Python builder always registers projection \
-                             joins.",
-                            field.name, field.path
-                        ))
-                    })?
-                };
+    let Some(fields) = projected else {
+        select.column((Alias::new(table_name), sea_query::Asterisk));
+        return Ok(());
+    };
+    for field in fields {
+        match &field.source {
+            ProjectedSource::Column { column, path } => {
+                let qualifier =
+                    record_field_qualifier(table_name, join_plan, &field.name, path)?;
                 select.expr_as(
-                    Expr::col((Alias::new(qualifier), Alias::new(field.column.as_str()))),
+                    Expr::col((Alias::new(qualifier), Alias::new(column.as_str()))),
                     Alias::new(field.name.as_str()),
                 );
             }
-        }
-        None => {
-            select.column((Alias::new(table_name), sea_query::Asterisk));
+            ProjectedSource::Aggregate { func, column, path } => {
+                let qualifier =
+                    record_field_qualifier(table_name, join_plan, &field.name, path)?;
+                let source = Expr::col((Alias::new(qualifier), Alias::new(column.as_str())));
+                let call = match func {
+                    ferro_schema_ir::AggregateFn::Count => sea_query::Func::count(source),
+                    ferro_schema_ir::AggregateFn::Sum => sea_query::Func::sum(source),
+                    ferro_schema_ir::AggregateFn::Avg => sea_query::Func::avg(source),
+                    ferro_schema_ir::AggregateFn::Min => sea_query::Func::min(source),
+                    ferro_schema_ir::AggregateFn::Max => sea_query::Func::max(source),
+                };
+                select.expr_as(call, Alias::new(field.name.as_str()));
+            }
         }
     }
     Ok(())
 }
 
+/// How one record result column decodes (#293/#294): through its source
+/// column's owning codec plan, with an optional aggregate contract on top.
+struct RecordFieldDecode<'a> {
+    plan: &'a crate::codec_plan::ModelCodecPlan,
+    column: &'a str,
+    agg: Option<ferro_schema_ir::AggregateFn>,
+}
+
+/// Coerce an aggregate result to a plain Python int (`count`, and `sum` over
+/// int sources). Postgres widens `SUM(bigint)`/`COUNT` results to `numeric`/
+/// `int8`, so the wire may carry a decimal string for an integral value; a
+/// value that does not parse integrally passes through as a Decimal — the
+/// truthful value in a degraded type, never a wrong number.
+fn coerce_aggregate_int(value: EngineValue) -> crate::state::RustValue {
+    use crate::state::RustValue;
+    match value {
+        EngineValue::I64(v) => RustValue::BigInt(v),
+        EngineValue::F64(v) if v.fract() == 0.0 => RustValue::BigInt(v as i64),
+        EngineValue::Decimal(s) | EngineValue::String(s) => match s.parse::<i64>() {
+            Ok(v) => RustValue::BigInt(v),
+            Err(_) => RustValue::Decimal(s),
+        },
+        _ => RustValue::None,
+    }
+}
+
+/// Coerce an aggregate result to a plain Python float (`avg` over int/float
+/// sources, `sum` over float sources). Postgres `AVG(int)` arrives as a
+/// numeric string; SQLite arrives as a float already.
+fn coerce_aggregate_float(value: EngineValue) -> crate::state::RustValue {
+    use crate::state::RustValue;
+    match value {
+        EngineValue::F64(v) => RustValue::Double(v),
+        EngineValue::I64(v) => RustValue::Double(v as f64),
+        EngineValue::Decimal(s) | EngineValue::String(s) => match s.parse::<f64>() {
+            Ok(v) => RustValue::Double(v),
+            Err(_) => RustValue::None,
+        },
+        _ => RustValue::None,
+    }
+}
+
+/// Decode one aggregate result value per the pinned cross-backend contract
+/// (#294, ADR-0009), derived from the SOURCE column's codec:
+///
+/// - `count` → int (never NULL in SQL);
+/// - `min`/`max` → the source type, via the source column's own codec;
+/// - `sum` → the source numeric type (int → int, float → float,
+///   Decimal → Decimal);
+/// - `avg` → float for int/float sources, Decimal for Decimal sources.
+///
+/// SQL's empty-input NULL passes through as `None` verbatim — no hidden
+/// COALESCE (`count` returns 0 from SQL itself).
+fn decode_aggregate_value(
+    func: ferro_schema_ir::AggregateFn,
+    value: EngineValue,
+    plan: &crate::codec_plan::ModelCodecPlan,
+    source_column: &str,
+) -> crate::state::RustValue {
+    use crate::codec_plan::ColumnCodec;
+    use ferro_schema_ir::AggregateFn;
+    if matches!(value, EngineValue::Null) {
+        return crate::state::RustValue::None;
+    }
+    let source_is_decimal = matches!(plan.codec(source_column), Some(ColumnCodec::Decimal));
+    match func {
+        AggregateFn::Count => coerce_aggregate_int(value),
+        AggregateFn::Min | AggregateFn::Max => {
+            crate::codec::decode_engine_value(value, plan, source_column)
+        }
+        AggregateFn::Sum => {
+            if source_is_decimal {
+                crate::codec::decode_engine_value(value, plan, source_column)
+            } else if matches!(plan.codec(source_column), Some(ColumnCodec::Float)) {
+                coerce_aggregate_float(value)
+            } else {
+                coerce_aggregate_int(value)
+            }
+        }
+        AggregateFn::Avg => {
+            if source_is_decimal {
+                crate::codec::decode_engine_value(value, plan, source_column)
+            } else {
+                coerce_aggregate_float(value)
+            }
+        }
+    }
+}
+
 /// Decode record-plan rows: each result column arrives under its OUTPUT name
 /// (the rendered `AS` alias, #293) and decodes against its SOURCE column's
 /// owning model — the root's codec plan for an empty path, the hop table's
-/// registration plan otherwise (the root-vs-hop codec lesson, #270). NULL
-/// decodes to `None` unconditionally: a `left_join` keeps relation-less rows,
-/// and their traversed fields are `None` even when the source column is
-/// non-nullable (a projected record is not the related model).
+/// registration plan otherwise (the root-vs-hop codec lesson, #270) — with
+/// aggregate fields decoding per the pinned contract
+/// ([`decode_aggregate_value`], #294). NULL decodes to `None`
+/// unconditionally: a `left_join` keeps relation-less rows, and their
+/// traversed fields are `None` even when the source column is non-nullable
+/// (a projected record is not the related model); an empty-input aggregate
+/// passes its SQL NULL through the same way.
 ///
 /// # Errors
 /// `PyValueError` when a traversed field's hop table has no resolved
@@ -575,17 +734,21 @@ fn record_rows_to_parsed_data(
     plan: &QueryPlan,
     join_plan: &JoinPlan,
 ) -> PyResult<Vec<ParsedRow>> {
-    // Output name -> (codec plan of the owning model, source column).
-    let mut decode: HashMap<&str, (&crate::codec_plan::ModelCodecPlan, &str)> = HashMap::new();
+    // Output name -> how that result column decodes.
+    let mut decode: HashMap<&str, RecordFieldDecode<'_>> = HashMap::new();
     for field in fields {
-        let codec_plan = if field.path.is_empty() {
+        let (column, path, agg) = match &field.source {
+            ProjectedSource::Column { column, path } => (column, path, None),
+            ProjectedSource::Aggregate { func, column, path } => (column, path, Some(*func)),
+        };
+        let codec_plan = if path.is_empty() {
             &root.codec_plan
         } else {
-            let table = join_plan.prefix_table.get(&field.path).ok_or_else(|| {
+            let table = join_plan.prefix_table.get(path).ok_or_else(|| {
                 pyo3::exceptions::PyValueError::new_err(format!(
                     "record field {:?} traverses relation path {:?} with no \
                      join-plan table entry.",
-                    field.name, field.path
+                    field.name, path
                 ))
             })?;
             let registration = plan.hop_registrations.get(table).ok_or_else(|| {
@@ -597,19 +760,38 @@ fn record_rows_to_parsed_data(
             })?;
             &registration.codec_plan
         };
-        decode.insert(field.name.as_str(), (codec_plan, field.column.as_str()));
+        decode.insert(
+            field.name.as_str(),
+            RecordFieldDecode {
+                plan: codec_plan,
+                column: column.as_str(),
+                agg,
+            },
+        );
     }
     let mut parsed = Vec::with_capacity(rows.len());
     for row in rows {
         let mut decoded_fields = Vec::with_capacity(row.values.len());
         for (name, value) in row.values {
-            let Some((codec_plan, source_column)) = decode.get(name.as_str()) else {
+            let Some(field_decode) = decode.get(name.as_str()) else {
                 return Err(pyo3::exceptions::PyValueError::new_err(format!(
                     "record decode received result column {name:?} that \
                      matches no projected field.",
                 )));
             };
-            let value = crate::codec::decode_engine_value(value, codec_plan, source_column);
+            let value = match field_decode.agg {
+                Some(func) => decode_aggregate_value(
+                    func,
+                    value,
+                    field_decode.plan,
+                    field_decode.column,
+                ),
+                None => crate::codec::decode_engine_value(
+                    value,
+                    field_decode.plan,
+                    field_decode.column,
+                ),
+            };
             decoded_fields.push((name, value));
         }
         // Projected records carry no persistence identity: no PK extraction.
@@ -620,11 +802,13 @@ fn record_rows_to_parsed_data(
 
 /// Build a record plan's enum catalog, keyed by OUTPUT field name (#293).
 ///
-/// Each projected field's enum class (when its source column is enum-typed)
-/// resolves through the source's OWNING model — the root class for plain
+/// Each plain field's enum class (when its source column is enum-typed)
+/// resolves through the source's OWNING model — the root class for root
 /// fields, the hop table's class (from `hop_classes`) for traversed ones — so
 /// hydration converts exactly the values full hydration of that model would,
-/// under the record's output names.
+/// under the record's output names. Aggregate fields never carry one: enum
+/// sources are rejected at build time and `count` decodes to a plain int
+/// (#294), so no aggregate output is enum-typed.
 ///
 /// # Errors
 /// `PyValueError` when a traversed field's path has no join-plan table or its
@@ -641,14 +825,17 @@ fn record_enum_classes_for<'py>(
     let mut hop_enums: HashMap<String, HashMap<String, Bound<'py, PyAny>>> = HashMap::new();
     let mut out: HashMap<String, Bound<'py, PyAny>> = HashMap::new();
     for field in fields {
-        let source_enums = if field.path.is_empty() {
+        let ProjectedSource::Column { column, path } = &field.source else {
+            continue;
+        };
+        let source_enums = if path.is_empty() {
             &root_enums
         } else {
-            let table = join_plan.prefix_table.get(&field.path).ok_or_else(|| {
+            let table = join_plan.prefix_table.get(path).ok_or_else(|| {
                 pyo3::exceptions::PyValueError::new_err(format!(
                     "record field {:?} traverses relation path {:?} with no \
                      join-plan table entry.",
-                    field.name, field.path
+                    field.name, path
                 ))
             })?;
             if !hop_enums.contains_key(table) {
@@ -670,7 +857,7 @@ fn record_enum_classes_for<'py>(
             }
             &hop_enums[table]
         };
-        if let Some(enum_cls) = source_enums.get(&field.column) {
+        if let Some(enum_cls) = source_enums.get(column) {
             out.insert(field.name.clone(), enum_cls.clone());
         }
     }
@@ -2229,12 +2416,16 @@ pub fn fetch_filtered<'py>(
     };
     // The hop-class map travels the same way, paired to the plans that decode
     // or hydrate through another model's protocol: every instances plan
-    // (population, #286) and a record plan with traversed fields (each leaf's
-    // enum catalog resolves through its owning model's class, #293).
+    // (population, #286) and a record plan with traversed PLAIN fields (each
+    // leaf's enum catalog resolves through its owning model's class, #293).
+    // Aggregate fields never need one — enum sources are rejected at build
+    // time and count decodes to a plain int (#294).
     let needs_hop_classes = include_paths.is_some()
-        || projected
-            .as_ref()
-            .is_some_and(|fields| fields.iter().any(|field| !field.path.is_empty()));
+        || projected.as_ref().is_some_and(|fields| {
+            fields.iter().any(|field| {
+                matches!(&field.source, ProjectedSource::Column { path, .. } if !path.is_empty())
+            })
+        });
     let hop_classes_py = match (needs_hop_classes, hop_classes) {
         (true, Some(hop_classes)) => Some(hop_classes.unbind()),
         (false, None) => None,
@@ -4991,15 +5182,92 @@ mod record_select_list_tests {
     }
 
     #[test]
-    fn record_field_with_expr_is_rejected() {
-        // A well-formed v5 expression field parses (the wire shape is the
-        // contract, #292) but this walker does not render it until #294.
+    fn global_aggregates_render_under_their_output_names() {
+        // The five aggregate functions render `<FN>(<root>.<col>) AS "<name>"`
+        // (#294) — no GROUP BY on an aggregate-only plan (a global aggregate
+        // collapses to one row).
         let plan = plan_with_materialization(record_fields(serde_json::json!([
             {"name": "n", "path": [],
-             "expr": {"fn": "count", "column": "id", "path": []}}
+             "expr": {"fn": "count", "column": "id", "path": []}},
+            {"name": "total", "path": [],
+             "expr": {"fn": "sum", "column": "amount", "path": []}},
+            {"name": "mean", "path": [],
+             "expr": {"fn": "avg", "column": "amount", "path": []}},
+            {"name": "lo", "path": [],
+             "expr": {"fn": "min", "column": "amount", "path": []}},
+            {"name": "hi", "path": [],
+             "expr": {"fn": "max", "column": "amount", "path": []}}
         ])));
-        let err = projected_record_fields(&plan).expect_err("expr field must be rejected");
-        assert!(err.to_string().contains("expression"), "got {err}");
+        let projected = projected_record_fields(&plan)
+            .expect("record plan resolves")
+            .expect("record plan projects fields");
+
+        let mut select = Query::select();
+        apply_select_list(&mut select, "transaction", Some(&projected), &JoinPlan::default())
+            .expect("aggregates render");
+        select.from(Alias::new("transaction"));
+        let sql = select.to_string(PostgresQueryBuilder);
+        assert_eq!(
+            sql,
+            "SELECT COUNT(\"transaction\".\"id\") AS \"n\", \
+             SUM(\"transaction\".\"amount\") AS \"total\", \
+             AVG(\"transaction\".\"amount\") AS \"mean\", \
+             MIN(\"transaction\".\"amount\") AS \"lo\", \
+             MAX(\"transaction\".\"amount\") AS \"hi\" FROM \"transaction\""
+        );
+        assert!(!sql.contains("GROUP BY"), "no grouping on a global aggregate: {sql}");
+    }
+
+    #[test]
+    fn traversed_aggregate_source_renders_through_its_paths_join() {
+        // An expr field's traversal is self-contained on the wire (hop facts,
+        // ADR-0009): with an EMPTY joins section, build_join_plan unions the
+        // source path in with traversal semantics (INNER), and the aggregate
+        // reads through that alias.
+        let plan = plan_with_materialization(record_fields(serde_json::json!([
+            {"name": "avg_balance", "path": [],
+             "expr": {"fn": "avg", "column": "balance", "path": [
+                 {"relation": "account", "from_column": "account_id",
+                  "to_table": "account", "to_column": "id"}
+             ]}}
+        ])));
+        let projected = projected_record_fields(&plan)
+            .expect("record plan resolves")
+            .expect("record plan projects fields");
+        let join_plan = query_join_plan(&plan, "transaction", &[]).expect("join plan");
+
+        let mut select = Query::select();
+        apply_select_list(&mut select, "transaction", Some(&projected), &join_plan)
+            .expect("traversed aggregate renders");
+        apply_relation_joins(&mut select, &join_plan).expect("joins render");
+        select.from(Alias::new("transaction"));
+
+        let sql = select.to_string(PostgresQueryBuilder);
+        assert!(
+            sql.contains("AVG(\"j1_account\".\"balance\") AS \"avg_balance\""),
+            "aggregate must read through the path's join alias: {sql}"
+        );
+        assert!(
+            sql.contains("INNER JOIN \"account\" AS \"j1_account\""),
+            "the source path must render INNER (traversal semantics): {sql}"
+        );
+    }
+
+    #[test]
+    fn mixed_aggregate_and_plain_plan_is_rejected() {
+        // A mixed projection is a grouped query (every plain field is a group
+        // key, ADR-0009) — boundary defense until #295 derives GROUP BY.
+        let plan = plan_with_materialization(record_fields(serde_json::json!([
+            {"name": "acct", "column": "account_id", "path": []},
+            {"name": "total", "path": [],
+             "expr": {"fn": "sum", "column": "amount", "path": []}}
+        ])));
+        let err = projected_record_fields(&plan).expect_err("mixed plan must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("grouped") && msg.contains("#295"),
+            "must point at grouped aggregates: {msg}"
+        );
     }
 
     #[test]

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -426,23 +426,31 @@ fn reject_unsupported_materialization(plan: &QueryPlan, operation: &str) -> PyRe
     )))
 }
 
-/// Resolve the fetch walker's SELECT-list plan from the query's
-/// materialization (#279).
+/// One projected record field resolved for rendering and decode (#279/#293):
+/// the output `name`, the source `column`, and the relation `path` to the
+/// source column's table (`[]` = root model).
+#[derive(Debug, Clone)]
+struct ProjectedField {
+    name: String,
+    column: String,
+    path: Vec<String>,
+}
+
+/// Resolve the fetch walker's record plan from the query's materialization
+/// (#279/#293).
 ///
 /// `root_instances` → `None` (render the root-table asterisk, full
-/// hydration). `record` → the ordered projected column names. The Python
-/// builder validates every field at build time; the per-field checks here are
-/// boundary defense (I-6) for the v5 field shapes this walker does not render
-/// yet: a relation `path` or an output alias (`name != column`) land with
-/// traversed projection (#293), an `expr` with aggregations (#294/#295) — all
-/// rejected loudly, never silently projected wrong.
+/// hydration). `record` → the ordered projected fields: plain, aliased
+/// (`name != column`), and traversed (non-empty `path`) fields all render
+/// (#293); an `expr` field is boundary defense (I-6) until aggregations land
+/// (#294) — rejected loudly, never silently projected wrong.
 ///
 /// # Errors
 /// `PyValueError` for `instances` (the joined-row hydration plan resolves no
 /// projected SELECT list — the instances fetch path widens the SELECT itself,
 /// #286, and dispatches before calling this), an empty `record` field list,
-/// or a field shape from #282.
-fn projected_columns(plan: &QueryPlan) -> PyResult<Option<Vec<String>>> {
+/// or an `expr` field (#294).
+fn projected_record_fields(plan: &QueryPlan) -> PyResult<Option<Vec<ProjectedField>>> {
     let fields = match &plan.materialization {
         Materialization::RootInstances => return Ok(None),
         Materialization::Instances { .. } => {
@@ -460,8 +468,19 @@ fn projected_columns(plan: &QueryPlan) -> PyResult<Option<Vec<String>>> {
              select at least one column.",
         ));
     }
-    let mut columns = Vec::with_capacity(fields.len());
+    let mut resolved = Vec::with_capacity(fields.len());
+    let mut names: HashSet<&str> = HashSet::with_capacity(fields.len());
     for field in fields {
+        // Output names key the record's decode map and result columns; the
+        // Python builder rejects collisions at build time, so a duplicate
+        // here is boundary defense (I-6) — loud, never a silent collapse.
+        if !names.insert(field.name.as_str()) {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "record plan declares two fields named {:?}; output names \
+                 must be unique.",
+                field.name
+            )));
+        }
         if field.expr.is_some() {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
                 "record field {:?} carries an expression: expression fields \
@@ -478,39 +497,184 @@ fn projected_columns(plan: &QueryPlan) -> PyResult<Option<Vec<String>>> {
                 field.name
             )));
         };
-        if !field.path.is_empty() {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "record field {:?} carries relation path {:?}: traversed \
-                 projection is not yet implemented (#293).",
-                field.name, field.path
-            )));
-        }
-        if field.name != column {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "record field {:?} aliases column {:?}: output aliases are not \
-                 yet implemented (#293).",
-                field.name, column
-            )));
-        }
-        columns.push(column.to_string());
+        resolved.push(ProjectedField {
+            name: field.name.clone(),
+            column: column.to_string(),
+            path: field.path.clone(),
+        });
     }
-    Ok(Some(columns))
+    Ok(Some(resolved))
 }
 
-/// Apply a fetch SELECT list: the projected columns of a `record` plan (in
-/// selection order, root-table-qualified) or the root-table asterisk for full
-/// hydration (#279).
-fn apply_select_list(select: &mut SelectStatement, table_name: &str, projected: Option<&[String]>) {
+/// Apply a fetch SELECT list: the projected fields of a `record` plan (in
+/// selection order) or the root-table asterisk for full hydration (#279).
+///
+/// Every record field renders `<qualifier>.<column> AS "<name>"` (#293): the
+/// qualifier is the root table for an empty `path` and the path's JOIN alias
+/// otherwise, so a traversed field reads through the same join its path
+/// renders for `where()`/`order_by()` (shared join identity, ADR-0006) and
+/// the result column arrives under the output name, aliases included.
+///
+/// # Errors
+/// `PyValueError` when a field's path has no join-plan entry — the Python
+/// builder always registers the join for a traversed projection, so this is
+/// defense-in-depth, never a silently unqualified column.
+fn apply_select_list(
+    select: &mut SelectStatement,
+    table_name: &str,
+    projected: Option<&[ProjectedField]>,
+    join_plan: &JoinPlan,
+) -> PyResult<()> {
     match projected {
-        Some(columns) => {
-            for column in columns {
-                select.column((Alias::new(table_name), Alias::new(column.as_str())));
+        Some(fields) => {
+            for field in fields {
+                let qualifier = if field.path.is_empty() {
+                    table_name
+                } else {
+                    join_plan.prefix_alias.get(&field.path).ok_or_else(|| {
+                        pyo3::exceptions::PyValueError::new_err(format!(
+                            "record field {:?} traverses relation path {:?} \
+                             but the query renders no join for that path; \
+                             the Python builder always registers projection \
+                             joins.",
+                            field.name, field.path
+                        ))
+                    })?
+                };
+                select.expr_as(
+                    Expr::col((Alias::new(qualifier), Alias::new(field.column.as_str()))),
+                    Alias::new(field.name.as_str()),
+                );
             }
         }
         None => {
             select.column((Alias::new(table_name), sea_query::Asterisk));
         }
     }
+    Ok(())
+}
+
+/// Decode record-plan rows: each result column arrives under its OUTPUT name
+/// (the rendered `AS` alias, #293) and decodes against its SOURCE column's
+/// owning model — the root's codec plan for an empty path, the hop table's
+/// registration plan otherwise (the root-vs-hop codec lesson, #270). NULL
+/// decodes to `None` unconditionally: a `left_join` keeps relation-less rows,
+/// and their traversed fields are `None` even when the source column is
+/// non-nullable (a projected record is not the related model).
+///
+/// # Errors
+/// `PyValueError` when a traversed field's hop table has no resolved
+/// registration ([`populate_hop_bind_context`] resolves every join-plan
+/// table first, so this is defense-in-depth), or a result column matches no
+/// projected field (render and decode cannot drift — the SELECT list is
+/// built from the same fields).
+fn record_rows_to_parsed_data(
+    rows: Vec<EngineRow>,
+    fields: &[ProjectedField],
+    root: &crate::state::RegisteredModel,
+    plan: &QueryPlan,
+    join_plan: &JoinPlan,
+) -> PyResult<Vec<ParsedRow>> {
+    // Output name -> (codec plan of the owning model, source column).
+    let mut decode: HashMap<&str, (&crate::codec_plan::ModelCodecPlan, &str)> = HashMap::new();
+    for field in fields {
+        let codec_plan = if field.path.is_empty() {
+            &root.codec_plan
+        } else {
+            let table = join_plan.prefix_table.get(&field.path).ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "record field {:?} traverses relation path {:?} with no \
+                     join-plan table entry.",
+                    field.name, field.path
+                ))
+            })?;
+            let registration = plan.hop_registrations.get(table).ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "record field {:?} decodes through table {table:?} but its \
+                     registration was not resolved before decode.",
+                    field.name
+                ))
+            })?;
+            &registration.codec_plan
+        };
+        decode.insert(field.name.as_str(), (codec_plan, field.column.as_str()));
+    }
+    let mut parsed = Vec::with_capacity(rows.len());
+    for row in rows {
+        let mut decoded_fields = Vec::with_capacity(row.values.len());
+        for (name, value) in row.values {
+            let Some((codec_plan, source_column)) = decode.get(name.as_str()) else {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "record decode received result column {name:?} that \
+                     matches no projected field.",
+                )));
+            };
+            let value = crate::codec::decode_engine_value(value, codec_plan, source_column);
+            decoded_fields.push((name, value));
+        }
+        // Projected records carry no persistence identity: no PK extraction.
+        parsed.push((None, decoded_fields));
+    }
+    Ok(parsed)
+}
+
+/// Build a record plan's enum catalog, keyed by OUTPUT field name (#293).
+///
+/// Each projected field's enum class (when its source column is enum-typed)
+/// resolves through the source's OWNING model — the root class for plain
+/// fields, the hop table's class (from `hop_classes`) for traversed ones — so
+/// hydration converts exactly the values full hydration of that model would,
+/// under the record's output names.
+///
+/// # Errors
+/// `PyValueError` when a traversed field's path has no join-plan table or its
+/// table is missing from `hop_classes` (the Python builder always passes
+/// every traversed path's hop classes — defense-in-depth).
+fn record_enum_classes_for<'py>(
+    py: Python<'py>,
+    cls: &Bound<'py, PyAny>,
+    fields: &[ProjectedField],
+    hop_classes: Option<&Py<pyo3::types::PyDict>>,
+    join_plan: &JoinPlan,
+) -> PyResult<HashMap<String, Bound<'py, PyAny>>> {
+    let root_enums = crate::hydration::enum_classes_for(py, cls);
+    let mut hop_enums: HashMap<String, HashMap<String, Bound<'py, PyAny>>> = HashMap::new();
+    let mut out: HashMap<String, Bound<'py, PyAny>> = HashMap::new();
+    for field in fields {
+        let source_enums = if field.path.is_empty() {
+            &root_enums
+        } else {
+            let table = join_plan.prefix_table.get(&field.path).ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "record field {:?} traverses relation path {:?} with no \
+                     join-plan table entry.",
+                    field.name, field.path
+                ))
+            })?;
+            if !hop_enums.contains_key(table) {
+                let hop_cls = hop_classes
+                    .and_then(|classes| {
+                        classes.bind(py).get_item(table.as_str()).ok().flatten()
+                    })
+                    .ok_or_else(|| {
+                        pyo3::exceptions::PyValueError::new_err(format!(
+                            "record field {:?} decodes through table {table:?} \
+                             but hop_classes has no model class for it.",
+                            field.name
+                        ))
+                    })?;
+                hop_enums.insert(
+                    table.clone(),
+                    crate::hydration::enum_classes_for(py, &hop_cls),
+                );
+            }
+            &hop_enums[table]
+        };
+        if let Some(enum_cls) = source_enums.get(&field.column) {
+            out.insert(field.name.clone(), enum_cls.clone());
+        }
+    }
+    Ok(out)
 }
 
 /// One included hop of an `instances` plan, resolved against the query's
@@ -2040,7 +2204,7 @@ pub fn fetch_filtered<'py>(
     let projected = if include_paths.is_some() {
         None
     } else {
-        projected_columns(&plan)?
+        projected_record_fields(&plan)?
     };
     // The record constructor travels with the call, paired to the plan kind:
     // a record plan requires it, a root plan must not carry one. A mismatch
@@ -2063,23 +2227,29 @@ pub fn fetch_filtered<'py>(
             ));
         }
     };
-    // The hop-class map travels the same way, paired to the instances plan
-    // (#286): population hydrates every hop through the full model protocol,
-    // so each included table's Python class must arrive with the call.
-    let hop_classes_py = match (&include_paths, hop_classes) {
-        (Some(_), Some(hop_classes)) => Some(hop_classes.unbind()),
-        (None, None) => None,
-        (Some(_), None) => {
+    // The hop-class map travels the same way, paired to the plans that decode
+    // or hydrate through another model's protocol: every instances plan
+    // (population, #286) and a record plan with traversed fields (each leaf's
+    // enum catalog resolves through its owning model's class, #293).
+    let needs_hop_classes = include_paths.is_some()
+        || projected
+            .as_ref()
+            .is_some_and(|fields| fields.iter().any(|field| !field.path.is_empty()));
+    let hop_classes_py = match (needs_hop_classes, hop_classes) {
+        (true, Some(hop_classes)) => Some(hop_classes.unbind()),
+        (false, None) => None,
+        (true, None) => {
             return Err(pyo3::exceptions::PyValueError::new_err(
-                "fetch_filtered(): an instances materialization plan requires \
-                 hop_classes; the Python builder always passes the included \
-                 hop model classes.",
+                "fetch_filtered(): this materialization plan requires \
+                 hop_classes (an instances plan, or a record plan with \
+                 traversed fields); the Python builder always passes the hop \
+                 model classes.",
             ));
         }
-        (None, Some(_)) => {
+        (false, Some(_)) => {
             return Err(pyo3::exceptions::PyValueError::new_err(
-                "fetch_filtered(): hop_classes was passed without an \
-                 instances materialization plan.",
+                "fetch_filtered(): hop_classes was passed for a plan that \
+                 traverses no relation.",
             ));
         }
     };
@@ -2115,7 +2285,7 @@ pub fn fetch_filtered<'py>(
             let pk = schema.meta.pk_col.clone();
 
             let mut select = Query::select();
-            apply_select_list(&mut select, &table_name, projected.as_deref());
+            apply_select_list(&mut select, &table_name, projected.as_deref(), &join_plan)?;
             apply_include_select_list(&mut select, &include_hops);
             select.from(Alias::new(&table_name));
 
@@ -2191,9 +2361,10 @@ pub fn fetch_filtered<'py>(
         // A record plan skips PK extraction entirely: projected records carry
         // no persistence identity and never enter the identity map (ADR-0007)
         // — the projection may not even include the PK column. Decode itself
-        // runs through the model's codec plan either way, so a projected
-        // datetime/uuid/enum/decimal column decodes identically to full
-        // hydration on both backends.
+        // runs through the owning model's codec plan either way (the root's,
+        // or a hop registration's for a traversed field, #293), so a
+        // projected datetime/uuid/enum/decimal column decodes identically to
+        // full hydration on both backends.
         let pk_for_decode = if projected.is_some() {
             None
         } else {
@@ -2335,7 +2506,11 @@ pub fn fetch_filtered<'py>(
             });
         }
 
-        let parsed_data = typed_rows_to_parsed_data(rows, &schema_for_decode, pk_for_decode);
+        let parsed_data = if let Some(fields) = &projected {
+            record_rows_to_parsed_data(rows, fields, &schema_for_decode, &plan, &join_plan)?
+        } else {
+            typed_rows_to_parsed_data(rows, &schema_for_decode, pk_for_decode)
+        };
 
         Python::attach(|py| {
             let results = pyo3::types::PyList::empty(py);
@@ -2350,15 +2525,26 @@ pub fn fetch_filtered<'py>(
                     );
                 }
             }
-            // The MODEL's enum catalog, for both paths: a projected native-
-            // enum column hydrates the same enum member as the model field
-            // (decode parity, FF-C C4).
-            let enum_classes = crate::hydration::enum_classes_for(py, cls);
 
             if let Some(record_cls) = record_cls_py {
                 // Record path (#279): direct-to-dict record construction,
                 // deliberately bypassing the identity map — no lookup, no
-                // insert, no refresh of live instances.
+                // insert, no refresh of live instances. The enum catalog is
+                // built per OUTPUT field name from each source column's
+                // OWNING model (#293) — the root's for plain fields, the hop
+                // class's for traversed ones — so a projected enum column
+                // hydrates the same enum member as full hydration would
+                // (decode parity, FF-C C4), aliases included.
+                let fields_spec = projected
+                    .as_ref()
+                    .expect("validated above: a record_cls pairs with a record plan");
+                let record_enum_classes = record_enum_classes_for(
+                    py,
+                    cls,
+                    fields_spec,
+                    hop_classes_py.as_ref(),
+                    &join_plan,
+                )?;
                 let record_cls = record_cls.bind(py);
                 for (_, fields) in parsed_data {
                     let record = crate::hydration::hydrate_record_instance(
@@ -2366,12 +2552,15 @@ pub fn fetch_filtered<'py>(
                         record_cls,
                         fields,
                         &py_col_names,
-                        &enum_classes,
+                        &record_enum_classes,
                     )?;
                     results.append(record)?;
                 }
                 return Ok(results.into_any().unbind());
             }
+
+            // The MODEL's enum catalog for full hydration (FF-C C4).
+            let enum_classes = crate::hydration::enum_classes_for(py, cls);
 
             for (row_pk_val, fields) in parsed_data {
                 let instance = materialize_model_row(
@@ -4576,28 +4765,37 @@ mod materialization_walker_gate_tests {
 
 #[cfg(test)]
 mod record_select_list_tests {
-    //! Pin the record plan's SELECT-list resolution and rendering (#279):
-    //! projected columns render as an explicit root-qualified column list in
-    //! selection order on both dialects, and the v5 field shapes this walker
-    //! does not render yet (paths and aliases → #293, expressions → #294) are
+    //! Pin the record plan's SELECT-list resolution and rendering (#279/#293):
+    //! every field renders `<qualifier>.<column> AS "<name>"` in selection
+    //! order — root-qualified for plain fields, join-alias-qualified for
+    //! traversed ones (sharing the path's join with `where()`, ADR-0006) —
+    //! and the expression shape this walker does not render yet (#294) is
     //! rejected loudly at the boundary.
 
-    use super::{apply_select_list, projected_columns, query_plan_from_ir_json};
+    use super::{
+        apply_relation_joins, apply_select_list, projected_record_fields, query_join_plan,
+        query_plan_from_ir_json,
+    };
+    use crate::query::JoinPlan;
     use sea_query::{Alias, PostgresQueryBuilder, Query, SqliteQueryBuilder};
 
-    fn plan_with_materialization(materialization: serde_json::Value) -> crate::query::QueryPlan {
+    fn plan_from_payload_parts(
+        joins: serde_json::Value,
+        where_nodes: serde_json::Value,
+        materialization: serde_json::Value,
+    ) -> crate::query::QueryPlan {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
                 "ir_version": 5,
                 "payload": {
                     "model_name": "Transaction",
-                    "where": [],
+                    "where": where_nodes,
                     "order_by": [],
                     "limit": null,
                     "offset": null,
                     "m2m": null,
-                    "joins": [],
+                    "joins": joins,
                     "materialization": materialization
                 }
             })
@@ -4606,29 +4804,50 @@ mod record_select_list_tests {
         .expect("envelope parses")
     }
 
+    fn plan_with_materialization(materialization: serde_json::Value) -> crate::query::QueryPlan {
+        plan_from_payload_parts(
+            serde_json::json!([]),
+            serde_json::json!([]),
+            materialization,
+        )
+    }
+
     fn record_fields(fields: serde_json::Value) -> serde_json::Value {
         serde_json::json!({"kind": "record", "fields": fields})
     }
 
+    fn account_joins() -> serde_json::Value {
+        serde_json::json!([{
+            "join_type": "inner",
+            "path": [
+                {"relation": "account", "from_column": "account_id",
+                 "to_table": "account", "to_column": "id"}
+            ]
+        }])
+    }
+
     #[test]
-    fn record_plan_renders_subset_select_in_selection_order_on_both_dialects() {
+    fn record_plan_renders_aliased_subset_select_in_selection_order_on_both_dialects() {
         let plan = plan_with_materialization(record_fields(serde_json::json!([
             {"name": "id", "column": "id", "path": []},
             {"name": "amount", "column": "amount", "path": []}
         ])));
-        let projected = projected_columns(&plan)
+        let projected = projected_record_fields(&plan)
             .expect("record plan resolves")
-            .expect("record plan projects columns");
-        assert_eq!(projected, vec!["id".to_string(), "amount".to_string()]);
+            .expect("record plan projects fields");
 
         let mut select = Query::select();
-        apply_select_list(&mut select, "transaction", Some(&projected));
+        apply_select_list(&mut select, "transaction", Some(&projected), &JoinPlan::default())
+            .expect("root fields render");
         select.from(Alias::new("transaction"));
 
+        // Every field renders under its output name (#293) — `AS "id"` here,
+        // so the result column names are the record field names uniformly.
         let pg = select.to_string(PostgresQueryBuilder);
         assert_eq!(
             pg,
-            "SELECT \"transaction\".\"id\", \"transaction\".\"amount\" FROM \"transaction\""
+            "SELECT \"transaction\".\"id\" AS \"id\", \
+             \"transaction\".\"amount\" AS \"amount\" FROM \"transaction\""
         );
         let sqlite = select.to_string(SqliteQueryBuilder).to_lowercase();
         assert!(
@@ -4643,38 +4862,131 @@ mod record_select_list_tests {
     #[test]
     fn root_instances_plan_renders_root_asterisk() {
         let plan = plan_with_materialization(serde_json::json!({"kind": "root_instances"}));
-        let projected = projected_columns(&plan).expect("root plan resolves");
+        let projected = projected_record_fields(&plan).expect("root plan resolves");
         assert!(projected.is_none());
 
         let mut select = Query::select();
-        apply_select_list(&mut select, "transaction", projected.as_deref());
+        apply_select_list(&mut select, "transaction", None, &JoinPlan::default())
+            .expect("asterisk renders");
         select.from(Alias::new("transaction"));
         let sql = select.to_string(PostgresQueryBuilder);
         assert_eq!(sql, "SELECT \"transaction\".* FROM \"transaction\"");
     }
 
     #[test]
-    fn record_field_with_relation_path_is_rejected() {
-        let plan = plan_with_materialization(record_fields(serde_json::json!([
-            {"name": "label", "column": "label", "path": ["account"]}
-        ])));
-        let err = projected_columns(&plan).expect_err("path field must be rejected");
-        let msg = err.to_string();
-        assert!(msg.contains("label"), "must name the field: {msg}");
-        assert!(msg.contains("account"), "must name the path: {msg}");
-        assert!(msg.contains("#293"), "must name the deferred slice: {msg}");
-    }
-
-    #[test]
-    fn record_field_with_alias_is_rejected() {
+    fn aliased_root_field_renders_under_its_output_name() {
+        // An output alias is pure rendering: same source column, new result
+        // column name (#293).
         let plan = plan_with_materialization(record_fields(serde_json::json!([
             {"name": "total", "column": "amount", "path": []}
         ])));
-        let err = projected_columns(&plan).expect_err("aliased field must be rejected");
+        let projected = projected_record_fields(&plan)
+            .expect("record plan resolves")
+            .expect("record plan projects fields");
+
+        let mut select = Query::select();
+        apply_select_list(&mut select, "transaction", Some(&projected), &JoinPlan::default())
+            .expect("aliased field renders");
+        select.from(Alias::new("transaction"));
+        let sql = select.to_string(PostgresQueryBuilder);
+        assert_eq!(
+            sql,
+            "SELECT \"transaction\".\"amount\" AS \"total\" FROM \"transaction\""
+        );
+    }
+
+    #[test]
+    fn traversed_field_renders_join_alias_qualified_under_its_output_name() {
+        // A traversed field reads through its path's JOIN alias — the same
+        // join `where()` traversal of the path would render (ADR-0006: the
+        // path is the join identity).
+        let plan = plan_from_payload_parts(
+            account_joins(),
+            serde_json::json!([]),
+            record_fields(serde_json::json!([
+                {"name": "id", "column": "id", "path": []},
+                {"name": "account_name", "column": "name", "path": ["account"]}
+            ])),
+        );
+        let projected = projected_record_fields(&plan)
+            .expect("record plan resolves")
+            .expect("record plan projects fields");
+        let join_plan = query_join_plan(&plan, "transaction", &[]).expect("join plan");
+
+        let mut select = Query::select();
+        apply_select_list(&mut select, "transaction", Some(&projected), &join_plan)
+            .expect("traversed field renders");
+        apply_relation_joins(&mut select, &join_plan).expect("joins render");
+        select.from(Alias::new("transaction"));
+
+        let sql = select.to_string(PostgresQueryBuilder);
+        assert!(
+            sql.contains("\"j1_account\".\"name\" AS \"account_name\""),
+            "traversed field must render join-alias-qualified: {sql}"
+        );
+        assert!(
+            sql.contains("INNER JOIN \"account\" AS \"j1_account\""),
+            "the path's join must render: {sql}"
+        );
+    }
+
+    #[test]
+    fn projection_and_where_share_one_join_for_the_same_path() {
+        // Shared-path join identity visible in rendered SQL (#293): a
+        // projected field and a WHERE leaf traversing the same path render
+        // exactly one JOIN.
+        let plan = plan_from_payload_parts(
+            account_joins(),
+            serde_json::json!([{
+                "node_kind": "leaf",
+                "operator": "==",
+                "column": "label",
+                "value": {"kind": "string", "value": "a1"},
+                "path": ["account"]
+            }]),
+            record_fields(serde_json::json!([
+                {"name": "account_name", "column": "name", "path": ["account"]}
+            ])),
+        );
+        let projected = projected_record_fields(&plan)
+            .expect("record plan resolves")
+            .expect("record plan projects fields");
+        let join_plan = query_join_plan(&plan, "transaction", &[]).expect("join plan");
+
+        let mut select = Query::select();
+        apply_select_list(&mut select, "transaction", Some(&projected), &join_plan)
+            .expect("traversed field renders");
+        apply_relation_joins(&mut select, &join_plan).expect("joins render");
+        select.from(Alias::new("transaction"));
+
+        let sql = select.to_string(PostgresQueryBuilder);
+        assert_eq!(
+            sql.matches("JOIN").count(),
+            1,
+            "one path, one join — shared by projection and predicate: {sql}"
+        );
+    }
+
+    #[test]
+    fn traversed_field_without_join_entry_errors_loudly() {
+        // Defense-in-depth: the Python builder always registers a projection
+        // path's join, so a missing entry is a loud error, never a silently
+        // unqualified column.
+        let plan = plan_with_materialization(record_fields(serde_json::json!([
+            {"name": "account_name", "column": "name", "path": ["account"]}
+        ])));
+        let projected = projected_record_fields(&plan)
+            .expect("record plan resolves")
+            .expect("record plan projects fields");
+
+        let mut select = Query::select();
+        let err =
+            apply_select_list(&mut select, "transaction", Some(&projected), &JoinPlan::default())
+                .expect_err("a pathed field with no join entry must error");
         let msg = err.to_string();
         assert!(
-            msg.contains("total") && msg.contains("amount"),
-            "must name alias and column: {msg}"
+            msg.contains("account_name") && msg.contains("account"),
+            "must name the field and its path: {msg}"
         );
     }
 
@@ -4686,14 +4998,14 @@ mod record_select_list_tests {
             {"name": "n", "path": [],
              "expr": {"fn": "count", "column": "id", "path": []}}
         ])));
-        let err = projected_columns(&plan).expect_err("expr field must be rejected");
+        let err = projected_record_fields(&plan).expect_err("expr field must be rejected");
         assert!(err.to_string().contains("expression"), "got {err}");
     }
 
     #[test]
     fn record_plan_with_no_fields_is_rejected() {
         let plan = plan_with_materialization(record_fields(serde_json::json!([])));
-        let err = projected_columns(&plan).expect_err("empty projection must be rejected");
+        let err = projected_record_fields(&plan).expect_err("empty projection must be rejected");
         assert!(err.to_string().contains("at least one"), "got {err}");
     }
 
@@ -4706,7 +5018,7 @@ mod record_select_list_tests {
                  "to_table": "account", "to_column": "id"}
             ]]
         }));
-        let err = projected_columns(&plan).expect_err("instances must be rejected");
+        let err = projected_record_fields(&plan).expect_err("instances must be rejected");
         assert!(
             err.to_string().contains("joined-row hydration"),
             "got {err}"
@@ -4782,7 +5094,7 @@ mod instances_select_list_tests {
         assert!(hops[0].parent_path.is_empty());
 
         let mut select = Query::select();
-        apply_select_list(&mut select, "transaction", None);
+        apply_select_list(&mut select, "transaction", None, &join_plan).expect("asterisk renders");
         apply_include_select_list(&mut select, &hops);
         select.from(Alias::new("transaction"));
         apply_relation_joins(&mut select, &join_plan).expect("joins render");

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -243,12 +243,12 @@ fn tx_remove(session_id: Option<&str>, tx_id: &str) -> PyResult<Option<Transacti
     Ok(TRANSACTION_REGISTRY.remove(tx_id).map(|(_, handle)| handle))
 }
 
-/// The only QueryIR version this build accepts (#269, #278, #285).
+/// The only QueryIR version this build accepts (#269, #278, #285, #292).
 ///
 /// Python and Rust ship in one wheel, so there is exactly one supported version at any
 /// time — no negotiation, no fallback. A mismatch can only mean a mixed build (a stale
 /// `.so` next to a rebuilt Python package, or vice versa).
-const SUPPORTED_QUERY_IR_VERSION: u32 = 4;
+const SUPPORTED_QUERY_IR_VERSION: u32 = 5;
 
 /// Envelope shell used only to read `ir_kind`/`ir_version` before committing to a strict
 /// [`QueryIrPayload`] parse. `payload` is deliberately raw JSON: a real earlier-version
@@ -432,10 +432,10 @@ fn reject_unsupported_materialization(plan: &QueryPlan, operation: &str) -> PyRe
 /// `root_instances` → `None` (render the root-table asterisk, full
 /// hydration). `record` → the ordered projected column names. The Python
 /// builder validates every field at build time; the per-field checks here are
-/// boundary defense (I-6) for the shapes the record plan already declares but
-/// this epic does not render: a relation `path`, an `expr`, or an output
-/// alias (`name != column`) — all #282, all rejected loudly, never silently
-/// projected wrong.
+/// boundary defense (I-6) for the v5 field shapes this walker does not render
+/// yet: a relation `path` or an output alias (`name != column`) land with
+/// traversed projection (#293), an `expr` with aggregations (#294/#295) — all
+/// rejected loudly, never silently projected wrong.
 ///
 /// # Errors
 /// `PyValueError` for `instances` (the joined-row hydration plan resolves no
@@ -462,28 +462,37 @@ fn projected_columns(plan: &QueryPlan) -> PyResult<Option<Vec<String>>> {
     }
     let mut columns = Vec::with_capacity(fields.len());
     for field in fields {
-        if !field.path.is_empty() {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "record field {:?} carries relation path {:?}: traversed \
-                 projection is not yet implemented (#282).",
-                field.name, field.path
-            )));
-        }
         if field.expr.is_some() {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
                 "record field {:?} carries an expression: expression fields \
-                 (aggregations) are not yet implemented (#282).",
+                 (aggregations) are not yet implemented (#294).",
                 field.name
             )));
         }
-        if field.name != field.column {
+        // Deserialization enforces exactly-one-of, so a field without an
+        // `expr` always carries a column; `None` here is a mixed-build shape
+        // that cannot reach this walker.
+        let Some(column) = field.column.as_deref() else {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "record field {:?} aliases column {:?}: output aliases are not \
-                 yet implemented (#282).",
-                field.name, field.column
+                "record field {:?} carries neither a column nor an expression.",
+                field.name
+            )));
+        };
+        if !field.path.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "record field {:?} carries relation path {:?}: traversed \
+                 projection is not yet implemented (#293).",
+                field.name, field.path
             )));
         }
-        columns.push(field.column.clone());
+        if field.name != column {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "record field {:?} aliases column {:?}: output aliases are not \
+                 yet implemented (#293).",
+                field.name, column
+            )));
+        }
+        columns.push(column.to_string());
     }
     Ok(Some(columns))
 }
@@ -4208,7 +4217,7 @@ mod mutation_pagination_guard_tests {
     fn envelope_without_pagination_keys() -> String {
         serde_json::json!({
             "ir_kind": "query",
-            "ir_version": 4,
+            "ir_version": 5,
             "payload": {
                 "model_name": "Widget",
                 "where": [{
@@ -4278,10 +4287,10 @@ mod mutation_pagination_guard_tests {
 mod query_ir_version_gate_tests {
     use super::query_plan_from_ir_json;
 
-    fn v4_envelope() -> serde_json::Value {
+    fn v5_envelope() -> serde_json::Value {
         serde_json::json!({
             "ir_kind": "query",
-            "ir_version": 4,
+            "ir_version": 5,
             "payload": {
                 "model_name": "Widget",
                 "where": [],
@@ -4296,9 +4305,9 @@ mod query_ir_version_gate_tests {
     }
 
     /// Assert a rejected envelope's message names the received version, this
-    /// build's supported version (4), and the one-wheel fix — the actionable
-    /// shape pinned since the v1-at-v2 bump (#269), re-pinned at v3 (#278)
-    /// and at v4 (#285).
+    /// build's supported version (5), and the one-wheel fix — the actionable
+    /// shape pinned since the v1-at-v2 bump (#269), re-pinned at v3 (#278),
+    /// v4 (#285), and v5 (#292).
     fn assert_actionable_version_rejection(err: pyo3::PyErr, received: char) {
         pyo3::Python::attach(|py| {
             assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
@@ -4309,7 +4318,7 @@ mod query_ir_version_gate_tests {
             "message should name the received version: {msg}"
         );
         assert!(
-            msg.contains('4'),
+            msg.contains('5'),
             "message should name the supported version: {msg}"
         );
         assert!(
@@ -4323,9 +4332,40 @@ mod query_ir_version_gate_tests {
     }
 
     #[test]
-    fn accepts_version_4() {
-        query_plan_from_ir_json(&v4_envelope().to_string())
-            .expect("a well-formed v4 envelope must be accepted");
+    fn accepts_version_5() {
+        query_plan_from_ir_json(&v5_envelope().to_string())
+            .expect("a well-formed v5 envelope must be accepted");
+    }
+
+    /// Contract test (#292 acceptance criteria): a v4 envelope must be
+    /// rejected on the version check with the actionable one-wheel message.
+    /// v5 is a pure widening of the v4 record-field shape (`column` became
+    /// optional next to the new `expr` arm), so every real v4 payload would
+    /// still strict-parse — the version gate alone retires it, keeping
+    /// "exactly one supported version" true rather than silently accepting
+    /// a stale wheel's envelopes.
+    #[test]
+    fn rejects_v4_envelope_with_actionable_message() {
+        let v4_envelope = serde_json::json!({
+            "ir_kind": "query",
+            "ir_version": 4,
+            "payload": {
+                "model_name": "Widget",
+                "where": [],
+                "order_by": [],
+                "limit": null,
+                "offset": null,
+                "m2m": null,
+                "joins": [],
+                "materialization": {"kind": "record", "fields": [
+                    {"name": "id", "column": "id", "path": []}
+                ]}
+            }
+        });
+
+        let err = query_plan_from_ir_json(&v4_envelope.to_string())
+            .expect_err("a v4 envelope must be rejected");
+        assert_actionable_version_rejection(err, '4');
     }
 
     /// Contract test (#285 acceptance criteria, mirroring the v2-at-v3
@@ -4407,14 +4447,14 @@ mod query_ir_version_gate_tests {
 
     #[test]
     fn rejects_unsupported_future_version() {
-        let mut envelope = v4_envelope();
-        envelope["ir_version"] = serde_json::json!(5);
+        let mut envelope = v5_envelope();
+        envelope["ir_version"] = serde_json::json!(6);
 
         let err = query_plan_from_ir_json(&envelope.to_string())
             .expect_err("an unsupported future version must be rejected");
         let msg = err.to_string();
         assert!(
-            msg.contains('5'),
+            msg.contains('6'),
             "message should name the received version: {msg}"
         );
     }
@@ -4423,7 +4463,7 @@ mod query_ir_version_gate_tests {
     /// naming the bad kind and the supported ones (#278).
     #[test]
     fn rejects_unknown_materialization_kind() {
-        let mut envelope = v4_envelope();
+        let mut envelope = v5_envelope();
         envelope["payload"]["materialization"] = serde_json::json!({"kind": "row_dicts"});
 
         let err = query_plan_from_ir_json(&envelope.to_string())
@@ -4436,18 +4476,18 @@ mod query_ir_version_gate_tests {
         );
     }
 
-    /// A v4 payload with NO materialization section fails the strict parse:
+    /// A v5 payload with NO materialization section fails the strict parse:
     /// the plan travels with the query as data (ADR-0007), never defaulted.
     #[test]
-    fn rejects_v4_payload_missing_materialization() {
-        let mut envelope = v4_envelope();
+    fn rejects_v5_payload_missing_materialization() {
+        let mut envelope = v5_envelope();
         envelope["payload"]
             .as_object_mut()
             .unwrap()
             .remove("materialization");
 
         let err = query_plan_from_ir_json(&envelope.to_string())
-            .expect_err("a v4 payload without a materialization section must be rejected");
+            .expect_err("a v5 payload without a materialization section must be rejected");
         let msg = err.to_string();
         assert!(
             msg.contains("materialization"),
@@ -4467,7 +4507,7 @@ mod materialization_walker_gate_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 4,
+                "ir_version": 5,
                 "payload": {
                     "model_name": "Widget",
                     "where": [],
@@ -4538,8 +4578,9 @@ mod materialization_walker_gate_tests {
 mod record_select_list_tests {
     //! Pin the record plan's SELECT-list resolution and rendering (#279):
     //! projected columns render as an explicit root-qualified column list in
-    //! selection order on both dialects, and the field shapes deferred to
-    //! #282 (paths, aliases, expressions) are rejected loudly at the boundary.
+    //! selection order on both dialects, and the v5 field shapes this walker
+    //! does not render yet (paths and aliases → #293, expressions → #294) are
+    //! rejected loudly at the boundary.
 
     use super::{apply_select_list, projected_columns, query_plan_from_ir_json};
     use sea_query::{Alias, PostgresQueryBuilder, Query, SqliteQueryBuilder};
@@ -4548,7 +4589,7 @@ mod record_select_list_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 4,
+                "ir_version": 5,
                 "payload": {
                     "model_name": "Transaction",
                     "where": [],
@@ -4621,7 +4662,7 @@ mod record_select_list_tests {
         let msg = err.to_string();
         assert!(msg.contains("label"), "must name the field: {msg}");
         assert!(msg.contains("account"), "must name the path: {msg}");
-        assert!(msg.contains("#282"), "must name the deferred slice: {msg}");
+        assert!(msg.contains("#293"), "must name the deferred slice: {msg}");
     }
 
     #[test]
@@ -4639,8 +4680,11 @@ mod record_select_list_tests {
 
     #[test]
     fn record_field_with_expr_is_rejected() {
+        // A well-formed v5 expression field parses (the wire shape is the
+        // contract, #292) but this walker does not render it until #294.
         let plan = plan_with_materialization(record_fields(serde_json::json!([
-            {"name": "n", "column": "n", "path": [], "expr": {"agg": "count"}}
+            {"name": "n", "path": [],
+             "expr": {"fn": "count", "column": "id", "path": []}}
         ])));
         let err = projected_columns(&plan).expect_err("expr field must be rejected");
         assert!(err.to_string().contains("expression"), "got {err}");
@@ -4691,7 +4735,7 @@ mod instances_select_list_tests {
         let mut plan = query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 4,
+                "ir_version": 5,
                 "payload": {
                     "model_name": "Transaction",
                     "where": [], "order_by": [], "limit": null, "offset": null,
@@ -4853,7 +4897,7 @@ mod mutation_qualification_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 4,
+                "ir_version": 5,
                 "payload": {
                     "model_name": "Widget",
                     "where": [{
@@ -4939,7 +4983,7 @@ mod select_join_render_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 4,
+                "ir_version": 5,
                 "payload": {
                     "model_name": "Transaction",
                     "where": [{
@@ -5045,7 +5089,7 @@ mod select_join_render_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 4,
+                "ir_version": 5,
                 "payload": {
                     "model_name": model_name,
                     "where": [], "order_by": [],
@@ -5067,7 +5111,7 @@ mod select_join_render_tests {
         let plan = query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 4,
+                "ir_version": 5,
                 "payload": {
                     "model_name": "Transaction",
                     "where": [{

--- a/src/query.rs
+++ b/src/query.rs
@@ -448,6 +448,20 @@ impl QueryPlan {
                 builder.walk_path(root_table, path, EdgeType::IncludeOnly);
             }
         }
+        // Aggregate-source edge union (#294): an `expr` field's traversal is
+        // self-contained on the wire (hop facts, ADR-0009), so the plan can
+        // render without a matching `joins` entry. The Python builder
+        // registers the path anyway (shared join identity with `where()`/
+        // `order_by()` — same prefix, same alias, deduped by walk_path);
+        // edges only an expression reaches render with traversal semantics:
+        // INNER unless a `joins` entry LEFT-marks them (ADR-0006).
+        if let Materialization::Record { fields } = &self.materialization {
+            for field in fields {
+                if let Some(expr) = &field.expr {
+                    builder.walk_path(root_table, &expr.path, EdgeType::Resolved(&left_edges));
+                }
+            }
+        }
         Ok(builder.finish())
     }
 

--- a/tests/fixtures/ir_vectors/README.md
+++ b/tests/fixtures/ir_vectors/README.md
@@ -28,10 +28,11 @@ Rules:
 
 - `domain` and `ir.ir_kind` must match.
 - `ir.ir_version` must equal `1` for `schema` and `codec` vectors. `query`
-  vectors are on `ir_version: 4` (#285 — unconditional bump; the payload
-  carries a required `materialization` section (ADR-0007), and the
-  `instances` kind carries `paths` of hop facts (ADR-0008)); there is no
-  earlier `query` vector left.
+  vectors are on `ir_version: 5` (#292 — unconditional bump; the payload
+  carries a required `materialization` section (ADR-0007), the `instances`
+  kind carries `paths` of hop facts (ADR-0008), and `record` fields carry
+  exactly one source — `column` + `path`, or an aggregate `expr` with its
+  own hop-fact `path` (ADR-0009)); there is no earlier `query` vector left.
 - `expect_valid` currently supports only `true` fixtures (negative vectors can be added later).
 - Fixture file names use `<domain>_<scenario>_v<version>.json` (matching that
   domain's current `ir_version`).

--- a/tests/fixtures/ir_vectors/query_transaction_aggregate_v5.json
+++ b/tests/fixtures/ir_vectors/query_transaction_aggregate_v5.json
@@ -1,0 +1,82 @@
+{
+  "vector_name": "query_transaction_aggregate_v5",
+  "domain": "query",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "query",
+    "ir_version": 5,
+    "payload": {
+      "model_name": "Transaction",
+      "where": [
+        {
+          "node_kind": "leaf",
+          "column": "amount",
+          "operator": ">=",
+          "value": {
+            "kind": "int",
+            "value": 100
+          },
+          "path": []
+        }
+      ],
+      "order_by": [
+        {
+          "column": "total",
+          "direction": "desc",
+          "path": []
+        }
+      ],
+      "limit": 5,
+      "offset": null,
+      "m2m": null,
+      "joins": [
+        {
+          "join_type": "inner",
+          "path": [
+            {
+              "relation": "account",
+              "from_column": "account_id",
+              "to_table": "account",
+              "to_column": "id"
+            }
+          ]
+        }
+      ],
+      "materialization": {
+        "kind": "record",
+        "fields": [
+          {
+            "name": "account_name",
+            "column": "name",
+            "path": ["account"]
+          },
+          {
+            "name": "total",
+            "path": [],
+            "expr": {
+              "fn": "sum",
+              "column": "amount",
+              "path": []
+            }
+          },
+          {
+            "name": "avg_balance",
+            "path": [],
+            "expr": {
+              "fn": "avg",
+              "column": "balance",
+              "path": [
+                {
+                  "relation": "account",
+                  "from_column": "account_id",
+                  "to_table": "account",
+                  "to_column": "id"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/ir_vectors/query_transaction_global_aggregate_v5.json
+++ b/tests/fixtures/ir_vectors/query_transaction_global_aggregate_v5.json
@@ -1,0 +1,80 @@
+{
+  "vector_name": "query_transaction_global_aggregate_v5",
+  "domain": "query",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "query",
+    "ir_version": 5,
+    "payload": {
+      "model_name": "Transaction",
+      "where": [
+        {
+          "node_kind": "leaf",
+          "column": "amount",
+          "operator": ">=",
+          "value": {
+            "kind": "int",
+            "value": 100
+          },
+          "path": []
+        }
+      ],
+      "order_by": [],
+      "limit": null,
+      "offset": null,
+      "m2m": null,
+      "joins": [
+        {
+          "join_type": "inner",
+          "path": [
+            {
+              "relation": "account",
+              "from_column": "account_id",
+              "to_table": "account",
+              "to_column": "id"
+            }
+          ]
+        }
+      ],
+      "materialization": {
+        "kind": "record",
+        "fields": [
+          {
+            "name": "n",
+            "path": [],
+            "expr": {
+              "fn": "count",
+              "column": "id",
+              "path": []
+            }
+          },
+          {
+            "name": "total",
+            "path": [],
+            "expr": {
+              "fn": "sum",
+              "column": "amount",
+              "path": []
+            }
+          },
+          {
+            "name": "avg_balance",
+            "path": [],
+            "expr": {
+              "fn": "avg",
+              "column": "balance",
+              "path": [
+                {
+                  "relation": "account",
+                  "from_column": "account_id",
+                  "to_table": "account",
+                  "to_column": "id"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/ir_vectors/query_transaction_include_v5.json
+++ b/tests/fixtures/ir_vectors/query_transaction_include_v5.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_transaction_include_v4",
+  "vector_name": "query_transaction_include_v5",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 4,
+    "ir_version": 5,
     "payload": {
       "model_name": "Transaction",
       "where": [

--- a/tests/fixtures/ir_vectors/query_transaction_left_join_v5.json
+++ b/tests/fixtures/ir_vectors/query_transaction_left_join_v5.json
@@ -1,61 +1,34 @@
 {
-  "vector_name": "query_transaction_traversal_v4",
+  "vector_name": "query_transaction_left_join_v5",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 4,
+    "ir_version": 5,
     "payload": {
       "model_name": "Transaction",
       "where": [
         {
-          "node_kind": "compound",
-          "operator": "AND",
-          "left": {
-            "node_kind": "leaf",
-            "column": "email",
-            "operator": "==",
-            "value": {
-              "kind": "string",
-              "value": "owner@ferro.dev"
-            },
-            "path": [
-              "account",
-              "owner"
-            ]
+          "node_kind": "leaf",
+          "column": "email",
+          "operator": "==",
+          "value": {
+            "kind": "string",
+            "value": "owner@ferro.dev"
           },
-          "right": {
-            "node_kind": "leaf",
-            "column": "amount",
-            "operator": ">=",
-            "value": {
-              "kind": "int",
-              "value": 100
-            },
-            "path": []
-          }
-        }
-      ],
-      "order_by": [
-        {
-          "column": "name",
-          "direction": "asc",
           "path": [
-            "account"
+            "account",
+            "owner"
           ]
-        },
-        {
-          "column": "id",
-          "direction": "asc",
-          "path": []
         }
       ],
-      "limit": 50,
-      "offset": 0,
+      "order_by": [],
+      "limit": null,
+      "offset": null,
       "m2m": null,
       "joins": [
         {
-          "join_type": "inner",
+          "join_type": "left",
           "path": [
             {
               "relation": "account",

--- a/tests/fixtures/ir_vectors/query_transaction_record_v5.json
+++ b/tests/fixtures/ir_vectors/query_transaction_record_v5.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_transaction_record_v4",
+  "vector_name": "query_transaction_record_v5",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 4,
+    "ir_version": 5,
     "payload": {
       "model_name": "Transaction",
       "where": [

--- a/tests/fixtures/ir_vectors/query_transaction_traversal_v5.json
+++ b/tests/fixtures/ir_vectors/query_transaction_traversal_v5.json
@@ -1,34 +1,61 @@
 {
-  "vector_name": "query_transaction_left_join_v4",
+  "vector_name": "query_transaction_traversal_v5",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 4,
+    "ir_version": 5,
     "payload": {
       "model_name": "Transaction",
       "where": [
         {
-          "node_kind": "leaf",
-          "column": "email",
-          "operator": "==",
-          "value": {
-            "kind": "string",
-            "value": "owner@ferro.dev"
+          "node_kind": "compound",
+          "operator": "AND",
+          "left": {
+            "node_kind": "leaf",
+            "column": "email",
+            "operator": "==",
+            "value": {
+              "kind": "string",
+              "value": "owner@ferro.dev"
+            },
+            "path": [
+              "account",
+              "owner"
+            ]
           },
-          "path": [
-            "account",
-            "owner"
-          ]
+          "right": {
+            "node_kind": "leaf",
+            "column": "amount",
+            "operator": ">=",
+            "value": {
+              "kind": "int",
+              "value": 100
+            },
+            "path": []
+          }
         }
       ],
-      "order_by": [],
-      "limit": null,
-      "offset": null,
+      "order_by": [
+        {
+          "column": "name",
+          "direction": "asc",
+          "path": [
+            "account"
+          ]
+        },
+        {
+          "column": "id",
+          "direction": "asc",
+          "path": []
+        }
+      ],
+      "limit": 50,
+      "offset": 0,
       "m2m": null,
       "joins": [
         {
-          "join_type": "left",
+          "join_type": "inner",
           "path": [
             {
               "relation": "account",

--- a/tests/fixtures/ir_vectors/query_transaction_traversed_record_v5.json
+++ b/tests/fixtures/ir_vectors/query_transaction_traversed_record_v5.json
@@ -1,0 +1,84 @@
+{
+  "vector_name": "query_transaction_traversed_record_v5",
+  "domain": "query",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "query",
+    "ir_version": 5,
+    "payload": {
+      "model_name": "Transaction",
+      "where": [
+        {
+          "node_kind": "leaf",
+          "column": "amount",
+          "operator": ">=",
+          "value": {
+            "kind": "int",
+            "value": 100
+          },
+          "path": []
+        }
+      ],
+      "order_by": [
+        {
+          "column": "id",
+          "direction": "asc",
+          "path": []
+        }
+      ],
+      "limit": null,
+      "offset": null,
+      "m2m": null,
+      "joins": [
+        {
+          "join_type": "left",
+          "path": [
+            {
+              "relation": "account",
+              "from_column": "account_id",
+              "to_table": "account",
+              "to_column": "id"
+            }
+          ]
+        },
+        {
+          "join_type": "inner",
+          "path": [
+            {
+              "relation": "account",
+              "from_column": "account_id",
+              "to_table": "account",
+              "to_column": "id"
+            },
+            {
+              "relation": "owner",
+              "from_column": "owner_id",
+              "to_table": "owner",
+              "to_column": "id"
+            }
+          ]
+        }
+      ],
+      "materialization": {
+        "kind": "record",
+        "fields": [
+          {
+            "name": "txn_id",
+            "column": "id",
+            "path": []
+          },
+          {
+            "name": "account_name",
+            "column": "name",
+            "path": ["account"]
+          },
+          {
+            "name": "owner_email",
+            "column": "email",
+            "path": ["account", "owner"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/ir_vectors/query_user_compound_v5.json
+++ b/tests/fixtures/ir_vectors/query_user_compound_v5.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_user_compound_v4",
+  "vector_name": "query_user_compound_v5",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 4,
+    "ir_version": 5,
     "payload": {
       "model_name": "User",
       "where": [

--- a/tests/static_fixtures/bad_projections.py
+++ b/tests/static_fixtures/bad_projections.py
@@ -43,3 +43,13 @@ async def _update_on_a_projection() -> None:
 
 async def _delete_on_a_projection() -> None:
     await BadPTxn.select(lambda t: (t.id,)).delete()
+
+
+# NOT statically checkable today (#293): selector-shape misuse — a dict
+# nested in a tuple, a tuple in a dict, a non-string dict key. ty does not
+# check a lambda argument's inferred return type against the expected
+# callable's return type (the same checker limitation bad_predicates.py
+# documents for RHS typing), so RowSelector's shape union cannot bite at
+# the call site yet. These rejections are pinned at runtime instead
+# (tests/test_traversed_projection.py::TestBuildTimeErrors); when ty grows
+# lambda-return checking, promote them to this file.

--- a/tests/static_fixtures/good_projections.py
+++ b/tests/static_fixtures/good_projections.py
@@ -70,6 +70,28 @@ async def _projection_composes_with_left_join() -> None:
     del rows
 
 
+async def _grouped_top_n_chain() -> None:
+    # The grouped query (#295): keys + aggregates, output-name ordering,
+    # group limit — still Rows[Row].
+    rows: Rows[Row] = await (
+        GoodPTxn.select(lambda t: {"acct": t.account_id, "total": t.amount.sum()})
+        .order_by("total", "desc")
+        .limit(5)
+        .all()
+    )
+    del rows
+
+
+async def _order_by_aggregate_lambda() -> None:
+    # Rule 2 (#295): the lambda form spells the aggregate source expression.
+    rows: Rows[Row] = await (
+        GoodPTxn.select(lambda t: {"acct": t.account_id, "total": t.amount.sum()})
+        .order_by(lambda t: t.amount.sum(), "desc")
+        .all()
+    )
+    del rows
+
+
 async def _aggregate_dict_selector() -> None:
     # Aggregate expressions (#294) are dict-selector values; they type
     # opaquely (AggregateExpr) and the result stays Rows[Row] / Row | None —

--- a/tests/static_fixtures/good_projections.py
+++ b/tests/static_fixtures/good_projections.py
@@ -1,0 +1,70 @@
+"""Type-checked (never executed): projected-query chains must PASS `ty check`.
+
+test_static_contracts.py asserts this file produces no diagnostics — the
+positive half of the projection gate (#279/#293): every selector form (tuple,
+single-field, dict-aliased, traversed at depth) yields a ``ProjectedQuery``
+whose ``all()`` is ``Rows[Row]`` and ``first()`` is ``Row | None``.
+"""
+
+from typing import Annotated
+
+from ferro import FerroField, ForeignKey, Model
+from ferro.query import Row, Rows
+
+
+class GoodPOwner(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    email: str = ""
+
+
+class GoodPAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str = ""
+    owner: Annotated[GoodPOwner | None, ForeignKey(related_name="accounts")] = None
+
+
+class GoodPTxn(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    amount: int = 0
+    account: Annotated[GoodPAccount | None, ForeignKey(related_name="txns")] = None
+
+
+async def _tuple_selector() -> None:
+    rows: Rows[Row] = await GoodPTxn.select(lambda t: (t.id, t.amount)).all()
+    del rows
+
+
+async def _single_field_selector() -> None:
+    one: Row | None = await GoodPTxn.select(lambda t: t.amount).first()
+    del one
+
+
+async def _traversed_tuple_selector() -> None:
+    # Traversal at depth 2 (#293): each hop types as FieldProxy[Any], the
+    # chain stays selector-shaped, and the result is still Rows[Row].
+    rows: Rows[Row] = await GoodPTxn.select(
+        lambda t: (t.amount, t.account.name, t.account.owner.email)
+    ).all()
+    del rows
+
+
+async def _dict_selector_with_aliases() -> None:
+    # The dict-returning selector (#293): string keys name output fields.
+    rows: Rows[Row] = await GoodPTxn.select(
+        lambda t: {
+            "txn_id": t.id,
+            "account_name": t.account.name,
+            "owner_email": t.account.owner.email,
+        }
+    ).all()
+    del rows
+
+
+async def _projection_composes_with_left_join() -> None:
+    rows: Rows[Row] = await (
+        GoodPTxn.select(lambda t: {"account_name": t.account.name})
+        .left_join(lambda t: t.account)
+        .order_by("id")
+        .all()
+    )
+    del rows

--- a/tests/static_fixtures/good_projections.py
+++ b/tests/static_fixtures/good_projections.py
@@ -68,3 +68,20 @@ async def _projection_composes_with_left_join() -> None:
         .all()
     )
     del rows
+
+
+async def _aggregate_dict_selector() -> None:
+    # Aggregate expressions (#294) are dict-selector values; they type
+    # opaquely (AggregateExpr) and the result stays Rows[Row] / Row | None —
+    # shape-not-names typing holds (record-field inference is #290's lane).
+    one: Row | None = await GoodPTxn.select(
+        lambda t: {
+            "n": t.id.count(),
+            "total": t.amount.sum(),
+            "mean": t.amount.avg(),
+            "lo": t.amount.min(),
+            "hi": t.amount.max(),
+            "avg_traversed": t.account.owner.id.avg(),
+        }
+    ).first()
+    del one

--- a/tests/test_global_aggregates.py
+++ b/tests/test_global_aggregates.py
@@ -1,0 +1,380 @@
+"""Backend-matrix integration tests for global aggregates (#294, ADR-0009).
+
+The five aggregate methods on scalar field proxies — ``t.amount.sum()``,
+traversal included (``t.account.balance.avg()``) — landing in projected
+records via the v5 ``expr`` plan, without grouping: an aggregate-only
+projection collapses to exactly one record, read idiomatically with
+``first()``. Pins the cross-backend decode-type contract per source family
+(``count → int``; ``min``/``max`` → source type; ``sum`` → source numeric
+type; ``avg`` → float for int/float, Decimal for Decimal), SQL's empty-input
+semantics passing through verbatim (``None``/``count=0``, no hidden
+COALESCE), and the build-time rejection catalog: disallowed source families,
+aggregates inside ``where()`` (→ having(), #291), iterating a field proxy
+(the builtin-``sum`` trap), unaliased aggregates, and mixed
+aggregate/plain projections (→ #295).
+"""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import StrEnum
+from typing import Annotated
+from uuid import UUID
+
+import pytest
+
+import ferro
+from ferro import BackRef, FerroField, ForeignKey, Model, Relation
+from ferro.query import Row
+
+pytestmark = pytest.mark.backend_matrix
+
+
+# ---------------------------------------------------------------------------
+# Schema: typed columns for the decode contract, a relation for traversal.
+# ---------------------------------------------------------------------------
+
+
+class GATier(StrEnum):
+    FREE = "free"
+    PRO = "pro"
+
+
+class GAAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str = ""
+    balance: Decimal | None = None
+    transactions: Relation[list["GATransaction"]] = BackRef()
+
+
+class GATransaction(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    amount: int = 0
+    rate: float = 0.0
+    price: Decimal | None = None
+    note: str | None = None
+    happened_at: datetime | None = None
+    tier: GATier = GATier.FREE
+    flagged: bool = False
+    external_id: UUID | None = None
+    payload: dict | None = None
+    account: Annotated[
+        GAAccount | None, ForeignKey(related_name="transactions")
+    ] = None
+
+
+_T1 = datetime(2026, 1, 1, 8, 0, 0, tzinfo=timezone.utc)
+_T2 = datetime(2026, 6, 15, 20, 30, 0, tzinfo=timezone.utc)
+
+
+async def _seed():
+    """Two accounts (balances 100.50 / 200.00); three transactions on a1 and
+    one account-less transaction; typed columns populated for the contract."""
+    a1 = GAAccount(id=1, name="a1", balance=Decimal("100.50"))
+    a2 = GAAccount(id=2, name="a2", balance=Decimal("200.00"))
+    await a1.save()
+    await a2.save()
+    await GATransaction(
+        id=1, amount=10, rate=0.5, price=Decimal("1.25"), note="x",
+        happened_at=_T1, account=a1,
+    ).save()
+    await GATransaction(
+        id=2, amount=20, rate=1.5, price=Decimal("2.75"), note=None,
+        happened_at=_T2, account=a1,
+    ).save()
+    await GATransaction(
+        id=3, amount=30, rate=2.0, price=Decimal("6.00"), note="z",
+        account=a1,
+    ).save()
+    await GATransaction(id=4, amount=40, rate=4.0, account=a2).save()
+
+
+# ---------------------------------------------------------------------------
+# The five aggregates + the pinned decode-type contract.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_int_source_contract(db_url):
+    """sum(int) → int, avg(int) → float, min/max(int) → int, count → int."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        row = await GATransaction.select(
+            lambda t: {
+                "n": t.id.count(),
+                "total": t.amount.sum(),
+                "mean": t.amount.avg(),
+                "lo": t.amount.min(),
+                "hi": t.amount.max(),
+            }
+        ).first()
+
+        assert row is not None
+        assert row.n == 4 and type(row.n) is int
+        assert row.total == 100 and type(row.total) is int
+        assert row.mean == 25.0 and type(row.mean) is float
+        assert row.lo == 10 and type(row.lo) is int
+        assert row.hi == 40 and type(row.hi) is int
+
+
+@pytest.mark.asyncio
+async def test_float_source_contract(db_url):
+    """sum(float) → float, avg(float) → float, min/max(float) → float."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        row = await GATransaction.select(
+            lambda t: {
+                "total": t.rate.sum(),
+                "mean": t.rate.avg(),
+                "lo": t.rate.min(),
+                "hi": t.rate.max(),
+            }
+        ).first()
+
+        assert row is not None
+        assert row.total == 8.0 and type(row.total) is float
+        assert row.mean == 2.0 and type(row.mean) is float
+        assert row.lo == 0.5 and type(row.lo) is float
+        assert row.hi == 4.0 and type(row.hi) is float
+
+
+@pytest.mark.asyncio
+async def test_decimal_source_contract(db_url):
+    """sum/avg/min/max over Decimal → Decimal — avg deliberately included
+    (float would silently lose the source's exactness)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        row = await (
+            GATransaction.select(
+                lambda t: {
+                    "total": t.price.sum(),
+                    "mean": t.price.avg(),
+                    "lo": t.price.min(),
+                    "hi": t.price.max(),
+                }
+            )
+            .where(lambda t: t.price != None)  # noqa: E711
+            .first()
+        )
+
+        assert row is not None
+        assert type(row.total) is Decimal and row.total == Decimal("10.00")
+        assert type(row.mean) is Decimal
+        assert row.mean == Decimal("10.00") / 3 or abs(
+            row.mean - Decimal("3.3333333333333333")
+        ) < Decimal("0.000001")
+        assert type(row.lo) is Decimal and row.lo == Decimal("1.25")
+        assert type(row.hi) is Decimal and row.hi == Decimal("6.00")
+
+
+@pytest.mark.asyncio
+async def test_min_max_over_text_and_datetime(db_url):
+    """min/max are ordered, not numeric: text and datetime sources decode to
+    the source type via the source codec."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        row = await GATransaction.select(
+            lambda t: {
+                "first_note": t.note.min(),
+                "last_note": t.note.max(),
+                "earliest": t.happened_at.min(),
+                "latest": t.happened_at.max(),
+            }
+        ).first()
+
+        assert row is not None
+        assert row.first_note == "x" and row.last_note == "z"
+        assert isinstance(row.earliest, datetime) and row.earliest == _T1
+        assert isinstance(row.latest, datetime) and row.latest == _T2
+
+
+@pytest.mark.asyncio
+async def test_count_skips_nulls_sql_semantics_pass_through(db_url):
+    """COUNT(column) counts non-NULL values — SQL semantics verbatim."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        row = await GATransaction.select(
+            lambda t: {"rows": t.id.count(), "notes": t.note.count()}
+        ).first()
+
+        assert row is not None
+        assert row.rows == 4
+        assert row.notes == 2  # two of four notes are NULL/absent
+
+
+# ---------------------------------------------------------------------------
+# The global-aggregate shape: one record, first() idiom, empty input.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aggregate_only_projection_collapses_to_one_record(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await GATransaction.select(lambda t: {"total": t.amount.sum()}).all()
+
+        assert len(rows) == 1
+        assert isinstance(rows[0], Row)
+        assert rows[0].total == 100
+
+
+@pytest.mark.asyncio
+async def test_empty_input_none_and_count_zero(db_url):
+    """Over zero matching rows the aggregates answer with SQL's own empty
+    semantics: one record, sum/avg/min/max None, count 0 — no COALESCE."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        row = await (
+            GATransaction.select(
+                lambda t: {
+                    "n": t.id.count(),
+                    "total": t.amount.sum(),
+                    "mean": t.amount.avg(),
+                    "lo": t.amount.min(),
+                    "hi": t.amount.max(),
+                }
+            )
+            .where(lambda t: t.amount > 10_000)
+            .first()
+        )
+
+        assert row is not None, "a global aggregate always yields one record"
+        assert row.n == 0 and type(row.n) is int
+        assert row.total is None
+        assert row.mean is None
+        assert row.lo is None and row.hi is None
+
+
+@pytest.mark.asyncio
+async def test_aggregates_compose_with_where_traversal(db_url):
+    """where() traversal narrows the aggregated rows (shared join identity)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        row = await (
+            GATransaction.select(lambda t: {"total": t.amount.sum()})
+            .where(lambda t: t.account.name == "a1")
+            .first()
+        )
+
+        assert row is not None and row.total == 60
+
+
+@pytest.mark.asyncio
+async def test_traversed_aggregate_source(db_url):
+    """t.account.balance.avg(): the source traverses; INNER narrowing drops
+    the account-less row from the aggregation; Decimal contract holds."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+        await GATransaction(id=9, amount=99).save()  # NULL FK — excluded
+
+        row = await GATransaction.select(
+            lambda t: {"n": t.id.count(), "avg_balance": t.account.balance.avg()}
+        ).first()
+
+        assert row is not None
+        assert row.n == 4, "INNER traversal narrows to rows with an account"
+        # a1 counted three times (100.50), a2 once (200.00): 501.50 / 4.
+        assert type(row.avg_balance) is Decimal
+        assert row.avg_balance == Decimal("125.375")
+
+
+# ---------------------------------------------------------------------------
+# Build-time rejections: source families with no portable meaning.
+# ---------------------------------------------------------------------------
+
+
+class TestSourceFamilyValidation:
+    def test_sum_over_text_raises(self):
+        with pytest.raises(TypeError, match=r"t\.note\.sum\(\).*string-typed.*numeric"):
+            GATransaction.select(lambda t: {"x": t.note.sum()})
+
+    def test_avg_over_datetime_raises(self):
+        with pytest.raises(TypeError, match=r"datetime-typed.*numeric"):
+            GATransaction.select(lambda t: {"x": t.happened_at.avg()})
+
+    def test_sum_over_bool_raises(self):
+        with pytest.raises(TypeError, match="boolean-typed"):
+            GATransaction.select(lambda t: {"x": t.flagged.sum()})
+
+    def test_min_over_uuid_raises(self):
+        with pytest.raises(TypeError, match="uuid-typed.*orderable"):
+            GATransaction.select(lambda t: {"x": t.external_id.min()})
+
+    def test_max_over_enum_raises(self):
+        with pytest.raises(TypeError, match="enum-typed"):
+            GATransaction.select(lambda t: {"x": t.tier.max()})
+
+    def test_min_over_json_raises(self):
+        with pytest.raises(TypeError, match="json-typed"):
+            GATransaction.select(lambda t: {"x": t.payload.min()})
+
+    def test_count_takes_any_column(self):
+        # count() is the one aggregate every family supports.
+        for selector in (
+            lambda t: {"x": t.tier.count()},
+            lambda t: {"x": t.external_id.count()},
+            lambda t: {"x": t.payload.count()},
+            lambda t: {"x": t.flagged.count()},
+        ):
+            assert GATransaction.select(selector) is not None
+
+    def test_traversed_family_validation_names_the_hop_model(self):
+        with pytest.raises(TypeError, match=r"GAAccount\.name is string-typed"):
+            GATransaction.select(lambda t: {"x": t.account.name.sum()})
+
+
+# ---------------------------------------------------------------------------
+# Build-time rejections: aggregate misuse.
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateMisuse:
+    def test_aggregate_comparison_in_where_points_at_having(self):
+        with pytest.raises(TypeError, match=r"having\(\) \(#291\)"):
+            GATransaction.where(lambda t: t.amount.sum() > 100)
+
+    def test_bare_aggregate_in_where_points_at_having(self):
+        with pytest.raises(TypeError, match=r"having\(\) \(#291\)"):
+            GATransaction.where(lambda t: t.amount.sum())
+
+    def test_iterating_a_field_proxy_names_the_sum_method(self):
+        with pytest.raises(
+            TypeError, match=r"did you mean t\.amount\.sum\(\)\?"
+        ):
+            GATransaction.select(lambda t: {"x": sum(t.amount)})  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def test_unaliased_aggregate_in_tuple_names_the_dict_form(self):
+        with pytest.raises(TypeError, match=r"user-named.*dict"):
+            GATransaction.select(lambda t: (t.amount.sum(),))  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def test_unaliased_single_aggregate_names_the_dict_form(self):
+        with pytest.raises(TypeError, match=r"user-named.*dict"):
+            GATransaction.select(lambda t: t.amount.sum())  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def test_mixed_aggregate_and_plain_points_at_grouped_aggregates(self):
+        with pytest.raises(NotImplementedError, match=r"grouped query.*#295"):
+            GATransaction.select(
+                lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+            )
+
+    def test_aggregate_has_no_truth_value(self):
+        with pytest.raises(TypeError, match="no truth value"):
+            GATransaction.select(
+                lambda t: {"x": t.amount.sum() and t.amount.avg()}  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+            )

--- a/tests/test_global_aggregates.py
+++ b/tests/test_global_aggregates.py
@@ -10,8 +10,8 @@ type; ``avg`` → float for int/float, Decimal for Decimal), SQL's empty-input
 semantics passing through verbatim (``None``/``count=0``, no hidden
 COALESCE), and the build-time rejection catalog: disallowed source families,
 aggregates inside ``where()`` (→ having(), #291), iterating a field proxy
-(the builtin-``sum`` trap), unaliased aggregates, and mixed
-aggregate/plain projections (→ #295).
+(the builtin-``sum`` trap), and unaliased aggregates. Mixed aggregate/plain
+projections are GROUPED queries — tests/test_grouped_aggregates.py (#295).
 """
 
 from datetime import datetime, timezone
@@ -366,12 +366,6 @@ class TestAggregateMisuse:
     def test_unaliased_single_aggregate_names_the_dict_form(self):
         with pytest.raises(TypeError, match=r"user-named.*dict"):
             GATransaction.select(lambda t: t.amount.sum())  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-
-    def test_mixed_aggregate_and_plain_points_at_grouped_aggregates(self):
-        with pytest.raises(NotImplementedError, match=r"grouped query.*#295"):
-            GATransaction.select(
-                lambda t: {"acct": t.account_id, "total": t.amount.sum()}
-            )
 
     def test_aggregate_has_no_truth_value(self):
         with pytest.raises(TypeError, match="no truth value"):

--- a/tests/test_grouped_aggregates.py
+++ b/tests/test_grouped_aggregates.py
@@ -1,0 +1,406 @@
+"""Backend-matrix integration tests for grouped aggregates (#295, ADR-0009).
+
+Mixed projections are GROUPED queries: every non-aggregate field is a group
+key, and GROUP BY is derived from the projection — never declared, never on
+the wire (the rendered-SQL pins live in the Rust walker unit tests). Covers
+derived grouping with ``where()`` composition (traversal included),
+traversed and ``None``-keyed group keys, the top-N idiom, the three
+``order_by`` rules (output names first; lambda spells source expressions
+including aggregates; on an aggregate projection every sort key is a group
+key or an aggregate), ``count()``/``exists()`` guidance errors,
+``limit()``/``offset()`` group semantics, and zero-rows → zero records.
+"""
+
+from decimal import Decimal
+from typing import Annotated
+
+import pytest
+
+import ferro
+from ferro import BackRef, FerroField, ForeignKey, Model, Relation
+
+pytestmark = pytest.mark.backend_matrix
+
+
+# ---------------------------------------------------------------------------
+# Schema: Transaction -> Account -> Owner (depth 2), for traversed keys.
+# ---------------------------------------------------------------------------
+
+
+class GRPOwner(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    email: str = ""
+    accounts: Relation[list["GRPAccount"]] = BackRef()
+
+
+class GRPAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str = ""
+    owner: Annotated[GRPOwner | None, ForeignKey(related_name="accounts")] = None
+    transactions: Relation[list["GRPTransaction"]] = BackRef()
+
+
+class GRPTransaction(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    amount: int = 0
+    price: Decimal | None = None
+    note: str = ""
+    account: Annotated[
+        GRPAccount | None, ForeignKey(related_name="transactions")
+    ] = None
+
+
+async def _seed():
+    """Owner alice <- a1 (txns 10, 20), owner bob <- a2 (txn 40), plus an
+    account-less transaction (30) for the None-bucket tests."""
+    alice = GRPOwner(id=1, email="alice@x.io")
+    bob = GRPOwner(id=2, email="bob@x.io")
+    await alice.save()
+    await bob.save()
+    a1 = GRPAccount(id=1, name="a1", owner=alice)
+    a2 = GRPAccount(id=2, name="a2", owner=bob)
+    await a1.save()
+    await a2.save()
+    await GRPTransaction(
+        id=1, amount=10, price=Decimal("1.00"), note="x", account=a1
+    ).save()
+    await GRPTransaction(
+        id=2, amount=20, price=Decimal("3.00"), note="y", account=a1
+    ).save()
+    await GRPTransaction(id=3, amount=30, note="orphan").save()
+    await GRPTransaction(
+        id=4, amount=40, price=Decimal("8.00"), note="z", account=a2
+    ).save()
+
+
+# ---------------------------------------------------------------------------
+# Derived grouping: bare fields are the keys.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mixed_projection_groups_by_the_plain_fields(db_url):
+    """The canonical grouped query (ADR-0009): one dict lambda, GROUP BY
+    derived from the non-aggregate field."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            GRPTransaction.select(
+                lambda t: {
+                    "acct": t.account_id,
+                    "total": t.amount.sum(),
+                    "n": t.id.count(),
+                }
+            )
+            .where(lambda t: t.account_id != None)  # noqa: E711
+            .order_by("acct")
+            .all()
+        )
+
+        assert rows.model_dump() == [
+            {"acct": 1, "total": 30, "n": 2},
+            {"acct": 2, "total": 40, "n": 1},
+        ]
+
+
+@pytest.mark.asyncio
+async def test_grouped_query_composes_with_where_traversal(db_url):
+    """where() traversal narrows the grouped rows through the shared join."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            GRPTransaction.select(
+                lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+            )
+            .where(lambda t: t.account.owner.email == "alice@x.io")
+            .all()
+        )
+
+        assert rows.model_dump() == [{"acct": 1, "total": 30}]
+
+
+@pytest.mark.asyncio
+async def test_traversed_group_key(db_url):
+    """Group keys may traverse (t.account.name), sharing join identity with
+    the aggregate's rows."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            GRPTransaction.select(
+                lambda t: {"account_name": t.account.name, "total": t.amount.sum()}
+            )
+            .order_by("account_name")
+            .all()
+        )
+
+        # INNER traversal narrows: the account-less txn (30) is dropped.
+        assert rows.model_dump() == [
+            {"account_name": "a1", "total": 30},
+            {"account_name": "a2", "total": 40},
+        ]
+
+
+@pytest.mark.asyncio
+async def test_left_joined_traversed_key_yields_a_none_keyed_group(db_url):
+    """'Has no relation' is a visible bucket, not a dropped row: the
+    left-joined traversed key groups the orphan under None."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            GRPTransaction.select(
+                lambda t: {"account_name": t.account.name, "total": t.amount.sum()}
+            )
+            .left_join(lambda t: t.account)
+            .all()
+        )
+
+        by_key = {row.account_name: row.total for row in rows}
+        assert by_key == {"a1": 30, "a2": 40, None: 30}
+
+
+@pytest.mark.asyncio
+async def test_multiple_group_keys(db_url):
+    """Every plain field is a key: two keys group by the pair."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            GRPTransaction.select(
+                lambda t: {
+                    "acct": t.account_id,
+                    "note": t.note,
+                    "n": t.id.count(),
+                }
+            )
+            .where(lambda t: t.account_id == 1)
+            .order_by("note")
+            .all()
+        )
+
+        assert rows.model_dump() == [
+            {"acct": 1, "note": "x", "n": 1},
+            {"acct": 1, "note": "y", "n": 1},
+        ]
+
+
+@pytest.mark.asyncio
+async def test_grouped_query_over_zero_rows_returns_zero_records(db_url):
+    """Unlike a global aggregate (one record), a grouped query over no rows
+    yields no groups at all."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            GRPTransaction.select(
+                lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+            )
+            .where(lambda t: t.amount > 10_000)
+            .all()
+        )
+
+        assert len(rows) == 0
+
+
+# ---------------------------------------------------------------------------
+# The top-N idiom.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_top_n_idiom_end_to_end(db_url):
+    """Keys + aggregates, order_by("total", "desc"), limit — the query the
+    epic exists for."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            GRPTransaction.select(
+                lambda t: {"account_name": t.account.name, "total": t.amount.sum()}
+            )
+            .order_by("total", "desc")
+            .limit(1)
+            .all()
+        )
+
+        assert rows.model_dump() == [{"account_name": "a2", "total": 40}]
+
+
+@pytest.mark.asyncio
+async def test_limit_and_offset_apply_to_groups(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        base = GRPTransaction.select(
+            lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+        ).where(lambda t: t.account_id != None)  # noqa: E711
+
+        first_group = await base.order_by("acct").limit(1).all()
+        second_group = await base.order_by("acct").limit(1).offset(1).all()
+
+        assert first_group.model_dump() == [{"acct": 1, "total": 30}]
+        assert second_group.model_dump() == [{"acct": 2, "total": 40}]
+
+
+# ---------------------------------------------------------------------------
+# The three order_by rules.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_order_by_string_resolves_output_names_before_root_columns(db_url):
+    """Rule 1, pinned where the pools differ: the output field 'note' aliases
+    the ACCOUNT NAME, while the root column 'note' holds other values —
+    order_by("note") must sort by the output field."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            GRPTransaction.select(
+                lambda t: {"note": t.account.name, "total": t.amount.sum()}
+            )
+            .order_by("note", "desc")
+            .all()
+        )
+
+        assert [row.note for row in rows] == ["a2", "a1"]
+
+
+@pytest.mark.asyncio
+async def test_order_by_lambda_spells_the_aggregate_source(db_url):
+    """Rule 2: order_by(lambda t: t.amount.sum(), "desc") resolves to the
+    projected aggregate and sorts by it."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            GRPTransaction.select(
+                lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+            )
+            .where(lambda t: t.account_id != None)  # noqa: E711
+            .order_by(lambda t: t.amount.sum(), "desc")
+            .all()
+        )
+
+        assert [row.acct for row in rows] == [2, 1]
+
+
+@pytest.mark.asyncio
+async def test_order_by_lambda_group_key_source(db_url):
+    """Rule 2, plain side: a lambda spelling a group key's source column
+    (traversal included) sorts the groups."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            GRPTransaction.select(
+                lambda t: {"account_name": t.account.name, "total": t.amount.sum()}
+            )
+            .order_by(lambda t: t.account.name, "desc")
+            .all()
+        )
+
+        assert [row.account_name for row in rows] == ["a2", "a1"]
+
+
+class TestOrderByGuardrails:
+    """Rule 3 and friends: build-time, before any SQL."""
+
+    def _grouped(self):
+        return GRPTransaction.select(
+            lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+        )
+
+    def test_ungrouped_bare_string_key_raises(self):
+        with pytest.raises(ValueError, match=r"group key or an aggregate"):
+            self._grouped().order_by("note")
+
+    def test_ungrouped_bare_lambda_key_raises(self):
+        with pytest.raises(ValueError, match=r"t\.note.*group key or an aggregate"):
+            self._grouped().order_by(lambda t: t.note)
+
+    def test_unprojected_aggregate_sort_key_raises(self):
+        with pytest.raises(ValueError, match=r"matches no.*projected"):
+            self._grouped().order_by(lambda t: t.price.avg())
+
+    def test_aggregate_sort_key_on_plain_projection_raises(self):
+        plain = GRPTransaction.select(lambda t: (t.id, t.amount))
+        with pytest.raises(ValueError, match=r"matches no.*projected"):
+            plain.order_by(lambda t: t.amount.sum())
+
+    def test_misspelled_string_names_output_fields_too(self):
+        with pytest.raises(AttributeError, match=r"output field names.*acct, total"):
+            self._grouped().order_by("tolat")
+
+    def test_ungrouped_sort_key_added_before_select_raises_too(self):
+        # Rule 3 reaches sort keys chained AHEAD of the projection: the
+        # select() call is where the query becomes grouped, so it validates
+        # what was already ordered.
+        with pytest.raises(ValueError, match=r"t\.note.*before this select"):
+            GRPTransaction.select().order_by("note").select(
+                lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+            )
+
+    def test_group_key_sort_added_before_select_is_allowed(self):
+        q = GRPTransaction.select().order_by("account_id").select(
+            lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+        )
+        assert q is not None
+
+    def test_group_key_source_string_is_allowed(self):
+        # 'account_id' is the source column of the 'acct' group key — a valid
+        # sort key even though the output name differs.
+        assert self._grouped().order_by("account_id") is not None
+
+    def test_plain_projection_keeps_unselected_column_sorting(self):
+        # Rule 3 is aggregate-only: a plain projection still sorts by
+        # unselected root columns (#279 behavior, unchanged).
+        plain = GRPTransaction.select(lambda t: (t.id,))
+        assert plain.order_by("amount") is not None
+
+
+# ---------------------------------------------------------------------------
+# count()/exists() guidance on aggregate projections.
+# ---------------------------------------------------------------------------
+
+
+class TestVerbGuardrails:
+    """Synchronous raises at the call — no coroutine, no round trip."""
+
+    def _grouped(self):
+        return GRPTransaction.select(
+            lambda t: {"acct": t.account_id, "total": t.amount.sum()}
+        )
+
+    def test_count_raises_with_both_spellings(self):
+        with pytest.raises(
+            ValueError, match=r"unprojected query.*len\(await q\.all\(\)\)"
+        ):
+            self._grouped().count()
+
+    def test_exists_raises_with_guidance(self):
+        with pytest.raises(ValueError, match=r"exactly one record"):
+            self._grouped().exists()
+
+    @pytest.mark.asyncio
+    async def test_count_and_exists_still_work_on_plain_projections(self, db_url):
+        await ferro.connect(db_url, auto_migrate=True)
+        async with ferro.engines.session():
+            await _seed()
+            plain = GRPTransaction.select(lambda t: (t.id,))
+            assert await plain.count() == 4
+            assert await plain.exists() is True

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -799,11 +799,19 @@ async def test_m2m_include_selector_names_the_future_mechanism(db_url):
 
 
 def test_include_and_projection_raise_in_both_chain_orders():
-    with pytest.raises(ValueError, match=r"exactly one materialization plan.*#282"):
+    # Flattened-as-final (#293, ADR-0009): the error points at traversed
+    # projection as the record-shaped way across a relation, permanently.
+    with pytest.raises(
+        ValueError,
+        match=r"exactly one materialization plan.*traversed projection",
+    ):
         INTransaction.select().include(lambda t: t.account).select(
             lambda t: (t.id, t.amount)
         )
-    with pytest.raises(ValueError, match=r"exactly one materialization plan.*#282"):
+    with pytest.raises(
+        ValueError,
+        match=r"exactly one materialization plan.*traversed projection",
+    ):
         INTransaction.select(lambda t: (t.id, t.amount)).include(  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
             lambda t: t.account
         )

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -11,12 +11,14 @@ from ferro import BackRef, Field, ManyToMany, Model, Relation, clear_registry
 
 VECTORS_DIR = Path(__file__).parent / "fixtures" / "ir_vectors"
 SUPPORTED_DOMAINS = {"schema", "query", "codec"}
-# `query` is on ir_version 4 (#285 — unconditional bump; the `instances`
-# materialization kind carries `paths` of hop facts, ADR-0008 on the
-# ADR-0007 plan substrate); `schema`/`codec` remain v1.
-SUPPORTED_IR_VERSIONS = {"schema": 1, "query": 4, "codec": 1}
+# `query` is on ir_version 5 (#292 — unconditional bump; `record` fields
+# carry exactly one source — `column` + `path`, or an aggregate `expr` with
+# hop-fact `path`, ADR-0009 on the ADR-0007 plan substrate); `schema`/`codec`
+# remain v1.
+SUPPORTED_IR_VERSIONS = {"schema": 1, "query": 5, "codec": 1}
 QUERY_OPERATORS = {"==", "!=", "<", "<=", ">", ">=", "IN", "LIKE", "AND", "OR"}
 MATERIALIZATION_KINDS = {"root_instances", "record", "instances"}
+AGGREGATE_FNS = {"count", "sum", "avg", "min", "max"}
 
 
 class _DocFormat(StrEnum):
@@ -128,12 +130,42 @@ def _validate_materialization(plan: dict[str, Any], label: str) -> None:
     for i, field in enumerate(fields):
         field_label = f"{label}.fields[{i}]"
         assert isinstance(field, dict), f"{field_label} must be object"
-        _require_keys(field, {"name", "column", "path"}, field_label)
-        for key in ("name", "column"):
-            assert isinstance(field[key], str) and field[key], (
-                f"{field_label}.{key} must be non-empty string"
-            )
+        _require_keys(field, {"name", "path"}, field_label)
+        assert isinstance(field["name"], str) and field["name"], (
+            f"{field_label}.name must be non-empty string"
+        )
         assert isinstance(field["path"], list), f"{field_label}.path must be a list"
+        # v5 (#292): a field reads from exactly one source — a `column` (+
+        # relation-name `path`) or an aggregate `expr` (ADR-0009).
+        has_column = "column" in field
+        has_expr = "expr" in field
+        assert has_column != has_expr, (
+            f"{field_label} must carry exactly one of column/expr"
+        )
+        if has_column:
+            assert isinstance(field["column"], str) and field["column"], (
+                f"{field_label}.column must be non-empty string"
+            )
+            continue
+        expr = field["expr"]
+        assert isinstance(expr, dict), f"{field_label}.expr must be object"
+        _require_keys(expr, {"fn", "column", "path"}, f"{field_label}.expr")
+        assert expr["fn"] in AGGREGATE_FNS, (
+            f"{field_label}.expr.fn invalid: {expr['fn']!r}"
+        )
+        assert isinstance(expr["column"], str) and expr["column"], (
+            f"{field_label}.expr.column must be non-empty string"
+        )
+        assert isinstance(expr["path"], list), (
+            f"{field_label}.expr.path must be a list"
+        )
+        for h, hop in enumerate(expr["path"]):
+            _validate_hop(hop, f"{field_label}.expr.path[{h}]")
+        # An expression field's traversal travels on expr.path (hop facts);
+        # its field-level path is always empty.
+        assert field["path"] == [], (
+            f"{field_label}.path must be empty on an expr field"
+        )
 
 
 def _validate_query_payload(payload: dict[str, Any], label: str) -> None:

--- a/tests/test_partial_selects.py
+++ b/tests/test_partial_selects.py
@@ -203,10 +203,6 @@ class TestSelectorValidation:
         with pytest.raises(AttributeError, match="Did you mean 'amount'"):
             PSTransaction.select(lambda t: (t.id, t.amonut))
 
-    def test_traversed_column_raises_pointed_not_yet_error(self):
-        with pytest.raises(NotImplementedError, match="account.label.*#282"):
-            PSTransaction.select(lambda t: t.account.label)
-
     def test_bare_relation_raises(self):
         with pytest.raises(TypeError, match="bare relation 'account'"):
             PSTransaction.select(lambda t: t.account)
@@ -215,8 +211,10 @@ class TestSelectorValidation:
         with pytest.raises(TypeError, match="comparison, not a column"):
             PSTransaction.select(lambda t: t.id == 1)
 
-    def test_duplicate_column_raises(self):
-        with pytest.raises(ValueError, match="'id' more than once"):
+    def test_duplicate_column_raises_naming_the_dict_form(self):
+        # The output-name collision error (#293): a plain duplicate is the
+        # root-level case of the same rule, resolved with the dict form.
+        with pytest.raises(ValueError, match=r"two fields named 'id'.*dict"):
             PSTransaction.select(lambda t: (t.id, t.id))
 
     def test_empty_selection_raises(self):

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -74,7 +74,7 @@ def test_query_ir_payload_to_json_serializes_m2m_context_without_mutating_query_
     assert query._m2m_context["source_id"] == source_id
     assert isinstance(query._m2m_context["source_id"], uuid.UUID)
     assert payload["ir_kind"] == "query"
-    assert payload["ir_version"] == 4
+    assert payload["ir_version"] == 5
     assert payload["payload"]["m2m"]["source_id"] == str(source_id)
 
 

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -174,6 +174,16 @@ def test_include_chains_pass_the_type_checker():
     )
 
 
+def test_projected_chains_pass_the_type_checker():
+    """Every selector form — tuple, single-field, dict-aliased, traversed at
+    depth (#293) — yields Rows[Row] / Row | None and composes with the join
+    chainers, statically."""
+    result = _run_ty(FIXTURES / "good_projections.py")
+    assert result.returncode == 0, (
+        f"projected chains must type-check cleanly:\n{result.stdout}\n{result.stderr}"
+    )
+
+
 def test_projected_shape_misuse_fails_the_type_checker():
     """A `Row` where a model instance is expected must be rejected statically
     (#279), and mutating a projected query is a static error at the call site

--- a/tests/test_traversed_projection.py
+++ b/tests/test_traversed_projection.py
@@ -1,0 +1,427 @@
+"""Backend-matrix integration tests for traversed projection + output aliases
+(#293, ADR-0009 on the ADR-0006/ADR-0007 substrate).
+
+``select()`` reaches across relations, end to end: lambda selectors traverse
+forward-FK paths at any depth (``select(lambda t: (t.amount,
+t.account.name))``), and the dict-returning lambda names output fields
+(``select(lambda t: {"account_name": t.account.name})`` — CONTEXT.md: Output
+alias, Traversed projection). Covers depth-2 traversal in both selector
+forms, decode parity vs full hydration, INNER-narrowing and the ``left_join``
+opt-out (rows kept, ``None`` fields, NULL-tolerant decode), shared-path join
+identity (behavioral — the rendered-SQL pins live in the Rust walker unit
+tests), and the build-time error catalog: output-name collision naming the
+dict form, mixed nesting, non-string dict keys.
+"""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import StrEnum
+from typing import Annotated
+from uuid import UUID
+
+import pytest
+
+import ferro
+from ferro import BackRef, FerroField, ForeignKey, Model, Relation
+from ferro.query import Row, Rows
+
+pytestmark = pytest.mark.backend_matrix
+
+
+# ---------------------------------------------------------------------------
+# Schema: Transaction -> Account -> Owner (depth 2), typed hop columns.
+# ---------------------------------------------------------------------------
+
+
+class TPTier(StrEnum):
+    FREE = "free"
+    PRO = "pro"
+
+
+class TPOwner(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    email: str = ""
+    tier: TPTier = TPTier.FREE
+    joined_at: datetime | None = None
+    external_id: UUID | None = None
+    accounts: Relation[list["TPAccount"]] = BackRef()
+
+
+class TPAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    # Deliberately non-nullable: the left_join tests pin that a kept row's
+    # traversed field decodes to None even from a NOT NULL source column.
+    name: str = ""
+    balance: Decimal | None = None
+    owner: Annotated[TPOwner | None, ForeignKey(related_name="accounts")] = None
+    transactions: Relation[list["TPTransaction"]] = BackRef()
+
+
+class TPTransaction(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    amount: int = 0
+    account: Annotated[
+        TPAccount | None, ForeignKey(related_name="transactions")
+    ] = None
+
+
+_JOINED = datetime(2026, 2, 1, 9, 0, 0, tzinfo=timezone.utc)
+_OWNER_UID = UUID("22222222-2222-2222-2222-222222222222")
+
+
+async def _seed():
+    """Owner alice <- account a1 <- txns 1/2 (10, 20); txn 3 (30) has NO
+    account (NULL FK); account a2 (owner bob) <- txn 4 (40)."""
+    alice = TPOwner(
+        id=1, email="alice@x.io", tier=TPTier.PRO, joined_at=_JOINED,
+        external_id=_OWNER_UID,
+    )
+    bob = TPOwner(id=2, email="bob@x.io", tier=TPTier.FREE)
+    await alice.save()
+    await bob.save()
+    a1 = TPAccount(id=1, name="a1", balance=Decimal("12.50"), owner=alice)
+    a2 = TPAccount(id=2, name="a2", owner=bob)
+    await a1.save()
+    await a2.save()
+    await TPTransaction(id=1, amount=10, account=a1).save()
+    await TPTransaction(id=2, amount=20, account=a1).save()
+    await TPTransaction(id=3, amount=30).save()
+    await TPTransaction(id=4, amount=40, account=a2).save()
+
+
+# ---------------------------------------------------------------------------
+# The tracer bullet: tuple and dict traversal at depth >= 2.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tuple_traversal_at_depth_two_takes_bare_leaf_names(db_url):
+    """Unaliased traversed fields take the bare leaf column name, in
+    selection order, at depth 1 and 2."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            TPTransaction.select(
+                lambda t: (t.amount, t.account.name, t.account.owner.email)
+            )
+            .order_by("id")
+            .all()
+        )
+
+        assert isinstance(rows, Rows)
+        assert list(rows[0].model_dump()) == ["amount", "name", "email"]
+        assert [(r.amount, r.name, r.email) for r in rows] == [
+            (10, "a1", "alice@x.io"),
+            (20, "a1", "alice@x.io"),
+            (40, "a2", "bob@x.io"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_dict_selector_names_output_fields_in_insertion_order(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            TPTransaction.select(
+                lambda t: {
+                    "txn_id": t.id,
+                    "account_name": t.account.name,
+                    "owner_email": t.account.owner.email,
+                }
+            )
+            .order_by("id")
+            .all()
+        )
+
+        assert list(rows[0].model_dump()) == ["txn_id", "account_name", "owner_email"]
+        assert rows.model_dump() == [
+            {"txn_id": 1, "account_name": "a1", "owner_email": "alice@x.io"},
+            {"txn_id": 2, "account_name": "a1", "owner_email": "alice@x.io"},
+            {"txn_id": 4, "account_name": "a2", "owner_email": "bob@x.io"},
+        ]
+
+
+@pytest.mark.asyncio
+async def test_aliased_root_field_renders_under_output_name(db_url):
+    """An output alias on a plain root column: same value, new name."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        row = await (
+            TPTransaction.select(lambda t: {"total": t.amount}).order_by("id").first()
+        )
+
+        assert row is not None
+        assert row.model_dump() == {"total": 10}
+
+
+@pytest.mark.asyncio
+async def test_same_leaf_selected_under_two_aliases(db_url):
+    """The dict form disambiguates what unaliased selection cannot: the same
+    output-colliding leaves (t.id vs t.account.id) under distinct names."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        row = await (
+            TPTransaction.select(lambda t: {"txn_id": t.id, "account_id": t.account.id})
+            .order_by("id")
+            .first()
+        )
+
+        assert row is not None
+        assert row.model_dump() == {"txn_id": 1, "account_id": 1}
+
+
+# ---------------------------------------------------------------------------
+# Decode parity: traversed values decode identically to full hydration.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_traversed_typed_columns_decode_identically_to_full_hydration(db_url):
+    """datetime / uuid / native enum / decimal across one and two hops come
+    back with the same types and values as hydrating the related models."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        owner = await TPOwner.where(lambda o: o.id == 1).first()
+        account = await TPAccount.where(lambda a: a.id == 1).first()
+        row = await (
+            TPTransaction.select(
+                lambda t: {
+                    "balance": t.account.balance,
+                    "tier": t.account.owner.tier,
+                    "joined_at": t.account.owner.joined_at,
+                    "external_id": t.account.owner.external_id,
+                }
+            )
+            .where(lambda t: t.id == 1)
+            .first()
+        )
+
+        assert owner is not None and account is not None and row is not None
+        assert type(row.balance) is type(account.balance)
+        assert row.balance == account.balance == Decimal("12.50")
+        assert isinstance(row.tier, TPTier) and row.tier is owner.tier is TPTier.PRO
+        assert type(row.joined_at) is type(owner.joined_at)
+        assert row.joined_at == owner.joined_at
+        assert isinstance(row.external_id, UUID)
+        assert row.external_id == owner.external_id == _OWNER_UID
+
+
+# ---------------------------------------------------------------------------
+# INNER-narrowing and the left_join opt-out (ADR-0006).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_projection_traversal_narrows_like_predicate_traversal(db_url):
+    """Traversing a nullable relation in the projection drops relation-less
+    rows — txn 3 (NULL FK) disappears, exactly like a where() traversal."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            TPTransaction.select(lambda t: (t.id, t.account.name)).order_by("id").all()
+        )
+
+        assert [r.id for r in rows] == [1, 2, 4]
+
+
+@pytest.mark.asyncio
+async def test_left_join_keeps_rows_and_decodes_traversed_fields_to_none(db_url):
+    """The opt-out: left_join keeps relation-less rows; their traversed
+    fields decode to None — including from the NOT NULL source column
+    ``TPAccount.name`` (a projected record is not the related model)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            TPTransaction.select(lambda t: {"id": t.id, "account_name": t.account.name})
+            .left_join(lambda t: t.account)
+            .order_by("id")
+            .all()
+        )
+
+        assert [r.id for r in rows] == [1, 2, 3, 4]
+        by_id = {r.id: r.account_name for r in rows}
+        assert by_id[3] is None
+        assert by_id[1] == "a1" and by_id[4] == "a2"
+
+
+@pytest.mark.asyncio
+async def test_left_join_whole_path_none_at_depth_two(db_url):
+    """A LEFT-marked path keeps rows missing the relation at any hop, and
+    every traversed field along it decodes to None — enum and datetime
+    columns included (NULL-tolerant decode)."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            TPTransaction.select(
+                lambda t: {
+                    "id": t.id,
+                    "owner_email": t.account.owner.email,
+                    "owner_tier": t.account.owner.tier,
+                    "owner_joined": t.account.owner.joined_at,
+                }
+            )
+            .left_join(lambda t: t.account.owner)
+            .order_by("id")
+            .all()
+        )
+
+        assert [r.id for r in rows] == [1, 2, 3, 4]
+        orphan = next(r for r in rows if r.id == 3)
+        assert orphan.owner_email is None
+        assert orphan.owner_tier is None
+        assert orphan.owner_joined is None
+        kept = next(r for r in rows if r.id == 1)
+        assert kept.owner_email == "alice@x.io" and kept.owner_tier is TPTier.PRO
+
+
+@pytest.mark.asyncio
+async def test_projection_shares_join_identity_with_where_traversal(db_url):
+    """The same path in select() and where() is ONE join (ADR-0006: the path
+    is the join identity) — narrowing applies once, values stay coherent.
+    The single-JOIN SQL pin lives in the Rust walker unit tests."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        rows = await (
+            TPTransaction.select(lambda t: (t.id, t.account.name))
+            .where(lambda t: t.account.name == "a1")
+            .order_by("id")
+            .all()
+        )
+
+        assert [(r.id, r.name) for r in rows] == [(1, "a1"), (2, "a1")]
+
+
+@pytest.mark.asyncio
+async def test_left_join_beats_projection_inner_on_shared_path(db_url):
+    """An explicit left_join wins over the projection's implicit INNER on the
+    shared edge — the ADR-0006 conflict rule extends to projection traversal."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        # Projection traverses account (implicit INNER); left_join overrides.
+        rows = await (
+            TPTransaction.select(lambda t: (t.id, t.account.name))
+            .left_join(lambda t: t.account)
+            .order_by("id")
+            .all()
+        )
+
+        assert [r.id for r in rows] == [1, 2, 3, 4]
+
+
+# ---------------------------------------------------------------------------
+# Build-time error catalog.
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTimeErrors:
+    def test_output_name_collision_names_the_dict_form(self):
+        with pytest.raises(ValueError, match=r"two fields named 'id'.*dict"):
+            TPTransaction.select(lambda t: (t.id, t.account.id))
+
+    def test_root_duplicate_is_the_same_collision(self):
+        with pytest.raises(ValueError, match=r"two fields named 'id'"):
+            TPTransaction.select(lambda t: (t.id, t.id))
+
+    def test_dict_in_tuple_raises(self):
+        with pytest.raises(TypeError, match="cannot nest a dict inside a tuple"):
+            TPTransaction.select(lambda t: (t.id, {"name": t.account.name}))  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def test_tuple_in_dict_raises(self):
+        with pytest.raises(TypeError, match=r"'pair' is a tuple.*flat"):
+            TPTransaction.select(lambda t: {"pair": (t.id, t.amount)})  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def test_dict_in_dict_raises(self):
+        with pytest.raises(TypeError, match=r"'nested' is a dict.*flat"):
+            TPTransaction.select(lambda t: {"nested": {"id": t.id}})  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def test_non_string_dict_key_raises(self):
+        with pytest.raises(TypeError, match="must be strings, got 1"):
+            TPTransaction.select(lambda t: {1: t.id})  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def test_empty_dict_raises(self):
+        with pytest.raises(ValueError, match="selected no columns"):
+            TPTransaction.select(lambda t: {})
+
+    def test_bare_relation_in_dict_raises(self):
+        with pytest.raises(TypeError, match="bare relation 'account'"):
+            TPTransaction.select(lambda t: {"acct": t.account})
+
+    def test_comparison_in_dict_raises(self):
+        with pytest.raises(TypeError, match="comparison"):
+            TPTransaction.select(lambda t: {"big": t.amount >= 10})
+
+    def test_misspelled_traversed_column_names_the_hop_model(self):
+        with pytest.raises(AttributeError, match="TPAccount.*Did you mean 'name'"):
+            TPTransaction.select(lambda t: t.account.nmae)
+
+    def test_include_then_select_final_error_points_at_traversed_projection(self):
+        with pytest.raises(
+            ValueError, match=r"record results are flat.*traversed projection"
+        ):
+            TPTransaction.select().include(lambda t: t.account).select(
+                lambda t: (t.id,)
+            )
+
+    def test_select_then_include_final_error_points_at_traversed_projection(self):
+        with pytest.raises(
+            ValueError, match=r"record results are flat.*traversed projection"
+        ):
+            TPTransaction.select(lambda t: (t.id,)).include(lambda t: t.account)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+@pytest.mark.asyncio
+async def test_count_reflects_projection_traversals_narrowing(db_url):
+    """count()/exists() stay projection-blind but join-aware: the traversed
+    path's INNER join narrows membership (ADR-0006 — joins decide membership,
+    projection decides shape), so count() equals len(all())."""
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        narrowed = TPTransaction.select(lambda t: (t.id, t.account.name))
+        assert await narrowed.count() == 3 == len(await narrowed.all())
+
+        kept = TPTransaction.select(lambda t: (t.id, t.account.name)).left_join(
+            lambda t: t.account
+        )
+        assert await kept.count() == 4 == len(await kept.all())
+
+
+# ---------------------------------------------------------------------------
+# Records stay records: no persistence surface on traversed rows.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_traversed_rows_are_records_not_instances(db_url):
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        await _seed()
+
+        row = await (
+            TPTransaction.select(lambda t: {"account_name": t.account.name}).first()
+        )
+
+        assert isinstance(row, Row)
+        assert not isinstance(row, Model)
+        assert not hasattr(row, "save")

--- a/uv.lock
+++ b/uv.lock
@@ -541,7 +541,7 @@ wheels = [
 
 [[package]]
 name = "ferro-orm"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -22,6 +22,7 @@ nav = [
   { "Guide" = [
     { "Models & Fields" = "guide/models-and-fields.md" },
     { "Queries" = "guide/queries.md" },
+    { "Aggregations" = "guide/aggregations.md" },
     { "Mutations" = "guide/mutations.md" },
     { "Relationships" = "guide/relationships.md" },
     { "Transactions" = "guide/transactions.md" },


### PR DESCRIPTION
Delivers the aggregations epic #282 slice by slice on one branch — QueryIR v5 substrate, traversed projection + output aliases, global aggregates, grouped aggregates, docs. One conventional commit per slice, in dependency order; each slice is reviewed before the next begins. `having()` (#291) is deliberately out of scope: `where()` rejects aggregate predicates with an error pointing at it, and that error is all of HAVING here.

## Slices

### 1 — QueryIR v5: the expr record-field shape (#292) ✅

The wire substrate (ADR-0009). A `record` field reads from exactly one source, enforced at deserialization: a `column` + relation `path`, or an `expr` — `{fn, column, path}` with `fn` as data (closed `count/sum/avg/min/max` set) and `path` as joins-section hop facts, self-contained on the wire. GROUP BY never travels: the renderer derives group keys from the plan (every non-expr field). Envelope bumps to `ir_version: 5` unconditionally (one-wheel policy, #285 precedent); v4 joins the rejected lineage with the actionable mixed-build message. Golden query vectors regenerated as v5 plus a new aggregate vector; IR-crate round-trip pins for expr root/traversed sources and the both/neither/unknown-fn rejections. Zero behavior change.

### 2 — traversed projection + output aliases (#293) ✅

`select()` reaches across relations end to end. Lambda selectors traverse forward-FK paths at any depth — tuple form and the new dict-returning form whose keys name output fields. Unaliased traversed fields take the bare leaf column name; output-name collisions raise at build time naming the dict form; mixed nesting and non-string dict keys are build-time errors. Projection traversal shares join identity with `where()`/`order_by()` (INNER, one join per path — pinned in rendered SQL); `left_join` keeps relation-less rows with NULL-tolerant `None` decode even from NOT NULL source columns. Fields render `<qualifier>.<column> AS "<name>"` and decode against the source column's owning model (root codec plan or hop registration), enum catalogs resolved per output field through hop classes. `include()` × `select()` rejection goes final (flattened-as-final, pointing at traversed projection). New traversed-record golden vector + IR pin; `good_projections.py` static fixture pins every selector form's typing.

### 3 — global aggregates (#294) ✅

The five aggregate methods on scalar field proxies (`t.amount.sum()`, traversal included: `t.account.balance.avg()`) land in projected records via the `expr` plan, without grouping — an aggregate-only projection collapses to one record, read with `first()`. Aggregates are user-named (dict selector only). Source families validate at build time (sum/avg: numeric; min/max: numeric/text/date-time; count: any; enum/uuid/json/bool rejected pointedly). Decode types are the pinned cross-backend contract derived from the source codec: count → int, min/max → source type, sum → source numeric type, avg → float (int/float) / Decimal (Decimal). Empty input passes SQL through verbatim: one record, `None`s, count 0 — no COALESCE. Guardrails: aggregate-in-`where()` points at `having()` (#291); iterating a proxy names `.sum()` (the builtin-sum trap); mixed aggregate/plain projections point at #295. Expression traversal is self-contained on the wire — `build_join_plan` unions hop facts in with INNER traversal semantics, sharing join identity. New global-aggregate golden vector + IR pin; rendered-SQL pins for all five functions.

### 4 — grouped aggregates + order_by rules + verb guardrails (#295) ✅

Mixed projections are grouped queries: every non-aggregate field is a group key, GROUP BY derived from the record plan in the Rust renderer — never on the wire. Keys and sources traverse (shared join identity); a left-joined traversed key yields a `None`-keyed group; zero rows → zero records; `limit`/`offset` act on groups (top-N idiom end to end). The three `order_by` rules: strings resolve output field names first then root columns (output-name terms render as bare result-column aliases — SQL's own scoping, deterministic in the renderer); the lambda form spells source expressions including aggregates (resolved against the projection); on an aggregate projection every sort key must be a group key or an aggregate — build-time error otherwise, covering sort keys chained before the `select()`, with renderer boundary defense. `count()`/`exists()` on an aggregate projection raise synchronously with both spellings. Rendered-SQL pins for derived GROUP BY and all ORDER BY paths.

### 5 — docs (#296) ✅

New **Aggregations & Grouped Queries** guide: the five aggregate methods, user-named (dict) aggregate fields, the global-aggregate + `first()` idiom, the decode-type contract table, empty-input `None`/`count=0` semantics, derived grouping ("bare fields are the keys" with the no-`group_by()` rationale), group-vs-partition, `None`-keyed groups, the top-N idiom, the three `order_by` rules, and the error catalog — backed by a runnable example script with an I-7 annotated companion. Traversed projection + output aliases fold into the partial-selects guide (collision error, INNER narrowing, `left_join` NULL-tolerant decode; include×projection goes final). API reference gains the four `select()` forms and an aggregates section; the typing page documents opaque `AggregateExpr` and shape-not-names (#290 lane). Stale "not implemented" claims updated across why-ferro, roadmap, the SQLAlchemy migration guide, and raw-SQL. Docs build clean.