### PR TITLE
fix: classify PG18 RESTRICT (23001) as ForeignKeyViolationError

### DIFF
--- a/docs/pages/api/exceptions.md
+++ b/docs/pages/api/exceptions.md
@@ -16,6 +16,13 @@ FerroError
 └── ModelDoesNotExist       (also a LookupError)
 ```
 
+`ForeignKeyViolationError` covers every foreign-key rejection: a dangling
+insert, and a parent delete or key update blocked by `on_delete="RESTRICT"`
+(or `ON UPDATE RESTRICT`). Catch the type, not a SQLSTATE. On PostgreSQL 17
+RESTRICT reports `23503`; PostgreSQL 18 reports `23001`
+(`restrict_violation`). Both are this class. `exc.sqlstate` is the raw
+driver code — it is not rewritten.
+
 Catch a duplicate insert without matching driver text:
 
 ```python

--- a/docs/pages/api/exceptions.md
+++ b/docs/pages/api/exceptions.md
@@ -17,11 +17,11 @@ FerroError
 ```
 
 `ForeignKeyViolationError` covers every foreign-key rejection: a dangling
-insert, and a parent delete or key update blocked by `on_delete="RESTRICT"`
-(or `ON UPDATE RESTRICT`). Catch the type, not a SQLSTATE. On PostgreSQL 17
-RESTRICT reports `23503`; PostgreSQL 18 reports `23001`
-(`restrict_violation`). Both are this class. `exc.sqlstate` is the raw
-driver code — it is not rewritten.
+insert, and deleting a row still referenced by `ForeignKey(on_delete="RESTRICT")`.
+Catch the type, not a SQLSTATE. On PostgreSQL 17 that RESTRICT delete
+reports `23503`; PostgreSQL 18 reports `23001` (`restrict_violation`).
+Both are this class. `exc.sqlstate` is the raw driver code — it is not
+rewritten.
 
 Catch a duplicate insert without matching driver text:
 

--- a/docs/solutions/issues/pg18-restrict-sqlstate-23001.md
+++ b/docs/solutions/issues/pg18-restrict-sqlstate-23001.md
@@ -1,0 +1,33 @@
+---
+title: PG18 RESTRICT is SQLSTATE 23001, not 23503
+type: issue
+tags: [gotcha, rust, postgres, sqlite, ffi, sqlx]
+related_files:
+  - src/errors.rs
+  - src/ferro/exceptions.py
+  - tests/test_exception_mapping.py
+related_issues: [306, 336, 337]
+captured: 2026-08-15
+---
+
+# PG18 RESTRICT is SQLSTATE 23001, not 23503
+
+**Problem:** Deleting a parent still referenced by `ForeignKey(on_delete="RESTRICT")` raised `ForeignKeyViolationError` on PostgreSQL 17 and `OperationalError` on PostgreSQL 18.
+
+**Takeaway:** Ferro owns the integrity-code table. Do not ask sqlx `kind()` alone, and do not match driver message text. `23001` (PG18 RESTRICT) and SQLite `1811` (RESTRICT implemented as a trigger) are `ForeignKeyViolationError`. `sqlstate` stays the raw driver code.
+
+## What happened
+
+PostgreSQL 18 changed `ON DELETE` / `ON UPDATE RESTRICT` from `23503` (`foreign_key_violation`) to `23001` (`restrict_violation`). The message picked up "RESTRICT setting of" at the same time — that is the symptom, not the cause.
+
+sqlx 0.8 and 0.9 still map only `23503` → `ErrorKind::ForeignKeyViolation`. `23001` is `Other`. Ferro's mapper used `kind()`, so the delete path fell through to `OperationalError`. Inserting a dangling FK stayed `23503` on both majors, which is why the existing INSERT test never caught this. CI is `postgres:17`.
+
+SQLite has a parallel hole: RESTRICT parent-delete reports extended result code `1811` (`SQLITE_CONSTRAINT_TRIGGER`), not `787` (`SQLITE_CONSTRAINT_FOREIGNKEY`). sqlx `kind()` is `Other` there too. The driver message still says `FOREIGN KEY constraint failed`.
+
+The table lives in `exception_name_for_database` (`src/errors.rs`). Known codes win; `kind()` is the fallback. `map_db_error` still copies `db.code()` onto `sqlstate` unchanged — do not rewrite `23001` to `23503`.
+
+`23000` (generic integrity) and `23P01` (exclusion) stay `OperationalError` until they get their own type decision.
+
+## How to recognize
+
+A RESTRICT parent-delete raises `OperationalError` instead of `ForeignKeyViolationError`, especially when CI is PG17 and someone is on PG18. Check `exc.sqlstate`: `23001` on Postgres, `1811` on SQLite. If classification missed, `sqlstate` should still be set — `None` is a second bug (the code was dropped on the wrap).

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,9 +8,9 @@
 //!
 //! Classification policy (DBAPI-shaped):
 //! - Constraint violations map to the `IntegrityError` subclasses.
-//!   Ferro's integrity-code table is the authority (`23001`/`23503` FK,
-//!   `23505` unique, `23502` not-null, `23514` check); sqlx `kind()` is
-//!   the fallback for SQLite and unknown codes.
+//!   Ferro's integrity-code table is the authority (`23001`/`23503`/`1811`
+//!   FK, `23505` unique, `23502` not-null, `23514` check); sqlx `kind()`
+//!   is the fallback for other SQLite codes and unknown SQLSTATEs.
 //! - Environment/runtime failures (I/O, TLS, pool exhaustion) map to
 //!   `OperationalError`.
 //! - Client-side misuse of the interface (configuration, protocol,
@@ -26,10 +26,11 @@ static EXCEPTIONS_MODULE: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
 /// Python exception class name for a database error, from Ferro's
 /// integrity-code table then sqlx `kind()` as fallback.
 ///
-/// Known codes win so Postgres 18 `23001` (`restrict_violation`) is
-/// `ForeignKeyViolationError` even though sqlx still reports `Other`.
-/// Unknown codes (including `23000` / `23P01`) and SQLite (no SQLSTATE)
-/// fall through to `kind()`.
+/// Known codes win so Postgres 18 `23001` (`restrict_violation`) and
+/// SQLite `1811` (`SQLITE_CONSTRAINT_TRIGGER`, how RESTRICT is
+/// implemented) are `ForeignKeyViolationError` even though sqlx reports
+/// `Other`. Unknown codes (including `23000` / `23P01`) fall through to
+/// `kind()`.
 pub(crate) fn exception_name_for_database(
     kind: sqlx::error::ErrorKind,
     code: Option<&str>,
@@ -37,7 +38,7 @@ pub(crate) fn exception_name_for_database(
     use sqlx::error::ErrorKind;
 
     match code {
-        Some("23001") | Some("23503") => "ForeignKeyViolationError",
+        Some("23001") | Some("23503") | Some("1811") => "ForeignKeyViolationError",
         Some("23505") => "UniqueViolationError",
         Some("23502") => "NotNullViolationError",
         Some("23514") => "CheckViolationError",
@@ -147,10 +148,19 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_restrict_trigger_1811_is_foreign_key() {
+        assert_eq!(
+            exception_name_for_database(ErrorKind::Other, Some("1811")),
+            "ForeignKeyViolationError"
+        );
+    }
+
+    #[test]
     fn integrity_codes_win_over_kind() {
         let cases = [
             ("23001", "ForeignKeyViolationError"),
             ("23503", "ForeignKeyViolationError"),
+            ("1811", "ForeignKeyViolationError"),
             ("23505", "UniqueViolationError"),
             ("23502", "NotNullViolationError"),
             ("23514", "CheckViolationError"),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,6 +8,9 @@
 //!
 //! Classification policy (DBAPI-shaped):
 //! - Constraint violations map to the `IntegrityError` subclasses.
+//!   Ferro's integrity-code table is the authority (`23001`/`23503` FK,
+//!   `23505` unique, `23502` not-null, `23514` check); sqlx `kind()` is
+//!   the fallback for SQLite and unknown codes.
 //! - Environment/runtime failures (I/O, TLS, pool exhaustion) map to
 //!   `OperationalError`.
 //! - Client-side misuse of the interface (configuration, protocol,
@@ -20,21 +23,41 @@ use pyo3::types::PyDict;
 
 static EXCEPTIONS_MODULE: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
 
-/// Python exception class name in `ferro.exceptions` for a `sqlx::Error`.
+/// Python exception class name for a database error, from Ferro's
+/// integrity-code table then sqlx `kind()` as fallback.
 ///
-/// Pure classifier so the mapping table is unit-testable without a live
-/// database or the GIL.
-pub(crate) fn exception_name_for(err: &sqlx::Error) -> &'static str {
+/// Known codes win so Postgres 18 `23001` (`restrict_violation`) is
+/// `ForeignKeyViolationError` even though sqlx still reports `Other`.
+/// Unknown codes (including `23000` / `23P01`) and SQLite (no SQLSTATE)
+/// fall through to `kind()`.
+pub(crate) fn exception_name_for_database(
+    kind: sqlx::error::ErrorKind,
+    code: Option<&str>,
+) -> &'static str {
     use sqlx::error::ErrorKind;
 
-    match err {
-        sqlx::Error::Database(db) => match db.kind() {
+    match code {
+        Some("23001") | Some("23503") => "ForeignKeyViolationError",
+        Some("23505") => "UniqueViolationError",
+        Some("23502") => "NotNullViolationError",
+        Some("23514") => "CheckViolationError",
+        _ => match kind {
             ErrorKind::UniqueViolation => "UniqueViolationError",
             ErrorKind::ForeignKeyViolation => "ForeignKeyViolationError",
             ErrorKind::NotNullViolation => "NotNullViolationError",
             ErrorKind::CheckViolation => "CheckViolationError",
             _ => "OperationalError",
         },
+    }
+}
+
+/// Python exception class name in `ferro.exceptions` for a `sqlx::Error`.
+///
+/// Pure classifier so the mapping table is unit-testable without a live
+/// database or the GIL.
+pub(crate) fn exception_name_for(err: &sqlx::Error) -> &'static str {
+    match err {
+        sqlx::Error::Database(db) => exception_name_for_database(db.kind(), db.code().as_deref()),
         sqlx::Error::Io(_)
         | sqlx::Error::Tls(_)
         | sqlx::Error::PoolTimedOut
@@ -112,7 +135,54 @@ pub(crate) fn interface_error(message: impl Into<String>) -> PyErr {
 
 #[cfg(test)]
 mod tests {
-    use super::exception_name_for;
+    use super::{exception_name_for, exception_name_for_database};
+    use sqlx::error::ErrorKind;
+
+    #[test]
+    fn restrict_violation_23001_is_foreign_key() {
+        assert_eq!(
+            exception_name_for_database(ErrorKind::Other, Some("23001")),
+            "ForeignKeyViolationError"
+        );
+    }
+
+    #[test]
+    fn integrity_codes_win_over_kind() {
+        let cases = [
+            ("23001", "ForeignKeyViolationError"),
+            ("23503", "ForeignKeyViolationError"),
+            ("23505", "UniqueViolationError"),
+            ("23502", "NotNullViolationError"),
+            ("23514", "CheckViolationError"),
+        ];
+        for (code, name) in cases {
+            assert_eq!(
+                exception_name_for_database(ErrorKind::Other, Some(code)),
+                name,
+                "code {code}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_codes_and_sqlite_fall_back_to_kind() {
+        assert_eq!(
+            exception_name_for_database(ErrorKind::Other, Some("23000")),
+            "OperationalError"
+        );
+        assert_eq!(
+            exception_name_for_database(ErrorKind::Other, Some("23P01")),
+            "OperationalError"
+        );
+        assert_eq!(
+            exception_name_for_database(ErrorKind::ForeignKeyViolation, None),
+            "ForeignKeyViolationError"
+        );
+        assert_eq!(
+            exception_name_for_database(ErrorKind::Other, None),
+            "OperationalError"
+        );
+    }
 
     #[test]
     fn pool_and_io_failures_are_operational() {

--- a/src/ferro/exceptions.py
+++ b/src/ferro/exceptions.py
@@ -105,9 +105,9 @@ class UniqueViolationError(IntegrityError):
 class ForeignKeyViolationError(IntegrityError):
     """A FOREIGN KEY constraint rejected the statement.
 
-    Includes ``ON DELETE`` / ``ON UPDATE RESTRICT`` (PostgreSQL 18 reports
-    SQLSTATE ``23001``; PostgreSQL 17 reports ``23503``). ``sqlstate`` is
-    the raw driver code.
+    Includes a parent delete blocked by ``ForeignKey(on_delete="RESTRICT")``.
+    PostgreSQL 18 reports SQLSTATE ``23001`` for that case; PostgreSQL 17
+    reports ``23503``. ``sqlstate`` is the raw driver code.
     """
 
 

--- a/src/ferro/exceptions.py
+++ b/src/ferro/exceptions.py
@@ -103,7 +103,12 @@ class UniqueViolationError(IntegrityError):
 
 
 class ForeignKeyViolationError(IntegrityError):
-    """A FOREIGN KEY constraint rejected the statement."""
+    """A FOREIGN KEY constraint rejected the statement.
+
+    Includes ``ON DELETE`` / ``ON UPDATE RESTRICT`` (PostgreSQL 18 reports
+    SQLSTATE ``23001``; PostgreSQL 17 reports ``23503``). ``sqlstate`` is
+    the raw driver code.
+    """
 
 
 class NotNullViolationError(IntegrityError):

--- a/tests/test_exception_mapping.py
+++ b/tests/test_exception_mapping.py
@@ -132,6 +132,71 @@ async def test_foreign_key_violation_is_typed(db_url, db_backend):
             assert exc.sqlstate == "23503"
 
 
+@pytest.mark.backend_matrix
+@pytest.mark.asyncio
+async def test_restrict_parent_instance_delete_is_typed(db_url, db_backend):
+    class RestrictDelParent(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+        kids: Relation[list["RestrictDelChild"]] = BackRef()
+
+    class RestrictDelChild(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        title: str
+        parent: Annotated[
+            RestrictDelParent, ForeignKey(related_name="kids", on_delete="RESTRICT")
+        ]
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        parent = RestrictDelParent(name="p")
+        await parent.save()
+        await RestrictDelChild(title="c", parent_id=parent.id).save()
+
+        with pytest.raises(ForeignKeyViolationError) as excinfo:
+            await parent.delete()
+
+        exc = excinfo.value
+        assert isinstance(exc, IntegrityError)
+        if db_backend == "postgres":
+            assert exc.sqlstate is not None
+            assert exc.sqlstate in {"23503", "23001"}
+            assert exc.constraint is not None
+
+
+@pytest.mark.backend_matrix
+@pytest.mark.asyncio
+async def test_restrict_parent_query_delete_is_typed(db_url, db_backend):
+    class RestrictQDelParent(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        name: str
+        kids: Relation[list["RestrictQDelChild"]] = BackRef()
+
+    class RestrictQDelChild(Model):
+        id: Annotated[int | None, FerroField(primary_key=True)] = None
+        title: str
+        parent: Annotated[
+            RestrictQDelParent, ForeignKey(related_name="kids", on_delete="RESTRICT")
+        ]
+
+    await connect(db_url, auto_migrate=True)
+    async with engines.session():
+        parent = RestrictQDelParent(name="p")
+        await parent.save()
+        pk = parent.id
+        await RestrictQDelChild(title="c", parent_id=pk).save()
+
+        with pytest.raises(ForeignKeyViolationError) as excinfo:
+            await RestrictQDelParent.where(lambda parent: parent.id == pk).delete()
+
+        exc = excinfo.value
+        assert isinstance(exc, IntegrityError)
+        if db_backend == "postgres":
+            assert exc.sqlstate is not None
+            assert exc.sqlstate in {"23503", "23001"}
+            assert exc.constraint is not None
+
+
 @pytest.mark.asyncio
 async def test_unopenable_database_is_operational_error(tmp_path):
     # No mode=rwc: SQLite refuses to open a missing file, which surfaces as a


### PR DESCRIPTION
## Summary
- Deleting a parent still referenced by `ForeignKey(on_delete="RESTRICT")` now raises `ForeignKeyViolationError` on PostgreSQL 18, same as 17. PG18 reports SQLSTATE `23001` (`restrict_violation`); sqlx `kind()` still treats that as `Other`.
- Ferro owns the integrity-code table (`23001` / `23503` / SQLite `1811` → FK). `sqlstate` stays the raw driver code. Catch the type, not a code or a message.
- Live pins on `instance.delete()` and `Query.delete()`. Solutions note: `docs/solutions/issues/pg18-restrict-sqlstate-23001.md`.

Closes #306
Fixes #336
Fixes #337

## Test plan
- [x] `cargo test --no-default-features --features testing` (207 passed)
- [x] `uv run pytest tests/test_exception_mapping.py --db-backends=sqlite` (8 passed)
- [ ] CI backend matrix (`postgres:17`) — RESTRICT delete asserts `sqlstate in {"23503", "23001"}`
- [ ] Issue status: #336 and #337 closed; this PR closes #306


Made with [Cursor](https://cursor.com)