### PR TITLE
Architecture deepenings: PK fact, CompiledQuery artifact, Registry owner

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,6 +84,10 @@ _Avoid_: Select list, projection spec, hydration mode flag
 The single typed wire artifact a query ships to the Rust runtime — model identity, predicates, ordering, paging, joins, and exactly one materialization plan, inside a versioned envelope. Compiled only by `compile_query`; no other code assembles query wire shape.
 _Avoid_: Query dict, query def, payload dict
 
+**Compiled query**:
+The single artifact `compile_query` returns: the QueryIR payload, its wire JSON, and the plan-scoped hop-class map, all views of one compile. The map is collected from the hop facts the payload itself carries, so wire and hop classes can never disagree; it is `None` unless the materialization plan decodes or hydrates through a hop model's class (mirroring the Rust `needs_hop_classes` guard — a both-sides double-check). No other code assembles hop classes for the FFI.
+_Avoid_: payload + kwargs, hop-class side-channel, wire tuple
+
 **Golden vector**:
 A hand-authored JSON fixture pinning one wire shape — the independent authority both the Python emitter and the Rust decoder assert against, never regenerated from either side's output. Updating one by hand is the contract-review moment for a wire change.
 _Avoid_: Snapshot, fixture dump, example payload

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -108,6 +108,10 @@ _Avoid_: Column alias, AS label, join alias
 The single cached answer to "which column is this model's primary key" — derived once at the compile choke point alongside column specs, stored as `__ferro_pk__` (`None` for a PK-less model). At most one `primary_key=True` column may be declared; a violation raises at class definition time. Operations that need a PK read the cached fact and raise clearly when it is `None` — never guess.
 _Avoid_: PK lookup, PK scan, first primary-key column
 
+**Registry**:
+The single owner of Python-side registration state (`ferro.registry.REGISTRY`): model classes, per-model SchemaIR envelopes + fingerprints, join-table bundles, pending relations, the modelset artifact, and the generation counters. Its stores are private; the agreement invariants (fingerprint pairs its envelope, join-table eviction clears envelopes, one-call test reset) live inside the interface, not in caller convention. Routing/session state is not the Registry — that is `ferro.state`.
+_Avoid_: state module, global dicts, model cache
+
 **Provisional registration**:
 The per-model state installed when a class body finishes executing — enough for runtime codec and PK metadata, but relationships may still be pending and the modelset is not yet authoritative for DDL.
 _Avoid_: Import-time registration, partial registry

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,6 +100,10 @@ _Avoid_: Nested select, join column, related-field pull
 A user-chosen name for one field of a projected record, given as the key in a dict-returning selector (`select(lambda t: {"account_name": t.account.name})`). Aliases name output fields only — never joins or tables; the relation path remains the sole join identity.
 _Avoid_: Column alias, AS label, join alias
 
+**Primary key fact**:
+The single cached answer to "which column is this model's primary key" — derived once at the compile choke point alongside column specs, stored as `__ferro_pk__` (`None` for a PK-less model). At most one `primary_key=True` column may be declared; a violation raises at class definition time. Operations that need a PK read the cached fact and raise clearly when it is `None` — never guess.
+_Avoid_: PK lookup, PK scan, first primary-key column
+
 **Provisional registration**:
 The per-model state installed when a class body finishes executing — enough for runtime codec and PK metadata, but relationships may still be pending and the modelset is not yet authoritative for DDL.
 _Avoid_: Import-time registration, partial registry

--- a/src/ferro/__init__.py
+++ b/src/ferro/__init__.py
@@ -73,13 +73,13 @@ async def _ensure_rust_registration_synced_for_operation() -> None:
     contention the event loop blocks for one resolve+install per generation; do
     not offload this to a thread pool — that would reintroduce interleaving.
     """
-    from .state import is_modelset_dirty
+    from .registry import REGISTRY
 
-    if not is_modelset_dirty():
+    if not REGISTRY.is_dirty():
         return
 
     with _OPERATION_REGISTRATION_SYNC_LOCK:
-        if is_modelset_dirty():
+        if REGISTRY.is_dirty():
             _ensure_rust_registration_synced()
 
 
@@ -97,25 +97,26 @@ def ensure_resolved_modelset() -> dict[str, Any]:
     path.
     """
     from .ir.compiler import compile_registry_schema_ir
+    from .registry import REGISTRY
     from .relations import resolve_relationships
-    from .state import is_modelset_dirty
 
-    if not is_modelset_dirty():
+    if not REGISTRY.is_dirty():
         return compile_registry_schema_ir()
 
     with _RESOLVED_MODELSET_LOCK:
-        if is_modelset_dirty():
+        if REGISTRY.is_dirty():
             resolve_relationships()
         return compile_registry_schema_ir()
 
 
 def _ensure_rust_registration_synced() -> None:
     """Resolve the modelset if needed, then push it to the Rust runtime."""
-    from . import state as ferro_state
+    from .registry import REGISTRY
 
     envelope = ensure_resolved_modelset()
+    cached = REGISTRY.modelset()
     _push_registration_to_rust(
-        envelope, fingerprint=ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT
+        envelope, fingerprint=cached[1] if cached is not None else None
     )
 
 
@@ -131,24 +132,21 @@ def clear_registry() -> None:
     tolerated by SQLite but rejected by Postgres (``relation ... does not
     exist``). (#153)
 
-    The Python model registry (``_MODEL_REGISTRY_PY``) is intentionally **not**
-    cleared here: clearing the Rust registry while keeping the declared Python
-    models is what allows cold re-hydration after ``reset_engine`` (see
-    ``tests/test_enum_cold_hydration.py``). Callers that want a full Python-side
-    reset clear ``_MODEL_REGISTRY_PY`` / ``_PENDING_RELATIONS`` themselves.
+    The Python model registry is intentionally **not** cleared here: clearing
+    the Rust registry while keeping the declared Python models is what allows
+    cold re-hydration after ``reset_engine`` (see
+    ``tests/test_enum_cold_hydration.py``). Callers that want a full
+    Python-side reset use ``REGISTRY.reset_for_test()``.
 
-    Each purged join table's compiled SchemaIR envelope is also evicted from the
-    per-model envelope cache (via ``evict_model_envelope`` — envelope-only, so the
-    model registry stays intact per the promise above), keeping the two stores the
-    #153 guard depends on in agreement: a lingering join envelope would let a
-    future assemble step resurrect the stale join table.
+    Each purged join table's compiled SchemaIR envelope is evicted with it —
+    ``Registry.clear_join_tables`` owns that agreement (#153): a lingering
+    join envelope would let a future assemble step resurrect the stale join
+    table.
     """
     _core_clear_registry()
-    from .state import _JOIN_TABLE_REGISTRY, evict_model_envelope
+    from .registry import REGISTRY
 
-    for join_table in list(_JOIN_TABLE_REGISTRY):
-        evict_model_envelope(join_table)
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.clear_join_tables()
 
 
 def _push_registration_to_rust(
@@ -172,18 +170,15 @@ def _push_registration_to_rust(
     """
     import json as _json
 
-    from . import state as ferro_state
     from .ir.compiler import compile_registry_schema_ir, schema_ir_fingerprint
+    from .registry import REGISTRY
 
     if envelope is None:
         envelope = compile_registry_schema_ir()
     if fingerprint is None:
-        cached = ferro_state._SCHEMA_IR_MODELSET
-        if (
-            cached is envelope
-            and ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT is not None
-        ):
-            fingerprint = ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT
+        cached = REGISTRY.modelset()
+        if cached is not None and cached[0] is envelope:
+            fingerprint = cached[1]
         else:
             fingerprint = schema_ir_fingerprint(envelope)
     _install_registration(_json.dumps(envelope), fingerprint)

--- a/src/ferro/_shadow_fk_types.py
+++ b/src/ferro/_shadow_fk_types.py
@@ -27,13 +27,12 @@ def _scalar_part_of_annotation(ann: Any) -> Any:
 
 def pk_python_type_for_model(target: type[Any]) -> Any | None:
     """Return the PK column's scalar python type from the target's specs."""
-    specs = getattr(target, "__ferro_columns__", None)
-    if not specs:
+    pk_field = getattr(target, "__ferro_pk__", None)
+    if pk_field is None:
         return None
-    for spec in specs.values():
-        if spec.primary_key:
-            return spec.python_type
-    return None
+    specs = getattr(target, "__ferro_columns__", None) or {}
+    spec = specs.get(pk_field)
+    return spec.python_type if spec is not None else None
 
 
 def shadow_annotation_for_pk(pk_ann: Any) -> Any:

--- a/src/ferro/columns.py
+++ b/src/ferro/columns.py
@@ -31,7 +31,35 @@ __all__ = [
     "build_relation_specs",
     "fk_shadow_spec",
     "pk_spec",
+    "primary_key_field_name",
 ]
+
+
+def primary_key_field_name(model_name: str, specs: dict[str, ColumnSpec]) -> str | None:
+    """Derive the model's single PK field name from its column specs.
+
+    The one derivation site for "which column is the primary key" — cached on
+    the class as ``__ferro_pk__`` at the compile choke point, so every
+    consumer (save, descriptors, shadow-FK typing, traversal) reads the cached
+    fact instead of re-looping specs. At most one ``primary_key=True`` column
+    is legal; zero is a valid declaration (``None``) and the operations that
+    need a PK raise their own errors.
+
+    Raises:
+        TypeError: If more than one column declares ``primary_key=True`` —
+            at class definition time, naming the model and offending fields,
+            rather than resolving the ambiguity silently by declaration order
+            (the follow-up ADR-0002 asked for). ``TypeError`` is the
+            declaration-error contract the metaclass surfaces unwrapped
+            (ADR-0003's db_type validation sets the precedent).
+    """
+    pks = [name for name, spec in specs.items() if spec.primary_key]
+    if len(pks) > 1:
+        raise TypeError(
+            f"Model {model_name!r} declares multiple primary-key columns: "
+            f"{sorted(pks)!r}. At most one primary_key=True column is supported."
+        )
+    return pks[0] if pks else None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/ferro/columns.py
+++ b/src/ferro/columns.py
@@ -154,13 +154,13 @@ def _property_is_integer(prop: dict[str, Any]) -> bool:
 
 
 def _target_table_name(target: Any) -> str:
-    from .state import resolve_model_reference
+    from .registry import REGISTRY
 
     if isinstance(target, ForwardRef):
         target = target.__forward_arg__
     if isinstance(target, str):
         try:
-            model = resolve_model_reference(target, default=None)
+            model = REGISTRY.resolve_reference(target, default=None)
         except RuntimeError:
             # Ambiguous short ref during first-pass schema build: defer the
             # loud, candidate-listing error to resolve_relationships (the

--- a/src/ferro/ir/compiler.py
+++ b/src/ferro/ir/compiler.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
-from .. import state as ferro_state
 from .._core import (
     _ddl_check_constraint_name,
     _ddl_composite_index_name,
@@ -27,11 +26,7 @@ from ..columns import (
 )
 from ..composite_indexes import drop_overlap_with_uniques, normalized_composite_indexes
 from ..composite_uniques import normalized_composite_uniques
-from ..state import (
-    _JOIN_TABLE_REGISTRY,
-    _MODEL_REGISTRY_PY,
-    _SCHEMA_IR_BY_MODEL,
-)
+from ..registry import REGISTRY, ir_fingerprint
 
 _IR_VERSION = 1
 
@@ -219,11 +214,11 @@ def compile_schema_ir_payload(
 def _persist_schema_ir_envelope(model_name: str, envelope: dict[str, Any]) -> None:
     """Store one model's compiled SchemaIR envelope and fingerprint.
 
-    Routes through the single ``ferro.state`` envelope-write entrypoint so every
-    per-model store mutation lives at the store-owning layer (#243); the
-    fingerprint is derived from the envelope inside that entrypoint.
+    Routes through the Registry's envelope-write entrypoint so every per-model
+    store mutation lives at the store-owning layer (#243); the fingerprint is
+    derived from the envelope inside that entrypoint.
     """
-    ferro_state.persist_model_envelope(model_name, envelope)
+    REGISTRY.persist_envelope(model_name, envelope)
 
 
 def _compile_and_persist_model_envelope(
@@ -341,12 +336,12 @@ def compile_model_schema_ir(
 def _model_payload_from_envelope(name: str) -> dict[str, Any]:
     """Return one model's SchemaIR payload object from the envelope cache.
 
-    The returned dict is a live reference into ``_SCHEMA_IR_BY_MODEL`` — the
-    assembled modelset shares these payload objects. Treat them as read-only;
-    in-place mutation corrupts the per-model cache and survives clean-path
-    re-assembles indefinitely (#245).
+    The returned dict is a live reference into the Registry's envelope cache —
+    the assembled modelset shares these payload objects. Treat them as
+    read-only; in-place mutation corrupts the per-model cache and survives
+    clean-path re-assembles indefinitely (#245).
     """
-    envelope = _SCHEMA_IR_BY_MODEL.get(name)
+    envelope = REGISTRY.envelope(name)
     if envelope is None:
         raise RuntimeError(
             f"Missing SchemaIR envelope for '{name}'. "
@@ -359,11 +354,11 @@ def _model_payload_from_envelope(name: str) -> dict[str, Any]:
 def _assemble_modelset_envelope() -> dict[str, Any]:
     """Stitch per-model envelopes into one sorted modelset envelope."""
     models: list[dict[str, Any]] = []
-    for model_name, _model_cls in sorted(_MODEL_REGISTRY_PY.items(), key=lambda item: item[0]):
+    for model_name in sorted(REGISTRY.models()):
         models.append(_model_payload_from_envelope(model_name))
 
     for table_name, bundle in sorted(
-        _JOIN_TABLE_REGISTRY.items(), key=lambda item: item[0]
+        REGISTRY.join_tables().items(), key=lambda item: item[0]
     ):
         if not isinstance(bundle, dict):
             continue
@@ -378,20 +373,8 @@ def _assemble_modelset_envelope() -> dict[str, Any]:
         },
     }
 
-    ferro_state._SCHEMA_IR_MODELSET = envelope
-    ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = ferro_state.ir_fingerprint(envelope)
+    REGISTRY.set_modelset(envelope)
     return envelope
-
-
-def _missing_registry_envelope_names() -> list[str]:
-    missing: list[str] = []
-    for name in _MODEL_REGISTRY_PY:
-        if name not in _SCHEMA_IR_BY_MODEL:
-            missing.append(name)
-    for table_name, bundle in _JOIN_TABLE_REGISTRY.items():
-        if isinstance(bundle, dict) and table_name not in _SCHEMA_IR_BY_MODEL:
-            missing.append(table_name)
-    return missing
 
 
 def _register_join_table_bundle(table_name: str, bundle: dict[str, Any]) -> None:
@@ -405,12 +388,12 @@ def _register_join_table_bundle(table_name: str, bundle: dict[str, Any]) -> None
 
 
 def _recompile_missing_registry_envelopes() -> None:
-    for model_name in _missing_registry_envelope_names():
-        model_cls = _MODEL_REGISTRY_PY.get(model_name)
+    for model_name in REGISTRY.missing_envelope_names():
+        model_cls = REGISTRY.models().get(model_name)
         if model_cls is not None:
             compile_model_schema_ir(model_name, model_cls)
             continue
-        bundle = _JOIN_TABLE_REGISTRY.get(model_name)
+        bundle = REGISTRY.join_tables().get(model_name)
         if isinstance(bundle, dict):
             _register_join_table_bundle(model_name, bundle)
 
@@ -423,10 +406,10 @@ def _recompile_all_registered_envelopes() -> None:
     Alembic-adjacent tooling) historically relied on compile-not-assemble here.
     The connect/reconnect clean path never hits this (#245).
     """
-    for model_name, model_cls in sorted(_MODEL_REGISTRY_PY.items(), key=lambda item: item[0]):
+    for model_name, model_cls in sorted(REGISTRY.models().items()):
         compile_model_schema_ir(model_name, model_cls)
     for table_name, bundle in sorted(
-        _JOIN_TABLE_REGISTRY.items(), key=lambda item: item[0]
+        REGISTRY.join_tables().items(), key=lambda item: item[0]
     ):
         if isinstance(bundle, dict):
             _register_join_table_bundle(table_name, bundle)
@@ -435,8 +418,8 @@ def _recompile_all_registered_envelopes() -> None:
 def compile_registry_schema_ir() -> dict[str, Any]:
     """Assemble and persist a deterministic SchemaIR envelope for all models.
 
-    Stitches already-compiled per-model envelopes from ``_SCHEMA_IR_BY_MODEL``
-    for every entry in ``_MODEL_REGISTRY_PY`` and ``_JOIN_TABLE_REGISTRY``.
+    Stitches already-compiled per-model envelopes from the Registry's envelope
+    cache for every registered model and join table.
     On a dirty registry, recompiles envelopes first so direct callers that
     bypass ``resolve_relationships()`` still observe current registry state.
     After ``ensure_resolved_modelset()`` on the clean path, this is
@@ -445,7 +428,7 @@ def compile_registry_schema_ir() -> dict[str, Any]:
     Returns:
         The assembled model-set SchemaIR envelope, sorted by model name.
     """
-    if ferro_state.is_modelset_dirty():
+    if REGISTRY.is_dirty():
         _recompile_all_registered_envelopes()
     else:
         _recompile_missing_registry_envelopes()
@@ -454,4 +437,4 @@ def compile_registry_schema_ir() -> dict[str, Any]:
 
 def schema_ir_fingerprint(ir_envelope: dict[str, Any]) -> str:
     """Return a deterministic SHA-256 fingerprint for a SchemaIR envelope."""
-    return ferro_state.ir_fingerprint(ir_envelope)
+    return ir_fingerprint(ir_envelope)

--- a/src/ferro/ir/compiler.py
+++ b/src/ferro/ir/compiler.py
@@ -19,7 +19,12 @@ from .._core import (
     _ddl_single_index_name,
     _ddl_single_unique_name,
 )
-from ..columns import ColumnSpec, build_column_specs, build_relation_specs
+from ..columns import (
+    ColumnSpec,
+    build_column_specs,
+    build_relation_specs,
+    primary_key_field_name,
+)
 from ..composite_indexes import drop_overlap_with_uniques, normalized_composite_indexes
 from ..composite_uniques import normalized_composite_uniques
 from ..state import (
@@ -300,6 +305,10 @@ def compile_model_schema_ir(
     """
     if specs is None:
         specs = build_column_specs(model_cls)
+    # Derive the PK fact (and run the at-most-one guard) before compile +
+    # persist: a multi-PK model raises here, at class definition time, and
+    # never persists an envelope or publishes specs.
+    pk_field = primary_key_field_name(model_name, specs)
     column_names = frozenset(specs)
     uniques = normalized_composite_uniques(model_cls, column_names)
     indexes = drop_overlap_with_uniques(
@@ -318,6 +327,9 @@ def compile_model_schema_ir(
     # "``__ferro_columns__`` can never go stale relative to the envelope"
     # invariant, made atomic.
     model_cls.__ferro_columns__ = specs
+    # Same choke point caches the PK fact: every ``__ferro_columns__`` refresh
+    # re-derives ``__ferro_pk__``, so it can never go stale relative to specs.
+    model_cls.__ferro_pk__ = pk_field
     # Same choke point compiles relation-traversal facts (#268): every
     # ``__ferro_columns__`` refresh (provisional class-body registration and
     # the resolved second pass) refreshes ``__ferro_relation_specs__`` too, so

--- a/src/ferro/metaclass.py
+++ b/src/ferro/metaclass.py
@@ -23,8 +23,8 @@ from .base import FerroField, ForeignKey, ManyToManyRelation
 from .fields import FERRO_FIELD_EXTRA_KEY
 from .ir import compile_model_schema_ir
 from .query import Relation
+from .registry import REGISTRY
 from .relations.descriptors import ForwardDescriptor
-from .state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS, register_model
 
 _TABLE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*\Z")
 
@@ -79,7 +79,7 @@ class ModelMetaclass(type(BaseModel)):
         cls.__ferro_identity__ = f"{cls.__module__}.{cls.__qualname__}"
         cls.__ferro_table__ = mcs._resolve_table_name(name, namespace)
         for field_name, metadata in pending_relations:
-            _PENDING_RELATIONS.append((cls.__ferro_identity__, field_name, metadata))
+            REGISTRY.defer_relation(cls.__ferro_identity__, field_name, metadata)
 
         mcs._register_model(cls, cls.__ferro_identity__, local_relations)
         ferro_fields = mcs._parse_ferro_field_metadata(cls)
@@ -278,8 +278,9 @@ class ModelMetaclass(type(BaseModel)):
         Returns:
             (local_relations, fields_to_remove, pending_relations): Relationship
             metadata, fields to hide from Pydantic, and ``(field_name, metadata)``
-            entries deferred to ``_PENDING_RELATIONS`` (flushed under the model's
-            resolved ``__ferro_identity__`` after the class object exists).
+            entries deferred to the Registry's pending-relation queue (flushed
+            under the model's resolved ``__ferro_identity__`` after the class
+            object exists).
         """
         local_relations = {}
         fields_to_remove = []
@@ -405,7 +406,7 @@ class ModelMetaclass(type(BaseModel)):
                 qualified identity is idempotent.
         """
         table_name = cls.__ferro_table__
-        for key, other in _MODEL_REGISTRY_PY.items():
+        for key, other in REGISTRY.models().items():
             if key == identity:
                 continue
             if getattr(other, "__ferro_table__", None) == table_name:
@@ -415,7 +416,7 @@ class ModelMetaclass(type(BaseModel)):
                     "models cannot share a table. Set __ferro_table__ on one of "
                     "them to give it a distinct table name."
                 )
-        register_model(cls)
+        REGISTRY.register(cls)
         cls.ferro_relations = local_relations
 
     @staticmethod

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -126,9 +126,9 @@ def evict_instance(
     directly with their already-resolved route instead of going through this
     wrapper, so a route is never resolved twice for one operation.
     """
-    from .state import resolve_model_reference
+    from .registry import REGISTRY
 
-    model_cls = resolve_model_reference(model) if isinstance(model, str) else model
+    model_cls = REGISTRY.resolve_reference(model) if isinstance(model, str) else model
     route = resolve_operation_scope(using=using, session=session)
     _core_evict_instance(model_cls.__ferro_identity__, pk, route)
 

--- a/src/ferro/models.py
+++ b/src/ferro/models.py
@@ -211,6 +211,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
     __ferro_composite_uniques__: ClassVar[tuple[tuple[str, ...], ...]] = ()
     __ferro_composite_indexes__: ClassVar[tuple[tuple[str, ...], ...]] = ()
     __ferro_columns__: ClassVar[dict[str, "ColumnSpec"]] = {}
+    #: The single PK field name, derived once at the compile choke point
+    #: alongside ``__ferro_columns__``; ``None`` for a PK-less model.
+    __ferro_pk__: ClassVar[str | None] = None
     __ferro_relation_specs__: ClassVar[dict[str, "RelationSpec"]] = {}
     _enum_fields: ClassVar[dict[str, type[Enum]]] = {}
 
@@ -247,9 +250,17 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                 if isinstance(val, Model):
                     # Read the *target* model's PK (FF-D D5) — the source
                     # model's PK name is irrelevant to the related instance.
-                    pk_field = val.__class__._primary_key_field_name() or "id"
-                    id_val = getattr(val, pk_field, None)
-                    data[f"{field_name}_id"] = id_val
+                    pk_field = val.__class__.__ferro_pk__
+                    if pk_field is None:
+                        raise ValueError(
+                            f"Cannot assign a {val.__class__.__name__} instance "
+                            f"to relationship field {field_name!r}: "
+                            f"{val.__class__.__name__} declares no primary-key "
+                            "column, so there is no value to store in "
+                            f"{field_name!r}_id. Pass the scalar value directly "
+                            "or declare a primary_key=True column."
+                        )
+                    data[f"{field_name}_id"] = getattr(val, pk_field, None)
                 else:
                     # It's already an ID or something else
                     data[f"{field_name}_id"] = val
@@ -323,7 +334,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                 mode="upsert",
             )
         elif _is_persisted(self):
-            pk_field_name = self.__class__._primary_key_field_name()
+            pk_field_name = self.__class__.__ferro_pk__
             pk_val = getattr(self, pk_field_name) if pk_field_name is not None else None
             if pk_val is None:
                 raise ValueError(
@@ -346,16 +357,17 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             )
 
         pk_val = None
-        pk_field_name = None
+        pk_field_name = self.__class__.__ferro_pk__
 
-        for field_name, spec in self.__class__.__ferro_columns__.items():
-            if not spec.primary_key:
-                continue
-            pk_field_name = field_name
-            if spec.autoincrement and getattr(self, field_name) is None and new_id is not None:
-                setattr(self, field_name, new_id)
-            pk_val = getattr(self, field_name)
-            break
+        if pk_field_name is not None:
+            spec = self.__class__.__ferro_columns__[pk_field_name]
+            if (
+                spec.autoincrement
+                and getattr(self, pk_field_name) is None
+                and new_id is not None
+            ):
+                setattr(self, pk_field_name, new_id)
+            pk_val = getattr(self, pk_field_name)
 
         if pk_val is not None:
             register_instance(
@@ -380,7 +392,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> if user:
             ...     await user.delete()
         """
-        pk_field_name = self.__class__._primary_key_field_name()
+        pk_field_name = self.__class__.__ferro_pk__
         pk_val = getattr(self, pk_field_name) if pk_field_name is not None else None
         route, _identity_using = await _instance_transaction_route(self, using, session)
 
@@ -393,13 +405,6 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             _core_evict_instance(name, str(pk_val), route)
             # The instance is transient again: a later save() re-INSERTs.
             _set_persisted(self, False)
-
-    @classmethod
-    def _primary_key_field_name(cls) -> str | None:
-        for field_name, spec in cls.__ferro_columns__.items():
-            if spec.primary_key:
-                return field_name
-        return None
 
     @classmethod
     async def all(
@@ -454,7 +459,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         Returns:
             The matching model instance, or None when no record exists.
         """
-        pk_field_name = cls._primary_key_field_name()
+        pk_field_name = cls.__ferro_pk__
         if pk_field_name is None:
             raise RuntimeError(f"Model {cls.__name__} does not define a primary key")
 
@@ -475,7 +480,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             >>> user = await User.get(1)
             >>> await user.refresh()
         """
-        pk_field_name = self.__class__._primary_key_field_name()
+        pk_field_name = self.__class__.__ferro_pk__
         pk_val = getattr(self, pk_field_name) if pk_field_name is not None else None
 
         if pk_val is None:
@@ -772,7 +777,7 @@ class ModelConnection[M: Model]:
         return instance
 
     async def get_or_none(self, pk: Any) -> M | None:
-        pk_field_name = self.model_cls._primary_key_field_name()
+        pk_field_name = self.model_cls.__ferro_pk__
         if pk_field_name is None:
             raise RuntimeError(
                 f"Model {self.model_cls.__name__} does not define a primary key"

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -12,7 +12,6 @@ from typing import (
     Any,
     Callable,
     Generic,
-    Iterable,
     NamedTuple,
     Never,
     NoReturn,
@@ -50,7 +49,6 @@ from .wire import (
     compile_query,
     model_identity,
     path_edges,
-    to_wire_json,
 )
 
 if TYPE_CHECKING:
@@ -953,38 +951,6 @@ class Query(Generic[T]):
         new._offset = value
         return new
 
-    def _include_hop_classes(self) -> dict[str, type]:
-        """Map each included hop's physical table to its model class (#286)."""
-        return self._hop_classes_for_paths(self._includes)
-
-    def _hop_classes_for_paths(
-        self, paths: "Iterable[tuple[str, ...]]"
-    ) -> dict[str, type]:
-        """Map each hop table along ``paths`` to its model class (#286/#293).
-
-        The Rust fetch walker needs a hop's Python class whenever it decodes
-        or hydrates through that model's protocol — every included hop (codec
-        plan, enum classes, identity map, #286) and every traversed
-        projection leaf (enum decode, #293). Resolved here, where the
-        relation-spec chain lives, and passed across the FFI keyed by
-        ``to_table`` (one model per table, enforced at registration).
-        """
-        hop_classes: dict[str, type] = {}
-        for path in paths:
-            current = self.model_cls
-            for relation in path:
-                specs = getattr(current, "__ferro_relation_specs__", None) or {}
-                spec = specs.get(relation)
-                if spec is None:
-                    raise ValueError(
-                        f"{current.__name__!r} has no relation {relation!r} "
-                        "for population."
-                    )
-                target = spec.target
-                hop_classes[target.__ferro_table__] = target
-                current = target
-        return hop_classes
-
     async def all(self) -> list[T]:
         """Return all model instances that match the current query
 
@@ -996,19 +962,13 @@ class Query(Generic[T]):
             >>> isinstance(users, list)
             True
         """
-        payload = compile_query(self, "fetch")
+        compiled = compile_query(self, "fetch")
         route = await self._transaction_or_using()
-        if self._includes:
-            return await fetch_filtered(
-                self.model_cls,
-                to_wire_json(payload),
-                route,
-                hop_classes=self._include_hop_classes(),
-            )
         return await fetch_filtered(
             self.model_cls,
-            to_wire_json(payload),
+            compiled.wire_json,
             route,
+            hop_classes=compiled.hop_classes,
         )
 
     async def count(self) -> int:
@@ -1022,11 +982,11 @@ class Query(Generic[T]):
             >>> isinstance(total, int)
             True
         """
-        payload = compile_query(self, "count")
+        compiled = compile_query(self, "count")
         route = await self._transaction_or_using()
         return await count_filtered(
             model_identity(self.model_cls),
-            to_wire_json(payload),
+            compiled.wire_json,
             route,
         )
 
@@ -1052,11 +1012,11 @@ class Query(Generic[T]):
             >>> isinstance(updated, int)
             True
         """
-        payload = compile_query(self, "update")
+        compiled = compile_query(self, "update")
         route = await self._transaction_or_using()
         return await update_filtered(
             model_identity(self.model_cls),
-            to_wire_json(payload),
+            compiled.wire_json,
             update_bind_payload(fields),
             route,
         )
@@ -1094,11 +1054,11 @@ class Query(Generic[T]):
             >>> isinstance(deleted, int)
             True
         """
-        payload = compile_query(self, "delete")
+        compiled = compile_query(self, "delete")
         route = await self._transaction_or_using()
         return await delete_filtered(
             model_identity(self.model_cls),
-            to_wire_json(payload),
+            compiled.wire_json,
             route,
         )
 
@@ -1444,22 +1404,6 @@ class ProjectedQuery(Query[T]):
             )
         return super().exists()
 
-    def _traversed_hop_classes(self) -> dict[str, type] | None:
-        """Hop classes for traversed PLAIN projection paths, or None.
-
-        The record decode path resolves each traversed leaf's enum catalog
-        through its owning model's class (#293) — the same per-table map the
-        instances plan travels with (#286). Aggregate fields never need one:
-        enum sources are rejected at build time and ``count`` decodes to a
-        plain int, so no aggregate output is enum-typed.
-        """
-        paths = {
-            field.path for field in self._projection if field.path and not field.agg
-        }
-        if not paths:
-            return None
-        return self._hop_classes_for_paths(paths)
-
     async def all(self) -> Rows[Row]:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         """Return the projected records for every matching row.
 
@@ -1472,24 +1416,15 @@ class ProjectedQuery(Query[T]):
             >>> [r.amount for r in rows]  # doctest: +SKIP
             [Decimal('12.50'), Decimal('7.00')]
         """
-        payload = compile_query(self, "fetch")
+        compiled = compile_query(self, "fetch")
         route = await self._transaction_or_using()
-        hop_classes = self._traversed_hop_classes()
-        if hop_classes is not None:
-            records = await fetch_filtered(
-                self.model_cls,
-                to_wire_json(payload),
-                route,
-                record_cls=Row,
-                hop_classes=hop_classes,
-            )
-        else:
-            records = await fetch_filtered(
-                self.model_cls,
-                to_wire_json(payload),
-                route,
-                record_cls=Row,
-            )
+        records = await fetch_filtered(
+            self.model_cls,
+            compiled.wire_json,
+            route,
+            record_cls=Row,
+            hop_classes=compiled.hop_classes,
+        )
         return _ROWS_OF_ROW._wrap(records)
 
     async def first(self) -> Row | None:  # type: ignore[override]  # ty: ignore[invalid-method-override]

--- a/src/ferro/query/wire.py
+++ b/src/ferro/query/wire.py
@@ -20,7 +20,7 @@ validation and state; this module owns everything whose output is wire shape.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
 from .nodes import QueryNode, _serialize_query_value
@@ -69,12 +69,19 @@ def path_edges(path: tuple[str, ...]) -> list[tuple[str, ...]]:
 @dataclass(frozen=True)
 class QueryJoinHop:
     """One hop fact of a relation path — the shared shape of the ``joins``
-    section, ``instances`` plan paths, and aggregate ``expr`` traversals."""
+    section, ``instances`` plan paths, and aggregate ``expr`` traversals.
+
+    ``target`` is the hop's model class — a compile-side fact riding the hop
+    (the hop-class map is collected from it), never serialized: the wire
+    carries ``to_table`` and Rust resolves registration facts from its own
+    registry.
+    """
 
     relation: str
     from_column: str
     to_table: str
     to_column: str
+    target: type = field(compare=False, repr=False, kw_only=True)
 
     def to_ir_dict(self) -> dict[str, str]:
         return {
@@ -309,6 +316,7 @@ def resolve_join_hops(
                 from_column=spec.shadow_column,
                 to_table=target.__ferro_table__,
                 to_column=_target_pk_column(target),
+                target=target,
             )
         )
         current = target
@@ -451,8 +459,52 @@ def _reject_mutation_misuse(query: "Query[Any]", operation: str) -> None:
         )
 
 
-def compile_query(query: "Query[Any]", verb: QueryVerb) -> QueryIrPayload:
-    """Compile a built query into its wire payload — the single choke point.
+@dataclass(frozen=True)
+class CompiledQuery:
+    """One compiled artifact per query — CONTEXT.md "Compiled query".
+
+    ``wire_json`` and ``hop_classes`` are two views of the same compile:
+    the map is collected from the hop facts the payload itself carries, so
+    the wire and the classes the runtime hydrates through can never
+    disagree (the builder previously re-walked relation-spec chains to
+    assemble ``hop_classes`` beside the wire, agreeing by hand).
+
+    ``hop_classes`` is plan-scoped, mirroring the Rust ``needs_hop_classes``
+    guard exactly (a both-sides double-check, like #272 join edges): ``None``
+    unless the materialization plan decodes or hydrates through a hop model's
+    class — an ``instances`` plan (#286) or a ``record`` plan with traversed
+    plain fields (#293). When it is a map, it covers every hop the payload
+    carries, keyed by physical table (one model per table, enforced at
+    registration).
+    """
+
+    payload: QueryIrPayload
+    wire_json: str
+    hop_classes: dict[str, type] | None
+
+
+def _payload_hop_classes(payload: QueryIrPayload) -> dict[str, type] | None:
+    """Collect the plan-scoped hop-class map from the payload's own hops."""
+    materialization = payload.materialization
+    needs = isinstance(materialization, Instances) or (
+        isinstance(materialization, Record)
+        and any(field.expr is None and field.path for field in materialization.fields)
+    )
+    if not needs:
+        return None
+    hop_classes: dict[str, type] = {}
+    for join in payload.joins:
+        for hop in join.path:
+            hop_classes[hop.to_table] = hop.target
+    if isinstance(materialization, Instances):
+        for path in materialization.paths:
+            for hop in path:
+                hop_classes[hop.to_table] = hop.target
+    return hop_classes
+
+
+def compile_query(query: "Query[Any]", verb: QueryVerb) -> CompiledQuery:
+    """Compile a built query into its wire artifact — the single choke point.
 
     What each verb carries is policy, stated here once:
 
@@ -473,7 +525,7 @@ def compile_query(query: "Query[Any]", verb: QueryVerb) -> QueryIrPayload:
     where = tuple(node.to_ir_dict() for node in query.where_clause)
     if verb in ("update", "delete"):
         _reject_mutation_misuse(query, verb)
-        return QueryIrPayload(
+        payload = QueryIrPayload(
             model_name=identity,
             where=where,
             order_by=(),
@@ -483,8 +535,8 @@ def compile_query(query: "Query[Any]", verb: QueryVerb) -> QueryIrPayload:
             joins=(),
             materialization=RootInstances(),
         )
-    if verb == "count":
-        return QueryIrPayload(
+    elif verb == "count":
+        payload = QueryIrPayload(
             model_name=identity,
             where=where,
             order_by=(),
@@ -494,15 +546,21 @@ def compile_query(query: "Query[Any]", verb: QueryVerb) -> QueryIrPayload:
             joins=_serialize_joins(query),
             materialization=RootInstances(),
         )
-    return QueryIrPayload(
-        model_name=identity,
-        where=where,
-        order_by=tuple(query.order_by_clause),
-        limit=query._limit,
-        offset=query._offset,
-        m2m=query._m2m_context,
-        joins=_serialize_joins(query),
-        materialization=_materialization(query),
+    else:
+        payload = QueryIrPayload(
+            model_name=identity,
+            where=where,
+            order_by=tuple(query.order_by_clause),
+            limit=query._limit,
+            offset=query._offset,
+            m2m=query._m2m_context,
+            joins=_serialize_joins(query),
+            materialization=_materialization(query),
+        )
+    return CompiledQuery(
+        payload=payload,
+        wire_json=to_wire_json(payload),
+        hop_classes=_payload_hop_classes(payload),
     )
 
 

--- a/src/ferro/query/wire.py
+++ b/src/ferro/query/wire.py
@@ -262,22 +262,21 @@ class QueryIrPayload:
 def _target_pk_column(model_cls: type) -> str:
     """Return the single primary-key column name of a relation target (#270).
 
+    Reads the cached ``__ferro_pk__`` fact (multi-PK models cannot exist past
+    class definition), so only the PK-less case remains to guard.
+
     Raises:
-        ValueError: If ``model_cls`` has zero or multiple primary-key columns —
-            relation traversal joins against exactly one PK column, so an
-            ambiguous target is a loud error naming the model, never a guess.
+        ValueError: If ``model_cls`` has no primary-key column — relation
+            traversal joins against the target's PK, so a PK-less target is a
+            loud error naming the model, never a guess.
     """
-    pks = [
-        name
-        for name, spec in getattr(model_cls, "__ferro_columns__", {}).items()
-        if spec.primary_key
-    ]
-    if len(pks) != 1:
+    pk = getattr(model_cls, "__ferro_pk__", None)
+    if pk is None:
         raise ValueError(
-            f"Relation traversal into {model_cls.__name__!r} requires exactly one "
-            f"primary-key column, found {len(pks)}: {sorted(pks)}."
+            f"Relation traversal into {model_cls.__name__!r} requires a "
+            "primary-key column, and it declares none."
         )
-    return pks[0]
+    return pk
 
 
 def resolve_join_hops(

--- a/src/ferro/registry.py
+++ b/src/ferro/registry.py
@@ -1,0 +1,328 @@
+"""The registry: single owner of Ferro's Python-side registration state.
+
+One :class:`Registry` instance (:data:`REGISTRY` — process-global by nature:
+the metaclass writes to it at import time) owns the model registry, per-model
+SchemaIR envelope + fingerprint caches, join-table bundles, pending
+relations, the modelset artifact, and the provisional/resolved generation
+counters (CONTEXT.md "Provisional registration" / "Resolved registration").
+
+The stores are private; every reader and writer goes through the interface,
+so their agreement invariants have exactly one home:
+
+- A stored fingerprint is always a pure function of the envelope it
+  accompanies (:meth:`Registry.persist_envelope` / :meth:`Registry.set_modelset`
+  compute it — no caller can persist a mismatched pair).
+- Evicting join tables evicts their envelopes with them
+  (:meth:`Registry.clear_join_tables` — previously a hand-written loop in
+  ``clear_registry`` guarded by a warning comment).
+- A test reset or snapshot/restore covers every store and counter in one
+  call (:meth:`Registry.reset_for_test`, :meth:`Registry.snapshot`).
+
+Ordering caveat (unchanged from the pre-Registry design, closed by a future
+atomic register→persist step): defining model classes concurrently with
+``connect``/``create_tables``/``migrate`` is unsupported — a registry entry
+becomes visible on :meth:`register` before its envelope is persisted, so an
+unlocked reader can observe a transient missing-envelope state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+class FerroModelClass(Protocol):
+    """Structural type for a registrable Ferro model class.
+
+    The registry keys by ``__ferro_identity__`` (what :meth:`Registry.register`
+    derives its key from) and resolves bare references against ``__name__`` /
+    ``__qualname__``. Typed as a ``Protocol`` rather than ``type[Model]`` so
+    ``registry`` — which ``models`` and ``metaclass`` import — does not import
+    back into them (circular import); a non-Ferro class handed to
+    :meth:`Registry.register` is then a type error at the call site instead of
+    a raw ``AttributeError`` at runtime.
+    """
+
+    __ferro_identity__: str
+    __name__: str
+    __qualname__: str
+
+
+_UNSET = object()
+
+
+def canonical_ir_json(value: dict[str, Any]) -> str:
+    """Serialize an IR artifact with deterministic key ordering."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def ir_fingerprint(value: dict[str, Any]) -> str:
+    """Return the canonical SHA-256 fingerprint for an IR artifact.
+
+    Single source of the fingerprint function so a stored fingerprint is
+    always a pure function of the envelope it accompanies (the ADR
+    fingerprint gate reads these; a mismatched pair would serve stale schema
+    silently).
+    """
+    return hashlib.sha256(canonical_ir_json(value).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class RegistrySnapshot:
+    """Opaque copy of every Registry store and counter (test fixtures)."""
+
+    models: dict[str, FerroModelClass]
+    envelopes: dict[str, dict[str, Any]]
+    fingerprints: dict[str, str]
+    join_tables: dict[str, Any]
+    pending_relations: list[Any] = field(repr=False)
+    modelset: dict[str, Any] | None
+    modelset_fingerprint: str | None
+    registration_generation: int
+    resolved_generation: int
+
+
+class Registry:
+    """Single owner of the registration stores — see module docstring."""
+
+    def __init__(self) -> None:
+        self._models: dict[str, FerroModelClass] = {}
+        self._envelopes: dict[str, dict[str, Any]] = {}
+        self._fingerprints: dict[str, str] = {}
+        self._join_tables: dict[str, Any] = {}
+        self._pending_relations: list[Any] = []
+        self._modelset: dict[str, Any] | None = None
+        self._modelset_fingerprint: str | None = None
+        # Monotonic generation counter bumped by register/deregister; matched
+        # to resolved at the end of relationship resolution (#245).
+        self._registration_generation = 0
+        self._resolved_generation = 0
+
+    # -- model registry ----------------------------------------------------
+
+    def register(self, cls: FerroModelClass) -> None:
+        """Record a model class (provisional registration).
+
+        The key is the model's canonical identity (``__ferro_identity__``),
+        derived from ``cls`` here rather than caller-supplied (#249): the
+        registry key is a pure function of the model, so every emitter — the
+        Rust runtime registry, the raw-FFI operations — keys the same model
+        by the same name. Idempotent by construction.
+        """
+        self._models[cls.__ferro_identity__] = cls
+        self._registration_generation += 1
+
+    def deregister(self, name: str) -> None:
+        """Evict one model from every per-model store (registry + envelopes).
+
+        Takes a ``name`` (the canonical identity) rather than a class, unlike
+        :meth:`register` — teardown paths iterate registry keys and hold the
+        identity string, not the class object. Idempotent.
+        """
+        removed = name in self._models
+        self._models.pop(name, None)
+        self.evict_envelope(name)
+        if removed:
+            self._registration_generation += 1
+
+    def models(self) -> dict[str, FerroModelClass]:
+        """The registered models, keyed by canonical identity.
+
+        A read view: callers iterate, look up, and pass it on (e.g. shadow-FK
+        reconciliation) — they never mutate it. Mutation goes through
+        :meth:`register` / :meth:`deregister`, which own the generation
+        counter bump.
+        """
+        return self._models
+
+    def resolve_reference(self, ref: str, *, default: Any = _UNSET) -> Any:
+        """Resolve a model reference to a registered model class (FF-E E1).
+
+        Accepts a qualified identity (``module.QualName``) or a bare class
+        name. A qualified reference is a direct hit; a bare name matching
+        exactly one registered model resolves to it; several matches raise
+        with the qualified candidates listed; no match raises (or returns
+        ``default`` when given). Ambiguity always raises.
+        """
+        model = self._models.get(ref)
+        if model is not None:
+            return model
+        candidates = [cls for cls in self._models.values() if cls.__name__ == ref]
+        if len(candidates) == 1:
+            return candidates[0]
+        if len(candidates) > 1:
+            listed = ", ".join(
+                sorted(
+                    getattr(c, "__ferro_identity__", c.__qualname__) for c in candidates
+                )
+            )
+            raise RuntimeError(
+                f"Model reference '{ref}' is ambiguous: {listed}. "
+                "Use the qualified 'module.QualName' form to disambiguate."
+            )
+        if default is not _UNSET:
+            return default
+        raise RuntimeError(f"Model '{ref}' not found in registry")
+
+    # -- per-model envelopes -----------------------------------------------
+
+    def persist_envelope(self, name: str, envelope: dict[str, Any]) -> None:
+        """Store one model's (or join table's) compiled SchemaIR envelope.
+
+        The fingerprint is computed here from the envelope — a pure function
+        of it, so no caller can persist a stale envelope/fingerprint pair.
+        Keyed by the same ``name`` the IR compiler uses (a model's
+        ``__ferro_identity__`` or a join-table name).
+        """
+        self._envelopes[name] = envelope
+        self._fingerprints[name] = ir_fingerprint(envelope)
+
+    def evict_envelope(self, name: str) -> None:
+        """Evict one entry from the envelope + fingerprint caches only."""
+        self._envelopes.pop(name, None)
+        self._fingerprints.pop(name, None)
+
+    def envelope(self, name: str) -> dict[str, Any] | None:
+        """One compiled envelope, or None — a live reference, not a copy
+        (the modelset assembler reads it in place)."""
+        return self._envelopes.get(name)
+
+    def fingerprint(self, name: str) -> str | None:
+        """The stored fingerprint paired with :meth:`envelope`."""
+        return self._fingerprints.get(name)
+
+    def missing_envelope_names(self) -> list[str]:
+        """Registered names whose envelope is absent — the store-agreement
+        arithmetic (registry keys and dict-bundle join tables minus envelope
+        keys). Non-empty means a cold-rehydrate must recompile first."""
+        missing = [name for name in self._models if name not in self._envelopes]
+        missing.extend(
+            table_name
+            for table_name, bundle in self._join_tables.items()
+            if isinstance(bundle, dict) and table_name not in self._envelopes
+        )
+        return missing
+
+    # -- join tables ---------------------------------------------------------
+
+    def add_join_table(self, name: str, bundle: Any) -> None:
+        """Record one auto-generated join table's bundle."""
+        self._join_tables[name] = bundle
+
+    def join_tables(self) -> dict[str, Any]:
+        """The join-table bundles, keyed by table name (read view)."""
+        return self._join_tables
+
+    def clear_join_tables(self) -> None:
+        """Drop every join-table bundle AND its envelope cache entry.
+
+        Join tables never live in the model registry, so this touches nothing
+        a declared model needs to cold-rehydrate; leaving their envelopes
+        behind would resurrect stale join-table DDL on the next assemble
+        (the #153 guard depends on these stores agreeing).
+        """
+        for name in list(self._join_tables):
+            self.evict_envelope(name)
+        self._join_tables.clear()
+
+    # -- pending relations ---------------------------------------------------
+
+    def defer_relation(self, identity: str, field_name: str, metadata: Any) -> None:
+        """Queue one relationship declaration for resolution (metaclass)."""
+        self._pending_relations.append((identity, field_name, metadata))
+
+    def drain_pending_relations(self) -> list[Any]:
+        """Return-and-clear the pending relation queue (resolution pass)."""
+        drained = list(self._pending_relations)
+        self._pending_relations.clear()
+        return drained
+
+    # -- modelset artifact -----------------------------------------------------
+
+    def set_modelset(self, envelope: dict[str, Any]) -> None:
+        """Cache the assembled modelset envelope; fingerprint computed here."""
+        self._modelset = envelope
+        self._modelset_fingerprint = ir_fingerprint(envelope)
+
+    def modelset(self) -> tuple[dict[str, Any], str] | None:
+        """The cached (envelope, fingerprint) pair, or None if never built."""
+        if self._modelset is None or self._modelset_fingerprint is None:
+            return None
+        return self._modelset, self._modelset_fingerprint
+
+    def clear_modelset(self) -> None:
+        """Drop the cached modelset pair, forcing the next assemble to
+        rebuild it (per-model envelopes are untouched)."""
+        self._modelset = None
+        self._modelset_fingerprint = None
+
+    # -- generations -----------------------------------------------------------
+
+    def registration_generation(self) -> int:
+        """Current registration generation counter (test/diagnostic)."""
+        return self._registration_generation
+
+    def resolved_generation(self) -> int:
+        """The generation last cleared by relationship resolution."""
+        return self._resolved_generation
+
+    def mark_resolved(self) -> None:
+        """Record that the current registry generation has been resolved."""
+        self._resolved_generation = self._registration_generation
+
+    def is_dirty(self) -> bool:
+        """True when the registry changed since last resolve or relations
+        are pending."""
+        return self._registration_generation != self._resolved_generation or bool(
+            self._pending_relations
+        )
+
+    # -- test surface ------------------------------------------------------------
+
+    def snapshot(self) -> RegistrySnapshot:
+        """Copy every store and counter — pair with :meth:`restore`."""
+        return RegistrySnapshot(
+            models=dict(self._models),
+            envelopes=dict(self._envelopes),
+            fingerprints=dict(self._fingerprints),
+            join_tables=dict(self._join_tables),
+            pending_relations=list(self._pending_relations),
+            modelset=self._modelset,
+            modelset_fingerprint=self._modelset_fingerprint,
+            registration_generation=self._registration_generation,
+            resolved_generation=self._resolved_generation,
+        )
+
+    def restore(self, snap: RegistrySnapshot) -> None:
+        """Replace every store and counter with the snapshot's contents."""
+        self._models.clear()
+        self._models.update(snap.models)
+        self._envelopes.clear()
+        self._envelopes.update(snap.envelopes)
+        self._fingerprints.clear()
+        self._fingerprints.update(snap.fingerprints)
+        self._join_tables.clear()
+        self._join_tables.update(snap.join_tables)
+        self._pending_relations.clear()
+        self._pending_relations.extend(snap.pending_relations)
+        self._modelset = snap.modelset
+        self._modelset_fingerprint = snap.modelset_fingerprint
+        self._registration_generation = snap.registration_generation
+        self._resolved_generation = snap.resolved_generation
+
+    def reset_for_test(self) -> None:
+        """Wipe every store and counter (``clean_registry`` fixture)."""
+        self._models.clear()
+        self._envelopes.clear()
+        self._fingerprints.clear()
+        self._join_tables.clear()
+        self._pending_relations.clear()
+        self._modelset = None
+        self._modelset_fingerprint = None
+        self._registration_generation = 0
+        self._resolved_generation = 0
+
+
+REGISTRY = Registry()

--- a/src/ferro/relations/__init__.py
+++ b/src/ferro/relations/__init__.py
@@ -4,13 +4,7 @@ from .._shadow_fk_types import pk_python_type_for_model, reconcile_shadow_fk_typ
 from ..base import ForeignKey, ManyToManyRelation
 from ..columns import fk_shadow_spec
 from ..ir.compiler import compile_model_schema_ir, register_model_with_ir
-from ..state import (  # noqa: F401
-    _JOIN_TABLE_REGISTRY,
-    _MODEL_REGISTRY_PY,
-    _PENDING_RELATIONS,
-    mark_modelset_resolved,
-    resolve_model_reference,
-)
+from ..registry import REGISTRY
 from .descriptors import RelationshipDescriptor
 
 
@@ -22,12 +16,9 @@ def resolve_relationships():
     model's PK type where applicable, then ``model_rebuild``s affected classes before
     the schema re-registration pass.
     """
-    global _PENDING_RELATIONS
-
-    # Copy and clear so that we don't process the same relations multiple times
-    # if resolve_relationships is called again (e.g. in tests)
-    to_process = list(_PENDING_RELATIONS)
-    _PENDING_RELATIONS.clear()
+    # Drain (copy-and-clear) so that we don't process the same relations
+    # multiple times if resolve_relationships is called again (e.g. in tests)
+    to_process = REGISTRY.drain_pending_relations()
 
     recompile_targets: set[str] = set()
 
@@ -36,7 +27,7 @@ def resolve_relationships():
         # 1. Resolve 'to' model
         if isinstance(rel.to, (str, ForwardRef)):
             to_name = rel.to if isinstance(rel.to, str) else rel.to.__forward_arg__
-            target_model = resolve_model_reference(to_name, default=None)
+            target_model = REGISTRY.resolve_reference(to_name, default=None)
             if not target_model:
                 raise RuntimeError(
                     f"Relationship resolution failed: '{to_name}' not found"
@@ -65,7 +56,7 @@ def resolve_relationships():
                 ),
             )
         elif isinstance(rel, ManyToManyRelation):
-            source_model = _MODEL_REGISTRY_PY[model_name]
+            source_model = REGISTRY.models()[model_name]
             source_table = source_model.__ferro_table__
             target_table = target_model.__ferro_table__
 
@@ -76,7 +67,7 @@ def resolve_relationships():
             else:
                 join_table = rel.through
 
-            for key, other in _MODEL_REGISTRY_PY.items():
+            for key, other in REGISTRY.models().items():
                 if getattr(other, "__ferro_table__", None) == join_table:
                     raise RuntimeError(
                         f"M2M relation '{model_name}.{field_name}' derives join "
@@ -140,13 +131,16 @@ def resolve_relationships():
                 composite_uniques=composite_uniques,
                 composite_indexes=composite_indexes,
             )
-            _JOIN_TABLE_REGISTRY[join_table] = {
-                "columns": join_columns,
-                "composite_uniques": composite_uniques,
-                "composite_indexes": composite_indexes,
-            }
+            REGISTRY.add_join_table(
+                join_table,
+                {
+                    "columns": join_columns,
+                    "composite_uniques": composite_uniques,
+                    "composite_indexes": composite_indexes,
+                },
+            )
 
-    rebuilt = reconcile_shadow_fk_types(_MODEL_REGISTRY_PY)
+    rebuilt = reconcile_shadow_fk_types(REGISTRY.models())
     for model_cls in rebuilt:
         recompile_targets.add(model_cls.__ferro_identity__)
 
@@ -154,7 +148,7 @@ def resolve_relationships():
     # resolution (relationship sources/targets and shadow-FK reconciliation
     # targets). Replacement, never mutation (grilling Q3).
     for model_name in sorted(recompile_targets):
-        model_cls = _MODEL_REGISTRY_PY.get(model_name)
+        model_cls = REGISTRY.models().get(model_name)
         if model_cls is None:
             continue
         try:
@@ -165,5 +159,5 @@ def resolve_relationships():
                 f"while resolving relationships: {exc}"
             ) from exc
 
-    mark_modelset_resolved()
-    _PENDING_RELATIONS.clear()
+    REGISTRY.mark_resolved()
+    REGISTRY.drain_pending_relations()

--- a/src/ferro/relations/descriptors.py
+++ b/src/ferro/relations/descriptors.py
@@ -38,12 +38,15 @@ class RelationshipDescriptor(BaseModel):
         if self._target_model is None:
             self._target_model = resolve_model_reference(self.target_model_name)
 
-        # Find the primary key value of the current instance
-        pk_field = "id"
-        for f_name, spec in getattr(instance.__class__, "__ferro_columns__", {}).items():
-            if spec.primary_key:
-                pk_field = f_name
-                break
+        # The related rows are keyed by this instance's PK (cached fact —
+        # this runs on every reverse-relation attribute access).
+        pk_field = instance.__class__.__ferro_pk__
+        if pk_field is None:
+            raise ValueError(
+                f"Cannot access relation {self.field_name!r}: "
+                f"{instance.__class__.__name__} declares no primary-key "
+                "column, so its related rows cannot be keyed."
+            )
         pk_val = getattr(instance, pk_field)
 
         if self.is_m2m:

--- a/src/ferro/relations/descriptors.py
+++ b/src/ferro/relations/descriptors.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
     from ferro.models import Model
 
-from ..state import resolve_model_reference
+from ..registry import REGISTRY
 
 
 def _instance_origin_outside_transaction(instance: object) -> str | None:
@@ -36,7 +36,7 @@ class RelationshipDescriptor(BaseModel):
             return self
 
         if self._target_model is None:
-            self._target_model = resolve_model_reference(self.target_model_name)
+            self._target_model = REGISTRY.resolve_reference(self.target_model_name)
 
         # The related rows are keyed by this instance's PK (cached fact —
         # this runs on every reverse-relation attribute access).
@@ -83,7 +83,7 @@ class ForwardDescriptor(BaseModel):
             return self
 
         if self._target_model is None:
-            self._target_model = resolve_model_reference(self.target_model_name)
+            self._target_model = REGISTRY.resolve_reference(self.target_model_name)
 
         async def _fetch():
             id_val = getattr(instance, f"{self.field_name}_id")

--- a/src/ferro/state.py
+++ b/src/ferro/state.py
@@ -1,8 +1,13 @@
-import hashlib
-import json
+"""Operation routing: sessions, transactions, and RouteHandle construction.
+
+The single resolution site for "which connection does this operation hit"
+(FF-D D3/D4) and the only module allowed to construct ``RouteHandle``.
+Registration state lives in :mod:`ferro.registry`.
+"""
+
 from contextvars import ContextVar
 
-from typing import Any, Protocol
+from typing import Protocol
 
 from ._core import RouteHandle
 
@@ -34,190 +39,6 @@ _SESSION_CLOSED_MESSAGE = (
 def _ensure_active_session(session: SessionLike | None) -> None:
     if session is not None and session.session_id is None:
         raise RuntimeError(_SESSION_CLOSED_MESSAGE)
-
-class FerroModelClass(Protocol):
-    """Structural type for a registrable Ferro model class.
-
-    The registry keys by ``__ferro_identity__`` (what ``register_model``
-    derives its key from) and resolves bare references against ``__name__`` /
-    ``__qualname__``. Typed as a ``Protocol`` rather than ``type[Model]`` so
-    ``state`` — which ``models`` and ``metaclass`` import — does not import back
-    into them (circular import); a non-Ferro class handed to ``register_model``
-    is then a type error at the call site instead of a raw ``AttributeError``
-    at runtime.
-    """
-
-    __ferro_identity__: str
-    __name__: str
-    __qualname__: str
-
-
-# Global registry for models (Python side)
-_MODEL_REGISTRY_PY: dict[str, FerroModelClass] = {}
-
-_UNSET = object()
-
-
-def resolve_model_reference(ref: str, *, default: Any = _UNSET) -> Any:
-    """Resolve a model reference to a registered model class (FF-E E1).
-
-    Accepts a qualified identity (``module.QualName``) or a bare class name.
-    The registry keys by ``__ferro_identity__``, so a qualified reference is a
-    direct dict hit. A bare name matching exactly one registered model resolves
-    to it; several matches raise with the qualified candidates listed; no match
-    raises (or returns ``default`` when given). Ambiguity always raises.
-    """
-    model = _MODEL_REGISTRY_PY.get(ref)
-    if model is not None:
-        return model
-    candidates = [cls for cls in _MODEL_REGISTRY_PY.values() if cls.__name__ == ref]
-    if len(candidates) == 1:
-        return candidates[0]
-    if len(candidates) > 1:
-        listed = ", ".join(
-            sorted(getattr(c, "__ferro_identity__", c.__qualname__) for c in candidates)
-        )
-        raise RuntimeError(
-            f"Model reference '{ref}' is ambiguous: {listed}. "
-            "Use the qualified 'module.QualName' form to disambiguate."
-        )
-    if default is not _UNSET:
-        return default
-    raise RuntimeError(f"Model '{ref}' not found in registry")
-
-
-# Global registry for relationships that need deferred resolution
-_PENDING_RELATIONS = []
-
-# Global registry for automatically generated join tables
-_JOIN_TABLE_REGISTRY = {}
-
-# Latest compiled SchemaIR model-set artifact and fingerprint.
-_SCHEMA_IR_MODELSET: dict[str, Any] | None = None
-_SCHEMA_IR_MODELSET_FINGERPRINT: str | None = None
-
-# Per-model compiled SchemaIR artifacts and fingerprints.
-_SCHEMA_IR_BY_MODEL: dict[str, dict[str, Any]] = {}
-_SCHEMA_IR_FINGERPRINT_BY_MODEL: dict[str, str] = {}
-
-# Monotonic generation counter bumped by register/deregister; cleared (matched to
-# resolved) at the end of relationship resolution (#245).
-_REGISTRATION_GENERATION: int = 0
-_RESOLVED_GENERATION: int = 0
-
-
-def registration_generation() -> int:
-    """Return the current registration generation counter (test/diagnostic)."""
-    return _REGISTRATION_GENERATION
-
-
-def resolved_generation() -> int:
-    """Return the generation counter last cleared by relationship resolution."""
-    return _RESOLVED_GENERATION
-
-
-def is_modelset_dirty() -> bool:
-    """True when the registry changed since last resolve or relations are pending."""
-    return _REGISTRATION_GENERATION != _RESOLVED_GENERATION or bool(_PENDING_RELATIONS)
-
-
-def _bump_registration_generation() -> None:
-    global _REGISTRATION_GENERATION
-    _REGISTRATION_GENERATION += 1
-
-
-def mark_modelset_resolved() -> None:
-    """Record that the current registry generation has been resolved."""
-    global _RESOLVED_GENERATION
-    _RESOLVED_GENERATION = _REGISTRATION_GENERATION
-
-
-def reset_registration_generations_for_test() -> None:
-    """Reset generation counters (``clean_registry`` fixture)."""
-    global _REGISTRATION_GENERATION, _RESOLVED_GENERATION
-    _REGISTRATION_GENERATION = 0
-    _RESOLVED_GENERATION = 0
-
-
-def canonical_ir_json(value: dict[str, Any]) -> str:
-    """Serialize an IR artifact with deterministic key ordering."""
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-
-
-def ir_fingerprint(value: dict[str, Any]) -> str:
-    """Return the canonical SHA-256 fingerprint for an IR artifact.
-
-    Single source of the fingerprint function so a stored fingerprint is always
-    a pure function of the envelope it accompanies (the ADR fingerprint gate
-    reads these; a mismatched pair would serve stale schema silently).
-    """
-    return hashlib.sha256(canonical_ir_json(value).encode("utf-8")).hexdigest()
-
-
-def register_model(cls: FerroModelClass) -> None:
-    """Record a model class in the Python registry (provisional registration).
-
-    Single entrypoint for every per-model ``_MODEL_REGISTRY_PY`` write. Today the
-    writers are the metaclass (class-body registration) and a handful of test
-    fixtures that re-add models after a registry wipe. Centralizing the write is
-    the prefactor (#243) that lets a later slice (#242) hook one site — e.g. a
-    generation counter — instead of chasing scattered dict assignments.
-    Idempotent by construction.
-
-    The key is the model's canonical identity (``__ferro_identity__``), derived
-    from ``cls`` here rather than caller-supplied (#249). Deriving it in one
-    place makes the registry key a pure function of the model: callers can no
-    longer register a model under a divergent bare ``__name__`` that a lookup by
-    canonical identity would miss (the "Model 'X' not found" footgun). Every
-    other emitter — the Rust runtime registry, the raw-FFI operations — keys the
-    same model by this identity, so there is exactly one name for a model.
-    """
-    _MODEL_REGISTRY_PY[cls.__ferro_identity__] = cls
-    _bump_registration_generation()
-
-
-def persist_model_envelope(name: str, envelope: dict[str, Any]) -> None:
-    """Store one model's (or join table's) compiled SchemaIR envelope + fingerprint.
-
-    The envelope-cache half of registration. The fingerprint is computed here
-    from the envelope — it is a pure function of it, so no caller can persist a
-    stale envelope/fingerprint pair. Keyed by the same ``name`` the IR compiler
-    uses (a model's ``__ferro_identity__`` or a join-table name).
-    """
-    _SCHEMA_IR_BY_MODEL[name] = envelope
-    _SCHEMA_IR_FINGERPRINT_BY_MODEL[name] = ir_fingerprint(envelope)
-
-
-def evict_model_envelope(name: str) -> None:
-    """Evict one entry from the SchemaIR envelope + fingerprint caches only.
-
-    The envelope-only counterpart of :func:`persist_model_envelope`. Used by the
-    join-table cleanup path (``clear_registry``), where the model registry must
-    stay untouched — join tables never live there, and ``clear_registry`` promises
-    declared models survive so they can cold-rehydrate.
-    """
-    _SCHEMA_IR_BY_MODEL.pop(name, None)
-    _SCHEMA_IR_FINGERPRINT_BY_MODEL.pop(name, None)
-
-
-def deregister_model(name: str) -> None:
-    """Evict one model from every per-model store (registry + envelope caches).
-
-    Single deregistration entrypoint: removes the class-registry entry plus the
-    compiled SchemaIR envelope and its fingerprint. Idempotent — absent keys are
-    ignored — so it is safe for teardown paths and re-runs.
-
-    Takes a ``name`` (the canonical identity) rather than a class, unlike
-    :func:`register_model` which derives the key from ``cls``. The asymmetry is
-    deliberate: teardown paths iterate registry keys (e.g. evicting every
-    function-local model added during a test) and hold the identity string, not
-    the class object.
-    """
-    removed = name in _MODEL_REGISTRY_PY
-    _MODEL_REGISTRY_PY.pop(name, None)
-    evict_model_envelope(name)
-    if removed:
-        _bump_registration_generation()
 
 
 _NO_ROUTE_MESSAGE = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,19 +220,12 @@ def clean_registry():
     the reset now happens once here instead of in each copy.
     """
     from ferro import clear_registry, reset_engine
-    from ferro import state as ferro_state
+    from ferro.registry import REGISTRY
 
     def _wipe() -> None:
         reset_engine()
         clear_registry()
-        ferro_state._MODEL_REGISTRY_PY.clear()
-        ferro_state._PENDING_RELATIONS.clear()
-        ferro_state._JOIN_TABLE_REGISTRY.clear()
-        ferro_state._SCHEMA_IR_BY_MODEL.clear()
-        ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL.clear()
-        ferro_state._SCHEMA_IR_MODELSET = None
-        ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = None
-        ferro_state.reset_registration_generations_for_test()
+        REGISTRY.reset_for_test()
         from ferro.ir.compiler import reset_schema_ir_compile_count_for_test
 
         reset_schema_ir_compile_count_for_test()
@@ -253,25 +246,11 @@ def _ferro_registry_isolation():
     captured in the baseline snapshot and survive; function-local models are
     dropped when the test ends.
     """
-    from ferro.state import (
-        _JOIN_TABLE_REGISTRY,
-        _MODEL_REGISTRY_PY,
-        _PENDING_RELATIONS,
-        deregister_model,
-    )
+    from ferro.registry import REGISTRY
 
-    models_snapshot = dict(_MODEL_REGISTRY_PY)
-    pending_snapshot = list(_PENDING_RELATIONS)
-    joins_snapshot = dict(_JOIN_TABLE_REGISTRY)
+    snapshot = REGISTRY.snapshot()
     yield
-    # Deregister function-local models through the entrypoint so their envelope
-    # + fingerprint are evicted too — a bare `.clear()`/restore of the registry
-    # would leave those caches disagreeing (the divergence #243 eliminates).
-    for name in set(_MODEL_REGISTRY_PY) - set(models_snapshot):
-        deregister_model(name)
-    _MODEL_REGISTRY_PY.clear()
-    _MODEL_REGISTRY_PY.update(models_snapshot)
-    _PENDING_RELATIONS.clear()
-    _PENDING_RELATIONS.extend(pending_snapshot)
-    _JOIN_TABLE_REGISTRY.clear()
-    _JOIN_TABLE_REGISTRY.update(joins_snapshot)
+    # Wholesale restore covers every store the old hand-rolled version had to
+    # keep in agreement by convention: function-local models drop with their
+    # envelope + fingerprint entries, module-scope state survives.
+    REGISTRY.restore(snapshot)

--- a/tests/test_alembic_autogenerate.py
+++ b/tests/test_alembic_autogenerate.py
@@ -21,11 +21,9 @@ from ferro.migrations import get_metadata
 
 @pytest.fixture(autouse=True)
 def cleanup():
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     reset_engine()
     clear_registry()
     yield
@@ -63,11 +61,9 @@ def test_schema_diff_simulation():
 
     # 2. Simulate code change (adding a field)
     # We clear the registry and redefine to simulate a fresh run after a code edit
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     clear_registry()
 
     class Product(Model):  # noqa
@@ -90,11 +86,9 @@ def test_index_and_unique_diff():
     meta_v1 = get_metadata()
     assert meta_v1.tables["settings"].indexes == set()
 
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     clear_registry()
 
     class Settings(Model):  # noqa

--- a/tests/test_alembic_bridge.py
+++ b/tests/test_alembic_bridge.py
@@ -20,11 +20,9 @@ from ferro.migrations import get_metadata
 
 @pytest.fixture(autouse=True)
 def cleanup():
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     reset_engine()
     clear_registry()
     yield

--- a/tests/test_alembic_db_type.py
+++ b/tests/test_alembic_db_type.py
@@ -31,15 +31,9 @@ class Priority(IntEnum):
 
 @pytest.fixture(autouse=True)
 def cleanup():
-    from ferro.state import (
-        _JOIN_TABLE_REGISTRY,
-        _MODEL_REGISTRY_PY,
-        _PENDING_RELATIONS,
-    )
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     reset_engine()
     clear_registry()
     yield

--- a/tests/test_alembic_nullability.py
+++ b/tests/test_alembic_nullability.py
@@ -23,11 +23,9 @@ from ferro.migrations import get_metadata
 
 @pytest.fixture(autouse=True)
 def cleanup():
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     reset_engine()
     clear_registry()
     yield

--- a/tests/test_alembic_type_mapping.py
+++ b/tests/test_alembic_type_mapping.py
@@ -18,11 +18,9 @@ class UserStatus(str, Enum):
 
 @pytest.fixture(autouse=True)
 def cleanup():
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     reset_engine()
     clear_registry()
     yield

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -52,13 +52,11 @@ async def test_m2m_join_table_created_during_auto_migrate(db_url):
     We clear registries, migrate a fresh in-memory DB, then use the M2M API; if the
     join table were not created, .add() would fail. No second connection needed."""
     from ferro import clear_registry, connect, reset_engine
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
     class Actor(Model):
         id: Annotated[int | None, FerroField(primary_key=True)] = None
@@ -101,13 +99,11 @@ async def test_m2m_join_table_created_during_auto_migrate(db_url):
 async def test_uuid_m2m_join_table_columns_inherit_pk_type_and_nullability(db_url):
     """Runtime join-table DDL should derive FK column metadata from source PKs."""
     from ferro import clear_registry, connect, reset_engine
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
     class UuidActor(Model):
         id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
@@ -154,13 +150,11 @@ async def test_uuid_m2m_relationship_query_serializes_source_id(db_url):
     from ferro import Field as FerroFieldFn
     from ferro import clear_registry, connect, reset_engine
     from ferro.models import transaction
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
     class UuidTag(Model):
         id: UUID = FerroFieldFn(default_factory=uuid4, primary_key=True)
@@ -217,13 +211,11 @@ from ferro.raw import execute, fetch_all  # noqa: E402
 @pytest.fixture
 def clean_registry():
     from ferro import clear_registry, reset_engine
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     yield
 
 
@@ -826,12 +818,10 @@ async def test_index_reconcile_adds_composite_index_to_existing_table(
 
     # Re-register a NEW model class with the composite index annotation.
     from ferro import clear_registry
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
     class IdxCompModel(Model):  # noqa: F811 — intentional redefinition
         __ferro_composite_indexes__: ClassVar[tuple[tuple[str, ...], ...]] = (
@@ -879,12 +869,10 @@ async def test_index_reconcile_adds_single_column_index_to_existing_column(
 
     # Re-register with index=True on the existing column.
     from ferro import clear_registry
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
     class IdxSingleModel(Model):  # noqa: F811
         id: Annotated[int | None, FerroField(primary_key=True)] = None
@@ -960,12 +948,10 @@ async def test_index_reconcile_destructive_drops_removed_composite_index(
 
     # Re-register model WITHOUT the composite index.
     from ferro import clear_registry
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
     class IdxDropModel(Model):  # noqa: F811
         id: Annotated[int | None, FerroField(primary_key=True)] = None
@@ -1062,12 +1048,10 @@ async def test_uuid_pk_derived_second_pass_is_noop(db_url, db_backend, clean_reg
 
     # Second connect: same model, same schema — must be a complete no-op.
     from ferro import clear_registry
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
     class UuidPkItem(Model):  # noqa: F811 — intentional re-declaration for second connect
         id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
@@ -1115,12 +1099,10 @@ async def test_uuid_pk_derived_drift_is_stable(db_url, db_backend, clean_registr
 
     # First migrate_updates pass — should apply nothing (fresh table).
     from ferro import clear_registry
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
     class UuidDriftModel(Model):  # noqa: F811
         id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
@@ -1134,9 +1116,7 @@ async def test_uuid_pk_derived_drift_is_stable(db_url, db_backend, clean_registr
 
     # Second migrate_updates pass — must be identical to the first (idempotent).
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
     class UuidDriftModel(Model):  # noqa: F811
         id: Annotated[UUID, FerroField(primary_key=True)] = Field(default_factory=uuid4)
@@ -1243,17 +1223,16 @@ async def test_db_check_reconnect_is_idempotent(db_url):
     from ferro import Field as FerroField
     from ferro import clear_registry, connect, reset_engine
     from ferro.raw import fetch_all
-    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    # Match this file's other reconnect tests: clearing the model registry
-    # without also draining the pending-relations queue leaves import-time
+    # Match this file's other reconnect tests: wiping the model registry
+    # without also draining the pending-relations queue would leave import-time
     # relations from module-level models in other test files dangling, so the
-    # connect() below crashes in resolve_relationships when their now-unregistered
-    # source model is looked up. (Pre-existing isolation gap surfaced by ordering.)
-    _PENDING_RELATIONS.clear()
+    # connect() below would crash in resolve_relationships when their
+    # now-unregistered source model is looked up. reset_for_test() clears both.
+    REGISTRY.reset_for_test()
 
     class DocStatus(StrEnum):
         PENDING = "pending"

--- a/tests/test_catalog_cache.py
+++ b/tests/test_catalog_cache.py
@@ -23,13 +23,11 @@ from ferro.base import FerroField
 @pytest.fixture
 def clean_registry():
     from ferro import clear_registry, reset_engine
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     yield
 
 

--- a/tests/test_compiled_query.py
+++ b/tests/test_compiled_query.py
@@ -1,0 +1,81 @@
+"""``compile_query`` returns one CompiledQuery artifact (CONTEXT.md term).
+
+The wire JSON and the hop-class map are two views of the same compile: the
+map is collected from the hop facts the payload itself carries, so the two
+can never disagree — the builder unpacks the artifact instead of re-walking
+relation-spec chains to assemble ``hop_classes`` by hand.
+
+The map is plan-scoped, mirroring the Rust ``needs_hop_classes`` guard
+exactly (the same both-sides double-check as #272 join edges): ``None``
+unless the materialization plan decodes or hydrates through a hop model's
+class — an ``instances`` plan (#286) or a ``record`` plan with traversed
+plain fields (#293).
+"""
+
+import json
+from typing import Annotated
+
+from ferro import BackRef, Model, Relation
+from ferro.base import FerroField, ForeignKey
+from ferro.query.builder import Query
+from ferro.query.wire import compile_query
+
+
+class CQLedger(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str = ""
+    accounts: Relation[list["CQAccount"]] = BackRef()
+
+
+class CQAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    label: str = ""
+    ledger: Annotated[CQLedger, ForeignKey(related_name="accounts")]
+    transactions: Relation[list["CQTransaction"]] = BackRef()
+
+
+class CQTransaction(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    amount: int = 0
+    account: Annotated[CQAccount, ForeignKey(related_name="transactions")]
+
+
+def test_compiled_query_carries_wire_json_payload_and_hop_classes():
+    q = Query(CQTransaction).where(lambda t: t.account.label == "x")
+    compiled = compile_query(q, "fetch")
+
+    envelope = json.loads(compiled.wire_json)
+    assert envelope["ir_kind"] == "query"
+    assert (
+        compiled.payload.to_ir_dict()["model_name"] == envelope["payload"]["model_name"]
+    )
+    # A root_instances plan hydrates only root rows: membership joins shape
+    # the SQL but nothing decodes through a hop class, so no map travels.
+    assert compiled.hop_classes is None
+
+
+def test_hop_classes_none_when_nothing_traverses():
+    compiled = compile_query(Query(CQTransaction), "fetch")
+    assert compiled.hop_classes is None
+
+
+def test_hop_classes_cover_include_paths():
+    # Include paths ride the materialization plan, not the membership joins
+    # (ADR-0008) — the map must cover them all the same.
+    q = Query(CQTransaction).include(lambda t: t.account.ledger)
+    compiled = compile_query(q, "fetch")
+    assert compiled.hop_classes == {
+        CQAccount.__ferro_table__: CQAccount,
+        CQLedger.__ferro_table__: CQLedger,
+    }
+
+
+def test_hop_classes_cover_traversed_projection_paths():
+    q = Query(CQTransaction).select(lambda t: t.account.label)
+    compiled = compile_query(q, "fetch")
+    assert compiled.hop_classes == {CQAccount.__ferro_table__: CQAccount}
+
+
+def test_mutation_verbs_compile_with_no_hop_classes():
+    compiled = compile_query(Query(CQTransaction), "delete")
+    assert compiled.hop_classes is None

--- a/tests/test_composite_index.py
+++ b/tests/test_composite_index.py
@@ -29,19 +29,15 @@ pytestmark = pytest.mark.backend_matrix
 
 @pytest.fixture(autouse=True)
 def cleanup_registry():
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     yield
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
 
 def _indexes(table: sa.Table) -> list[sa.Index]:

--- a/tests/test_composite_unique.py
+++ b/tests/test_composite_unique.py
@@ -33,19 +33,15 @@ def _expected_uq_constraint_name(table_name: str, col_ids: list[str]) -> str:
 
 @pytest.fixture(autouse=True)
 def cleanup_registry():
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     yield
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
 
 def _unique_constraints(table: sa.Table) -> list[sa.Index]:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -17,10 +17,10 @@ class ConnectionRouteMarker(ferro.Model):
 
 @pytest.fixture(autouse=True)
 def _ensure_models_registered():
-    from ferro.state import register_model
+    from ferro.registry import REGISTRY
 
     ConnectionRouteMarker._reregister_ferro()
-    register_model(ConnectionRouteMarker)
+    REGISTRY.register(ConnectionRouteMarker)
     yield
 
 

--- a/tests/test_cross_emitter_parity.py
+++ b/tests/test_cross_emitter_parity.py
@@ -49,17 +49,13 @@ pytestmark = pytest.mark.backend_matrix
 
 @pytest.fixture(autouse=True)
 def cleanup():
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     reset_engine()
     clear_registry()
     yield
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
 
 class OrgRole(StrEnum):
@@ -265,16 +261,14 @@ async def test_alembic_autogen_after_migrate_updates_is_idempotent(db_url):
     ``uq_`` index / a constraint-less column) plus a ``UserWarning`` — visible
     divergence by design, covered in ``test_auto_migrate.py``.
     """
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
     _build_migration_v1_models()
     await connect(db_url, auto_migrate=True)
 
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
     _build_migration_v2_models()
     await connect(db_url, migrate_updates=True)

--- a/tests/test_db_type_cross_emitter_parity.py
+++ b/tests/test_db_type_cross_emitter_parity.py
@@ -47,21 +47,13 @@ def _render_create_table_via_ir(
 
 @pytest.fixture(autouse=True)
 def cleanup():
-    from ferro.state import (
-        _JOIN_TABLE_REGISTRY,
-        _MODEL_REGISTRY_PY,
-        _PENDING_RELATIONS,
-    )
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     reset_engine()
     clear_registry()
     yield
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     reset_engine()
     clear_registry()
 

--- a/tests/test_db_type_integration.py
+++ b/tests/test_db_type_integration.py
@@ -15,7 +15,7 @@ import pytest
 
 import ferro
 from ferro import Field, Model, clear_registry, connect, reset_engine, varchar
-from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+from ferro.registry import REGISTRY
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -30,8 +30,8 @@ def cleanup():
     """Drop inline models from the Python registry after each test.
 
     ``clear_registry()`` only clears the Rust side; ``connect()`` calls
-    ``resolve_relationships()`` which re-registers every entry in
-    ``_MODEL_REGISTRY_PY``. Clearing the Python registries at setup keeps each
+    ``resolve_relationships()`` which re-registers every entry in the model
+    registry. Wiping the Registry at setup keeps each
     test's ``connect()`` scoped to its own inline model (module-level models
     from other files would otherwise leak their tables/enums into this test's
     schema); the global ``_ferro_registry_isolation`` fixture restores the
@@ -39,9 +39,7 @@ def cleanup():
     """
     reset_engine()
     clear_registry()
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     yield
     reset_engine()
     clear_registry()

--- a/tests/test_documentation_features.py
+++ b/tests/test_documentation_features.py
@@ -101,18 +101,18 @@ class DocProduct(Model):
 def _ensure_models_registered():
     from ferro.base import ForeignKey, ManyToManyRelation
     from ferro.relations import resolve_relationships
-    from ferro.state import _PENDING_RELATIONS, register_model
+    from ferro.registry import REGISTRY
 
     for model_cls in (DocUser, DocPost, Comment, Tag, DocProduct):
-        register_model(model_cls)
+        REGISTRY.register(model_cls)
 
     # Some tests clear private relationship state to model fresh imports. These
     # module-level models must restore both schemas and descriptors afterward.
     for model_cls in (DocUser, DocPost, Comment, Tag, DocProduct):
         for field_name, relation in model_cls.ferro_relations.items():
             if isinstance(relation, (ForeignKey, ManyToManyRelation)):
-                _PENDING_RELATIONS.append(
-                    (model_cls.__ferro_identity__, field_name, relation)
+                REGISTRY.defer_relation(
+                    model_cls.__ferro_identity__, field_name, relation
                 )
 
     resolve_relationships()

--- a/tests/test_enum_cold_hydration.py
+++ b/tests/test_enum_cold_hydration.py
@@ -9,7 +9,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from ferro import FerroField, Model, clear_registry, connect, engines, reset_engine
-from ferro.state import _MODEL_REGISTRY_PY, deregister_model, register_model
+from ferro.registry import REGISTRY
 
 pytestmark = pytest.mark.backend_matrix
 
@@ -26,17 +26,17 @@ class BillingRow(Model):
 
 @pytest.fixture(autouse=True)
 def cleanup():
-    registered_before = set(_MODEL_REGISTRY_PY)
+    registered_before = set(REGISTRY.models())
     # Other tests (e.g. test_sqlite_alembic_reconnect_hydration) clear the Python registry.
-    if BillingRow.__ferro_identity__ not in _MODEL_REGISTRY_PY:
-        register_model(BillingRow)
+    if BillingRow.__ferro_identity__ not in REGISTRY.models():
+        REGISTRY.register(BillingRow)
     reset_engine()
     clear_registry()
     yield
     reset_engine()
     clear_registry()
-    for name in set(_MODEL_REGISTRY_PY) - registered_before:
-        deregister_model(name)
+    for name in set(REGISTRY.models()) - registered_before:
+        REGISTRY.deregister(name)
 
 
 def test_enum_fields_populated_for_deferred_annotations():

--- a/tests/test_fk_target_pk.py
+++ b/tests/test_fk_target_pk.py
@@ -18,9 +18,9 @@ def _isolate_relation_state():
     """Restore the global relation registries after each test.
 
     Each test below declares its models *inside the test function*, but
-    `ModelMetaclass` still appends their `ForeignKey` metadata to the
-    module-level `_PENDING_RELATIONS` list and registers the classes in
-    `_MODEL_REGISTRY_PY` (see `src/ferro/metaclass.py`) unconditionally at
+    `ModelMetaclass` still queues their `ForeignKey` metadata on the
+    Registry's pending-relations queue and registers the classes in
+    the model registry (see `src/ferro/metaclass.py`) unconditionally at
     class-creation time -- nothing about being defined inside a function
     scopes that registration. Nothing ever removes those entries once the
     test function returns, so without this fixture the test-local
@@ -30,19 +30,11 @@ def _isolate_relation_state():
     relation, including these stale ones, and blows up because their
     target models never declared the matching `BackRef()`.
     """
-    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS, deregister_model
+    from ferro.registry import REGISTRY
 
-    models_snapshot = dict(_MODEL_REGISTRY_PY)
-    relations_snapshot = list(_PENDING_RELATIONS)
+    snapshot = REGISTRY.snapshot()
     yield
-    # Evict test-local models through the entrypoint so their envelope caches go
-    # with them, then restore the baseline snapshot (bulk teardown restore).
-    for name in set(_MODEL_REGISTRY_PY) - set(models_snapshot):
-        deregister_model(name)
-    _MODEL_REGISTRY_PY.clear()
-    _MODEL_REGISTRY_PY.update(models_snapshot)
-    _PENDING_RELATIONS.clear()
-    _PENDING_RELATIONS.extend(relations_snapshot)
+    REGISTRY.restore(snapshot)
 
 
 def test_fk_extraction_uses_target_pk_name():

--- a/tests/test_generation_counter_dirty_tracking.py
+++ b/tests/test_generation_counter_dirty_tracking.py
@@ -13,24 +13,24 @@ from ferro.ir.compiler import (
     reset_schema_ir_compile_count_for_test,
     schema_ir_compile_count_for_test,
 )
-from ferro import state as ferro_state
+from ferro.registry import REGISTRY
 
 
 def test_register_and_deregister_bump_generation_counter(clean_registry) -> None:
-    assert ferro_state.registration_generation() == 0
-    assert ferro_state.resolved_generation() == 0
-    assert not ferro_state.is_modelset_dirty()
+    assert REGISTRY.registration_generation() == 0
+    assert REGISTRY.resolved_generation() == 0
+    assert not REGISTRY.is_dirty()
 
     class GcWidget(Model):
         id: Annotated[int | None, FerroField(primary_key=True)] = None
         name: str
 
-    assert ferro_state.registration_generation() == 1
-    assert ferro_state.is_modelset_dirty()
+    assert REGISTRY.registration_generation() == 1
+    assert REGISTRY.is_dirty()
 
-    ferro_state.deregister_model(GcWidget.__ferro_identity__)
-    assert ferro_state.registration_generation() == 2
-    assert ferro_state.is_modelset_dirty()
+    REGISTRY.deregister(GcWidget.__ferro_identity__)
+    assert REGISTRY.registration_generation() == 2
+    assert REGISTRY.is_dirty()
 
 
 def test_resolve_clears_dirty_generation(clean_registry) -> None:
@@ -46,10 +46,10 @@ def test_resolve_clears_dirty_generation(clean_registry) -> None:
         title: str
         author: Annotated["GcAuthor", ForeignKey(related_name="posts")]
 
-    assert ferro_state.is_modelset_dirty()
+    assert REGISTRY.is_dirty()
     resolve_relationships()
-    assert not ferro_state.is_modelset_dirty()
-    assert ferro_state.resolved_generation() == ferro_state.registration_generation()
+    assert not REGISTRY.is_dirty()
+    assert REGISTRY.resolved_generation() == REGISTRY.registration_generation()
 
 
 def test_assemble_fails_loudly_on_missing_envelope(clean_registry) -> None:
@@ -61,7 +61,7 @@ def test_assemble_fails_loudly_on_missing_envelope(clean_registry) -> None:
     from ferro.ir.compiler import _assemble_modelset_envelope
 
     resolve_relationships()
-    ferro_state.evict_model_envelope(GcOrphan.__ferro_identity__)
+    REGISTRY.evict_envelope(GcOrphan.__ferro_identity__)
 
     with pytest.raises(RuntimeError, match="Missing SchemaIR envelope"):
         _assemble_modelset_envelope()
@@ -147,4 +147,6 @@ async def test_ensure_rust_registration_synced_routes_connect(db_url, clean_regi
     reset_schema_ir_compile_count_for_test()
     modelset = ensure_resolved_modelset()
     assert schema_ir_compile_count_for_test() == 0
-    assert modelset is ferro_state._SCHEMA_IR_MODELSET
+    cached = REGISTRY.modelset()
+    assert cached is not None
+    assert modelset is cached[0]

--- a/tests/test_hydration_equivalence.py
+++ b/tests/test_hydration_equivalence.py
@@ -59,17 +59,13 @@ class Priority(enum.IntEnum):
 
 @pytest.fixture(autouse=True)
 def cleanup():
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     reset_engine()
     clear_registry()
     yield
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
 
 def _build_specimen() -> type[Model]:

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -508,7 +508,7 @@ def test_include_paths_never_enter_the_joins_wire_section():
     from ferro.query.wire import compile_query
 
     q = INTransaction.select().include(lambda t: t.account)
-    payload = compile_query(q, "fetch").to_ir_dict()
+    payload = compile_query(q, "fetch").payload.to_ir_dict()
 
     assert q._joins == {}
     assert payload["joins"] == []

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -376,21 +376,23 @@ def test_phase1_schema_compiler_is_deterministic(clean_model_registry: None) -> 
 def test_compile_registry_schema_ir_persists_modelset_cache(
     clean_model_registry: None,
 ) -> None:
-    from ferro import state as ferro_state
     from ferro.ir import compile_registry_schema_ir, schema_ir_fingerprint
+    from ferro.registry import REGISTRY
     from ferro.relations import resolve_relationships
     from tests.test_cross_emitter_parity import _build_fixture_models
 
     _build_fixture_models()
     resolve_relationships()
 
-    ferro_state._SCHEMA_IR_MODELSET = None
-    ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT = None
+    REGISTRY.clear_modelset()
 
     compiled = compile_registry_schema_ir()
 
-    assert ferro_state._SCHEMA_IR_MODELSET == compiled
-    assert ferro_state._SCHEMA_IR_MODELSET_FINGERPRINT == schema_ir_fingerprint(compiled)
+    cached = REGISTRY.modelset()
+    assert cached is not None
+    envelope, fingerprint = cached
+    assert envelope == compiled
+    assert fingerprint == schema_ir_fingerprint(compiled)
 
 
 def test_schema_ir_compiler_emits_db_check_expression_for_closed_domain(
@@ -534,8 +536,8 @@ def test_clear_registry_clears_join_table_registry(clean_model_registry: None) -
     be re-created with foreign keys to tables that no longer exist — tolerated by
     SQLite, rejected by Postgres (``relation ... does not exist``). (#153)
     """
-    from ferro import state as ferro_state
     from ferro.ir import compile_registry_schema_ir
+    from ferro.registry import REGISTRY
     from ferro.relations import resolve_relationships
 
     class Tag(Model):
@@ -549,15 +551,16 @@ def test_clear_registry_clears_join_table_registry(clean_model_registry: None) -
         tags: Relation[list["Tag"]] = BackRef()
 
     resolve_relationships()
-    assert ferro_state._JOIN_TABLE_REGISTRY, "precondition: a join table is registered"
+    assert REGISTRY.join_tables(), "precondition: a join table is registered"
 
-    # Simulate a lean test cleanup that clears the declared models but (as the
+    # Simulate a lean test cleanup that drops the declared models but (as the
     # failing fixtures did) NOT the join-table registry directly. clear_registry
     # must reset the join registry so a later full-registry compile can't
     # resurrect a stale join table whose FK targets no longer exist.
     clear_registry()
-    ferro_state._MODEL_REGISTRY_PY.clear()
+    for name in list(REGISTRY.models()):
+        REGISTRY.deregister(name)
 
-    assert ferro_state._JOIN_TABLE_REGISTRY == {}, "clear_registry must clear join tables"
+    assert REGISTRY.join_tables() == {}, "clear_registry must clear join tables"
     table_names = {m["table_name"] for m in compile_registry_schema_ir()["payload"]["models"]}
     assert "tag_posts" not in table_names, f"stale join table resurrected: {table_names}"

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -5,20 +5,14 @@ from typing import ClassVar
 import pytest
 
 from ferro import Model
-from ferro.state import resolve_model_reference
+from ferro.registry import REGISTRY
 
 
 @pytest.fixture(autouse=True)
 def _isolate_relation_state():
-    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
-
-    models_snapshot = dict(_MODEL_REGISTRY_PY)
-    relations_snapshot = list(_PENDING_RELATIONS)
+    snapshot = REGISTRY.snapshot()
     yield
-    _MODEL_REGISTRY_PY.clear()
-    _MODEL_REGISTRY_PY.update(models_snapshot)
-    _PENDING_RELATIONS.clear()
-    _PENDING_RELATIONS.extend(relations_snapshot)
+    REGISTRY.restore(snapshot)
 
 
 def test_models_are_stamped_with_identity_and_table():
@@ -68,14 +62,14 @@ def test_resolve_model_reference_short_and_qualified():
     class RefTarget(Model):
         id: int | None = None
 
-    assert resolve_model_reference("RefTarget") is RefTarget
-    assert resolve_model_reference(RefTarget.__ferro_identity__) is RefTarget
+    assert REGISTRY.resolve_reference("RefTarget") is RefTarget
+    assert REGISTRY.resolve_reference(RefTarget.__ferro_identity__) is RefTarget
 
 
 def test_resolve_model_reference_not_found():
     with pytest.raises(RuntimeError, match="NoSuchModelAnywhere"):
-        resolve_model_reference("NoSuchModelAnywhere")
-    assert resolve_model_reference("NoSuchModelAnywhere", default=None) is None
+        REGISTRY.resolve_reference("NoSuchModelAnywhere")
+    assert REGISTRY.resolve_reference("NoSuchModelAnywhere", default=None) is None
 
 
 def test_registry_keys_by_qualified_identity():
@@ -83,10 +77,8 @@ def test_registry_keys_by_qualified_identity():
         __ferro_table__: ClassVar[str] = "qualified_key_model_a"
         id: int | None = None
 
-    from ferro.state import _MODEL_REGISTRY_PY
-
-    assert _MODEL_REGISTRY_PY[QualifiedKeyModel.__ferro_identity__] is QualifiedKeyModel
-    assert "QualifiedKeyModel" not in _MODEL_REGISTRY_PY
+    assert REGISTRY.models()[QualifiedKeyModel.__ferro_identity__] is QualifiedKeyModel
+    assert "QualifiedKeyModel" not in REGISTRY.models()
 
 
 def test_same_named_models_in_distinct_scopes_coexist():
@@ -105,10 +97,8 @@ def test_same_named_models_in_distinct_scopes_coexist():
         return ScopedModel
 
     a, b = make_a(), make_b()
-    from ferro.state import _MODEL_REGISTRY_PY
-
-    assert _MODEL_REGISTRY_PY[a.__ferro_identity__] is a
-    assert _MODEL_REGISTRY_PY[b.__ferro_identity__] is b
+    assert REGISTRY.models()[a.__ferro_identity__] is a
+    assert REGISTRY.models()[b.__ferro_identity__] is b
 
 
 def test_resolve_model_reference_ambiguous_lists_candidates():
@@ -128,7 +118,7 @@ def test_resolve_model_reference_ambiguous_lists_candidates():
 
     a, b = make_a(), make_b()
     with pytest.raises(RuntimeError) as excinfo:
-        resolve_model_reference("AmbiguousRef")
+        REGISTRY.resolve_reference("AmbiguousRef")
     message = str(excinfo.value)
     assert a.__ferro_identity__ in message
     assert b.__ferro_identity__ in message
@@ -197,8 +187,6 @@ def test_two_distinct_models_sharing_a_table_error_names_both():
 
 
 def test_same_identity_redefinition_is_idempotent():
-    from ferro.state import _MODEL_REGISTRY_PY
-
     class Redefined(Model):  # noqa: F811
         id: int | None = None
         name: str
@@ -209,7 +197,7 @@ def test_same_identity_redefinition_is_idempotent():
         age: int
 
     assert "age" in Redefined.model_fields
-    assert _MODEL_REGISTRY_PY[Redefined.__ferro_identity__] is Redefined
+    assert REGISTRY.models()[Redefined.__ferro_identity__] is Redefined
 
 
 def test_m2m_join_table_colliding_with_model_table_errors():

--- a/tests/test_mutation_pagination_guard.py
+++ b/tests/test_mutation_pagination_guard.py
@@ -50,7 +50,7 @@ def test_mutating_payload_omits_pagination_keys():
 
     query = PaginationGuardItem.where(lambda item: item.flagged == True)  # noqa: E712
     for operation in ("update", "delete"):
-        payload = compile_query(query, operation).to_ir_dict()
+        payload = compile_query(query, operation).payload.to_ir_dict()
         assert "limit" not in payload
         assert "offset" not in payload
         assert payload["model_name"] == PaginationGuardItem.__ferro_identity__

--- a/tests/test_named_connections_integration.py
+++ b/tests/test_named_connections_integration.py
@@ -50,10 +50,10 @@ if TYPE_CHECKING:
 
 @pytest.fixture(autouse=True)
 def _ensure_models_registered():
-    from ferro.state import register_model
+    from ferro.registry import REGISTRY
 
     NamedSmokeMarker._reregister_ferro()
-    register_model(NamedSmokeMarker)
+    REGISTRY.register(NamedSmokeMarker)
     yield
 
 

--- a/tests/test_naming_single_source.py
+++ b/tests/test_naming_single_source.py
@@ -37,17 +37,13 @@ from ferro.migrations import get_metadata
 
 @pytest.fixture(autouse=True)
 def cleanup():
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     reset_engine()
     clear_registry()
     yield
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
 
 
 def test_ffi_naming_helpers_match_i1_conventions():
@@ -240,7 +236,7 @@ def test_m2m_join_artifacts_follow_custom_table_names():
     """FF-E E2 exit gate: default join table/columns derive from table names."""
     from ferro import ManyToMany
     from ferro.relations import resolve_relationships
-    from ferro.state import _JOIN_TABLE_REGISTRY
+    from ferro.registry import REGISTRY
 
     class WikiPage(Model):
         __ferro_table__: ClassVar[str] = "wiki_pages"
@@ -254,8 +250,8 @@ def test_m2m_join_artifacts_follow_custom_table_names():
 
     resolve_relationships()
 
-    assert "wiki_pages_tags" in _JOIN_TABLE_REGISTRY
-    bundle = _JOIN_TABLE_REGISTRY["wiki_pages_tags"]
+    assert "wiki_pages_tags" in REGISTRY.join_tables()
+    bundle = REGISTRY.join_tables()["wiki_pages_tags"]
     columns_by_name = {spec.name: spec for spec in bundle["columns"]}
     assert set(columns_by_name) == {"wiki_pages_id", "wiki_tags_id"}
     assert columns_by_name["wiki_pages_id"].foreign_key.to_table == "wiki_pages"
@@ -265,7 +261,7 @@ def test_m2m_join_artifacts_follow_custom_table_names():
 def test_forward_declared_fk_to_custom_table_model_resolves_configured_table():
     """FF-E E2: a string/ForwardRef FK target's to_table follows the target's
     __ferro_table__ — both while the reference is still an unresolved string
-    (registry lookup via resolve_model_reference) and after
+    (registry lookup via REGISTRY.resolve_reference) and after
     resolve_relationships binds it (the schema DDL consumes)."""
     from ferro.relations import resolve_relationships
 
@@ -288,7 +284,7 @@ def test_forward_declared_fk_to_custom_table_model_resolves_configured_table():
 
     # Pre-resolution: metadata.to is still the string/ForwardRef, but the
     # target IS registered — _target_table_name's string branch must resolve
-    # it through resolve_model_reference, not lowercase the class name.
+    # it through REGISTRY.resolve_reference, not lowercase the class name.
     raw_to = FwdArticle.ferro_relations["author"].to
     assert isinstance(raw_to, (str, ForwardRef))
     fk = _article_fk()

--- a/tests/test_one_to_one.py
+++ b/tests/test_one_to_one.py
@@ -19,10 +19,9 @@ pytestmark = pytest.mark.backend_matrix
 def cleanup():
     reset_engine()
     clear_registry()
-    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
+    REGISTRY.reset_for_test()
     yield
 
 

--- a/tests/test_operation_seam_sync.py
+++ b/tests/test_operation_seam_sync.py
@@ -10,7 +10,7 @@ import ferro
 from ferro import Model, OperationalError, connect, execute
 from ferro._core import _bulk_install_count_for_test
 from ferro.base import FerroField
-from ferro import state as ferro_state
+from ferro.registry import REGISTRY
 
 
 @pytest.mark.asyncio
@@ -228,12 +228,12 @@ async def test_failed_resolve_stays_dirty_and_retries(
     async with ferro.engines.session():
         with pytest.raises(RuntimeError, match="simulated resolve failure"):
             await OsRetryLate.create(payload="first")
-    assert ferro_state.is_modelset_dirty()
+    assert REGISTRY.is_dirty()
 
     async with ferro.engines.session():
         row = await OsRetryLate.create(payload="second")
         assert (await OsRetryLate.get(row.id)).payload == "second"
-    assert not ferro_state.is_modelset_dirty()
+    assert not REGISTRY.is_dirty()
 
 
 def test_alembic_metadata_uses_ensure_resolved_not_operation_seam(

--- a/tests/test_primary_key_facts.py
+++ b/tests/test_primary_key_facts.py
@@ -1,0 +1,83 @@
+"""The PK fact is derived once at class-body compile and cached on the class.
+
+``__ferro_pk__`` is set at the compile choke point (the same site that attaches
+``__ferro_columns__``), so every consumer — save, descriptors, shadow-FK typing,
+traversal — reads one cached fact instead of re-looping the column specs.
+At most one ``primary_key=True`` column is legal; the violation raises at class
+definition time (ADR-0002's flagged follow-up). Zero PKs stays a legal
+declaration: ``__ferro_pk__`` is ``None`` and the operations that genuinely
+need a PK raise clear errors instead of guessing (the old silent ``"id"``
+fallback).
+"""
+
+from typing import Annotated
+
+import pytest
+
+from ferro import Field, Model
+from ferro.base import ForeignKey
+
+
+@pytest.fixture(autouse=True)
+def _isolate_relation_state():
+    """Restore the global relation registries after each test.
+
+    Same pattern as ``test_fk_target_pk.py``: models declared inside test
+    functions still register globally at class-creation time, so snapshot and
+    restore the registry and pending-relations stores around each test.
+    """
+    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS, deregister_model
+
+    models_snapshot = dict(_MODEL_REGISTRY_PY)
+    relations_snapshot = list(_PENDING_RELATIONS)
+    yield
+    for name in set(_MODEL_REGISTRY_PY) - set(models_snapshot):
+        deregister_model(name)
+    _MODEL_REGISTRY_PY.clear()
+    _MODEL_REGISTRY_PY.update(models_snapshot)
+    _PENDING_RELATIONS.clear()
+    _PENDING_RELATIONS.extend(relations_snapshot)
+
+
+def test_pk_field_name_cached_on_class():
+    class PkCachedDefault(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        name: str
+
+    class PkCachedCustom(Model):
+        code: str = Field(primary_key=True)
+        city: str
+
+    assert PkCachedDefault.__ferro_pk__ == "id"
+    assert PkCachedCustom.__ferro_pk__ == "code"
+
+
+def test_zero_pk_model_caches_none():
+    class PkLessLog(Model):
+        message: str
+        level: int
+
+    assert PkLessLog.__ferro_pk__ is None
+
+
+def test_multiple_primary_keys_rejected_at_class_definition():
+    # TypeError is the declaration-error contract: the metaclass surfaces it
+    # unwrapped rather than disguising it as a registration RuntimeError.
+    with pytest.raises(TypeError, match=r"PkTwice.*'code'.*'id'"):
+
+        class PkTwice(Model):
+            id: int | None = Field(default=None, primary_key=True)
+            code: str = Field(primary_key=True)
+
+
+def test_fk_assignment_to_pkless_target_raises_instead_of_guessing_id():
+    class PkLessTarget(Model):
+        label: str
+
+    class PkGuessReferrer(Model):
+        id: int | None = Field(default=None, primary_key=True)
+        target: Annotated[PkLessTarget, ForeignKey(related_name="referrers")]
+
+    target = PkLessTarget(label="orphan")
+    with pytest.raises(ValueError, match=r"PkLessTarget.*no primary-key column"):
+        PkGuessReferrer(target=target)

--- a/tests/test_primary_key_facts.py
+++ b/tests/test_primary_key_facts.py
@@ -26,17 +26,11 @@ def _isolate_relation_state():
     functions still register globally at class-creation time, so snapshot and
     restore the registry and pending-relations stores around each test.
     """
-    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS, deregister_model
+    from ferro.registry import REGISTRY
 
-    models_snapshot = dict(_MODEL_REGISTRY_PY)
-    relations_snapshot = list(_PENDING_RELATIONS)
+    snapshot = REGISTRY.snapshot()
     yield
-    for name in set(_MODEL_REGISTRY_PY) - set(models_snapshot):
-        deregister_model(name)
-    _MODEL_REGISTRY_PY.clear()
-    _MODEL_REGISTRY_PY.update(models_snapshot)
-    _PENDING_RELATIONS.clear()
-    _PENDING_RELATIONS.extend(relations_snapshot)
+    REGISTRY.restore(snapshot)
 
 
 def test_pk_field_name_cached_on_class():

--- a/tests/test_provisional_import.py
+++ b/tests/test_provisional_import.py
@@ -32,7 +32,7 @@ from ferro.ir.compiler import (
     reset_schema_ir_compile_count_for_test,
     schema_ir_compile_count_for_test,
 )
-from ferro import state as ferro_state
+from ferro.registry import REGISTRY
 
 _SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "ferro"
 
@@ -52,8 +52,8 @@ def _cold_pi_row_survives_registry_wipe():
     Runs before ``clean_registry`` (autouse precedes explicit fixtures), so
     ``clean_registry`` tests still start from a truly empty registry.
     """
-    if _ColdPiRow.__ferro_identity__ not in ferro_state._MODEL_REGISTRY_PY:
-        ferro_state.register_model(_ColdPiRow)
+    if _ColdPiRow.__ferro_identity__ not in REGISTRY.models():
+        REGISTRY.register(_ColdPiRow)
     yield
 
 
@@ -89,9 +89,9 @@ def test_rust_registry_empty_after_import_before_connect(clean_registry) -> None
         note: str
 
     identity = PiFresh.__ferro_identity__
-    assert ferro_state._MODEL_REGISTRY_PY[identity] is PiFresh
-    assert identity in ferro_state._SCHEMA_IR_BY_MODEL
-    assert ferro_state.registration_generation() == 1
+    assert REGISTRY.models()[identity] is PiFresh
+    assert REGISTRY.envelope(identity) is not None
+    assert REGISTRY.registration_generation() == 1
     assert _rust_model_registry_count_for_test() == 0
 
 
@@ -154,7 +154,7 @@ async def test_cold_rehydration_after_clear_registry(db_url) -> None:
     """Module-level models survive clear_registry + connect (#246 / #65 pattern)."""
     reset_engine()
     clear_registry()
-    assert _ColdPiRow.__ferro_identity__ in ferro_state._MODEL_REGISTRY_PY
+    assert _ColdPiRow.__ferro_identity__ in REGISTRY.models()
 
     await connect(db_url, auto_migrate=True)
     row_id = uuid4()
@@ -189,8 +189,8 @@ async def test_relationship_models_stay_python_only_until_connect(
 
     resolve_relationships()
     assert _rust_model_registry_count_for_test() == 0
-    assert ferro_state._MODEL_REGISTRY_PY[PiAuthor.__ferro_identity__] is PiAuthor
-    assert ferro_state._MODEL_REGISTRY_PY[PiPost.__ferro_identity__] is PiPost
+    assert REGISTRY.models()[PiAuthor.__ferro_identity__] is PiAuthor
+    assert REGISTRY.models()[PiPost.__ferro_identity__] is PiPost
 
     baseline = _bulk_install_count_for_test()
     await connect(db_url, auto_migrate=True)

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -10,7 +10,7 @@ import ferro
 from ferro import Model, connect
 from ferro.query import Query, QueryNode
 from ferro.query.nodes import FieldProxy, _serialize_query_value
-from ferro.query.wire import compile_query, to_wire_json
+from ferro.query.wire import compile_query
 from pydantic import Field
 
 pytestmark = pytest.mark.backend_matrix
@@ -61,7 +61,7 @@ def test_to_wire_json_serializes_m2m_context_without_mutating_query_state():
         source_id,
     )
 
-    query_json = to_wire_json(compile_query(query, "fetch"))
+    query_json = compile_query(query, "fetch").wire_json
     payload = json.loads(query_json)
 
     assert query._m2m_context.source_id == source_id
@@ -78,7 +78,7 @@ def test_query_carries_root_instances_materialization_by_default():
     class WirePlainRow(Model):
         id: int | None = Field(default=None, json_schema_extra={"primary_key": True})
 
-    payload = compile_query(Query(WirePlainRow), "fetch").to_ir_dict()
+    payload = compile_query(Query(WirePlainRow), "fetch").payload.to_ir_dict()
     assert payload["materialization"] == {"kind": "root_instances"}
 
 

--- a/tests/test_query_joins.py
+++ b/tests/test_query_joins.py
@@ -696,7 +696,7 @@ class TestMutatingTraversalRejection:
 
     def test_join_free_relation_filter_is_allowed(self):
         q = Query(QJTransaction).where(lambda t: t.account == _persisted_account(1))
-        payload = compile_query(q, "update").to_ir_dict()  # must NOT raise
+        payload = compile_query(q, "update").payload.to_ir_dict()  # must NOT raise
         assert payload["where"][0]["column"] == "account_id"
         assert payload["where"][0]["path"] == []
 
@@ -720,7 +720,7 @@ async def test_update_and_delete_reject_traversal_before_db():
 
 def _serialized_join_types(query) -> list[tuple[tuple[str, ...], str]]:
     """(path, join_type) for each serialized ``joins`` entry, in wire order."""
-    payload = compile_query(query, "fetch").to_ir_dict()
+    payload = compile_query(query, "fetch").payload.to_ir_dict()
     return [
         (tuple(hop["relation"] for hop in entry["path"]), entry["join_type"])
         for entry in payload["joins"]

--- a/tests/test_query_typing.py
+++ b/tests/test_query_typing.py
@@ -27,10 +27,9 @@ pytestmark = pytest.mark.sqlite_only
 @pytest.fixture(autouse=True)
 def _clear_state():
     """Reset model registry and engine between typing tests."""
-    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
+    REGISTRY.reset_for_test()
     reset_engine()
     clear_registry()
     yield

--- a/tests/test_query_wire_vectors.py
+++ b/tests/test_query_wire_vectors.py
@@ -1,7 +1,7 @@
 """Builder→wire golden-vector equality: the Python half of the QueryIR contract.
 
 Each test builds one real query through the public chainers and asserts the
-compiled wire envelope (``compile_query`` → ``to_wire_json``) equals the
+compiled wire envelope (``compile_query(...).wire_json``) equals the
 hand-authored golden vector in ``tests/fixtures/ir_vectors/`` byte-for-byte.
 The Rust half round-trips the same fixture files in ``crates/ferro-schema-ir``
 — one artifact, both sides assert, so neither side can drift silently.
@@ -27,7 +27,7 @@ from typing import Annotated, Any, Callable
 import pytest
 
 from ferro import BackRef, FerroField, ForeignKey, Model, Relation
-from ferro.query.wire import compile_query, to_wire_json
+from ferro.query.wire import compile_query
 from ferro.relations import resolve_relationships
 
 VECTORS_DIR = Path(__file__).parent / "fixtures" / "ir_vectors"
@@ -221,7 +221,7 @@ def test_builder_emission_matches_vector(
     expected = vector["ir"]
     assert expected["payload"]["model_name"] == root
 
-    emitted = json.loads(to_wire_json(compile_query(build(models), "fetch")))
+    emitted = json.loads(compile_query(build(models), "fetch").wire_json)
 
     expected["payload"]["model_name"] = models[root].__ferro_identity__
     assert emitted == expected
@@ -233,7 +233,7 @@ def test_builder_emission_matches_vector(
 
 
 def _payload(query: Any, verb: str) -> dict[str, Any]:
-    return json.loads(to_wire_json(compile_query(query, verb)))["payload"]
+    return json.loads(compile_query(query, verb).wire_json)["payload"]
 
 
 def test_count_zeroes_ordering_and_paging_but_keeps_joins(
@@ -283,6 +283,6 @@ def test_mutate_payload_omits_pagination_keys(models: dict[str, type]) -> None:
 
 
 def test_envelope_is_versioned(models: dict[str, type]) -> None:
-    envelope = json.loads(to_wire_json(compile_query(models["User"].select(), "fetch")))
+    envelope = json.loads(compile_query(models["User"].select(), "fetch").wire_json)
     assert envelope["ir_kind"] == "query"
     assert envelope["ir_version"] == 5

--- a/tests/test_registry_entrypoints.py
+++ b/tests/test_registry_entrypoints.py
@@ -1,9 +1,9 @@
 """#243 prefactor: centralized register/deregister registry entrypoints.
 
 Every per-model registry/envelope write and eviction goes through the single
-``register_model`` / ``persist_model_envelope`` / ``deregister_model``
-entrypoints in :mod:`ferro.state`; no ``src/`` code mutates
-``_MODEL_REGISTRY_PY`` / ``_SCHEMA_IR_BY_MODEL`` (or their fingerprint maps)
+``REGISTRY.register`` / ``REGISTRY.persist_envelope`` / ``REGISTRY.deregister``
+entrypoints on :data:`ferro.registry.REGISTRY`; no ``src/`` code mutates the
+Registry's private stores (``_models`` / ``_envelopes`` / ``_fingerprints``)
 directly. ``clear_registry()`` additionally evicts join-table envelopes from
 the per-model envelope cache, preserving the #153 stale-join-table guard.
 
@@ -28,7 +28,7 @@ from ferro import (
 
 
 def test_register_model_is_the_single_registry_write(clean_registry):
-    from ferro import state as ferro_state
+    from ferro.registry import REGISTRY
 
     class Widget(Model):
         id: Annotated[int | None, FerroField(primary_key=True)] = None
@@ -37,80 +37,75 @@ def test_register_model_is_the_single_registry_write(clean_registry):
     identity = Widget.__ferro_identity__
     # Class-body registration flowed through the entrypoint into the registry
     # (keyed by the canonical identity) and persisted the envelope + fingerprint.
-    assert ferro_state._MODEL_REGISTRY_PY[identity] is Widget
-    assert identity in ferro_state._SCHEMA_IR_BY_MODEL
-    assert identity in ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL
+    assert REGISTRY.models()[identity] is Widget
+    assert REGISTRY.envelope(identity) is not None
+    assert REGISTRY.fingerprint(identity) is not None
 
 
 def test_register_model_keys_by_canonical_identity(clean_registry):
-    from ferro import state as ferro_state
-    from ferro.state import register_model
+    from ferro.registry import REGISTRY
 
     class Marker(Model):
         id: Annotated[int | None, FerroField(primary_key=True)] = None
 
-    ferro_state._MODEL_REGISTRY_PY.clear()
+    REGISTRY.deregister(Marker.__ferro_identity__)
     # #249: the key is derived from the model's canonical identity, never
     # caller-supplied. A bare ``__name__`` must never become a registry key.
-    register_model(Marker)
+    REGISTRY.register(Marker)
 
-    assert ferro_state._MODEL_REGISTRY_PY[Marker.__ferro_identity__] is Marker
-    assert Marker.__name__ not in ferro_state._MODEL_REGISTRY_PY
+    assert REGISTRY.models()[Marker.__ferro_identity__] is Marker
+    assert Marker.__name__ not in REGISTRY.models()
 
 
 def test_persist_model_envelope_fingerprint_matches_envelope(clean_registry):
-    from ferro import state as ferro_state
+    from ferro.registry import REGISTRY, ir_fingerprint
 
     envelope = {"ir_kind": "schema", "ir_version": 1, "payload": {"models": []}}
-    ferro_state.persist_model_envelope("x.Thing", envelope)
+    REGISTRY.persist_envelope("x.Thing", envelope)
 
-    assert ferro_state._SCHEMA_IR_BY_MODEL["x.Thing"] is envelope
-    assert ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL[
-        "x.Thing"
-    ] == ferro_state.ir_fingerprint(envelope)
+    assert REGISTRY.envelope("x.Thing") is envelope
+    assert REGISTRY.fingerprint("x.Thing") == ir_fingerprint(envelope)
 
 
 def test_deregister_model_evicts_registry_and_envelope(clean_registry):
-    from ferro import state as ferro_state
-    from ferro.state import deregister_model
+    from ferro.registry import REGISTRY
 
     class Gadget(Model):
         id: Annotated[int | None, FerroField(primary_key=True)] = None
         name: str
 
     identity = Gadget.__ferro_identity__
-    assert identity in ferro_state._MODEL_REGISTRY_PY
-    assert identity in ferro_state._SCHEMA_IR_BY_MODEL
-    assert identity in ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL
+    assert identity in REGISTRY.models()
+    assert REGISTRY.envelope(identity) is not None
+    assert REGISTRY.fingerprint(identity) is not None
 
-    deregister_model(identity)
+    REGISTRY.deregister(identity)
 
-    assert identity not in ferro_state._MODEL_REGISTRY_PY
-    assert identity not in ferro_state._SCHEMA_IR_BY_MODEL
-    assert identity not in ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL
+    assert identity not in REGISTRY.models()
+    assert REGISTRY.envelope(identity) is None
+    assert REGISTRY.fingerprint(identity) is None
 
 
 def test_evict_model_envelope_leaves_model_registry(clean_registry):
-    from ferro import state as ferro_state
-    from ferro.state import evict_model_envelope
+    from ferro.registry import REGISTRY
 
     class Doohickey(Model):
         id: Annotated[int | None, FerroField(primary_key=True)] = None
 
     identity = Doohickey.__ferro_identity__
-    evict_model_envelope(identity)
+    REGISTRY.evict_envelope(identity)
 
     # Envelope-only: the model registry entry survives (cold-rehydration path).
-    assert identity in ferro_state._MODEL_REGISTRY_PY
-    assert identity not in ferro_state._SCHEMA_IR_BY_MODEL
-    assert identity not in ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL
+    assert identity in REGISTRY.models()
+    assert REGISTRY.envelope(identity) is None
+    assert REGISTRY.fingerprint(identity) is None
 
 
 def test_deregister_model_is_idempotent(clean_registry):
-    from ferro.state import deregister_model
+    from ferro.registry import REGISTRY
 
     # Evicting an unknown identity is a no-op, not a KeyError.
-    deregister_model("does.not.Exist")
+    REGISTRY.deregister("does.not.Exist")
 
 
 def test_clear_registry_evicts_join_table_envelopes(clean_registry):
@@ -120,7 +115,7 @@ def test_clear_registry_evicts_join_table_envelopes(clean_registry):
     assembled modelset resurrect foreign keys to tables that no longer exist —
     tolerated by SQLite, rejected by Postgres.
     """
-    from ferro import state as ferro_state
+    from ferro.registry import REGISTRY
     from ferro.relations import resolve_relationships
 
     class Page(Model):
@@ -136,27 +131,27 @@ def test_clear_registry_evicts_join_table_envelopes(clean_registry):
     resolve_relationships()
 
     join_table = "reg_pages_tags"
-    assert join_table in ferro_state._JOIN_TABLE_REGISTRY
-    assert join_table in ferro_state._SCHEMA_IR_BY_MODEL
-    assert join_table in ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL
+    assert join_table in REGISTRY.join_tables()
+    assert REGISTRY.envelope(join_table) is not None
+    assert REGISTRY.fingerprint(join_table) is not None
 
     clear_registry()
 
-    assert join_table not in ferro_state._JOIN_TABLE_REGISTRY
-    assert join_table not in ferro_state._SCHEMA_IR_BY_MODEL
-    assert join_table not in ferro_state._SCHEMA_IR_FINGERPRINT_BY_MODEL
+    assert join_table not in REGISTRY.join_tables()
+    assert REGISTRY.envelope(join_table) is None
+    assert REGISTRY.fingerprint(join_table) is None
 
 
 def test_clear_registry_keeps_model_registry(clean_registry):
     """clear_registry() promises declared models survive (cold rehydration)."""
-    from ferro import state as ferro_state
+    from ferro.registry import REGISTRY
 
     class Survivor(Model):
         id: Annotated[int | None, FerroField(primary_key=True)] = None
 
     identity = Survivor.__ferro_identity__
     clear_registry()
-    assert ferro_state._MODEL_REGISTRY_PY[identity] is Survivor
+    assert REGISTRY.models()[identity] is Survivor
 
 
 # ---------------------------------------------------------------------------
@@ -169,23 +164,23 @@ def test_clear_registry_keeps_model_registry(clean_registry):
 
 _SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "ferro"
 _STORE_NAMES = {
-    "_MODEL_REGISTRY_PY",
-    "_SCHEMA_IR_BY_MODEL",
-    "_SCHEMA_IR_FINGERPRINT_BY_MODEL",
+    "_models",
+    "_envelopes",
+    "_fingerprints",
 }
 _MUTATING_METHODS = {"pop", "popitem", "clear", "setdefault", "update"}
-# state.py is where the entrypoints live — the one file allowed to mutate the
-# stores directly. Matched by path relative to _SRC_ROOT (not basename), so a
-# nested ``.../state.py`` would still be scanned.
-_ALLOWED_RELPATHS = {Path("state.py")}
+# registry.py is where the Registry entrypoints live — the one file allowed to
+# mutate the stores directly. Matched by path relative to _SRC_ROOT (not
+# basename), so a nested ``.../registry.py`` would still be scanned.
+_ALLOWED_RELPATHS = {Path("registry.py")}
 
 
 def _refers_to_store(node: ast.AST) -> bool:
     """True if ``node`` (a subscript/method container) resolves to a store.
 
     Peels nested subscripts (``store[a][b]``) down to the container, then matches
-    a bare imported name (``_MODEL_REGISTRY_PY``) or an attribute access
-    (``ferro_state._MODEL_REGISTRY_PY``).
+    a bare name (``_models``) or an attribute access (``REGISTRY._models`` /
+    ``self._models``).
     """
     while isinstance(node, ast.Subscript):
         node = node.value
@@ -250,8 +245,8 @@ def test_no_direct_store_writes_outside_state():
     assert scanned >= 10, f"expected to scan the ferro package, only saw {scanned} files"
     assert not offenders, (
         "Direct per-model registry/envelope writes must route through "
-        "ferro.state.register_model / persist_model_envelope / "
-        "evict_model_envelope / deregister_model:\n" + "\n".join(offenders)
+        "REGISTRY.register / REGISTRY.persist_envelope / "
+        "REGISTRY.evict_envelope / REGISTRY.deregister:\n" + "\n".join(offenders)
     )
 
 
@@ -263,19 +258,19 @@ def test_store_write_detector_flags_known_idioms():
     """
     sample = "\n".join(
         [
-            "_MODEL_REGISTRY_PY[k] = v",  # subscript assign
-            "_SCHEMA_IR_BY_MODEL[names[0]] = v",  # nested-subscript key
-            "_SCHEMA_IR_BY_MODEL[name]['payload'] = v",  # in-place mutation
-            "_MODEL_REGISTRY_PY.setdefault(k, v)",
-            "_MODEL_REGISTRY_PY.update(other)",
-            "_MODEL_REGISTRY_PY.pop(k, None)",
-            "_SCHEMA_IR_BY_MODEL.popitem()",
-            "_SCHEMA_IR_FINGERPRINT_BY_MODEL.clear()",
-            "del _MODEL_REGISTRY_PY[k]",
-            "_MODEL_REGISTRY_PY |= other",
-            "ferro_state._MODEL_REGISTRY_PY[k] = v",  # attribute-qualified access
-            "ferro_state._SCHEMA_IR_BY_MODEL.pop(k, None)",
-            "_MODEL_REGISTRY_PY[\n    k\n] = v",  # multi-line statement
+            "_models[k] = v",  # subscript assign
+            "_envelopes[names[0]] = v",  # nested-subscript key
+            "_envelopes[name]['payload'] = v",  # in-place mutation
+            "_models.setdefault(k, v)",
+            "_models.update(other)",
+            "_models.pop(k, None)",
+            "_envelopes.popitem()",
+            "_fingerprints.clear()",
+            "del _models[k]",
+            "_models |= other",
+            "REGISTRY._models[k] = v",  # attribute-qualified access
+            "REGISTRY._envelopes.pop(k, None)",
+            "_models[\n    k\n] = v",  # multi-line statement
         ]
     )
     # Each statement is one logical write; the multi-line one spans 3 source
@@ -284,11 +279,11 @@ def test_store_write_detector_flags_known_idioms():
 
     clean = "\n".join(
         [
-            "value = _MODEL_REGISTRY_PY[k]",  # read
-            "snapshot = list(_MODEL_REGISTRY_PY.items())",  # iteration
-            "found = _SCHEMA_IR_BY_MODEL.get(k)",  # get
-            "present = k in _MODEL_REGISTRY_PY",  # membership
-            "source_model = _MODEL_REGISTRY_PY[name]",  # RHS subscript read
+            "value = _models[k]",  # read
+            "snapshot = list(_models.items())",  # iteration
+            "found = _envelopes.get(k)",  # get
+            "present = k in _models",  # membership
+            "source_model = _models[name]",  # RHS subscript read
         ]
     )
     assert _store_write_linenos(clean) == []

--- a/tests/test_registry_owner.py
+++ b/tests/test_registry_owner.py
@@ -1,0 +1,119 @@
+"""The Registry owns every Python-side registration store and their agreement.
+
+One module-level instance (``REGISTRY``) holds the model registry, envelope +
+fingerprint caches, join-table bundles, pending relations, the modelset
+artifact, and the generation counters. The agreement invariants — fingerprint
+is a pure function of its envelope, join-table eviction clears envelopes too,
+a test reset wipes everything — are the Registry's locality, not a convention
+spread across callers and fixtures.
+"""
+
+from ferro.registry import REGISTRY, ir_fingerprint
+
+
+class _FakeModel:
+    __ferro_identity__ = "tests.fake.RegFake"
+    __name__ = "RegFake"
+    __qualname__ = "RegFake"
+    __ferro_table__ = "regfake"
+
+
+def test_register_and_deregister_round_trip_bumps_generation():
+    snap = REGISTRY.snapshot()
+    try:
+        before = REGISTRY.registration_generation()
+        REGISTRY.register(_FakeModel)
+        assert REGISTRY.models()["tests.fake.RegFake"] is _FakeModel
+        assert REGISTRY.registration_generation() == before + 1
+        assert REGISTRY.is_dirty()
+
+        REGISTRY.deregister("tests.fake.RegFake")
+        assert "tests.fake.RegFake" not in REGISTRY.models()
+        assert REGISTRY.registration_generation() == before + 2
+    finally:
+        REGISTRY.restore(snap)
+
+
+def test_persist_envelope_pairs_fingerprint():
+    snap = REGISTRY.snapshot()
+    try:
+        envelope = {"ir_kind": "schema", "payload": {"model_name": "X"}}
+        REGISTRY.persist_envelope("tests.fake.RegFake", envelope)
+        assert REGISTRY.envelope("tests.fake.RegFake") is envelope
+        assert REGISTRY.fingerprint("tests.fake.RegFake") == ir_fingerprint(envelope)
+
+        REGISTRY.evict_envelope("tests.fake.RegFake")
+        assert REGISTRY.envelope("tests.fake.RegFake") is None
+        assert REGISTRY.fingerprint("tests.fake.RegFake") is None
+    finally:
+        REGISTRY.restore(snap)
+
+
+def test_missing_envelope_names_is_store_arithmetic():
+    snap = REGISTRY.snapshot()
+    try:
+        REGISTRY.register(_FakeModel)
+        REGISTRY.evict_envelope("tests.fake.RegFake")
+        assert "tests.fake.RegFake" in REGISTRY.missing_envelope_names()
+
+        REGISTRY.persist_envelope("tests.fake.RegFake", {"payload": {}})
+        assert "tests.fake.RegFake" not in REGISTRY.missing_envelope_names()
+    finally:
+        REGISTRY.restore(snap)
+
+
+def test_clear_join_tables_evicts_their_envelopes_too():
+    snap = REGISTRY.snapshot()
+    try:
+        REGISTRY.add_join_table("jt_a_b", {"columns": []})
+        REGISTRY.persist_envelope("jt_a_b", {"payload": {"model_name": "jt_a_b"}})
+        REGISTRY.clear_join_tables()
+        assert "jt_a_b" not in REGISTRY.join_tables()
+        assert REGISTRY.envelope("jt_a_b") is None
+    finally:
+        REGISTRY.restore(snap)
+
+
+def test_snapshot_restore_round_trips_every_store():
+    snap = REGISTRY.snapshot()
+    try:
+        REGISTRY.register(_FakeModel)
+        REGISTRY.defer_relation("tests.fake.RegFake", "other", object())
+        REGISTRY.add_join_table("jt_x_y", {"columns": []})
+        REGISTRY.set_modelset({"payload": {"models": []}})
+        assert REGISTRY.is_dirty()
+    finally:
+        REGISTRY.restore(snap)
+    assert "tests.fake.RegFake" not in REGISTRY.models()
+    assert "jt_x_y" not in REGISTRY.join_tables()
+
+
+def test_set_modelset_pairs_fingerprint():
+    snap = REGISTRY.snapshot()
+    try:
+        envelope = {"payload": {"models": []}}
+        REGISTRY.set_modelset(envelope)
+        stored, fingerprint = REGISTRY.modelset()
+        assert stored is envelope
+        assert fingerprint == ir_fingerprint(envelope)
+    finally:
+        REGISTRY.restore(snap)
+
+
+def test_pending_relations_drain_and_dirty():
+    snap = REGISTRY.snapshot()
+    try:
+        # Earlier-collected modules may have left deferred relations behind;
+        # drain to a known-clean baseline (restored by the snapshot below).
+        REGISTRY.drain_pending_relations()
+        REGISTRY.mark_resolved()
+        assert not REGISTRY.is_dirty()
+        REGISTRY.defer_relation("tests.fake.RegFake", "other", object())
+        assert REGISTRY.is_dirty()
+
+        drained = REGISTRY.drain_pending_relations()
+        assert len(drained) == 1
+        assert drained[0][0] == "tests.fake.RegFake"
+        assert REGISTRY.drain_pending_relations() == []
+    finally:
+        REGISTRY.restore(snap)

--- a/tests/test_relationship_engine.py
+++ b/tests/test_relationship_engine.py
@@ -23,10 +23,9 @@ class RelationshipError(Exception):
 
 @pytest.fixture(autouse=True)
 def cleanup():
-    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
+    REGISTRY.reset_for_test()
     reset_engine()
     clear_registry()
     yield

--- a/tests/test_relationship_resolution_errors.py
+++ b/tests/test_relationship_resolution_errors.py
@@ -15,15 +15,11 @@ from ferro.relations import resolve_relationships
 
 @pytest.fixture(autouse=True)
 def _isolate_relation_state():
-    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    models_snapshot = dict(_MODEL_REGISTRY_PY)
-    relations_snapshot = list(_PENDING_RELATIONS)
+    snapshot = REGISTRY.snapshot()
     yield
-    _MODEL_REGISTRY_PY.clear()
-    _MODEL_REGISTRY_PY.update(models_snapshot)
-    _PENDING_RELATIONS.clear()
-    _PENDING_RELATIONS.extend(relations_snapshot)
+    REGISTRY.restore(snapshot)
 
 
 def test_second_pass_rebuild_failure_aborts_with_model_named(monkeypatch):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -19,10 +19,10 @@ class SessionMarker(ferro.Model):
 
 @pytest.fixture(autouse=True)
 def _ensure_models_registered():
-    from ferro.state import register_model
+    from ferro.registry import REGISTRY
 
     SessionMarker._reregister_ferro()
-    register_model(SessionMarker)
+    REGISTRY.register(SessionMarker)
     yield
 
 

--- a/tests/test_shadow_fk_types.py
+++ b/tests/test_shadow_fk_types.py
@@ -55,17 +55,15 @@ def test_shadow_annotation_for_foreign_key_unresolved_string():
 
 @pytest.fixture
 def _cleanup_registry():
-    from ferro.state import _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
+    REGISTRY.reset_for_test()
     yield
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
+    REGISTRY.reset_for_test()
 
 
 def test_reconcile_upgrades_forward_ref_shadow(_cleanup_registry):
-    """Models self-register on class creation; do not hand-fill _MODEL_REGISTRY_PY."""
+    """Models self-register on class creation; do not hand-fill the registry."""
     from ferro.relations import resolve_relationships
 
     class ReconcileChild(Model):

--- a/tests/test_sqlite_alembic_reconnect_hydration.py
+++ b/tests/test_sqlite_alembic_reconnect_hydration.py
@@ -36,11 +36,9 @@ pytestmark = pytest.mark.sqlite_only
 
 @pytest.fixture(autouse=True)
 def cleanup() -> None:
-    from ferro.state import _JOIN_TABLE_REGISTRY, _MODEL_REGISTRY_PY, _PENDING_RELATIONS
+    from ferro.registry import REGISTRY
 
-    _MODEL_REGISTRY_PY.clear()
-    _PENDING_RELATIONS.clear()
-    _JOIN_TABLE_REGISTRY.clear()
+    REGISTRY.reset_for_test()
     reset_engine()
     clear_registry()
     yield


### PR DESCRIPTION
Three deepening refactors from the 2026-07-15 architecture review, grilled and agreed candidate-by-candidate. One commit per candidate, each independently green on the full backend matrix — intended for a rebase merge.

## 1. `fix:` Derive the primary-key fact once (b80d6cc)

"Which column is the PK" was re-derived by looping column specs in six modules, with the multi-PK guard in only one — a two-PK model saved fine but raised on traversal. Now:

- `__ferro_pk__` is derived once at the compile choke point (the same atomic publish as `__ferro_columns__`) and every consumer reads the cached fact; `Model._primary_key_field_name` is deleted and the reverse-descriptor hot path stops looping specs per attribute access.
- **New error:** more than one `primary_key=True` column raises `TypeError` at class definition time (closes the follow-up ADR-0002's Consequences section asked for), naming the model and fields.
- **New error:** assigning an instance to a relationship field whose target has no PK raises instead of silently guessing an `id` attribute and writing `None` into the shadow FK; reverse-relation access on a PK-less instance likewise.

## 2. `refactor:` One CompiledQuery artifact (7544be1)

The hop-class map the FFI needs (include hydration #286, traversed-projection enum decode #293) was assembled beside the wire: three builder walkers re-walked the same relation-spec chains `resolve_join_hops` had already walked, with `all()` branching on when to pass the result. `compile_query` now returns a frozen `CompiledQuery` — payload, wire JSON, and hop-class map, three views of one compile — collected from the hop facts the payload itself carries, so wire and hop classes can never disagree. The map is plan-scoped, mirroring Rust's `needs_hop_classes` guard exactly (a both-sides double-check, like #272 edge resolution).

No wire change, no golden-vector change, no Rust change, FFI signature untouched.

## 3. `refactor:` Registry owner (47dbd96)

`state.py` mixed the deep routing module with six module-global registration stores whose agreement was everyone's job (the compiler iterated the dicts, `clear_registry` hand-synced two of them under a warning comment, a correct test reset touched six pieces of state). `ferro.registry.REGISTRY` now owns all of it behind private stores:

- Fingerprints are computed inside `persist_envelope`/`set_modelset` — no mismatched pairs possible.
- `clear_join_tables` owns the join-table/envelope agreement (#153).
- `snapshot()`/`restore()`/`reset_for_test()` replace the hand-rolled multi-store fixtures copy-pasted across ~30 test files; conftest's six-part wipe is one call.
- Stitching stays in `ir/compiler` (envelope format is compiler knowledge); the sync locks/entrypoints in `__init__.py` are deliberately untouched as their own follow-up.

`state.py` is reduced to routing and sessions.

## Verification

- Built test-first; 16 new tests (`test_primary_key_facts`, `test_compiled_query`, `test_registry_owner`).
- Full backend matrix per commit; final: **1576 passed, 11 skipped** (sqlite + postgres), `ty check` clean.
- CONTEXT.md gains three terms: **Primary key fact**, **Compiled query**, **Registry**.