### PR TITLE
refactor: compile QueryIR payloads at a single wire choke point

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,6 +80,14 @@ _Avoid_: Eager-loaded field, select_related, prefetched attribute, joined attrib
 A query's declaration of what its result columns become: complete root instances (every query today), a projected record of named fields, or — in the future — a populated instance graph. Every query carries exactly one plan; the plan travels with the query rather than being inferred from its column list.
 _Avoid_: Select list, projection spec, hydration mode flag
 
+**QueryIR payload**:
+The single typed wire artifact a query ships to the Rust runtime — model identity, predicates, ordering, paging, joins, and exactly one materialization plan, inside a versioned envelope. Compiled only by `compile_query`; no other code assembles query wire shape.
+_Avoid_: Query dict, query def, payload dict
+
+**Golden vector**:
+A hand-authored JSON fixture pinning one wire shape — the independent authority both the Python emitter and the Rust decoder assert against, never regenerated from either side's output. Updating one by hand is the contract-review moment for a wire change.
+_Avoid_: Snapshot, fixture dump, example payload
+
 **Aggregate projection**:
 A projection containing at least one aggregate field. Each group collapses to exactly one projected record: every non-aggregate field is a group key, so grouping is derived from the projection and never declared separately. With no non-aggregate fields, the whole result collapses to a single record. Grouping collapses rows — bucketing complete instances by a key ("partitioning") is a different, client-side operation and is not grouping.
 _Avoid_: Group-by query, summary query, rollup, partition

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -1,4 +1,10 @@
-"""Build fluent query objects that serialize QueryIR payloads for the Rust core."""
+"""Build fluent query objects; ``ferro.query.wire`` compiles them to QueryIR.
+
+This module owns chainer-time state and validation (predicates, joins,
+projection, includes). Everything whose output is wire shape — the payload
+dataclasses, hop-fact resolution, join serialization, materialization plans,
+verb policy, and the versioned envelope — lives behind ``wire.compile_query``.
+"""
 
 import copy
 from typing import (
@@ -35,10 +41,17 @@ from .nodes import (
     QueryProxy,
     RelationProxy,
     RowSelector,
-    _serialize_query_value,
     validate_query_column,
 )
 from .rows import Row, Rows
+from .wire import (
+    M2mContext,
+    OrderByEntry,
+    compile_query,
+    model_identity,
+    path_edges,
+    to_wire_json,
+)
 
 if TYPE_CHECKING:
     from .._core import RouteHandle
@@ -50,32 +63,6 @@ E = TypeVar("E")
 # at import; `into=` record types would parameterize per call). Construction
 # always goes through Rows._wrap — never pydantic validation (ADR-0007).
 _ROWS_OF_ROW: type[Rows[Row]] = Rows[Row]
-
-
-def _query_ir_payload_to_json(query_payload: dict[str, Any]) -> str:
-    """Serialize a QueryIR payload into a versioned IR envelope JSON string.
-
-    Always emits ``ir_version: 5`` (#292 — unconditional bump, exactly like v4
-    at #285, v3 at #278, and v2 at #269; there is no earlier envelope left
-    anywhere). v5 gives ``record`` fields expression sources (ADR-0009): a
-    field carries either a ``column`` + ``path`` or an aggregate ``expr``.
-    Python and Rust ship in one wheel, so a single supported version is the
-    whole contract (#267 Implementation Decisions).
-    """
-    import json
-
-    return json.dumps(
-        {
-            "ir_kind": "query",
-            "ir_version": 5,
-            "payload": _serialize_query_value(query_payload),
-        }
-    )
-
-
-def _model_identity(model_cls: type) -> str:
-    """Qualified registry identity of a Ferro model class (FF-E)."""
-    return model_cls.__ferro_identity__  # ty: ignore[unresolved-attribute]
 
 
 def _resolve_where_node(predicate: "Predicate[Any]", model_cls: type) -> QueryNode:
@@ -130,20 +117,6 @@ def _register_join_paths(node: QueryNode, joins: dict[tuple[str, ...], str]) -> 
         joins.setdefault(tuple(node.path), "inner")
 
 
-def _where_node_traverses(node: QueryNode) -> bool:
-    """True if any leaf under ``node`` carries a non-empty relation path (#273).
-
-    Used by :meth:`Query._mutating_query_def` to reject relation traversal on
-    ``update()``/``delete()``. A join-free shadow-FK leaf (``t.account ==
-    instance`` desugars to ``path=()``) is NOT traversal and stays allowed.
-    """
-    if node.is_compound:
-        return (node.left is not None and _where_node_traverses(node.left)) or (
-            node.right is not None and _where_node_traverses(node.right)
-        )
-    return bool(node.path)
-
-
 def _resolve_join_selector(
     selector: "Callable[[QueryProxy[Any]], Any]", model_cls: type
 ) -> tuple[str, ...]:
@@ -182,11 +155,6 @@ def _resolve_join_selector(
             f"(e.g. `lambda t: t.account`), got {type(result).__name__}"
         )
     return result._path
-
-
-def _path_edges(path: tuple[str, ...]) -> list[tuple[str, ...]]:
-    """Every edge (prefix of length ≥ 1) of a relation ``path`` (#272)."""
-    return [path[:i] for i in range(1, len(path) + 1)]
 
 
 def _reject_reverse_relation_include(exc: AttributeError) -> None:
@@ -485,63 +453,6 @@ def _collect_dict_projection(result: dict[Any, Any]) -> tuple[_ProjectedField, .
     return tuple(fields)
 
 
-def _target_pk_column(model_cls: type) -> str:
-    """Return the single primary-key column name of a relation target (#270).
-
-    Raises:
-        ValueError: If ``model_cls`` has zero or multiple primary-key columns —
-            relation traversal joins against exactly one PK column, so an
-            ambiguous target is a loud error naming the model, never a guess.
-    """
-    pks = [
-        name
-        for name, spec in getattr(model_cls, "__ferro_columns__", {}).items()
-        if spec.primary_key
-    ]
-    if len(pks) != 1:
-        raise ValueError(
-            f"Relation traversal into {model_cls.__name__!r} requires exactly one "
-            f"primary-key column, found {len(pks)}: {sorted(pks)}."
-        )
-    return pks[0]
-
-
-def _resolve_join_hops(
-    model_cls: type, path: tuple[str, ...]
-) -> list[dict[str, str]]:
-    """Resolve a relation path into ordered hop facts for the QueryIR ``joins``.
-
-    Each hop's ``relation``/``from_column``/``to_table``/``to_column`` is read
-    from the relation-spec chain starting at ``model_cls`` — ``from_column`` is
-    the shadow FK column on the source side, ``to_column`` the target's PK.
-
-    Raises:
-        ValueError: If a path element is not a declared relation of the current
-            model (should not happen — proxies validate at build time), or the
-            target has no single primary key (:func:`_target_pk_column`).
-    """
-    hops: list[dict[str, str]] = []
-    current = model_cls
-    for relation in path:
-        specs = getattr(current, "__ferro_relation_specs__", None) or {}
-        spec = specs.get(relation)
-        if spec is None:
-            raise ValueError(
-                f"{current.__name__!r} has no relation {relation!r} for traversal."
-            )
-        target = spec.target
-        hops.append(
-            {
-                "relation": relation,
-                "from_column": spec.shadow_column,
-                "to_table": target.__ferro_table__,
-                "to_column": _target_pk_column(target),
-            }
-        )
-        current = target
-    return hops
-
-
 class Query(Generic[T]):
     """Build and execute fluent ORM queries.
 
@@ -568,10 +479,10 @@ class Query(Generic[T]):
         self._using = using
         self._session = session
         self.where_clause: list["QueryNode"] = []
-        self.order_by_clause: list[dict[str, Any]] = []
+        self.order_by_clause: list[OrderByEntry] = []
         self._limit: int | None = None
         self._offset: int | None = None
-        self._m2m_context: dict[str, Any] | None = None
+        self._m2m_context: M2mContext | None = None
         # Relation paths that must render a join, insertion-ordered (full path
         # tuple -> registered join_type). Populated by where()/order_by()
         # traversal ("inner") and by the explicit join()/left_join() chainers
@@ -587,7 +498,7 @@ class Query(Generic[T]):
         self._explicit_edges: dict[tuple[str, ...], str] = {}
         # Relation paths to populate (#286, ADR-0008), insertion-ordered and
         # deduped by path identity (dict-as-ordered-set). CRITICAL: include
-        # paths never enter ``_joins``/``_serialize_joins`` — they ride the
+        # paths never enter ``_joins``/the wire ``joins`` section — they ride the
         # ``instances`` materialization plan, so the ``joins`` wire section
         # keeps its stage-1 semantics untouched and include contributes no
         # join-type opinion on any edge another clause references.
@@ -610,9 +521,8 @@ class Query(Generic[T]):
         new = copy.copy(self)
         new.where_clause = list(self.where_clause)
         new.order_by_clause = list(self.order_by_clause)
-        new._m2m_context = (
-            dict(self._m2m_context) if self._m2m_context is not None else None
-        )
+        # M2mContext is frozen, so clones can share it safely.
+        new._m2m_context = self._m2m_context
         new._joins = dict(self._joins)
         new._explicit_edges = dict(self._explicit_edges)
         new._includes = dict(self._includes)
@@ -626,12 +536,12 @@ class Query(Generic[T]):
         A new ``Query`` with the m2m context set; ``self`` is unchanged.
         """
         new = self._clone()
-        new._m2m_context = {
-            "join_table": join_table,
-            "source_col": source_col,
-            "target_col": target_col,
-            "source_id": source_id,
-        }
+        new._m2m_context = M2mContext(
+            join_table=join_table,
+            source_col=source_col,
+            target_col=target_col,
+            source_id=source_id,
+        )
         return new
 
     def where(self, predicate: "Predicate[T]") -> Self:
@@ -862,11 +772,7 @@ class Query(Generic[T]):
 
         new = self._clone()
         new.order_by_clause.append(
-            {
-                "column": col_name,
-                "direction": direction.lower(),
-                "path": list(path),
-            }
+            OrderByEntry(column=col_name, direction=direction.lower(), path=path)
         )
         if path:
             new._joins.setdefault(path, "inner")
@@ -994,7 +900,7 @@ class Query(Generic[T]):
         direction is idempotent.
         """
         path = _resolve_join_selector(selector, self.model_cls)
-        edges = _path_edges(path)
+        edges = path_edges(path)
         new = self._clone()
         for edge in edges:
             existing = new._explicit_edges.get(edge)
@@ -1047,27 +953,6 @@ class Query(Generic[T]):
         new._offset = value
         return new
 
-    def _materialization_ir(self) -> dict[str, Any]:
-        """Serialize this query's materialization plan (ADR-0007, v4).
-
-        Every fetching query carries exactly one plan on the wire. A query
-        without a projection or includes materializes complete root
-        instances; an included query carries the ``instances`` plan — one
-        ordered hop-fact list per include path (#286), the same hop shape as
-        the ``joins`` section but deliberately separate from it (ADR-0008):
-        the fetch walker unions include-only edges in as LEFT, so include
-        can never change membership or a shared edge's join type.
-        """
-        if self._includes:
-            return {
-                "kind": "instances",
-                "paths": [
-                    _resolve_join_hops(self.model_cls, path)
-                    for path in self._includes
-                ],
-            }
-        return {"kind": "root_instances"}
-
     def _include_hop_classes(self) -> dict[str, type]:
         """Map each included hop's physical table to its model class (#286)."""
         return self._hop_classes_for_paths(self._includes)
@@ -1100,109 +985,6 @@ class Query(Generic[T]):
                 current = target
         return hop_classes
 
-    def _serialize_joins(self) -> list[dict[str, Any]]:
-        """Serialize collected relation paths into QueryIR ``joins`` entries.
-
-        Emits one entry per registered full path, in insertion order, each
-        carrying its ordered hop facts (:func:`_resolve_join_hops`). The Rust
-        SELECT walkers assign deterministic ``j{i}_{relation}`` aliases and
-        dedup shared prefixes at render time (#270).
-
-        The wire ``join_type`` is resolved from ``_explicit_edges`` at the EDGE
-        level so it is already unambiguous (#272): an entry is ``"left"`` iff
-        ALL of its edges are explicitly LEFT-marked, else ``"inner"``. Because
-        ``.left_join`` is whole-path and the only source of LEFT, a proper
-        prefix of a longer path can be LEFT while the deeper hop is INNER — that
-        prefix is itself a registered ``_joins`` entry (``left_join`` registers
-        its full path) and is emitted as its own ``"left"`` entry; the longer
-        entry is emitted ``"inner"``. The Rust edge resolver then renders the
-        prefix edges LEFT and the deeper edges INNER (a pure double-check of
-        this wire). This also makes "explicit LEFT beats implicit INNER on a
-        shared edge" visible in the IR itself.
-        """
-        entries: list[dict[str, Any]] = []
-        for path in self._joins:
-            is_left = all(
-                self._explicit_edges.get(edge) == "left" for edge in _path_edges(path)
-            )
-            entries.append(
-                {
-                    "join_type": "left" if is_left else "inner",
-                    "path": _resolve_join_hops(self.model_cls, path),
-                }
-            )
-        return entries
-
-    def _mutating_query_def(self, operation: str) -> dict[str, Any]:
-        """Build the QueryIR payload for a mutating operation (update/delete).
-
-        Mutating payloads never carry ``limit``/``offset`` keys: portable SQL
-        has no ``UPDATE/DELETE ... LIMIT``, so pagination on a mutation is
-        rejected loudly instead of being silently ignored.
-
-        Raises:
-            ValueError: If ``limit()``/``offset()`` was set, or if the query
-                traverses a relation (a joined/explicit-edge path, or a
-                where-clause leaf carrying a non-empty path). Portable SQL has
-                no ``UPDATE/DELETE ... JOIN``; a join-free shadow-FK filter
-                (``t.account == instance``) stays allowed. Rejected here, before
-                any DB round-trip (the Rust guard from #270 stays as boundary
-                defense).
-        """
-        if self._limit is not None or self._offset is not None:
-            raise ValueError(
-                f"{operation}() does not support limit/offset: portable SQL has "
-                f"no {operation.upper()} ... LIMIT. Remove the .limit()/.offset() "
-                f"call, or fetch primary keys first and {operation} by "
-                "primary-key set."
-            )
-        if (
-            self._joins
-            or self._explicit_edges
-            or any(_where_node_traverses(node) for node in self.where_clause)
-        ):
-            raise ValueError(
-                f"{operation}() does not support relation traversal: portable SQL "
-                f"has no {operation.upper()} ... JOIN. Fetch primary keys via the "
-                f"joined query first, then {operation} by primary-key set. "
-                "(A join-free relation filter like `t.account == instance` is "
-                "allowed.)"
-            )
-        if self._includes:
-            raise ValueError(
-                f"{operation}() does not support include(): a mutation is a "
-                "single-table write shape and returns no instances to "
-                "populate. Drop the .include(...) call, or fetch the "
-                "populated rows first and mutate by primary-key set."
-            )
-        return {
-            "model_name": _model_identity(self.model_cls),
-            "where": [node.to_ir_dict() for node in self.where_clause],
-            "order_by": [],
-            "m2m": None,
-            "joins": [],
-            # A mutation never materializes a projected result; projection on
-            # a mutating query is rejected before this payload is built.
-            "materialization": {"kind": "root_instances"},
-        }
-
-    def _fetch_query_def(self) -> dict[str, Any]:
-        """Build the QueryIR payload for a fetching operation (``all()``).
-
-        Carries the query's own materialization plan — ``root_instances``
-        here, a ``record`` plan on a :class:`ProjectedQuery` (ADR-0007).
-        """
-        return {
-            "model_name": _model_identity(self.model_cls),
-            "where": [node.to_ir_dict() for node in self.where_clause],
-            "order_by": self.order_by_clause,
-            "limit": self._limit,
-            "offset": self._offset,
-            "m2m": self._m2m_context,
-            "joins": self._serialize_joins(),
-            "materialization": self._materialization_ir(),
-        }
-
     async def all(self) -> list[T]:
         """Return all model instances that match the current query
 
@@ -1214,18 +996,18 @@ class Query(Generic[T]):
             >>> isinstance(users, list)
             True
         """
-        query_def = self._fetch_query_def()
+        payload = compile_query(self, "fetch")
         route = await self._transaction_or_using()
         if self._includes:
             return await fetch_filtered(
                 self.model_cls,
-                _query_ir_payload_to_json(query_def),
+                to_wire_json(payload),
                 route,
                 hop_classes=self._include_hop_classes(),
             )
         return await fetch_filtered(
             self.model_cls,
-            _query_ir_payload_to_json(query_def),
+            to_wire_json(payload),
             route,
         )
 
@@ -1240,23 +1022,11 @@ class Query(Generic[T]):
             >>> isinstance(total, int)
             True
         """
-        query_def = {
-            "model_name": _model_identity(self.model_cls),
-            "where": [node.to_ir_dict() for node in self.where_clause],
-            "order_by": [],
-            "limit": None,
-            "offset": None,
-            "m2m": self._m2m_context,
-            "joins": self._serialize_joins(),
-            # count() is unaffected by projection (PRD #277 verb table): it
-            # materializes a scalar, so the plan is root_instances even on a
-            # projected query.
-            "materialization": {"kind": "root_instances"},
-        }
+        payload = compile_query(self, "count")
         route = await self._transaction_or_using()
         return await count_filtered(
-            _model_identity(self.model_cls),
-            _query_ir_payload_to_json(query_def),
+            model_identity(self.model_cls),
+            to_wire_json(payload),
             route,
         )
 
@@ -1282,11 +1052,11 @@ class Query(Generic[T]):
             >>> isinstance(updated, int)
             True
         """
-        query_def = self._mutating_query_def("update")
+        payload = compile_query(self, "update")
         route = await self._transaction_or_using()
         return await update_filtered(
-            _model_identity(self.model_cls),
-            _query_ir_payload_to_json(query_def),
+            model_identity(self.model_cls),
+            to_wire_json(payload),
             update_bind_payload(fields),
             route,
         )
@@ -1324,11 +1094,11 @@ class Query(Generic[T]):
             >>> isinstance(deleted, int)
             True
         """
-        query_def = self._mutating_query_def("delete")
+        payload = compile_query(self, "delete")
         route = await self._transaction_or_using()
         return await delete_filtered(
-            _model_identity(self.model_cls),
-            _query_ir_payload_to_json(query_def),
+            model_identity(self.model_cls),
+            to_wire_json(payload),
             route,
         )
 
@@ -1372,10 +1142,10 @@ class Query(Generic[T]):
 
         route = await self._transaction_or_using()
         await add_m2m_links(
-            self._m2m_context["join_table"],
-            self._m2m_context["source_col"],
-            self._m2m_context["target_col"],
-            self._m2m_context["source_id"],
+            self._m2m_context.join_table,
+            self._m2m_context.source_col,
+            self._m2m_context.target_col,
+            self._m2m_context.source_id,
             ids,
             route,
         )
@@ -1405,10 +1175,10 @@ class Query(Generic[T]):
 
         route = await self._transaction_or_using()
         await remove_m2m_links(
-            self._m2m_context["join_table"],
-            self._m2m_context["source_col"],
-            self._m2m_context["target_col"],
-            self._m2m_context["source_id"],
+            self._m2m_context.join_table,
+            self._m2m_context.source_col,
+            self._m2m_context.target_col,
+            self._m2m_context.source_id,
             ids,
             route,
         )
@@ -1430,9 +1200,9 @@ class Query(Generic[T]):
 
         route = await self._transaction_or_using()
         await clear_m2m_links(
-            self._m2m_context["join_table"],
-            self._m2m_context["source_col"],
-            self._m2m_context["source_id"],
+            self._m2m_context.join_table,
+            self._m2m_context.source_col,
+            self._m2m_context.source_id,
             route,
         )
 
@@ -1480,7 +1250,7 @@ class ProjectedQuery(Query[T]):
         if self._has_aggregate():
             output_names = {field.name for field in fields}
             for order in self.order_by_clause:
-                column, path = order["column"], tuple(order["path"])
+                column, path = order.column, order.path
                 if not path and column in output_names:
                     continue
                 if self._is_group_key_source(column, path):
@@ -1494,39 +1264,6 @@ class ProjectedQuery(Query[T]):
                     "after the select()."
                 )
 
-    def _materialization_ir(self) -> dict[str, Any]:
-        """Serialize the ``record`` plan: one field per projected field.
-
-        ``name`` is declared separately from ``column`` (output aliases) and
-        each plain field carries its relation ``path`` (traversed projection,
-        #293). An aggregate field carries an ``expr`` instead (#294): ``fn``
-        as data and the source's traversal as hop facts on ``expr.path`` —
-        self-contained on the wire — with the field-level ``path`` empty.
-        """
-        fields: list[dict[str, Any]] = []
-        for field in self._projection:
-            if field.agg is not None:
-                fields.append(
-                    {
-                        "name": field.name,
-                        "path": [],
-                        "expr": {
-                            "fn": field.agg,
-                            "column": field.column,
-                            "path": _resolve_join_hops(self.model_cls, field.path),
-                        },
-                    }
-                )
-            else:
-                fields.append(
-                    {
-                        "name": field.name,
-                        "column": field.column,
-                        "path": list(field.path),
-                    }
-                )
-        return {"kind": "record", "fields": fields}
-
     def _has_aggregate(self) -> bool:
         """True when this is an AGGREGATE PROJECTION (CONTEXT.md): at least
         one aggregate field, so every plain field is a group key (#295)."""
@@ -1538,7 +1275,7 @@ class ProjectedQuery(Query[T]):
         """Clone with one resolved ORDER BY entry appended (#295)."""
         new = self._clone()
         new.order_by_clause.append(
-            {"column": column, "direction": direction.lower(), "path": list(path)}
+            OrderByEntry(column=column, direction=direction.lower(), path=path)
         )
         if path:
             new._joins.setdefault(path, "inner")
@@ -1735,13 +1472,13 @@ class ProjectedQuery(Query[T]):
             >>> [r.amount for r in rows]  # doctest: +SKIP
             [Decimal('12.50'), Decimal('7.00')]
         """
-        query_def = self._fetch_query_def()
+        payload = compile_query(self, "fetch")
         route = await self._transaction_or_using()
         hop_classes = self._traversed_hop_classes()
         if hop_classes is not None:
             records = await fetch_filtered(
                 self.model_cls,
-                _query_ir_payload_to_json(query_def),
+                to_wire_json(payload),
                 route,
                 record_cls=Row,
                 hop_classes=hop_classes,
@@ -1749,7 +1486,7 @@ class ProjectedQuery(Query[T]):
         else:
             records = await fetch_filtered(
                 self.model_cls,
-                _query_ir_payload_to_json(query_def),
+                to_wire_json(payload),
                 route,
                 record_cls=Row,
             )

--- a/src/ferro/query/nodes.py
+++ b/src/ferro/query/nodes.py
@@ -673,8 +673,8 @@ class RelationProxy:
             )
         if isinstance(other, self._target):
             # Reuse the Task 3 PK resolver (loud on zero/multiple PKs); local
-            # import avoids a builder <-> nodes import cycle at module load.
-            from .builder import _target_pk_column
+            # import avoids a wire <-> nodes import cycle at module load.
+            from .wire import _target_pk_column
 
             pk_column = _target_pk_column(self._target)
             pk_value = getattr(other, pk_column, None)

--- a/src/ferro/query/wire.py
+++ b/src/ferro/query/wire.py
@@ -1,0 +1,518 @@
+"""The QueryIR payload: Ferro's single query wire contract (CONTEXT.md).
+
+Every query the ORM executes crosses the Python→Rust seam as one versioned
+JSON envelope. This module is the only place that wire shape exists on the
+Python side: :func:`compile_query` is the sole compiler from a built query to
+a :class:`QueryIrPayload`, and :func:`to_wire_json` the sole envelope
+serializer. The dataclasses mirror ``crates/ferro-schema-ir``'s serde structs
+one-for-one; golden vectors in ``tests/fixtures/ir_vectors/`` pin both sides
+to the same bytes (builder equality in ``tests/test_query_wire_vectors.py``,
+serde round-trips in the Rust crate's tests).
+
+Friend contract: :func:`compile_query` reads the query object's build state
+(``where_clause``, ``order_by_clause``, ``_limit``, ``_offset``, ``_joins``,
+``_explicit_edges``, ``_includes``, ``_m2m_context``, ``_projection``)
+directly — the builder and this module are one package, and the seam is
+``compile_query``, not a snapshot type. The builder owns chainer-time
+validation and state; this module owns everything whose output is wire shape.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from .nodes import QueryNode, _serialize_query_value
+
+if TYPE_CHECKING:
+    from .builder import Query
+
+# The verb a payload is compiled for. ``update`` and ``delete`` share the
+# mutate arm; they stay distinct values so guardrail errors name the caller.
+QueryVerb = Literal["fetch", "count", "update", "delete"]
+
+# Always 5 (#292 — unconditional bump, exactly like v4 at #285, v3 at #278,
+# and v2 at #269; there is no earlier envelope left anywhere). v5 gives
+# ``record`` fields expression sources (ADR-0009): a field carries either a
+# ``column`` + ``path`` or an aggregate ``expr``. Python and Rust ship in one
+# wheel, so a single supported version is the whole contract (#267
+# Implementation Decisions).
+_IR_VERSION = 5
+
+
+class _AbsentType:
+    """Marks a wire key that is omitted entirely — absent, not ``null``.
+
+    Mutating payloads never carry ``limit``/``offset`` keys (portable SQL has
+    no ``UPDATE/DELETE ... LIMIT``); the absent keys are pinned wire bytes,
+    distinct from a fetch payload's explicit ``null``.
+    """
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<absent>"
+
+
+_ABSENT = _AbsentType()
+
+
+def model_identity(model_cls: type) -> str:
+    """Qualified registry identity of a Ferro model class (FF-E)."""
+    return model_cls.__ferro_identity__  # ty: ignore[unresolved-attribute]
+
+
+def path_edges(path: tuple[str, ...]) -> list[tuple[str, ...]]:
+    """Every edge (prefix of length ≥ 1) of a relation ``path`` (#272)."""
+    return [path[:i] for i in range(1, len(path) + 1)]
+
+
+@dataclass(frozen=True)
+class QueryJoinHop:
+    """One hop fact of a relation path — the shared shape of the ``joins``
+    section, ``instances`` plan paths, and aggregate ``expr`` traversals."""
+
+    relation: str
+    from_column: str
+    to_table: str
+    to_column: str
+
+    def to_ir_dict(self) -> dict[str, str]:
+        return {
+            "relation": self.relation,
+            "from_column": self.from_column,
+            "to_table": self.to_table,
+            "to_column": self.to_column,
+        }
+
+
+@dataclass(frozen=True)
+class QueryJoin:
+    """One ``joins`` entry: a full relation path and its resolved join type."""
+
+    join_type: str
+    path: tuple[QueryJoinHop, ...]
+
+    def to_ir_dict(self) -> dict[str, Any]:
+        return {
+            "join_type": self.join_type,
+            "path": [hop.to_ir_dict() for hop in self.path],
+        }
+
+
+@dataclass(frozen=True)
+class OrderByEntry:
+    """One ``ORDER BY`` clause: column, direction, and relation path."""
+
+    column: str
+    direction: str
+    path: tuple[str, ...]
+
+    def to_ir_dict(self) -> dict[str, Any]:
+        return {
+            "column": self.column,
+            "direction": self.direction,
+            "path": list(self.path),
+        }
+
+
+@dataclass(frozen=True)
+class M2mContext:
+    """Many-to-many linkage context riding the payload's ``m2m`` section."""
+
+    join_table: str
+    source_col: str
+    target_col: str
+    source_id: Any
+
+    def to_ir_dict(self) -> dict[str, Any]:
+        return {
+            "join_table": self.join_table,
+            "source_col": self.source_col,
+            "target_col": self.target_col,
+            "source_id": self.source_id,
+        }
+
+
+@dataclass(frozen=True)
+class RecordExpr:
+    """The expression source of an aggregate record field (v5, ADR-0009).
+
+    Self-contained on the wire: ``fn`` travels as data (the closed aggregate
+    set) and ``path`` carries the source column's traversal as ordered hop
+    facts rather than keying into the ``joins`` section.
+    """
+
+    fn: str
+    column: str
+    path: tuple[QueryJoinHop, ...]
+
+    def to_ir_dict(self) -> dict[str, Any]:
+        return {
+            "fn": self.fn,
+            "column": self.column,
+            "path": [hop.to_ir_dict() for hop in self.path],
+        }
+
+
+@dataclass(frozen=True)
+class RecordField:
+    """One projected field of a ``record`` plan (ADR-0007/ADR-0009).
+
+    ``name`` is declared separately from the source (output aliases are
+    free). A field reads from exactly one source: a ``column`` + relation
+    ``path``, or an aggregate ``expr`` whose traversal rides the expression —
+    never both, never neither (the Rust side enforces this at
+    deserialization).
+    """
+
+    name: str
+    column: str | None
+    path: tuple[str, ...]
+    expr: RecordExpr | None
+
+    def to_ir_dict(self) -> dict[str, Any]:
+        if self.expr is not None:
+            return {
+                "name": self.name,
+                "path": list(self.path),
+                "expr": self.expr.to_ir_dict(),
+            }
+        return {
+            "name": self.name,
+            "column": self.column,
+            "path": list(self.path),
+        }
+
+
+@dataclass(frozen=True)
+class RootInstances:
+    """Complete root-model instances — the default materialization plan."""
+
+    def to_ir_dict(self) -> dict[str, Any]:
+        return {"kind": "root_instances"}
+
+
+@dataclass(frozen=True)
+class Record:
+    """Projected records: a typed column subset decoded into ``Row`` records."""
+
+    fields: tuple[RecordField, ...]
+
+    def to_ir_dict(self) -> dict[str, Any]:
+        return {
+            "kind": "record",
+            "fields": [field.to_ir_dict() for field in self.fields],
+        }
+
+
+@dataclass(frozen=True)
+class Instances:
+    """Populated instance graphs (joined-row hydration, ADR-0008): one
+    ordered hop-fact list per include path, deliberately separate from the
+    ``joins`` section so include can never change membership or a shared
+    edge's join type."""
+
+    paths: tuple[tuple[QueryJoinHop, ...], ...]
+
+    def to_ir_dict(self) -> dict[str, Any]:
+        return {
+            "kind": "instances",
+            "paths": [[hop.to_ir_dict() for hop in path] for path in self.paths],
+        }
+
+
+Materialization = RootInstances | Record | Instances
+
+
+@dataclass(frozen=True)
+class QueryIrPayload:
+    """The single typed wire artifact a query ships to the Rust runtime.
+
+    Mirrors ``ferro_schema_ir::QueryIrPayload`` field-for-field. ``where``
+    holds :meth:`QueryNode.to_ir_dict` output — the node module owns the
+    predicate wire shape. ``limit``/``offset`` may be :data:`_ABSENT`
+    (mutating payloads omit the keys entirely).
+    """
+
+    model_name: str
+    where: tuple[dict[str, Any], ...]
+    order_by: tuple[OrderByEntry, ...]
+    limit: int | None | _AbsentType
+    offset: int | None | _AbsentType
+    m2m: M2mContext | None
+    joins: tuple[QueryJoin, ...]
+    materialization: Materialization
+
+    def to_ir_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model_name": self.model_name,
+            "where": list(self.where),
+            "order_by": [entry.to_ir_dict() for entry in self.order_by],
+        }
+        if not isinstance(self.limit, _AbsentType):
+            payload["limit"] = self.limit
+        if not isinstance(self.offset, _AbsentType):
+            payload["offset"] = self.offset
+        payload["m2m"] = self.m2m.to_ir_dict() if self.m2m is not None else None
+        payload["joins"] = [join.to_ir_dict() for join in self.joins]
+        payload["materialization"] = self.materialization.to_ir_dict()
+        return payload
+
+
+def _target_pk_column(model_cls: type) -> str:
+    """Return the single primary-key column name of a relation target (#270).
+
+    Raises:
+        ValueError: If ``model_cls`` has zero or multiple primary-key columns —
+            relation traversal joins against exactly one PK column, so an
+            ambiguous target is a loud error naming the model, never a guess.
+    """
+    pks = [
+        name
+        for name, spec in getattr(model_cls, "__ferro_columns__", {}).items()
+        if spec.primary_key
+    ]
+    if len(pks) != 1:
+        raise ValueError(
+            f"Relation traversal into {model_cls.__name__!r} requires exactly one "
+            f"primary-key column, found {len(pks)}: {sorted(pks)}."
+        )
+    return pks[0]
+
+
+def resolve_join_hops(
+    model_cls: type, path: tuple[str, ...]
+) -> tuple[QueryJoinHop, ...]:
+    """Resolve a relation path into ordered hop facts.
+
+    Each hop's ``relation``/``from_column``/``to_table``/``to_column`` is read
+    from the relation-spec chain starting at ``model_cls`` — ``from_column`` is
+    the shadow FK column on the source side, ``to_column`` the target's PK.
+
+    Raises:
+        ValueError: If a path element is not a declared relation of the current
+            model (should not happen — proxies validate at build time), or the
+            target has no single primary key (:func:`_target_pk_column`).
+    """
+    hops: list[QueryJoinHop] = []
+    current = model_cls
+    for relation in path:
+        specs = getattr(current, "__ferro_relation_specs__", None) or {}
+        spec = specs.get(relation)
+        if spec is None:
+            raise ValueError(
+                f"{current.__name__!r} has no relation {relation!r} for traversal."
+            )
+        target = spec.target
+        hops.append(
+            QueryJoinHop(
+                relation=relation,
+                from_column=spec.shadow_column,
+                to_table=target.__ferro_table__,
+                to_column=_target_pk_column(target),
+            )
+        )
+        current = target
+    return tuple(hops)
+
+
+def _where_node_traverses(node: QueryNode) -> bool:
+    """True if any leaf under ``node`` carries a non-empty relation path (#273).
+
+    Used by the mutate guardrails to reject relation traversal on
+    ``update()``/``delete()``. A join-free shadow-FK leaf (``t.account ==
+    instance`` desugars to ``path=()``) is NOT traversal and stays allowed.
+    """
+    if node.is_compound:
+        return (node.left is not None and _where_node_traverses(node.left)) or (
+            node.right is not None and _where_node_traverses(node.right)
+        )
+    return bool(node.path)
+
+
+def _serialize_joins(query: "Query[Any]") -> tuple[QueryJoin, ...]:
+    """Serialize the query's registered relation paths into ``joins`` entries.
+
+    Emits one entry per registered full path, in insertion order, each
+    carrying its ordered hop facts (:func:`resolve_join_hops`). The Rust
+    SELECT walkers assign deterministic ``j{i}_{relation}`` aliases and
+    dedup shared prefixes at render time (#270).
+
+    The wire ``join_type`` is resolved from the explicit edge marks at the
+    EDGE level so it is already unambiguous (#272): an entry is ``"left"``
+    iff ALL of its edges are explicitly LEFT-marked, else ``"inner"``.
+    Because ``.left_join`` is whole-path and the only source of LEFT, a
+    proper prefix of a longer path can be LEFT while the deeper hop is INNER
+    — that prefix is itself a registered path (``left_join`` registers its
+    full path) and is emitted as its own ``"left"`` entry; the longer entry
+    is emitted ``"inner"``. The Rust edge resolver then renders the prefix
+    edges LEFT and the deeper edges INNER (a pure double-check of this
+    wire). This also makes "explicit LEFT beats implicit INNER on a shared
+    edge" visible in the IR itself.
+    """
+    entries: list[QueryJoin] = []
+    for path in query._joins:
+        is_left = all(
+            query._explicit_edges.get(edge) == "left" for edge in path_edges(path)
+        )
+        entries.append(
+            QueryJoin(
+                join_type="left" if is_left else "inner",
+                path=resolve_join_hops(query.model_cls, path),
+            )
+        )
+    return tuple(entries)
+
+
+def _record_field(model_cls: type, field: Any) -> RecordField:
+    """Convert one builder ``_ProjectedField`` into its wire field (v5).
+
+    ``name`` is declared separately from ``column`` (output aliases) and each
+    plain field carries its relation ``path`` (traversed projection, #293).
+    An aggregate field carries an ``expr`` instead (#294): ``fn`` as data and
+    the source's traversal as hop facts on ``expr.path`` — self-contained on
+    the wire — with the field-level ``path`` empty.
+    """
+    if field.agg is not None:
+        return RecordField(
+            name=field.name,
+            column=None,
+            path=(),
+            expr=RecordExpr(
+                fn=field.agg,
+                column=field.column,
+                path=resolve_join_hops(model_cls, field.path),
+            ),
+        )
+    return RecordField(
+        name=field.name, column=field.column, path=tuple(field.path), expr=None
+    )
+
+
+def _materialization(query: "Query[Any]") -> Materialization:
+    """Compile the query's materialization plan (ADR-0007).
+
+    Every fetching query carries exactly one plan on the wire: a ``record``
+    plan when projected, the ``instances`` plan when it includes relation
+    paths (#286 — the same hop shape as ``joins`` but deliberately separate,
+    ADR-0008: the fetch walker unions include-only edges in as LEFT, so
+    include can never change membership or a shared edge's join type), and
+    complete root instances otherwise.
+    """
+    projection = getattr(query, "_projection", None)
+    if projection is not None:
+        return Record(
+            fields=tuple(_record_field(query.model_cls, field) for field in projection)
+        )
+    if query._includes:
+        return Instances(
+            paths=tuple(
+                resolve_join_hops(query.model_cls, path) for path in query._includes
+            )
+        )
+    return RootInstances()
+
+
+def _reject_mutation_misuse(query: "Query[Any]", operation: str) -> None:
+    """Reject query state a mutating verb cannot carry (FF-A A1, #273, #287).
+
+    Raises:
+        ValueError: If ``limit()``/``offset()`` was set, the query traverses
+            a relation (a joined/explicit-edge path, or a where-clause leaf
+            carrying a non-empty path — portable SQL has no ``UPDATE/DELETE
+            ... JOIN``; a join-free shadow-FK filter stays allowed), or the
+            query carries ``include()``. Rejected here, before any DB
+            round-trip (the Rust guard from #270 stays as boundary defense).
+    """
+    if query._limit is not None or query._offset is not None:
+        raise ValueError(
+            f"{operation}() does not support limit/offset: portable SQL has "
+            f"no {operation.upper()} ... LIMIT. Remove the .limit()/.offset() "
+            f"call, or fetch primary keys first and {operation} by "
+            "primary-key set."
+        )
+    if (
+        query._joins
+        or query._explicit_edges
+        or any(_where_node_traverses(node) for node in query.where_clause)
+    ):
+        raise ValueError(
+            f"{operation}() does not support relation traversal: portable SQL "
+            f"has no {operation.upper()} ... JOIN. Fetch primary keys via the "
+            f"joined query first, then {operation} by primary-key set. "
+            "(A join-free relation filter like `t.account == instance` is "
+            "allowed.)"
+        )
+    if query._includes:
+        raise ValueError(
+            f"{operation}() does not support include(): a mutation is a "
+            "single-table write shape and returns no instances to "
+            "populate. Drop the .include(...) call, or fetch the "
+            "populated rows first and mutate by primary-key set."
+        )
+
+
+def compile_query(query: "Query[Any]", verb: QueryVerb) -> QueryIrPayload:
+    """Compile a built query into its wire payload — the single choke point.
+
+    What each verb carries is policy, stated here once:
+
+    - ``fetch`` carries everything: ordering, paging, m2m context, joins,
+      and the query's own materialization plan.
+    - ``count`` is unaffected by ordering, paging, and projection (PRD #277
+      verb table): it materializes a scalar, so ordering is dropped, paging
+      is ``null``, and the plan is ``root_instances`` even on a projected
+      query — joins and the m2m context still shape membership.
+    - ``update``/``delete`` are single-table write shapes: guardrails reject
+      paging, traversal, and includes (:func:`_reject_mutation_misuse`), and
+      the payload omits the paging keys entirely.
+
+    Raises:
+        ValueError: From the mutate guardrails.
+    """
+    identity = model_identity(query.model_cls)
+    where = tuple(node.to_ir_dict() for node in query.where_clause)
+    if verb in ("update", "delete"):
+        _reject_mutation_misuse(query, verb)
+        return QueryIrPayload(
+            model_name=identity,
+            where=where,
+            order_by=(),
+            limit=_ABSENT,
+            offset=_ABSENT,
+            m2m=None,
+            joins=(),
+            materialization=RootInstances(),
+        )
+    if verb == "count":
+        return QueryIrPayload(
+            model_name=identity,
+            where=where,
+            order_by=(),
+            limit=None,
+            offset=None,
+            m2m=query._m2m_context,
+            joins=_serialize_joins(query),
+            materialization=RootInstances(),
+        )
+    return QueryIrPayload(
+        model_name=identity,
+        where=where,
+        order_by=tuple(query.order_by_clause),
+        limit=query._limit,
+        offset=query._offset,
+        m2m=query._m2m_context,
+        joins=_serialize_joins(query),
+        materialization=_materialization(query),
+    )
+
+
+def to_wire_json(payload: QueryIrPayload) -> str:
+    """Serialize a payload into the versioned IR envelope JSON string."""
+    return json.dumps(
+        {
+            "ir_kind": "query",
+            "ir_version": _IR_VERSION,
+            "payload": _serialize_query_value(payload.to_ir_dict()),
+        }
+    )

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -505,11 +505,14 @@ def test_include_is_immutable_and_idempotent():
 
 
 def test_include_paths_never_enter_the_joins_wire_section():
+    from ferro.query.wire import compile_query
+
     q = INTransaction.select().include(lambda t: t.account)
+    payload = compile_query(q, "fetch").to_ir_dict()
 
     assert q._joins == {}
-    assert q._serialize_joins() == []
-    assert q._materialization_ir() == {
+    assert payload["joins"] == []
+    assert payload["materialization"] == {
         "kind": "instances",
         "paths": [
             [

--- a/tests/test_mutation_pagination_guard.py
+++ b/tests/test_mutation_pagination_guard.py
@@ -45,10 +45,12 @@ async def test_update_with_offset_raises_value_error():
         ).update(name="renamed")
 
 
-def test_mutating_query_def_omits_pagination_keys():
+def test_mutating_payload_omits_pagination_keys():
+    from ferro.query.wire import compile_query
+
     query = PaginationGuardItem.where(lambda item: item.flagged == True)  # noqa: E712
     for operation in ("update", "delete"):
-        payload = query._mutating_query_def(operation)
+        payload = compile_query(query, operation).to_ir_dict()
         assert "limit" not in payload
         assert "offset" not in payload
         assert payload["model_name"] == PaginationGuardItem.__ferro_identity__

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -9,8 +9,8 @@ import pytest
 import ferro
 from ferro import Model, connect
 from ferro.query import Query, QueryNode
-from ferro.query.builder import _query_ir_payload_to_json
 from ferro.query.nodes import FieldProxy, _serialize_query_value
+from ferro.query.wire import compile_query, to_wire_json
 from pydantic import Field
 
 pytestmark = pytest.mark.backend_matrix
@@ -49,30 +49,23 @@ def test_serialize_query_value_normalizes_non_json_native_values():
     json.dumps(serialized)
 
 
-def test_query_ir_payload_to_json_serializes_m2m_context_without_mutating_query_state():
+def test_to_wire_json_serializes_m2m_context_without_mutating_query_state():
+    class WireM2mPost(Model):
+        id: int | None = Field(default=None, json_schema_extra={"primary_key": True})
+
     source_id = uuid.uuid4()
-    query = Query(Model)._m2m(
+    query = Query(WireM2mPost)._m2m(
         "post_tags",
         "post_id",
         "tag_id",
         source_id,
     )
-    query_def = {
-        "model_name": "Tag",
-        "where": [],
-        "order_by": [],
-        "limit": None,
-        "offset": None,
-        "m2m": query._m2m_context,
-        "joins": [],
-        "materialization": {"kind": "root_instances"},
-    }
 
-    query_json = _query_ir_payload_to_json(query_def)
+    query_json = to_wire_json(compile_query(query, "fetch"))
     payload = json.loads(query_json)
 
-    assert query._m2m_context["source_id"] == source_id
-    assert isinstance(query._m2m_context["source_id"], uuid.UUID)
+    assert query._m2m_context.source_id == source_id
+    assert isinstance(query._m2m_context.source_id, uuid.UUID)
     assert payload["ir_kind"] == "query"
     assert payload["ir_version"] == 5
     assert payload["payload"]["m2m"]["source_id"] == str(source_id)
@@ -81,7 +74,12 @@ def test_query_ir_payload_to_json_serializes_m2m_context_without_mutating_query_
 def test_query_carries_root_instances_materialization_by_default():
     """Every query without a projection materializes complete root instances
     (ADR-0007): the v3 plan is explicit data on the wire, never inferred."""
-    assert Query(Model)._materialization_ir() == {"kind": "root_instances"}
+
+    class WirePlainRow(Model):
+        id: int | None = Field(default=None, json_schema_extra={"primary_key": True})
+
+    payload = compile_query(Query(WirePlainRow), "fetch").to_ir_dict()
+    assert payload["materialization"] == {"kind": "root_instances"}
 
 
 def test_query_node_to_dict_serializes_uuid_values_inside_in_filters():

--- a/tests/test_query_column_validation.py
+++ b/tests/test_query_column_validation.py
@@ -6,6 +6,7 @@ import pytest
 
 from ferro import FerroField, ForeignKey, Model
 from ferro.query import Query, QueryProxy
+from ferro.query.wire import OrderByEntry
 
 
 pytestmark = pytest.mark.sqlite_only
@@ -87,7 +88,7 @@ class TestOrderByValidation:
 
         q = ObUser.select().order_by(lambda u: u.created_at, "desc")
         assert q.order_by_clause == [
-            {"column": "created_at", "direction": "desc", "path": []}
+            OrderByEntry(column="created_at", direction="desc", path=())
         ]
 
     def test_order_by_string_is_validated(self):
@@ -96,7 +97,9 @@ class TestOrderByValidation:
             age: int = 0
 
         q = ObUser2.select().order_by("age")
-        assert q.order_by_clause == [{"column": "age", "direction": "asc", "path": []}]
+        assert q.order_by_clause == [
+            OrderByEntry(column="age", direction="asc", path=())
+        ]
 
     def test_order_by_misspelled_string_raises(self):
         class ObUser3(Model):

--- a/tests/test_query_immutability.py
+++ b/tests/test_query_immutability.py
@@ -7,6 +7,7 @@ import pytest
 import ferro
 from ferro import FerroField, Model
 from ferro.query import Query, Relation
+from ferro.query.wire import OrderByEntry
 
 
 pytestmark = pytest.mark.sqlite_only
@@ -48,17 +49,20 @@ class TestImmutableChaining:
         assert (q1._limit, q1._offset, q1.order_by_clause) == (None, None, [])
         assert q2._limit == 5 and q2._offset is None
         assert q3._offset == 10
-        assert q4.order_by_clause == [{"column": "age", "direction": "desc", "path": []}]
+        assert q4.order_by_clause == [
+            OrderByEntry(column="age", direction="desc", path=())
+        ]
         assert q3.order_by_clause == []
 
-    def test_m2m_context_is_not_shared_between_clones(self):
+    def test_m2m_context_is_immutable_so_clones_share_it_safely(self):
         class ImmUser4(Model):
             id: Annotated[int | None, FerroField(primary_key=True)] = None
 
         q1 = Query(ImmUser4)._m2m("jt", "src", "tgt", 1)
         q2 = q1.limit(3)
-        assert q1._m2m_context is not q2._m2m_context
         assert q2._m2m_context == q1._m2m_context
+        with pytest.raises(AttributeError):
+            q2._m2m_context.join_table = "other"  # frozen: no aliasing hazard
 
     def test_relation_chaining_preserves_relation_type(self):
         class ImmUser5(Model):

--- a/tests/test_query_joins.py
+++ b/tests/test_query_joins.py
@@ -22,6 +22,7 @@ import ferro
 from ferro import BackRef, FerroField, ForeignKey, ManyToMany, Model, Relation
 from ferro.query import Query, QueryNode
 from ferro.query.nodes import FieldProxy, QueryProxy
+from ferro.query.wire import compile_query
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -680,22 +681,22 @@ def test_query_node_boolean_coercion_raises():
 
 class TestMutatingTraversalRejection:
     """update()/delete() reject relation traversal at the shared choke point
-    (:meth:`Query._mutating_query_def`), before any serialization or DB."""
+    (:func:`ferro.query.wire.compile_query`), before any serialization or DB."""
 
     def test_traversed_predicate_rejected_for_update_and_delete(self):
         q = Query(QJTransaction).where(lambda t: t.account.label == "a1")
         for operation in ("update", "delete"):
             with pytest.raises(ValueError, match="does not support relation traversal"):
-                q._mutating_query_def(operation)
+                compile_query(q, operation)
 
     def test_explicit_join_rejected(self):
         q = Query(QJTransaction).join(lambda t: t.account)
         with pytest.raises(ValueError, match="relation traversal"):
-            q._mutating_query_def("update")
+            compile_query(q, "update")
 
     def test_join_free_relation_filter_is_allowed(self):
         q = Query(QJTransaction).where(lambda t: t.account == _persisted_account(1))
-        payload = q._mutating_query_def("update")  # must NOT raise
+        payload = compile_query(q, "update").to_ir_dict()  # must NOT raise
         assert payload["where"][0]["column"] == "account_id"
         assert payload["where"][0]["path"] == []
 
@@ -719,9 +720,10 @@ async def test_update_and_delete_reject_traversal_before_db():
 
 def _serialized_join_types(query) -> list[tuple[tuple[str, ...], str]]:
     """(path, join_type) for each serialized ``joins`` entry, in wire order."""
+    payload = compile_query(query, "fetch").to_ir_dict()
     return [
         (tuple(hop["relation"] for hop in entry["path"]), entry["join_type"])
-        for entry in query._serialize_joins()
+        for entry in payload["joins"]
     ]
 
 

--- a/tests/test_query_wire_vectors.py
+++ b/tests/test_query_wire_vectors.py
@@ -1,0 +1,288 @@
+"""Builder→wire golden-vector equality: the Python half of the QueryIR contract.
+
+Each test builds one real query through the public chainers and asserts the
+compiled wire envelope (``compile_query`` → ``to_wire_json``) equals the
+hand-authored golden vector in ``tests/fixtures/ir_vectors/`` byte-for-byte.
+The Rust half round-trips the same fixture files in ``crates/ferro-schema-ir``
+— one artifact, both sides assert, so neither side can drift silently.
+
+The vectors pin the wire *shape*, not this module's import path: their
+``model_name`` is the bare class name, while the builder emits the
+module-qualified registry identity, so the expected payload substitutes the
+real identity before comparing (and asserts the bare name matches).
+
+Vectors are hand-authored, never regenerated from builder output — an
+independent authority is what makes drift detectable. When the wire
+legitimately changes (the next ``ir_version`` bump), updating the vectors by
+hand is the contract-review moment.
+
+Verb policy (what ``count()`` and the mutating verbs carry) has no fetch-shaped
+vector; it is pinned here against inline expected payloads instead.
+"""
+
+import json
+from pathlib import Path
+from typing import Annotated, Any, Callable
+
+import pytest
+
+from ferro import BackRef, FerroField, ForeignKey, Model, Relation
+from ferro.query.wire import compile_query, to_wire_json
+from ferro.relations import resolve_relationships
+
+VECTORS_DIR = Path(__file__).parent / "fixtures" / "ir_vectors"
+
+
+def _vector(name: str) -> dict[str, Any]:
+    return json.loads((VECTORS_DIR / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def _build_models() -> dict[str, type]:
+    """Declare the model graph the query vectors reference.
+
+    Class names, relation field names, and shadow columns must line up with
+    the vectors' hop facts (``account``/``owner`` tables, ``account_id``/
+    ``owner_id`` shadow FKs), so the classes carry the vectors' bare names.
+    """
+
+    class Owner(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        email: str = ""
+        accounts: Relation[list["Account"]] = BackRef()
+
+    class Account(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str = ""
+        balance: int = 0
+        owner: Annotated[Owner | None, ForeignKey(related_name="accounts")] = None
+        transactions: Relation[list["Transaction"]] = BackRef()
+
+    class Transaction(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        amount: int = 0
+        account: Annotated[Account | None, ForeignKey(related_name="transactions")] = (
+            None
+        )
+
+    class User(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        active: bool = True
+        email: str = ""
+        role: str = ""
+
+    resolve_relationships()
+    return {
+        "Owner": Owner,
+        "Account": Account,
+        "Transaction": Transaction,
+        "User": User,
+    }
+
+
+@pytest.fixture()
+def models(clean_registry: None) -> dict[str, type]:
+    return _build_models()
+
+
+# ---------------------------------------------------------------------------
+# One public-chainer query per vector. Chainer order matters where the vector
+# pins join insertion order (the ``joins`` list is insertion-ordered).
+# ---------------------------------------------------------------------------
+
+
+def _q_user_compound(m: dict[str, type]) -> Any:
+    return (
+        m["User"]
+        .where(
+            lambda u: (
+                (u.active == True)  # noqa: E712
+                & ((u.email.like("%@ferro.dev")) | (u.role.in_(["admin", "owner"])))
+            )
+        )
+        .order_by("id")
+        .limit(100)
+        .offset(0)
+    )
+
+
+def _q_traversal(m: dict[str, type]) -> Any:
+    # order_by first so the ("account",) join registers before the where
+    # clause's ("account", "owner") — the vector pins that insertion order.
+    return (
+        m["Transaction"]
+        .select()
+        .order_by(lambda t: t.account.name)
+        .order_by("id")
+        .where(
+            lambda t: (t.account.owner.email == "owner@ferro.dev") & (t.amount >= 100)
+        )
+        .limit(50)
+        .offset(0)
+    )
+
+
+def _q_left_join(m: dict[str, type]) -> Any:
+    return (
+        m["Transaction"]
+        .select()
+        .left_join(lambda t: t.account)
+        .where(lambda t: t.account.owner.email == "owner@ferro.dev")
+    )
+
+
+def _q_include(m: dict[str, type]) -> Any:
+    return (
+        m["Transaction"]
+        .where(lambda t: t.amount >= 100)
+        .order_by("id")
+        .include(lambda t: t.account)
+    )
+
+
+def _q_record(m: dict[str, type]) -> Any:
+    return (
+        m["Transaction"]
+        .where(lambda t: t.amount >= 100)
+        .select(lambda t: (t.id, t.amount))
+        .order_by("amount", "desc")
+        .limit(25)
+    )
+
+
+def _q_traversed_record(m: dict[str, type]) -> Any:
+    return (
+        m["Transaction"]
+        .select()
+        .left_join(lambda t: t.account)
+        .where(lambda t: t.amount >= 100)
+        .select(
+            lambda t: {
+                "txn_id": t.id,
+                "account_name": t.account.name,
+                "owner_email": t.account.owner.email,
+            }
+        )
+        .order_by("id")
+    )
+
+
+def _q_aggregate(m: dict[str, type]) -> Any:
+    return (
+        m["Transaction"]
+        .where(lambda t: t.amount >= 100)
+        .select(
+            lambda t: {
+                "account_name": t.account.name,
+                "total": t.amount.sum(),
+                "avg_balance": t.account.balance.avg(),
+            }
+        )
+        .order_by("total", "desc")
+        .limit(5)
+    )
+
+
+def _q_global_aggregate(m: dict[str, type]) -> Any:
+    return (
+        m["Transaction"]
+        .where(lambda t: t.amount >= 100)
+        .select(
+            lambda t: {
+                "n": t.id.count(),
+                "total": t.amount.sum(),
+                "avg_balance": t.account.balance.avg(),
+            }
+        )
+    )
+
+
+CASES: list[tuple[str, Callable[[dict[str, type]], Any], str]] = [
+    ("query_user_compound_v5", _q_user_compound, "User"),
+    ("query_transaction_traversal_v5", _q_traversal, "Transaction"),
+    ("query_transaction_left_join_v5", _q_left_join, "Transaction"),
+    ("query_transaction_include_v5", _q_include, "Transaction"),
+    ("query_transaction_record_v5", _q_record, "Transaction"),
+    ("query_transaction_traversed_record_v5", _q_traversed_record, "Transaction"),
+    ("query_transaction_aggregate_v5", _q_aggregate, "Transaction"),
+    ("query_transaction_global_aggregate_v5", _q_global_aggregate, "Transaction"),
+]
+
+
+@pytest.mark.parametrize(
+    ("vector_name", "build", "root"), CASES, ids=[case[0] for case in CASES]
+)
+def test_builder_emission_matches_vector(
+    models: dict[str, type],
+    vector_name: str,
+    build: Callable[[dict[str, type]], Any],
+    root: str,
+) -> None:
+    vector = _vector(vector_name)
+    expected = vector["ir"]
+    assert expected["payload"]["model_name"] == root
+
+    emitted = json.loads(to_wire_json(compile_query(build(models), "fetch")))
+
+    expected["payload"]["model_name"] = models[root].__ferro_identity__
+    assert emitted == expected
+
+
+# ---------------------------------------------------------------------------
+# Verb policy: what count() and the mutating verbs put on the wire.
+# ---------------------------------------------------------------------------
+
+
+def _payload(query: Any, verb: str) -> dict[str, Any]:
+    return json.loads(to_wire_json(compile_query(query, verb)))["payload"]
+
+
+def test_count_zeroes_ordering_and_paging_but_keeps_joins(
+    models: dict[str, type],
+) -> None:
+    query = (
+        models["Transaction"]
+        .where(lambda t: t.account.name == "checking")
+        .order_by("id")
+        .limit(3)
+        .offset(1)
+    )
+    payload = _payload(query, "count")
+    assert payload["order_by"] == []
+    assert payload["limit"] is None
+    assert payload["offset"] is None
+    assert len(payload["joins"]) == 1
+    assert payload["materialization"] == {"kind": "root_instances"}
+
+
+def test_count_on_a_projection_stays_root_instances(
+    models: dict[str, type],
+) -> None:
+    # count() is projection-blind (PRD #277 verb table): it materializes a
+    # scalar, so the plan is root_instances even on a projected query.
+    query = (
+        models["Transaction"]
+        .where(lambda t: t.amount >= 100)
+        .select(lambda t: (t.id, t.amount))
+    )
+    assert _payload(query, "count")["materialization"] == {"kind": "root_instances"}
+
+
+def test_mutate_payload_omits_pagination_keys(models: dict[str, type]) -> None:
+    # Mutating payloads carry no limit/offset keys at all (absent, not null):
+    # portable SQL has no UPDATE/DELETE ... LIMIT, and pagination is rejected
+    # before compilation — the absent keys are the pinned wire bytes.
+    query = models["User"].where(lambda u: u.active == True)  # noqa: E712
+    for verb in ("update", "delete"):
+        payload = _payload(query, verb)
+        assert "limit" not in payload
+        assert "offset" not in payload
+        assert payload["order_by"] == []
+        assert payload["m2m"] is None
+        assert payload["joins"] == []
+        assert payload["materialization"] == {"kind": "root_instances"}
+
+
+def test_envelope_is_versioned(models: dict[str, type]) -> None:
+    envelope = json.loads(to_wire_json(compile_query(models["User"].select(), "fetch")))
+    assert envelope["ir_kind"] == "query"
+    assert envelope["ir_version"] == 5

--- a/tests/test_static_contracts.py
+++ b/tests/test_static_contracts.py
@@ -3,11 +3,19 @@ import subprocess
 from pathlib import Path
 
 
-def test_query_methods_use_query_ir_serializer_instead_of_raw_json_dumps():
-    source = Path("src/ferro/query/builder.py").read_text(encoding="utf-8")
+def test_wire_module_is_the_only_query_payload_serializer():
+    """The QueryIR payload has one compiler and one envelope serializer
+    (ferro.query.wire); the builder carries zero wire vocabulary."""
+    wire_source = Path("src/ferro/query/wire.py").read_text(encoding="utf-8")
+    assert wire_source.count("def compile_query(") == 1
+    assert wire_source.count("def to_wire_json(") == 1
 
-    assert source.count("def _query_ir_payload_to_json(") == 1
-    assert "json.dumps(query_def)" not in source
+    builder_source = Path("src/ferro/query/builder.py").read_text(encoding="utf-8")
+    assert "json.dumps" not in builder_source
+    assert '"ir_version"' not in builder_source
+    assert '"materialization"' not in builder_source
+    assert '"model_name"' not in builder_source
+    assert '"join_type"' not in builder_source
 
 
 def test_mutating_query_methods_cannot_carry_pagination():
@@ -28,16 +36,21 @@ def test_mutating_query_methods_cannot_carry_pagination():
         attributes = {
             node.attr for node in ast.walk(method) if isinstance(node, ast.Attribute)
         }
+        called = {
+            node.func.id
+            for node in ast.walk(method)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
         assert "_limit" not in attributes, (
             f"Query.{method_name}() must not read _limit; pagination is rejected "
-            "by _mutating_query_def (FF-A A1)"
+            "by compile_query's mutate guardrails (FF-A A1)"
         )
         assert "_offset" not in attributes, (
             f"Query.{method_name}() must not read _offset; pagination is rejected "
-            "by _mutating_query_def (FF-A A1)"
+            "by compile_query's mutate guardrails (FF-A A1)"
         )
-        assert "_mutating_query_def" in attributes, (
-            f"Query.{method_name}() must build its payload via _mutating_query_def"
+        assert "compile_query" in called, (
+            f"Query.{method_name}() must build its payload via compile_query"
         )
 
 


### PR DESCRIPTION
## What

Pins the QueryIR seam — the Python→Rust query wire contract — behind one typed choke point, and closes the test gap where neither side's tests verified the other's half of the contract.

- **`ferro/query/wire.py`** (new) owns the wire vocabulary end to end: frozen dataclasses mirroring `crates/ferro-schema-ir`'s serde structs one-for-one (`QueryIrPayload`, `Materialization` ×3, `RecordField`, `RecordExpr`, `QueryJoin`/`QueryJoinHop`, `OrderByEntry`, `M2mContext`), hop-fact resolution, join serialization, materialization-plan compilation, verb policy, and the versioned envelope (`ir_version: 5` lives only here).
- **`compile_query(query, verb)`** is the sole compiler, `to_wire_json()` the sole serializer. The five emission sites in `builder.py` (`all`/`count`/`update`/`delete`/`ProjectedQuery.all`) are one-liners; the three inline payload dicts and both `_materialization_ir` bodies are gone. A static contract test pins that builder.py carries zero wire vocabulary.
- **Verb policy is data in one place**: fetch carries everything; count zeroes ordering, nulls paging, and stays projection-blind (PRD #277 verb table); mutations omit the paging keys entirely. The mutate guardrails (#295 messages byte-identical) moved into the compiler's mutate arm; aggregate `order_by` rules stay on the chainers.

## Why

Every roadmap axis (includes ADR-0008, aggregate projections ADR-0009, the `instances` plan) rides this wire, and each new feature was re-smearing the contract across another inline dict. Meanwhile the golden vectors in `tests/fixtures/ir_vectors/` were consumed by ~900 lines of Rust round-trip tests but nothing verified the Python builder actually emits them — builder drift was invisible to both suites.

## Test story

**`tests/test_query_wire_vectors.py`** (new) builds one real query per existing hand-authored golden vector through the public chainers and asserts the emitted envelope equals the fixture **byte-for-byte** (module-qualified `model_name` substituted). Combined with the existing Rust round-trips over the same files, the contract is now pinned from both sides by one artifact. Vectors stay hand-authored — never regenerated from builder output — so drift stays detectable.

## Verification

Behaviour-preserving by construction: no Rust changes, no FFI signature changes, identical wire bytes.

- SQLite suite: 1185 passed
- Postgres matrix (`--db-backends=postgres`): 1230 passed
- `cargo test --no-default-features --features testing`: 113 passed
- `ty check`: clean

## Follow-up

A typed plan on the wire makes `fetch_filtered`'s paired kwargs (`record_cls`/`hop_classes`, four runtime pairing-guard arms in `operations.rs`) collapsible into plan-driven dispatch — filed separately.

CONTEXT.md gains **QueryIR payload** and **Golden vector**.