### PR TITLE
fix: self-referential FKs no longer evict their component from CREATE TABLE order

### DIFF
--- a/crates/ferro-migrate/src/emit.rs
+++ b/crates/ferro-migrate/src/emit.rs
@@ -255,47 +255,23 @@ fn post_create_artifacts(
 
 /// Order `AddTable` models so each table's FK targets are created before it.
 ///
-/// A FK dependency on a table that is *not* part of this add set (already
-/// exists in the live DB) does not constrain ordering. Cycles fall through in
-/// arbitrary order — the inline FKs are anonymous, so a cyclic create still
-/// runs (SQLite is lenient; Postgres `CREATE TABLE` with a forward inline FK
-/// reference is the pre-existing behavior preserved here).
+/// Delegates to [`crate::order_by_dependencies`] for the dependency
+/// semantics: a self-referential FK and a FK to a table outside this add set
+/// do not constrain ordering, and genuine cross-table cycles fall through in
+/// input order (SQLite tolerates the forward references; Postgres rejects
+/// them — #302 follow-up).
 pub fn order_models_for_create<'a>(models: &[&'a SchemaModel]) -> Vec<&'a SchemaModel> {
-    let mut remaining: Vec<&SchemaModel> = models.to_vec();
-    let mut ordered = Vec::new();
-    let mut created = std::collections::HashSet::new();
-
-    while !remaining.is_empty() {
-        let available: std::collections::HashSet<String> = remaining
-            .iter()
-            .map(|m| m.table_name.clone())
-            .collect();
-        let mut progress = false;
-        let mut index = 0;
-        while index < remaining.len() {
-            let deps: Vec<String> = remaining[index]
+    crate::order_by_dependencies(
+        models.to_vec(),
+        |model| model.table_name.clone(),
+        |model| {
+            model
                 .foreign_keys
                 .iter()
                 .map(|fk| fk.to_table.clone())
-                .collect();
-            if deps
-                .iter()
-                .all(|dep| created.contains(dep) || !available.contains(dep))
-            {
-                let model = remaining.remove(index);
-                created.insert(model.table_name.clone());
-                ordered.push(model);
-                progress = true;
-            } else {
-                index += 1;
-            }
-        }
-        if !progress {
-            ordered.append(&mut remaining);
-            break;
-        }
-    }
-    ordered
+                .collect()
+        },
+    )
 }
 
 fn emit_add_table_passes(

--- a/crates/ferro-migrate/src/lib.rs
+++ b/crates/ferro-migrate/src/lib.rs
@@ -4,12 +4,14 @@
 //! [`emit_sql_with_ir`] lowers structural ops to executable backend-specific DDL.
 
 mod emit;
+mod order;
 
 use ferro_ddl_lowering::schema_columns_storage_drift;
 use ferro_schema_ir::{IrEnvelope, SchemaIrPayload, SchemaModel};
 use std::collections::{BTreeMap, BTreeSet};
 
 pub use emit::{emit_sql_with_ir, order_models_for_create, render_create_table, CreateTableEmission};
+pub use order::order_by_dependencies;
 pub use ferro_ddl_lowering::Dialect;
 
 /// Executable SQL plus non-fatal warnings from [`emit_sql_with_ir`].

--- a/crates/ferro-migrate/src/order.rs
+++ b/crates/ferro-migrate/src/order.rs
@@ -1,0 +1,56 @@
+//! Dependency ordering shared by every path that emits or reconciles tables.
+
+use std::collections::HashSet;
+
+/// Order `items` so every FK dependency of an item is emitted before it.
+///
+/// This is the single dependency-order primitive: both the CREATE TABLE
+/// emitter ([`crate::order_models_for_create`]) and the runtime's migrate
+/// reconcile loop funnel through it, so the semantics live in one place:
+///
+/// - A dependency on the item's **own** table (a self-referential FK) is not
+///   an ordering constraint — the inline `REFERENCES` resolves against the
+///   table its own `CREATE TABLE` statement is creating (#302).
+/// - A dependency on a table **outside** `items` (already live in the DB)
+///   does not constrain ordering.
+/// - Genuine cross-table cycles cannot be dependency-ordered; the remaining
+///   items are appended in input order. SQLite tolerates the resulting
+///   forward references; Postgres rejects them at CREATE time (#302
+///   follow-up: defer those FKs to post-create `ALTER TABLE ADD CONSTRAINT`).
+///
+/// Ordering is deterministic: input order is preserved except where a
+/// dependency forces an item later.
+pub fn order_by_dependencies<T>(
+    items: Vec<T>,
+    table_of: impl Fn(&T) -> String,
+    deps_of: impl Fn(&T) -> Vec<String>,
+) -> Vec<T> {
+    let mut remaining = items;
+    let mut ordered = Vec::with_capacity(remaining.len());
+    let mut created: HashSet<String> = HashSet::new();
+
+    while !remaining.is_empty() {
+        let available: HashSet<String> = remaining.iter().map(&table_of).collect();
+        let mut progress = false;
+        let mut index = 0;
+        while index < remaining.len() {
+            let table = table_of(&remaining[index]);
+            let satisfied = deps_of(&remaining[index])
+                .iter()
+                .all(|dep| dep == &table || created.contains(dep) || !available.contains(dep));
+            if satisfied {
+                let item = remaining.remove(index);
+                created.insert(table);
+                ordered.push(item);
+                progress = true;
+            } else {
+                index += 1;
+            }
+        }
+        if !progress {
+            ordered.append(&mut remaining);
+            break;
+        }
+    }
+    ordered
+}

--- a/crates/ferro-migrate/src/tests.rs
+++ b/crates/ferro-migrate/src/tests.rs
@@ -1459,3 +1459,36 @@ fn emit_sql_with_ir_add_column_db_check_postgres_quoted_and_sqlite_warns() {
         lite.warnings
     );
 }
+
+#[test]
+fn order_models_for_create_self_fk_is_not_an_ordering_constraint() {
+    // #302: `znode` carries a self-referential FK; `areferrer` arrives first
+    // (mirroring the alphabetical incoming order) and requires `znode`. The
+    // self-loop is satisfied by the table's own CREATE, so it must not evict
+    // the component from the dependency order.
+    let znode = SchemaModel {
+        foreign_keys: vec![SchemaForeignKey {
+            column: "parent_id".to_string(),
+            to_table: "znode".to_string(),
+            to_column: "id".to_string(),
+            on_delete: None,
+            name: None,
+        }],
+        ..schema_model("znode", vec![col("id", "uuid", false)])
+    };
+    let areferrer = SchemaModel {
+        foreign_keys: vec![SchemaForeignKey {
+            column: "node_id".to_string(),
+            to_table: "znode".to_string(),
+            to_column: "id".to_string(),
+            on_delete: None,
+            name: None,
+        }],
+        ..schema_model("areferrer", vec![col("id", "uuid", false)])
+    };
+
+    let models = vec![&areferrer, &znode];
+    let ordered = order_models_for_create(&models);
+    let tables: Vec<&str> = ordered.iter().map(|m| m.table_name.as_str()).collect();
+    assert_eq!(tables, vec!["znode", "areferrer"]);
+}

--- a/docs/solutions/issues/self-fk-evicts-component-from-create-order.md
+++ b/docs/solutions/issues/self-fk-evicts-component-from-create-order.md
@@ -1,0 +1,59 @@
+---
+title: Self-referential FK evicted its whole component from CREATE TABLE order
+type: issue
+tags: [rust, schema, migrations, gotcha, postgres]
+related_files:
+  - crates/ferro-migrate/src/order.rs
+  - crates/ferro-migrate/src/emit.rs
+  - src/schema.rs
+related_issues: [302]
+captured: 2026-07-15
+---
+
+# Self-referential FK evicted its whole component from CREATE TABLE order
+
+**Problem:** On a fresh Postgres schema, `auto_migrate` created a referrer
+table before its FK target whenever the target carried a self-referential FK —
+the inline `REFERENCES` failed with `relation "..." does not exist`.
+
+**Takeaway:** In a dependency sort, an edge to your own table is already
+satisfied by your own `CREATE TABLE`; treating it as a pending dependency makes
+the table permanently ineligible, stalls everything downstream of it, and drops
+the whole component into the cycle fallback (input/alphabetical order).
+
+## What happened
+
+Both ordering loops (`order_models_for_create` in `ferro-migrate` and
+`order_models_for_migration` in `src/schema.rs`) only scheduled a table once
+every `fk.to_table` was in the `created` set. A self-FK's target can never be
+in `created` before the table itself, so the self-FK table never became
+eligible, its dependents stalled behind it, and the no-progress fallback
+appended the remainder in incoming order. Any referrer sorting before its
+target then failed on Postgres. Existing schemas survived by alphabetical
+luck.
+
+Two things let the bug survive review:
+
+1. The ordering loop existed in **two hand-rolled copies** with the same flaw.
+   Both now delegate to one primitive:
+   `ferro_migrate::order_by_dependencies` (`crates/ferro-migrate/src/order.rs`),
+   where the self-edge rule lives exactly once.
+2. A doc comment claimed cycles were harmless because "Postgres `CREATE TABLE`
+   with a forward inline FK reference is the pre-existing behavior" — false.
+   Postgres rejects forward references at CREATE time; only SQLite tolerates
+   them. Don't trust ordering-doesn't-matter claims without a Postgres test.
+
+Genuine cross-table cycles (A→B→A) still fall through in input order and fail
+on Postgres — a real fix needs post-create `ALTER TABLE ADD CONSTRAINT`
+deferral (follow-up tracked from #302).
+
+## How to recognize
+
+- `relation "X" does not exist` during `auto_migrate` on a fresh Postgres
+  schema, where X *is* among the registered models.
+- The failure appears/disappears when a self-FK is added/removed anywhere in
+  the dependency component, or when table names are renamed across the
+  alphabetical boundary.
+- SQLite passes while Postgres fails: SQLite accepts forward FK references, so
+  ordering bugs are invisible there — regression tests for CREATE order must
+  run on the Postgres matrix.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -7,7 +7,7 @@ use crate::backend::EngineHandle;
 use crate::state::{Dialect, MODEL_REGISTRY, engine_for_connection};
 use ferro_schema_ir::{IrEnvelope, SchemaIrPayload};
 use pyo3::prelude::*;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 fn model_ir_dependencies(
@@ -32,52 +32,26 @@ fn model_ir_dependencies(
     deps
 }
 
-/// Topologically sort registered models for the migrate ALTER reconcile loop.
+/// Dependency-sort registered models for the migrate ALTER reconcile loop.
 ///
 /// FK edges come from [`SchemaModel::foreign_keys`] in the pushed modelset.
-/// External targets (not among registered table names) do not block ordering.
-/// Cycles append the remaining entries when no progress is possible.
+/// Entries are sorted by model name first, then delegated to
+/// [`ferro_migrate::order_by_dependencies`] — the shared primitive that also
+/// orders CREATE TABLE emission — so self-referential FKs, external targets,
+/// and cycle fallback behave identically on both paths (#302).
 pub(crate) fn order_models_for_migration(
     registry: HashMap<String, Arc<crate::state::RegisteredModel>>,
     modelset: &IrEnvelope<SchemaIrPayload>,
 ) -> Vec<(String, Arc<crate::state::RegisteredModel>)> {
-    let mut remaining: Vec<(String, Arc<crate::state::RegisteredModel>)> =
+    let mut entries: Vec<(String, Arc<crate::state::RegisteredModel>)> =
         registry.into_iter().collect();
-    remaining.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
 
-    let mut ordered = Vec::with_capacity(remaining.len());
-    let mut created = HashSet::new();
-
-    while !remaining.is_empty() {
-        let available_names: HashSet<String> = remaining
-            .iter()
-            .map(|(_, model)| model.table_name.clone())
-            .collect();
-        let mut progress = false;
-        let mut index = 0;
-
-        while index < remaining.len() {
-            let deps = model_ir_dependencies(&remaining[index].1.table_name, modelset);
-            if deps
-                .iter()
-                .all(|dep| created.contains(dep) || !available_names.contains(dep))
-            {
-                let item = remaining.remove(index);
-                let table = item.1.table_name.clone();
-                created.insert(table);
-                ordered.push(item);
-                progress = true;
-            } else {
-                index += 1;
-            }
-        }
-
-        if !progress {
-            ordered.append(&mut remaining);
-        }
-    }
-
-    ordered
+    ferro_migrate::order_by_dependencies(
+        entries,
+        |(_, model)| model.table_name.clone(),
+        |(_, model)| model_ir_dependencies(&model.table_name, modelset),
+    )
 }
 
 /// Internal utility to create all registered tables in the database.
@@ -527,6 +501,27 @@ mod tests {
             .collect();
         assert!(tables.contains(&"alpha"));
         assert!(tables.contains(&"beta"));
+    }
+
+    #[test]
+    fn order_models_for_migration_self_fk_is_not_an_ordering_constraint() {
+        // #302: `znode` carries a self-referential FK and `areferrer`
+        // (alphabetically first) requires it. The self-loop must not evict
+        // the component from the dependency order.
+        let modelset = test_modelset(vec![
+            test_schema_model("znode", &["znode"]),
+            test_schema_model("areferrer", &["znode"]),
+        ]);
+        let mut registry = HashMap::new();
+        registry.insert("ZNode".to_string(), test_registered("znode"));
+        registry.insert("AReferrer".to_string(), test_registered("areferrer"));
+
+        let ordered = order_models_for_migration(registry, &modelset);
+        let tables: Vec<&str> = ordered
+            .iter()
+            .map(|(_, model)| model.table_name.as_str())
+            .collect();
+        assert_eq!(tables, vec!["znode", "areferrer"]);
     }
 
     #[test]

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -1376,3 +1376,45 @@ async def test_pg_json_to_jsonb_declaration_edit_alters_in_place(
     async with ferro.engines.session():
         migrated = await JsonbMigrated.get(1)
     assert migrated.payload == {"kept": True}
+
+
+# ---------------------------------------------------------------------------
+# CREATE TABLE dependency order with a self-referential FK (issue #302)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.backend_matrix
+async def test_self_fk_does_not_evict_component_from_create_order(
+    db_url, clean_registry
+):
+    """A self-referential FK is not a cycle — the table depends only on itself —
+    so it must not knock its dependency component out of the CREATE TABLE
+    topological order. Before the #302 fix, `zorderednode`'s self-loop made the
+    whole component fall back to name order, and `aorderedref` (which sorts
+    first but carries a required FK to it) failed on a fresh Postgres schema
+    with `relation "zorderednode" does not exist`."""
+    from typing import Optional
+
+    from ferro import ForeignKey
+
+    class ZOrderedNode(Model):
+        id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
+        parent: Annotated[
+            Optional["ZOrderedNode"], ForeignKey(related_name="children")
+        ] = None
+        children: Relation[list["ZOrderedNode"]] = BackRef()
+        refs: Relation[list["AOrderedRef"]] = BackRef()
+
+    class AOrderedRef(Model):
+        id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
+        node: Annotated[ZOrderedNode, ForeignKey(related_name="refs")]
+
+    await ferro.connect(db_url, auto_migrate=True)
+    async with ferro.engines.session():
+        root = await ZOrderedNode.create()
+        child = await ZOrderedNode.create(parent=root)
+        ref = await AOrderedRef.create(node=child)
+
+        fetched = await AOrderedRef.get(ref.id)
+        assert fetched.node_id == child.id


### PR DESCRIPTION
Closes #302.

## The bug

Both dependency-ordering loops (`order_models_for_create` in `ferro-migrate` and `order_models_for_migration` in `src/schema.rs`) treated a self-referential FK as a pending dependency. A table can never precede itself, so a self-FK table was never eligible for scheduling, its dependents stalled behind it, and the no-progress fallback appended the whole component in incoming (alphabetical) order. On a fresh Postgres schema, any referrer sorting before its FK target then failed:

```sql
-- emitted first, because "areferrer" < "znode":
CREATE TABLE "areferrer" (..., "node_id" uuid ... REFERENCES "znode" ("id"))
-- ERROR: relation "znode" does not exist
```

## The fix

A self-edge is satisfied by the table's own `CREATE TABLE` — it is not an ordering constraint. Rather than patching the same flaw in two hand-rolled copies of the sort, both paths now delegate to one shared primitive, `ferro_migrate::order_by_dependencies` (new `crates/ferro-migrate/src/order.rs`), where the self-edge, external-target, and cycle-fallback semantics live exactly once. Also corrects a doc comment that wrongly claimed Postgres tolerates forward inline FK references (SQLite does; Postgres rejects them — which is this bug).

## Tests

- `order_models_for_create_self_fk_is_not_an_ordering_constraint` (ferro-migrate) and `order_models_for_migration_self_fk_is_not_an_ordering_constraint` (src/schema.rs): self-FK target + referrer arriving first must order target-first. Both red before the fix.
- `test_self_fk_does_not_evict_component_from_create_order` (tests/test_auto_migrate.py, backend matrix): the issue's repro — reproduced the exact `relation "zorderednode" does not exist` failure on Postgres before the fix; green on sqlite+postgres after.
- Full matrix: 1560 pytest passed (sqlite+postgres), 187 + 53 cargo tests passed.

## Stated boundary (follow-up needed)

Genuine cross-table cycles (`a → b → a`) still cannot be dependency-ordered and fall through in input order — they fail loudly on Postgres at CREATE time (SQLite tolerates forward references, which is what hid this whole class of bug). The real fix is stripping cycle FKs from CREATE and re-adding them via named post-create `ALTER TABLE ADD CONSTRAINT` (names are already single-sourced in `ferro_ddl_lowering::fk_name`; the ALTER emitter already renders named FK constraints; Alembic's `use_alter` produces the same shape for parity). This needs its own issue — filing it was outside this session's authorization, so it still needs to be created.