### PR TITLE
feat(query): uniform predicate negation — prefix `~` as a NOT wire node

### DIFF
--- a/crates/ferro-schema-ir/src/lib.rs
+++ b/crates/ferro-schema-ir/src/lib.rs
@@ -137,13 +137,14 @@ pub struct SchemaCheck {
 /// Query IR: filter, sort, pagination, joins, materialization plan, and
 /// optional M2M join context.
 ///
-/// `ir_version: 5` (unconditional, no earlier version emitted anywhere —
-/// #269, #278, #285, #292). `joins` is required and always present (`[]` when
-/// the query traverses no relation); every leaf and `order_by` entry carries a
-/// `path` (required, `[]` = root model); `materialization` is required — the
-/// plan travels with the query as data (ADR-0007), never inferred from a
-/// column list. v5 gives `record` fields expression sources: a field carries
-/// either a `column` + `path` or an `expr` (#292, ADR-0009).
+/// `ir_version: 6` (unconditional, no earlier version emitted anywhere —
+/// #269, #278, #285, #292, #310). `joins` is required and always present
+/// (`[]` when the query traverses no relation); every leaf and `order_by`
+/// entry carries a `path` (required, `[]` = root model); `materialization` is
+/// required — the plan travels with the query as data (ADR-0007), never
+/// inferred from a column list. v5 gave `record` fields expression sources
+/// (#292, ADR-0009); v6 gives predicate trees the recursive `not` node kind
+/// (uniform negation, #310, ADR-0008).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueryIrPayload {
     /// Model class name the query targets.
@@ -333,7 +334,8 @@ pub struct QueryOrderBy {
     pub path: Vec<String>,
 }
 
-/// Predicate tree node in query IR (leaf comparison or compound AND/OR).
+/// Predicate tree node in query IR: leaf comparison, compound AND/OR, or a
+/// recursive NOT wrapping any child (uniform negation, v6, ADR-0008).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "node_kind")]
 pub enum QueryNode {
@@ -359,6 +361,14 @@ pub enum QueryNode {
         left: Box<QueryNode>,
         /// Right subtree.
         right: Box<QueryNode>,
+    },
+    /// Uniform negation (`~`, ADR-0008): SQL `NOT (...)` over the child.
+    /// Fully general — the child may be any node kind, at any depth; there
+    /// are no per-operator negative forms on the wire.
+    #[serde(rename = "not")]
+    Not {
+        /// The negated subtree.
+        child: Box<QueryNode>,
     },
 }
 
@@ -438,7 +448,7 @@ mod tests {
     #[test]
     fn query_fixture_roundtrip() {
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_user_compound_v5.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_user_compound_v6.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query fixture must parse");
         let ir = parsed
@@ -457,11 +467,66 @@ mod tests {
     }
 
     #[test]
+    fn query_not_leaf_fixture_roundtrip() {
+        // The not-over-leaf golden vector (#312, ADR-0008): uniform negation
+        // travels as one recursive `not` node wrapping its child — here a
+        // leaf `IN` comparison (the NOT IN spelling) — and must survive a
+        // deserialize/serialize round-trip without drift.
+        let fixture =
+            include_str!("../../../tests/fixtures/ir_vectors/query_user_not_leaf_v6.json");
+        let parsed: serde_json::Value =
+            serde_json::from_str(fixture).expect("query not-leaf fixture must parse");
+        let ir = parsed
+            .get("ir")
+            .cloned()
+            .expect("fixture must contain ir envelope");
+        let envelope: IrEnvelope<QueryIrPayload> =
+            serde_json::from_value(ir.clone()).expect("query not-leaf IR must deserialize");
+        // The wire carries a `not` node whose child is the IN leaf.
+        match &envelope.payload.where_clause[0] {
+            QueryNode::Not { child } => match child.as_ref() {
+                QueryNode::Leaf { operator, .. } => assert_eq!(operator, "IN"),
+                other => panic!("not child must be the IN leaf, got {other:?}"),
+            },
+            other => panic!("where[0] must be a not node, got {other:?}"),
+        }
+        let encoded = serde_json::to_value(&envelope).expect("query not-leaf IR must serialize");
+        assert_eq!(encoded, ir, "query not-leaf round-trip must not drift");
+    }
+
+    #[test]
+    fn query_not_compound_fixture_roundtrip() {
+        // The not-over-compound golden vector (#313, ADR-0008): `~` wraps an
+        // OR compound whole — no De Morgan expansion on the wire — and must
+        // survive a deserialize/serialize round-trip without drift.
+        let fixture =
+            include_str!("../../../tests/fixtures/ir_vectors/query_user_not_compound_v6.json");
+        let parsed: serde_json::Value =
+            serde_json::from_str(fixture).expect("query not-compound fixture must parse");
+        let ir = parsed
+            .get("ir")
+            .cloned()
+            .expect("fixture must contain ir envelope");
+        let envelope: IrEnvelope<QueryIrPayload> =
+            serde_json::from_value(ir.clone()).expect("query not-compound IR must deserialize");
+        match &envelope.payload.where_clause[0] {
+            QueryNode::Not { child } => match child.as_ref() {
+                QueryNode::Compound { operator, .. } => assert_eq!(operator, "OR"),
+                other => panic!("not child must be the OR compound, got {other:?}"),
+            },
+            other => panic!("where[0] must be a not node, got {other:?}"),
+        }
+        let encoded =
+            serde_json::to_value(&envelope).expect("query not-compound IR must serialize");
+        assert_eq!(encoded, ir, "query not-compound round-trip must not drift");
+    }
+
+    #[test]
     fn query_traversal_fixture_roundtrip() {
         // Multi-hop `joins` section + path-carrying leaves must survive a
         // deserialize/serialize round-trip without drift (#270 wire stability).
         let fixture = include_str!(
-            "../../../tests/fixtures/ir_vectors/query_transaction_traversal_v5.json"
+            "../../../tests/fixtures/ir_vectors/query_transaction_traversal_v6.json"
         );
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query traversal fixture must parse");
@@ -487,7 +552,7 @@ mod tests {
         // deserialize/serialize round-trip without drift, and the join_type
         // tokens must reach Rust exactly as written on the wire.
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_left_join_v5.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_left_join_v6.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query left_join fixture must parse");
         let ir = parsed
@@ -513,7 +578,7 @@ mod tests {
         // payload — predicate, order, limit, and a two-field record plan —
         // survives a deserialize/serialize round-trip without drift.
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_record_v5.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_record_v6.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query record fixture must parse");
         let ir = parsed
@@ -712,7 +777,7 @@ mod tests {
         // identity) — survives a deserialize/serialize round-trip without
         // drift. No group keys: the whole result collapses to one record.
         let fixture = include_str!(
-            "../../../tests/fixtures/ir_vectors/query_transaction_global_aggregate_v5.json"
+            "../../../tests/fixtures/ir_vectors/query_transaction_global_aggregate_v6.json"
         );
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("global aggregate fixture must parse");
@@ -750,7 +815,7 @@ mod tests {
         // joins section included — survives a deserialize/serialize
         // round-trip without drift.
         let fixture = include_str!(
-            "../../../tests/fixtures/ir_vectors/query_transaction_traversed_record_v5.json"
+            "../../../tests/fixtures/ir_vectors/query_transaction_traversed_record_v6.json"
         );
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query traversed record fixture must parse");
@@ -788,7 +853,7 @@ mod tests {
         // a deserialize/serialize round-trip without drift. GROUP BY does not
         // travel: the renderer derives it from the non-expr fields (ADR-0009).
         let fixture = include_str!(
-            "../../../tests/fixtures/ir_vectors/query_transaction_aggregate_v5.json"
+            "../../../tests/fixtures/ir_vectors/query_transaction_aggregate_v6.json"
         );
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query aggregate fixture must parse");
@@ -856,7 +921,7 @@ mod tests {
         // payload — root predicate, empty `joins`, and a one-path instances
         // plan — survives a deserialize/serialize round-trip without drift.
         let fixture =
-            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_include_v5.json");
+            include_str!("../../../tests/fixtures/ir_vectors/query_transaction_include_v6.json");
         let parsed: serde_json::Value =
             serde_json::from_str(fixture).expect("query include fixture must parse");
         let ir = parsed

--- a/docs/examples/predicates.py
+++ b/docs/examples/predicates.py
@@ -15,6 +15,14 @@ class User(Model):
 # --8<-- [end:setup]
 
 
+# --8<-- [start:nullable-model]
+class Invoice(Model):
+    id: int | None = Field(default=None, primary_key=True)
+    reference: str
+    amount: float | None = None  # None until the invoice is issued
+# --8<-- [end:nullable-model]
+
+
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
 
@@ -56,6 +64,40 @@ async def main() -> None:
         # --8<-- [end:combining]
         assert len(flagged) == 2
         assert len(young_members) == 2
+
+        # --8<-- [start:negation]
+        # ~ negates ANY predicate: a comparison, .in_(), .like(), or a whole
+        # &/| group. There are no per-operator negative forms to memorize.
+        not_staff = await User.where(lambda user: ~user.role.in_(["admin", "moderator"])).all()
+        not_a_names = await User.where(lambda user: ~user.name.like("a%")).all()
+        active_adults = await User.where(lambda user: ~((user.age < 18) | (user.archived == True))).all()  # noqa: E712
+        # --8<-- [end:negation]
+        assert len(not_staff) == 3
+        assert len(not_a_names) == 3
+        assert len(active_adults) == 2
+
+        await Invoice.bulk_create(
+            [
+                Invoice(reference="inv-1", amount=250.0),
+                Invoice(reference="inv-2", amount=40.0),
+                Invoice(reference="inv-3", amount=None),
+            ]
+        )
+
+        # --8<-- [start:three-valued]
+        big = await Invoice.where(lambda invoice: invoice.amount > 100).all()
+        not_big = await Invoice.where(lambda invoice: ~(invoice.amount > 100)).all()
+
+        # inv-3 (amount is NULL) appears in NEITHER list
+        assert {invoice.reference for invoice in big} == {"inv-1"}
+        assert {invoice.reference for invoice in not_big} == {"inv-2"}
+
+        # keeping the NULL rows is an explicit extra condition
+        not_big_or_unissued = await Invoice.where(
+            lambda invoice: ~(invoice.amount > 100) | (invoice.amount == None)  # noqa: E711
+        ).all()
+        assert {invoice.reference for invoice in not_big_or_unissued} == {"inv-2", "inv-3"}
+        # --8<-- [end:three-valued]
 
         # --8<-- [start:ordering-slicing]
         oldest_first = await User.select().order_by(lambda user: user.age, "desc").all()

--- a/docs/examples/predicates_annotated.py
+++ b/docs/examples/predicates_annotated.py
@@ -17,6 +17,14 @@ class User(Model):
 # --8<-- [end:setup]
 
 
+# --8<-- [start:nullable-model]
+class Invoice(Model):
+    id: Annotated[int | None, Field(default=None, primary_key=True)]
+    reference: str
+    amount: float | None = None  # None until the invoice is issued
+# --8<-- [end:nullable-model]
+
+
 async def main() -> None:
     await connect("sqlite::memory:", auto_migrate=True)
 
@@ -30,6 +38,20 @@ async def main() -> None:
 
         adults = await User.where(lambda user: user.age >= 18).all()
         assert len(adults) == 2
+
+        not_admins = await User.where(lambda user: ~(user.role == "admin")).all()
+        assert len(not_admins) == 1
+
+        await Invoice.bulk_create(
+            [
+                Invoice(reference="inv-1", amount=250.0),
+                Invoice(reference="inv-2", amount=None),
+            ]
+        )
+
+        # three-valued logic: the NULL-amount row matches neither predicate
+        assert len(await Invoice.where(lambda invoice: invoice.amount > 100).all()) == 1
+        assert len(await Invoice.where(lambda invoice: ~(invoice.amount > 100)).all()) == 0
 
     print("predicates_annotated example ran successfully")
 

--- a/docs/pages/api/queries.md
+++ b/docs/pages/api/queries.md
@@ -2,6 +2,8 @@
 
 `Model.where(...)` and `Model.select()` return a `Query` — an immutable, chainable builder that executes when awaited via `all()`, `first()`, `count()`, `exists()`, `update()`, or `delete()`. Predicates are lambda-only (`User.where(lambda user: user.age >= 18)`) — a fresh `QueryProxy` validates column names against the model at build time.
 
+Prefix `~` negates **any** predicate — leaf comparison or `&`/`|` compound — rendering as SQL `NOT (...)` over the condition it wraps (ADR-0008). It is the universal negation rule: there are no per-operator negative forms (`~t.role.in_([...])` is NOT IN, `~t.email.like(p)` is NOT LIKE), and double negation nests. Like SQL `NOT` and the `!=` operator, a negated comparison excludes rows where the compared column is `NULL` — see [Negation and NULL values](../guide/queries.md#negation-and-null-values).
+
 `where()` and `order_by()` lambdas may **traverse** a forward-FK relation (`lambda t: t.account.ledger_id == 1`): each hop renders one INNER join, deduplicated by relation path (ADR-0006). `join()` forces a join on a relation path (a bare `join()` is an existence filter on a nullable relation), and `left_join()` marks the whole path LEFT to keep relation-less rows. See the [Querying Across Relationships](../guide/queries.md#querying-across-relationships) guide for worked examples.
 
 ## `include()` and populated relations

--- a/docs/pages/guide/queries.md
+++ b/docs/pages/guide/queries.md
@@ -100,6 +100,7 @@ Lambda predicates keep the call site fully type-checked: the proxy's attributes 
 | `.in_(values)` | `IN` | `lambda user: user.role.in_(["admin", "moderator"])` |
 | `== None` | `IS NULL` | `lambda user: user.deleted_at == None` |
 | `!= None` | `IS NOT NULL` | `lambda user: user.deleted_at != None` |
+| `~` | `NOT` | `lambda user: ~user.role.in_(["admin", "moderator"])` |
 
 ```python
 --8<-- "docs/examples/predicates.py:operators"
@@ -115,6 +116,52 @@ Combine predicates with `&` (AND) and `|` (OR), or chain multiple `.where()` cal
 
 !!! warning "Always parenthesize `&` and `|` operands"
     Python's `&` and `|` bind tighter than comparison operators, so `user.age < 18 | user.archived == True` parses as `user.age < (18 | user.archived) == True` — not what you meant. Wrap each condition in parentheses: `(user.age < 18) | (user.archived == True)`.
+
+## Negating Conditions
+
+Prefix `~` negates **any** predicate — a comparison, `.in_()`, `.like()`, or a whole `&`/`|` group. It is the one negation rule in Ferro: there are no per-operator negative forms (no `not_in()`, no `not_like()`), because `~` already covers every predicate the same way:
+
+```python
+--8<-- "docs/examples/predicates.py:negation"
+```
+
+Each `~` renders as a faithful SQL `NOT (...)` over the condition it wraps. The last example above ships to the database as:
+
+```sql
+SELECT ... FROM user WHERE NOT (user.age < 18 OR user.archived = TRUE)
+```
+
+Negated conditions compose exactly like un-negated ones — mix them into `&`/`|` trees at any depth, chain `.order_by()`/`.limit()` after them, and double negation (`~~p`) means what it says. Adding a `~` never restructures your query.
+
+### Negation and NULL values
+
+SQL comparisons follow **three-valued logic**: a comparison against `NULL` is neither true nor false but *unknown*, and a `WHERE` clause only keeps rows whose condition is **true**. `NOT` maps unknown to unknown — so a negated comparison still excludes rows where the column is `NULL`. `~` is SQL's `NOT`, not Python's set complement.
+
+Concretely, with a nullable column:
+
+=== "Assignment"
+
+    ```python
+    --8<-- "docs/examples/predicates.py:nullable-model"
+    ```
+
+=== "Annotated"
+
+    ```python
+    --8<-- "docs/examples/predicates_annotated.py:nullable-model"
+    ```
+
+`~(invoice.amount > 100)` renders as:
+
+```sql
+SELECT ... FROM invoice WHERE NOT (invoice.amount > 100)
+```
+
+For a row where `amount` is `NULL`, `amount > 100` is unknown, `NOT unknown` is still unknown, and the row is excluded — from the negated query *and* from the original one. This matches the `!=` operator you already use (`invoice.amount != 100` excludes `NULL` rows too); `~` just makes the rule visible on every predicate. When you want the `NULL` rows kept, say so explicitly with an `IS NULL` branch:
+
+```python
+--8<-- "docs/examples/predicates.py:three-valued"
+```
 
 ## Ordering, Limit & Offset
 
@@ -387,7 +434,7 @@ Do the two-step: fetch the primary keys with the joined query, then mutate by th
 ### Guardrails
 
 - A predicate lambda that returns a **bare relation** (`lambda transaction: transaction.account`) is meaningless as a filter and raises `TypeError` pointing you at `== None`, `== an instance`, or a column comparison. The same bare relation in `order_by()` is likewise rejected.
-- Combining predicates with Python's `and`/`or` (instead of `&`/`|`) coerces a node to `bool` and raises `TypeError: QueryNode cannot be used in a boolean context; use & / |`. Always parenthesize and use the bitwise operators.
+- Combining predicates with Python's `and`/`or`/`not` (instead of `&`/`|`/`~`) coerces a node to `bool` and raises `TypeError: QueryNode cannot be used in a boolean context; use & / | to combine predicates and ~ to negate them`. Always parenthesize and use the bitwise operators.
 
 See [Relationships](relationships.md) for the schema-declaration side of foreign keys and reverse relations.
 
@@ -630,7 +677,6 @@ Aggregation builds directly on this machinery — `select(lambda t: {"total": t.
     - `having()` — post-aggregation filtering; `where()` rejects aggregate predicates pointing at it ([#291](https://github.com/syn54x/ferro-orm/issues/291))
     - Reverse (`BackRef`) and many-to-many population — [`include()`](#populating-relations-with-include) covers forward FKs; collection population is a separate future mechanism
     - Case-insensitive `ilike()`
-    - `not_in()` (negate with `!=` conditions combined with `&` in the meantime)
 
 ## See Also
 

--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -8,7 +8,6 @@ Ferro is pre-1.0 and under active development. The items below are known gaps we
 - **Typed record fields** — a projected `Row`'s fields type as `Any` on access today; inferring per-field types from the selector (so `row.total` checks as `int | None`) is [#290](https://github.com/syn54x/ferro-orm/issues/290).
 - **Reverse and many-to-many population** — [`include()`](guide/queries.md#populating-relations-with-include) populates forward-FK paths in one statement; populating `BackRef` collections and M2M sets is a separate future mechanism (a batched second query stitched onto the results). Today each awaited collection is its own query.
 - **`ilike()`** — case-insensitive pattern matching. Workaround: `like()` with normalized case.
-- **`not_in_()`** — NOT IN exclusion lists. Workaround: combine `!=` comparisons with `&`.
 - **Atomic update expressions** — database-side expressions in batch updates, e.g. `update(view_count=Post.view_count + 1)`, avoiding the read-modify-write race. Workaround today: load, mutate, `save()` (or raw SQL).
 
 ## Connections

--- a/src/ferro/query/builder.py
+++ b/src/ferro/query/builder.py
@@ -105,6 +105,9 @@ def _register_join_paths(node: QueryNode, joins: dict[tuple[str, ...], str]) -> 
     ``&``/``|`` trees and across multiple ``where()`` calls falls out of the
     dict.
     """
+    if node.child is not None:
+        _register_join_paths(node.child, joins)
+        return
     if node.is_compound:
         if node.left is not None:
             _register_join_paths(node.left, joins)

--- a/src/ferro/query/nodes.py
+++ b/src/ferro/query/nodes.py
@@ -53,6 +53,7 @@ class QueryNode:
         left: Left child node for compound expressions.
         right: Right child node for compound expressions.
         is_compound: Flag indicating whether the node combines two child nodes.
+        child: Negated child node for NOT nodes (``~``, ADR-0008).
 
     Examples:
         >>> active_filter = FieldProxy("active") == True
@@ -71,6 +72,7 @@ class QueryNode:
         right: "QueryNode | None" = None,
         is_compound: bool = False,
         path: tuple[str, ...] = (),
+        child: "QueryNode | None" = None,
     ):
         """Initialize a query expression node
 
@@ -85,6 +87,8 @@ class QueryNode:
                 table; empty (default) means the root model. Plumbed through
                 so relation traversal (#270) can populate it — this slice
                 never produces a non-empty path.
+            child: The negated child for a NOT node (built by ``~``,
+                ADR-0008); ``None`` for leaf and compound nodes.
         """
         self.column = column
         self.operator = operator
@@ -93,6 +97,7 @@ class QueryNode:
         self.right = right
         self.is_compound = is_compound
         self.path = path
+        self.child = child
 
     def __or__(self, other: "QueryNode") -> "QueryNode":
         """Combine two nodes with logical OR
@@ -133,8 +138,29 @@ class QueryNode:
             return NotImplemented
         return QueryNode(left=self, operator="AND", right=other, is_compound=True)
 
+    def __invert__(self) -> "QueryNode":
+        """Negate this predicate with prefix ``~`` (ADR-0008)
+
+        One universal rule: ``~`` negates ANY predicate node — leaf
+        comparison, AND/OR compound, or a negation itself (``~~p`` nests) —
+        by wrapping it in a NOT node rendered as SQL ``NOT (...)``. There are
+        no per-operator negative forms: ``~t.col.in_(ids)`` is NOT IN,
+        ``~t.col.like(p)`` is NOT LIKE.
+
+        Returns:
+            A NOT node wrapping ``self``.
+
+        Examples:
+            >>> node = ~FieldProxy("role").in_(["admin", "owner"])
+            >>> node.child.operator
+            'IN'
+        """
+        return QueryNode(child=self)
+
     def to_ir_dict(self) -> dict[str, Any]:
         """Serialize the query node tree into a QueryIR payload shape."""
+        if self.child is not None:
+            return {"node_kind": "not", "child": self.child.to_ir_dict()}
         if not self.is_compound:
             serialized = _serialize_query_value(self.value)
             return {
@@ -157,23 +183,26 @@ class QueryNode:
     def __bool__(self) -> bool:
         """Reject boolean coercion of a query node (#273).
 
-        Python evaluates ``and``/``or`` by calling ``bool()`` on the operands,
-        so ``(u.age >= 18) and (u.active == True)`` would silently collapse to
-        one branch instead of building a compound predicate. Raising here turns
-        that mistake into a pointed error at build time; combine predicates with
-        the bitwise ``&`` / ``|`` operators instead.
+        Python evaluates ``and``/``or`` by calling ``bool()`` on the operands
+        (and ``not`` coerces its operand the same way), so ``(u.age >= 18) and
+        (u.active == True)`` would silently collapse to one branch instead of
+        building a compound predicate. Raising here turns that mistake into a
+        pointed error at build time; combine predicates with the bitwise
+        ``&`` / ``|`` operators and negate with ``~``.
 
         Raises:
             TypeError: Always — a ``QueryNode`` has no truth value.
         """
         raise TypeError(
             "QueryNode cannot be used in a boolean context; use & / | to "
-            "combine predicates, not and/or "
-            "(e.g. (u.age >= 18) & (u.active == True))."
+            "combine predicates and ~ to negate them, not and/or/not "
+            "(e.g. (u.age >= 18) & ~(u.active == True))."
         )
 
     def __repr__(self):
         """Return a developer-friendly representation of the node"""
+        if self.child is not None:
+            return f"QueryNode(NOT {self.child!r})"
         if not self.is_compound:
             return f"QueryNode(column={self.column!r}, operator={self.operator!r}, value={self.value!r})"
         return (

--- a/src/ferro/query/wire.py
+++ b/src/ferro/query/wire.py
@@ -32,13 +32,13 @@ if TYPE_CHECKING:
 # mutate arm; they stay distinct values so guardrail errors name the caller.
 QueryVerb = Literal["fetch", "count", "update", "delete"]
 
-# Always 5 (#292 — unconditional bump, exactly like v4 at #285, v3 at #278,
-# and v2 at #269; there is no earlier envelope left anywhere). v5 gives
-# ``record`` fields expression sources (ADR-0009): a field carries either a
-# ``column`` + ``path`` or an aggregate ``expr``. Python and Rust ship in one
+# Always 6 (#310 — unconditional bump, exactly like v5 at #292, v4 at #285,
+# v3 at #278, and v2 at #269; there is no earlier envelope left anywhere). v6
+# gives predicate trees the recursive ``not`` node kind beside ``leaf`` and
+# ``compound`` (uniform negation, ADR-0008). Python and Rust ship in one
 # wheel, so a single supported version is the whole contract (#267
 # Implementation Decisions).
-_IR_VERSION = 5
+_IR_VERSION = 6
 
 
 class _AbsentType:
@@ -329,7 +329,10 @@ def _where_node_traverses(node: QueryNode) -> bool:
     Used by the mutate guardrails to reject relation traversal on
     ``update()``/``delete()``. A join-free shadow-FK leaf (``t.account ==
     instance`` desugars to ``path=()``) is NOT traversal and stays allowed.
+    A negation traverses iff its child does (``~`` never adds a path).
     """
+    if node.child is not None:
+        return _where_node_traverses(node.child)
     if node.is_compound:
         return (node.left is not None and _where_node_traverses(node.left)) or (
             node.right is not None and _where_node_traverses(node.right)

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -243,12 +243,12 @@ fn tx_remove(session_id: Option<&str>, tx_id: &str) -> PyResult<Option<Transacti
     Ok(TRANSACTION_REGISTRY.remove(tx_id).map(|(_, handle)| handle))
 }
 
-/// The only QueryIR version this build accepts (#269, #278, #285, #292).
+/// The only QueryIR version this build accepts (#269, #278, #285, #292, #310).
 ///
 /// Python and Rust ship in one wheel, so there is exactly one supported version at any
 /// time — no negotiation, no fallback. A mismatch can only mean a mixed build (a stale
 /// `.so` next to a rebuilt Python package, or vice versa).
-const SUPPORTED_QUERY_IR_VERSION: u32 = 5;
+const SUPPORTED_QUERY_IR_VERSION: u32 = 6;
 
 /// Envelope shell used only to read `ir_kind`/`ir_version` before committing to a strict
 /// [`QueryIrPayload`] parse. `payload` is deliberately raw JSON: a real earlier-version
@@ -4734,7 +4734,7 @@ mod mutation_pagination_guard_tests {
     fn envelope_without_pagination_keys() -> String {
         serde_json::json!({
             "ir_kind": "query",
-            "ir_version": 5,
+            "ir_version": 6,
             "payload": {
                 "model_name": "Widget",
                 "where": [{
@@ -4804,10 +4804,10 @@ mod mutation_pagination_guard_tests {
 mod query_ir_version_gate_tests {
     use super::query_plan_from_ir_json;
 
-    fn v5_envelope() -> serde_json::Value {
+    fn v6_envelope() -> serde_json::Value {
         serde_json::json!({
             "ir_kind": "query",
-            "ir_version": 5,
+            "ir_version": 6,
             "payload": {
                 "model_name": "Widget",
                 "where": [],
@@ -4822,9 +4822,9 @@ mod query_ir_version_gate_tests {
     }
 
     /// Assert a rejected envelope's message names the received version, this
-    /// build's supported version (5), and the one-wheel fix — the actionable
+    /// build's supported version (6), and the one-wheel fix — the actionable
     /// shape pinned since the v1-at-v2 bump (#269), re-pinned at v3 (#278),
-    /// v4 (#285), and v5 (#292).
+    /// v4 (#285), v5 (#292), and v6 (#310).
     fn assert_actionable_version_rejection(err: pyo3::PyErr, received: char) {
         pyo3::Python::attach(|py| {
             assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
@@ -4835,7 +4835,7 @@ mod query_ir_version_gate_tests {
             "message should name the received version: {msg}"
         );
         assert!(
-            msg.contains('5'),
+            msg.contains('6'),
             "message should name the supported version: {msg}"
         );
         assert!(
@@ -4849,9 +4849,44 @@ mod query_ir_version_gate_tests {
     }
 
     #[test]
-    fn accepts_version_5() {
-        query_plan_from_ir_json(&v5_envelope().to_string())
-            .expect("a well-formed v5 envelope must be accepted");
+    fn accepts_version_6() {
+        query_plan_from_ir_json(&v6_envelope().to_string())
+            .expect("a well-formed v6 envelope must be accepted");
+    }
+
+    /// Contract test (#310 acceptance criteria): a v5 envelope must be
+    /// rejected on the version check with the actionable one-wheel message.
+    /// v6 is a pure widening of the v5 predicate-tree shape (the recursive
+    /// `not` node kind joined `leaf`/`compound`, ADR-0008), so every real v5
+    /// payload would still strict-parse — the version gate alone retires it,
+    /// keeping "exactly one supported version" true rather than silently
+    /// accepting a stale wheel's envelopes.
+    #[test]
+    fn rejects_v5_envelope_with_actionable_message() {
+        let v5_envelope = serde_json::json!({
+            "ir_kind": "query",
+            "ir_version": 5,
+            "payload": {
+                "model_name": "Widget",
+                "where": [{
+                    "node_kind": "leaf",
+                    "operator": "==",
+                    "column": "name",
+                    "value": {"kind": "string", "value": "a"},
+                    "path": []
+                }],
+                "order_by": [],
+                "limit": null,
+                "offset": null,
+                "m2m": null,
+                "joins": [],
+                "materialization": {"kind": "root_instances"}
+            }
+        });
+
+        let err = query_plan_from_ir_json(&v5_envelope.to_string())
+            .expect_err("a v5 envelope must be rejected");
+        assert_actionable_version_rejection(err, '5');
     }
 
     /// Contract test (#292 acceptance criteria): a v4 envelope must be
@@ -4964,14 +4999,14 @@ mod query_ir_version_gate_tests {
 
     #[test]
     fn rejects_unsupported_future_version() {
-        let mut envelope = v5_envelope();
-        envelope["ir_version"] = serde_json::json!(6);
+        let mut envelope = v6_envelope();
+        envelope["ir_version"] = serde_json::json!(7);
 
         let err = query_plan_from_ir_json(&envelope.to_string())
             .expect_err("an unsupported future version must be rejected");
         let msg = err.to_string();
         assert!(
-            msg.contains('6'),
+            msg.contains('7'),
             "message should name the received version: {msg}"
         );
     }
@@ -4980,7 +5015,7 @@ mod query_ir_version_gate_tests {
     /// naming the bad kind and the supported ones (#278).
     #[test]
     fn rejects_unknown_materialization_kind() {
-        let mut envelope = v5_envelope();
+        let mut envelope = v6_envelope();
         envelope["payload"]["materialization"] = serde_json::json!({"kind": "row_dicts"});
 
         let err = query_plan_from_ir_json(&envelope.to_string())
@@ -4993,18 +5028,18 @@ mod query_ir_version_gate_tests {
         );
     }
 
-    /// A v5 payload with NO materialization section fails the strict parse:
+    /// A v6 payload with NO materialization section fails the strict parse:
     /// the plan travels with the query as data (ADR-0007), never defaulted.
     #[test]
-    fn rejects_v5_payload_missing_materialization() {
-        let mut envelope = v5_envelope();
+    fn rejects_v6_payload_missing_materialization() {
+        let mut envelope = v6_envelope();
         envelope["payload"]
             .as_object_mut()
             .unwrap()
             .remove("materialization");
 
         let err = query_plan_from_ir_json(&envelope.to_string())
-            .expect_err("a v5 payload without a materialization section must be rejected");
+            .expect_err("a v6 payload without a materialization section must be rejected");
         let msg = err.to_string();
         assert!(
             msg.contains("materialization"),
@@ -5024,7 +5059,7 @@ mod materialization_walker_gate_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 5,
+                "ir_version": 6,
                 "payload": {
                     "model_name": "Widget",
                     "where": [],
@@ -5116,7 +5151,7 @@ mod record_select_list_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 5,
+                "ir_version": 6,
                 "payload": {
                     "model_name": "Transaction",
                     "where": where_nodes,
@@ -5397,7 +5432,7 @@ mod record_select_list_tests {
         // wire — the renderer derives it from the plan, one key per plain
         // field in selection order, qualified like the SELECT list. Pins the
         // rendered SQL for the wire shape golden-vectored in
-        // query_transaction_aggregate_v5.json.
+        // query_transaction_aggregate_v6.json.
         let plan = plan_from_payload_parts(
             account_joins(),
             serde_json::json!([]),
@@ -5587,7 +5622,7 @@ mod instances_select_list_tests {
         let mut plan = query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 5,
+                "ir_version": 6,
                 "payload": {
                     "model_name": "Transaction",
                     "where": [], "order_by": [], "limit": null, "offset": null,
@@ -5749,7 +5784,7 @@ mod mutation_qualification_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 5,
+                "ir_version": 6,
                 "payload": {
                     "model_name": "Widget",
                     "where": [{
@@ -5835,7 +5870,7 @@ mod select_join_render_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 5,
+                "ir_version": 6,
                 "payload": {
                     "model_name": "Transaction",
                     "where": [{
@@ -5941,7 +5976,7 @@ mod select_join_render_tests {
         query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 5,
+                "ir_version": 6,
                 "payload": {
                     "model_name": model_name,
                     "where": [], "order_by": [],
@@ -5963,7 +5998,7 @@ mod select_join_render_tests {
         let plan = query_plan_from_ir_json(
             &serde_json::json!({
                 "ir_kind": "query",
-                "ir_version": 5,
+                "ir_version": 6,
                 "payload": {
                     "model_name": "Transaction",
                     "where": [{

--- a/src/query.rs
+++ b/src/query.rs
@@ -33,6 +33,7 @@ fn reject_non_empty_leaf_path(node: &QueryNode) -> Result<(), String> {
             reject_non_empty_leaf_path(left)?;
             reject_non_empty_leaf_path(right)
         }
+        QueryNode::Not { child } => reject_non_empty_leaf_path(child),
     }
 }
 
@@ -548,6 +549,13 @@ impl QueryPlan {
                     op => return Err(format!("unsupported compound QueryNode operator: {op}")),
                 })
             }
+            QueryNode::Not { child } => {
+                // Uniform negation (ADR-0008): a faithful SQL `NOT (...)` over
+                // the rebuilt child — no operator rewriting, no De Morgan.
+                Ok(self
+                    .node_to_condition_for_backend(child, backend, qualifier)?
+                    .not())
+            }
             QueryNode::Leaf {
                 operator,
                 column,
@@ -810,6 +818,102 @@ mod tests {
         assert!(
             sql.contains("is not null"),
             "expected IS NOT NULL, got {sql}"
+        );
+    }
+
+    #[test]
+    fn not_node_renders_sql_not_over_leaf_child() {
+        // Uniform negation (#312, ADR-0008): a `not` node lowers to a faithful
+        // SQL `NOT (...)` over the rebuilt child — here NOT (role IN (...)),
+        // with no operator rewriting.
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Pending",
+            "where": [
+                {"node_kind": "not", "child":
+                    {"node_kind": "leaf", "column": "role", "operator": "IN",
+                     "value": {"kind": "list", "value": ["admin", "owner"]}, "path": []}}
+            ],
+            "order_by": [],
+            "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"}, "joins": []
+        }))
+        .expect("payload deserializes");
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+        let mut select = Query::select();
+        select.from(Alias::new("pending")).cond_where(
+            plan.to_condition_for_backend(Dialect::Sqlite, None)
+                .expect("valid test query"),
+        );
+        let sql = select.to_string(SqliteQueryBuilder).to_lowercase();
+        // SQL NOT binds looser than IN, so this parses as NOT (role IN (...)).
+        assert!(
+            sql.contains("not \"role\" in ('admin', 'owner')"),
+            "expected NOT over the un-rewritten IN child, got {sql}"
+        );
+    }
+
+    #[test]
+    fn not_node_renders_sql_not_over_compound_child() {
+        // `~` over a compound negates the whole group (#313): NOT (a OR b),
+        // never a De Morgan expansion of the children.
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Pending",
+            "where": [
+                {"node_kind": "not", "child":
+                    {"node_kind": "compound", "operator": "OR",
+                     "left": {"node_kind": "leaf", "column": "age", "operator": ">=",
+                              "value": {"kind": "int", "value": 18}, "path": []},
+                     "right": {"node_kind": "leaf", "column": "name", "operator": "LIKE",
+                               "value": {"kind": "string", "value": "%x%"}, "path": []}}}
+            ],
+            "order_by": [],
+            "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"}, "joins": []
+        }))
+        .expect("payload deserializes");
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+        let mut select = Query::select();
+        select.from(Alias::new("pending")).cond_where(
+            plan.to_condition_for_backend(Dialect::Sqlite, None)
+                .expect("valid test query"),
+        );
+        let sql = select.to_string(SqliteQueryBuilder).to_lowercase();
+        assert!(sql.contains("not"), "expected SQL NOT, got {sql}");
+        assert!(sql.contains("or"), "compound OR preserved under NOT: {sql}");
+        assert!(
+            sql.contains("like"),
+            "child LIKE must render un-rewritten: {sql}"
+        );
+    }
+
+    #[test]
+    fn double_not_renders_as_the_plain_child() {
+        // `~~p` reaches Rust as two nested `not` wire nodes; SeaQuery's
+        // `Condition::not` toggles a negation flag, so the even nesting
+        // renders as the plain child. That collapse is semantically exact
+        // under SQL three-valued logic (NOT NOT x ≡ x for TRUE, FALSE, and
+        // UNKNOWN alike) — the wire stays faithful, only the rendering
+        // simplifies.
+        let payload: ferro_schema_ir::QueryIrPayload = serde_json::from_value(json!({
+            "model_name": "Pending",
+            "where": [
+                {"node_kind": "not", "child":
+                    {"node_kind": "not", "child":
+                        {"node_kind": "leaf", "column": "age", "operator": ">=",
+                         "value": {"kind": "int", "value": 18}, "path": []}}}
+            ],
+            "order_by": [],
+            "limit": null, "offset": null, "m2m": null, "materialization": {"kind": "root_instances"}, "joins": []
+        }))
+        .expect("payload deserializes");
+        let plan = QueryPlan::from_ir_payload(payload).expect("plan builds");
+        let mut select = Query::select();
+        select.from(Alias::new("pending")).cond_where(
+            plan.to_condition_for_backend(Dialect::Sqlite, None)
+                .expect("valid test query"),
+        );
+        let sql = select.to_string(SqliteQueryBuilder).to_lowercase();
+        assert!(
+            !sql.contains("not") && sql.contains("\"age\" >= 18"),
+            "expected the double negation to render as the plain child, got {sql}"
         );
     }
 

--- a/tests/fixtures/ir_vectors/README.md
+++ b/tests/fixtures/ir_vectors/README.md
@@ -28,11 +28,10 @@ Rules:
 
 - `domain` and `ir.ir_kind` must match.
 - `ir.ir_version` must equal `1` for `schema` and `codec` vectors. `query`
-  vectors are on `ir_version: 5` (#292 — unconditional bump; the payload
-  carries a required `materialization` section (ADR-0007), the `instances`
-  kind carries `paths` of hop facts (ADR-0008), and `record` fields carry
-  exactly one source — `column` + `path`, or an aggregate `expr` with its
-  own hop-fact `path` (ADR-0009)); there is no earlier `query` vector left.
+  vectors are on `ir_version: 6` (#310 — unconditional bump, exactly like v5
+  at #292; predicate trees gain the recursive `not` node kind beside `leaf`
+  and `compound` (ADR-0008): `{"node_kind": "not", "child": {...}}`, any
+  child, any depth); there is no earlier `query` vector left.
 - `expect_valid` currently supports only `true` fixtures (negative vectors can be added later).
 - Fixture file names use `<domain>_<scenario>_v<version>.json` (matching that
   domain's current `ir_version`).

--- a/tests/fixtures/ir_vectors/query_transaction_aggregate_v6.json
+++ b/tests/fixtures/ir_vectors/query_transaction_aggregate_v6.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_transaction_global_aggregate_v5",
+  "vector_name": "query_transaction_aggregate_v6",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 5,
+    "ir_version": 6,
     "payload": {
       "model_name": "Transaction",
       "where": [
@@ -19,8 +19,14 @@
           "path": []
         }
       ],
-      "order_by": [],
-      "limit": null,
+      "order_by": [
+        {
+          "column": "total",
+          "direction": "desc",
+          "path": []
+        }
+      ],
+      "limit": 5,
       "offset": null,
       "m2m": null,
       "joins": [
@@ -40,13 +46,9 @@
         "kind": "record",
         "fields": [
           {
-            "name": "n",
-            "path": [],
-            "expr": {
-              "fn": "count",
-              "column": "id",
-              "path": []
-            }
+            "name": "account_name",
+            "column": "name",
+            "path": ["account"]
           },
           {
             "name": "total",

--- a/tests/fixtures/ir_vectors/query_transaction_global_aggregate_v6.json
+++ b/tests/fixtures/ir_vectors/query_transaction_global_aggregate_v6.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_transaction_aggregate_v5",
+  "vector_name": "query_transaction_global_aggregate_v6",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 5,
+    "ir_version": 6,
     "payload": {
       "model_name": "Transaction",
       "where": [
@@ -19,14 +19,8 @@
           "path": []
         }
       ],
-      "order_by": [
-        {
-          "column": "total",
-          "direction": "desc",
-          "path": []
-        }
-      ],
-      "limit": 5,
+      "order_by": [],
+      "limit": null,
       "offset": null,
       "m2m": null,
       "joins": [
@@ -46,9 +40,13 @@
         "kind": "record",
         "fields": [
           {
-            "name": "account_name",
-            "column": "name",
-            "path": ["account"]
+            "name": "n",
+            "path": [],
+            "expr": {
+              "fn": "count",
+              "column": "id",
+              "path": []
+            }
           },
           {
             "name": "total",

--- a/tests/fixtures/ir_vectors/query_transaction_include_v6.json
+++ b/tests/fixtures/ir_vectors/query_transaction_include_v6.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_transaction_include_v5",
+  "vector_name": "query_transaction_include_v6",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 5,
+    "ir_version": 6,
     "payload": {
       "model_name": "Transaction",
       "where": [

--- a/tests/fixtures/ir_vectors/query_transaction_left_join_v6.json
+++ b/tests/fixtures/ir_vectors/query_transaction_left_join_v6.json
@@ -1,31 +1,28 @@
 {
-  "vector_name": "query_transaction_traversed_record_v5",
+  "vector_name": "query_transaction_left_join_v6",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 5,
+    "ir_version": 6,
     "payload": {
       "model_name": "Transaction",
       "where": [
         {
           "node_kind": "leaf",
-          "column": "amount",
-          "operator": ">=",
+          "column": "email",
+          "operator": "==",
           "value": {
-            "kind": "int",
-            "value": 100
+            "kind": "string",
+            "value": "owner@ferro.dev"
           },
-          "path": []
+          "path": [
+            "account",
+            "owner"
+          ]
         }
       ],
-      "order_by": [
-        {
-          "column": "id",
-          "direction": "asc",
-          "path": []
-        }
-      ],
+      "order_by": [],
       "limit": null,
       "offset": null,
       "m2m": null,
@@ -60,24 +57,7 @@
         }
       ],
       "materialization": {
-        "kind": "record",
-        "fields": [
-          {
-            "name": "txn_id",
-            "column": "id",
-            "path": []
-          },
-          {
-            "name": "account_name",
-            "column": "name",
-            "path": ["account"]
-          },
-          {
-            "name": "owner_email",
-            "column": "email",
-            "path": ["account", "owner"]
-          }
-        ]
+        "kind": "root_instances"
       }
     }
   }

--- a/tests/fixtures/ir_vectors/query_transaction_record_v6.json
+++ b/tests/fixtures/ir_vectors/query_transaction_record_v6.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_transaction_record_v5",
+  "vector_name": "query_transaction_record_v6",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 5,
+    "ir_version": 6,
     "payload": {
       "model_name": "Transaction",
       "where": [

--- a/tests/fixtures/ir_vectors/query_transaction_traversal_v6.json
+++ b/tests/fixtures/ir_vectors/query_transaction_traversal_v6.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_transaction_traversal_v5",
+  "vector_name": "query_transaction_traversal_v6",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 5,
+    "ir_version": 6,
     "payload": {
       "model_name": "Transaction",
       "where": [

--- a/tests/fixtures/ir_vectors/query_transaction_traversed_record_v6.json
+++ b/tests/fixtures/ir_vectors/query_transaction_traversed_record_v6.json
@@ -1,28 +1,31 @@
 {
-  "vector_name": "query_transaction_left_join_v5",
+  "vector_name": "query_transaction_traversed_record_v6",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 5,
+    "ir_version": 6,
     "payload": {
       "model_name": "Transaction",
       "where": [
         {
           "node_kind": "leaf",
-          "column": "email",
-          "operator": "==",
+          "column": "amount",
+          "operator": ">=",
           "value": {
-            "kind": "string",
-            "value": "owner@ferro.dev"
+            "kind": "int",
+            "value": 100
           },
-          "path": [
-            "account",
-            "owner"
-          ]
+          "path": []
         }
       ],
-      "order_by": [],
+      "order_by": [
+        {
+          "column": "id",
+          "direction": "asc",
+          "path": []
+        }
+      ],
       "limit": null,
       "offset": null,
       "m2m": null,
@@ -57,7 +60,24 @@
         }
       ],
       "materialization": {
-        "kind": "root_instances"
+        "kind": "record",
+        "fields": [
+          {
+            "name": "txn_id",
+            "column": "id",
+            "path": []
+          },
+          {
+            "name": "account_name",
+            "column": "name",
+            "path": ["account"]
+          },
+          {
+            "name": "owner_email",
+            "column": "email",
+            "path": ["account", "owner"]
+          }
+        ]
       }
     }
   }

--- a/tests/fixtures/ir_vectors/query_user_compound_v6.json
+++ b/tests/fixtures/ir_vectors/query_user_compound_v6.json
@@ -1,10 +1,10 @@
 {
-  "vector_name": "query_user_compound_v5",
+  "vector_name": "query_user_compound_v6",
   "domain": "query",
   "expect_valid": true,
   "ir": {
     "ir_kind": "query",
-    "ir_version": 5,
+    "ir_version": 6,
     "payload": {
       "model_name": "User",
       "where": [

--- a/tests/fixtures/ir_vectors/query_user_not_compound_v6.json
+++ b/tests/fixtures/ir_vectors/query_user_not_compound_v6.json
@@ -1,0 +1,49 @@
+{
+  "vector_name": "query_user_not_compound_v6",
+  "domain": "query",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "query",
+    "ir_version": 6,
+    "payload": {
+      "model_name": "User",
+      "where": [
+        {
+          "node_kind": "not",
+          "child": {
+            "node_kind": "compound",
+            "operator": "OR",
+            "left": {
+              "node_kind": "leaf",
+              "column": "active",
+              "operator": "==",
+              "value": {
+                "kind": "bool",
+                "value": true
+              },
+              "path": []
+            },
+            "right": {
+              "node_kind": "leaf",
+              "column": "email",
+              "operator": "LIKE",
+              "value": {
+                "kind": "string",
+                "value": "%@ferro.dev"
+              },
+              "path": []
+            }
+          }
+        }
+      ],
+      "order_by": [],
+      "limit": null,
+      "offset": null,
+      "m2m": null,
+      "joins": [],
+      "materialization": {
+        "kind": "root_instances"
+      }
+    }
+  }
+}

--- a/tests/fixtures/ir_vectors/query_user_not_leaf_v6.json
+++ b/tests/fixtures/ir_vectors/query_user_not_leaf_v6.json
@@ -1,0 +1,44 @@
+{
+  "vector_name": "query_user_not_leaf_v6",
+  "domain": "query",
+  "expect_valid": true,
+  "ir": {
+    "ir_kind": "query",
+    "ir_version": 6,
+    "payload": {
+      "model_name": "User",
+      "where": [
+        {
+          "node_kind": "not",
+          "child": {
+            "node_kind": "leaf",
+            "column": "role",
+            "operator": "IN",
+            "value": {
+              "kind": "list",
+              "value": [
+                "admin",
+                "owner"
+              ]
+            },
+            "path": []
+          }
+        }
+      ],
+      "order_by": [
+        {
+          "column": "id",
+          "direction": "asc",
+          "path": []
+        }
+      ],
+      "limit": 100,
+      "offset": 0,
+      "m2m": null,
+      "joins": [],
+      "materialization": {
+        "kind": "root_instances"
+      }
+    }
+  }
+}

--- a/tests/test_ir_vectors_contract.py
+++ b/tests/test_ir_vectors_contract.py
@@ -11,11 +11,10 @@ from ferro import BackRef, Field, ManyToMany, Model, Relation, clear_registry
 
 VECTORS_DIR = Path(__file__).parent / "fixtures" / "ir_vectors"
 SUPPORTED_DOMAINS = {"schema", "query", "codec"}
-# `query` is on ir_version 5 (#292 — unconditional bump; `record` fields
-# carry exactly one source — `column` + `path`, or an aggregate `expr` with
-# hop-fact `path`, ADR-0009 on the ADR-0007 plan substrate); `schema`/`codec`
-# remain v1.
-SUPPORTED_IR_VERSIONS = {"schema": 1, "query": 5, "codec": 1}
+# `query` is on ir_version 6 (#310 — unconditional bump; predicate trees
+# gain the recursive `not` node kind beside `leaf`/`compound`, ADR-0008);
+# `schema`/`codec` remain v1.
+SUPPORTED_IR_VERSIONS = {"schema": 1, "query": 6, "codec": 1}
 QUERY_OPERATORS = {"==", "!=", "<", "<=", ">", ">=", "IN", "LIKE", "AND", "OR"}
 MATERIALIZATION_KINDS = {"root_instances", "record", "instances"}
 AGGREGATE_FNS = {"count", "sum", "avg", "min", "max"}
@@ -39,10 +38,22 @@ def _require_keys(obj: dict[str, Any], required: set[str], label: str) -> None:
 
 
 def _validate_query_node(node: dict[str, Any], label: str) -> None:
-    _require_keys(node, {"node_kind", "operator"}, label)
+    _require_keys(node, {"node_kind"}, label)
     node_kind = node["node_kind"]
+    assert node_kind in {"leaf", "compound", "not"}, (
+        f"{label}.node_kind invalid: {node_kind!r}"
+    )
+
+    if node_kind == "not":
+        # v6 (ADR-0008): uniform negation is one recursive node wrapping any
+        # child — no operator token, no per-operator negative forms.
+        _require_keys(node, {"child"}, label)
+        assert isinstance(node["child"], dict), f"{label}.child must be object"
+        _validate_query_node(node["child"], f"{label}.child")
+        return
+
+    _require_keys(node, {"operator"}, label)
     operator = node["operator"]
-    assert node_kind in {"leaf", "compound"}, f"{label}.node_kind invalid: {node_kind!r}"
     assert operator in QUERY_OPERATORS, f"{label}.operator invalid: {operator!r}"
 
     if node_kind == "leaf":

--- a/tests/test_negation.py
+++ b/tests/test_negation.py
@@ -1,0 +1,226 @@
+"""End-to-end behavior of uniform predicate negation (`~`, #310).
+
+Prefix `~` negates any predicate node — leaf comparison or AND/OR compound —
+and renders as a faithful SQL ``NOT (...)`` over the child. These tests assert
+result sets only, on both database backends via the backend matrix; the wire
+shape is pinned separately by the ``not`` golden vectors.
+"""
+
+import pytest
+from typing import Annotated
+from ferro import BackRef, Model, ForeignKey, Relation, connect, FerroField, engines
+
+pytestmark = pytest.mark.backend_matrix
+
+
+class NegProduct(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    name: str
+    price: float
+    category: str
+
+
+async def _seed_products():
+    await NegProduct(name="apple", price=10.0, category="fruit").save()
+    await NegProduct(name="banana", price=20.0, category="fruit").save()
+    await NegProduct(name="carrot", price=30.0, category="veg").save()
+    await NegProduct(name="donut", price=40.0, category="bakery").save()
+
+
+async def _names(query) -> list[str]:
+    return sorted(r.name for r in await query.all())
+
+
+@pytest.mark.asyncio
+async def test_not_over_equality_and_inequality(db_url):
+    """`~(col == v)` matches the `!=` rows and `~(col != v)` the `==` rows."""
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        await _seed_products()
+
+        negated_eq = await _names(
+            NegProduct.where(lambda p: ~(p.category == "fruit"))
+        )
+        assert negated_eq == ["carrot", "donut"]
+        assert negated_eq == await _names(
+            NegProduct.where(lambda p: p.category != "fruit")
+        )
+
+        negated_ne = await _names(
+            NegProduct.where(lambda p: ~(p.category != "fruit"))
+        )
+        assert negated_ne == ["apple", "banana"]
+
+
+@pytest.mark.asyncio
+async def test_not_over_ordering_comparisons(db_url):
+    """`~` over `<`, `<=`, `>`, `>=` selects exactly the complement rows."""
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        await _seed_products()
+
+        assert await _names(NegProduct.where(lambda p: ~(p.price < 30))) == [
+            "carrot",
+            "donut",
+        ]
+        assert await _names(NegProduct.where(lambda p: ~(p.price <= 30))) == ["donut"]
+        assert await _names(NegProduct.where(lambda p: ~(p.price > 30))) == [
+            "apple",
+            "banana",
+            "carrot",
+        ]
+        assert await _names(NegProduct.where(lambda p: ~(p.price >= 30))) == [
+            "apple",
+            "banana",
+        ]
+
+
+@pytest.mark.asyncio
+async def test_not_in_closes_the_not_in_gap(db_url):
+    """`~t.col.in_(values)` is NOT IN — the previously unspellable shape."""
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        await _seed_products()
+
+        rows = await _names(
+            NegProduct.where(lambda p: ~p.category.in_(["fruit", "veg"]))
+        )
+        assert rows == ["donut"]
+
+
+@pytest.mark.asyncio
+async def test_not_like_closes_the_not_like_gap(db_url):
+    """`~t.col.like(pattern)` is NOT LIKE."""
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        await _seed_products()
+
+        rows = await _names(NegProduct.where(lambda p: ~p.name.like("%a%")))
+        assert rows == ["donut"]
+
+
+@pytest.mark.asyncio
+async def test_not_over_compounds(db_url):
+    """`~` over an AND/OR compound negates the whole group — no hand-applied
+    De Morgan required."""
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        await _seed_products()
+
+        not_and = await _names(
+            NegProduct.where(
+                lambda p: ~((p.category == "fruit") & (p.price >= 20))
+            )
+        )
+        assert not_and == ["apple", "carrot", "donut"]
+
+        not_or = await _names(
+            NegProduct.where(
+                lambda p: ~((p.category == "fruit") | (p.price >= 30))
+            )
+        )
+        assert not_or == []
+
+
+@pytest.mark.asyncio
+async def test_double_negation_round_trips(db_url):
+    """`~~p` selects exactly the rows `p` selects."""
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        await _seed_products()
+
+        plain = await _names(NegProduct.where(lambda p: p.category == "fruit"))
+        doubled = await _names(NegProduct.where(lambda p: ~~(p.category == "fruit")))
+        assert doubled == plain == ["apple", "banana"]
+
+
+@pytest.mark.asyncio
+async def test_not_mixed_into_and_or_trees(db_url):
+    """Negated nodes compose with `&`/`|` at any nesting level."""
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        await _seed_products()
+
+        rows = await _names(
+            NegProduct.where(
+                lambda p: (~(p.category == "fruit") & (p.price < 40))
+                | ~(p.name.like("%o%"))
+            )
+        )
+        # Left branch: carrot (non-fruit under 40). Right branch: no "o" in
+        # the name — apple, banana.
+        assert rows == ["apple", "banana", "carrot"]
+
+
+@pytest.mark.asyncio
+async def test_negation_composes_with_order_by_and_limit(db_url):
+    """Adding `~` never restructures the query: ordering and paging chain on."""
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        await _seed_products()
+
+        rows = (
+            await NegProduct.where(lambda p: ~(p.category == "fruit"))
+            .order_by("price", direction="desc")
+            .limit(1)
+            .all()
+        )
+        assert [r.name for r in rows] == ["donut"]
+
+
+class NegReading(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    sensor: str
+    amount: float | None = None
+
+
+@pytest.mark.asyncio
+async def test_null_rows_are_excluded_under_negation(db_url):
+    """SQL three-valued logic: `~(t.amount > 5)` excludes NULL-amount rows —
+    NOT UNKNOWN is UNKNOWN, exactly as the existing `!=` spelling behaves."""
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        await NegReading(sensor="low", amount=3.0).save()
+        await NegReading(sensor="high", amount=9.0).save()
+        await NegReading(sensor="missing", amount=None).save()
+
+        negated = sorted(
+            r.sensor for r in await NegReading.where(lambda r: ~(r.amount > 5)).all()
+        )
+        assert negated == ["low"]  # NOT a Python set complement: no "missing"
+
+        # Same three-valued behavior as the pre-existing `!=` spelling.
+        ne_rows = sorted(
+            r.sensor for r in await NegReading.where(lambda r: r.amount != 9.0).all()
+        )
+        assert ne_rows == ["low"]
+
+
+class NegAccount(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    label: str
+    transactions: Relation[list["NegTxn"]] = BackRef()
+
+
+class NegTxn(Model):
+    id: Annotated[int | None, FerroField(primary_key=True)] = None
+    amount: float
+    account: Annotated[
+        NegAccount | None, ForeignKey(related_name="transactions")
+    ] = None
+
+
+@pytest.mark.asyncio
+async def test_not_over_traversed_leaf(db_url):
+    """`~` over a relation-traversing leaf keeps the traversal's join."""
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        checking = NegAccount(label="checking")
+        await checking.save()
+        savings = NegAccount(label="savings")
+        await savings.save()
+        await NegTxn(amount=5.0, account=checking).save()
+        await NegTxn(amount=7.0, account=savings).save()
+
+        rows = await NegTxn.where(lambda t: ~(t.account.label == "checking")).all()
+        assert [r.amount for r in rows] == [7.0]

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -67,7 +67,7 @@ def test_to_wire_json_serializes_m2m_context_without_mutating_query_state():
     assert query._m2m_context.source_id == source_id
     assert isinstance(query._m2m_context.source_id, uuid.UUID)
     assert payload["ir_kind"] == "query"
-    assert payload["ir_version"] == 5
+    assert payload["ir_version"] == 6
     assert payload["payload"]["m2m"]["source_id"] == str(source_id)
 
 

--- a/tests/test_query_joins.py
+++ b/tests/test_query_joins.py
@@ -671,12 +671,15 @@ class TestRelationProxySugar:
 
 
 def test_query_node_boolean_coercion_raises():
-    """`and`/`or` misuse coerces a QueryNode to bool; that raises pointedly."""
+    """`and`/`or`/`not` misuse coerces a QueryNode to bool; that raises
+    pointedly, naming `~` as the supported negation spelling (#313)."""
     node = FieldProxy("age") >= 18
     with pytest.raises(TypeError, match="boolean context.*use & / |"):
         bool(node)
     with pytest.raises(TypeError, match="use & / |"):
         _ = (FieldProxy("age") >= 18) and (FieldProxy("age") <= 30)
+    with pytest.raises(TypeError, match=r"~ to negate"):
+        _ = not (FieldProxy("age") >= 18)
 
 
 class TestMutatingTraversalRejection:
@@ -685,6 +688,15 @@ class TestMutatingTraversalRejection:
 
     def test_traversed_predicate_rejected_for_update_and_delete(self):
         q = Query(QJTransaction).where(lambda t: t.account.label == "a1")
+        for operation in ("update", "delete"):
+            with pytest.raises(ValueError, match="does not support relation traversal"):
+                compile_query(q, operation)
+
+    def test_negated_traversed_predicate_rejected_for_update_and_delete(self):
+        # A traversing leaf stays traversal under `~` (#312): the guard sees
+        # through the NOT wrapper, so negation can't smuggle a join into a
+        # single-table mutation.
+        q = Query(QJTransaction).where(lambda t: ~(t.account.label == "a1"))
         for operation in ("update", "delete"):
             with pytest.raises(ValueError, match="does not support relation traversal"):
                 compile_query(q, operation)

--- a/tests/test_query_wire_vectors.py
+++ b/tests/test_query_wire_vectors.py
@@ -196,15 +196,33 @@ def _q_global_aggregate(m: dict[str, type]) -> Any:
     )
 
 
+def _q_not_leaf(m: dict[str, type]) -> Any:
+    return (
+        m["User"]
+        .where(lambda u: ~u.role.in_(["admin", "owner"]))
+        .order_by("id")
+        .limit(100)
+        .offset(0)
+    )
+
+
+def _q_not_compound(m: dict[str, type]) -> Any:
+    return m["User"].where(
+        lambda u: ~((u.active == True) | (u.email.like("%@ferro.dev")))  # noqa: E712
+    )
+
+
 CASES: list[tuple[str, Callable[[dict[str, type]], Any], str]] = [
-    ("query_user_compound_v5", _q_user_compound, "User"),
-    ("query_transaction_traversal_v5", _q_traversal, "Transaction"),
-    ("query_transaction_left_join_v5", _q_left_join, "Transaction"),
-    ("query_transaction_include_v5", _q_include, "Transaction"),
-    ("query_transaction_record_v5", _q_record, "Transaction"),
-    ("query_transaction_traversed_record_v5", _q_traversed_record, "Transaction"),
-    ("query_transaction_aggregate_v5", _q_aggregate, "Transaction"),
-    ("query_transaction_global_aggregate_v5", _q_global_aggregate, "Transaction"),
+    ("query_user_compound_v6", _q_user_compound, "User"),
+    ("query_user_not_leaf_v6", _q_not_leaf, "User"),
+    ("query_user_not_compound_v6", _q_not_compound, "User"),
+    ("query_transaction_traversal_v6", _q_traversal, "Transaction"),
+    ("query_transaction_left_join_v6", _q_left_join, "Transaction"),
+    ("query_transaction_include_v6", _q_include, "Transaction"),
+    ("query_transaction_record_v6", _q_record, "Transaction"),
+    ("query_transaction_traversed_record_v6", _q_traversed_record, "Transaction"),
+    ("query_transaction_aggregate_v6", _q_aggregate, "Transaction"),
+    ("query_transaction_global_aggregate_v6", _q_global_aggregate, "Transaction"),
 ]
 
 
@@ -285,4 +303,4 @@ def test_mutate_payload_omits_pagination_keys(models: dict[str, type]) -> None:
 def test_envelope_is_versioned(models: dict[str, type]) -> None:
     envelope = json.loads(compile_query(models["User"].select(), "fetch").wire_json)
     assert envelope["ir_kind"] == "query"
-    assert envelope["ir_version"] == 5
+    assert envelope["ir_version"] == 6


### PR DESCRIPTION
Implements PRD #310 across both slices in one PR: the `~` tracer bullet on leaf predicates (#312) and compounds, guard rails, and docs (#313).

## What

One universal negation rule: prefix `~` negates **any** predicate node — leaf comparison or AND/OR compound.

```python
Txn.where(lambda t: ~t.category_id.in_(ids))          # NOT IN — previously unspellable
User.where(lambda u: ~u.email.like("%@example.com"))  # NOT LIKE — likewise
User.where(lambda u: ~((u.active == True) | (u.email.like("%@ferro.dev"))))
```

renders as a faithful `NOT (...)` over the child:

```sql
SELECT ... FROM "user" WHERE NOT ("category_id" IN (...))
SELECT ... FROM "user" WHERE NOT ("active" = TRUE OR "email" LIKE '%@ferro.dev')
```

## How

- **Python:** `QueryNode.__invert__` wraps any node in a NOT node; the truthiness guard (`__bool__`) now names `~` as the supported spelling. The mutate traversal guard and join registration see through NOT, so `~` can neither smuggle a join into `update()`/`delete()` nor drop a traversed child's join.
- **Wire:** a new recursive `not` node kind beside `leaf`/`compound` — `{"node_kind": "not", "child": {...}}`, any child, any depth. QueryIR version bumps to v6 (unconditional, single supported version; the Rust gate rejects v5 with the actionable one-wheel message). No per-operator negative forms anywhere (ADR-0008).
- **Rust:** one recursion case in the condition builder emitting SeaQuery `Cond::not` over the rebuilt child. Double negation reaches Rust as two nested `not` nodes; SeaQuery's negation toggle renders the even nesting as the plain child — semantically exact under three-valued logic (`NOT NOT x ≡ x` for TRUE/FALSE/UNKNOWN alike).
- **Golden vectors:** two hand-authored vectors pin the not-over-leaf and not-over-compound shapes, asserted byte-for-byte from the Python emitter and round-tripped by the Rust decoder; the existing query vectors move to v6.

## Testing

- End-to-end result-set tests (`tests/test_negation.py`), green on **both** backends: `~` over every leaf operator kind (`==`, `!=`, orderings, `in_`, `like`), `~` over AND/OR compounds, double negation, `~` mixed into `&`/`|` trees at multiple levels, NULL-row behavior under negation (three-valued semantics, matching `!=`), composition with `order_by()`/`limit()`, and `~` over a relation-traversing leaf.
- Error paths: the truthiness-guard message pinned to name `~`; NOT-wrapped traversal rejected on `update()`/`delete()`.
- Full suite: 1599 passed on sqlite+postgres; all Rust workspace suites green.

## Docs

New "Negating Conditions" guide section with the central three-valued-logic note (real nullable-column model in Assignment + Annotated tabs, rendered SQL); `~`/`NOT` row in the operators table; API reference states the universal rule; `not_in()` removed from the roadmap. All examples lambda-style and runnable under the docs test harness.

Closes #312
Closes #313